### PR TITLE
Add manual macOS-only build workflow

### DIFF
--- a/.github/workflows/vibecad-macos.yml
+++ b/.github/workflows/vibecad-macos.yml
@@ -1,0 +1,256 @@
+name: VibeCAD macOS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Branch, tag, or commit to build."
+        required: true
+        default: "dev"
+        type: string
+      architecture:
+        description: "macOS architecture to build."
+        required: true
+        default: "arm64"
+        type: choice
+        options:
+          - arm64
+          - x86_64
+          - both
+      publish_release:
+        description: "Publish the successful macOS artifacts as a GitHub prerelease."
+        required: true
+        default: false
+        type: boolean
+      release_tag:
+        description: "Optional release tag. Leave empty for vibecad-macos-YYYYMMDD-SHA."
+        required: false
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: vibecad-macos-${{ inputs.source_ref }}-${{ inputs.architecture }}
+  cancel-in-progress: false
+
+env:
+  UPLOAD_RELEASE: "false"
+
+jobs:
+  prepare:
+    name: Prepare macOS Build
+    runs-on: ubuntu-24.04
+    outputs:
+      source_sha: ${{ steps.meta.outputs.source_sha }}
+      build_tag: ${{ steps.meta.outputs.build_tag }}
+      release_tag: ${{ steps.meta.outputs.release_tag }}
+      matrix: ${{ steps.meta.outputs.matrix }}
+    steps:
+      - name: Resolve source and architecture matrix
+        id: meta
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+          ARCHITECTURE: ${{ inputs.architecture }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          source_sha="$(
+            gh api "repos/${GITHUB_REPOSITORY}/commits/${SOURCE_REF}" --jq '.sha'
+          )"
+          if [[ ! "${source_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Could not resolve ${SOURCE_REF} to a commit: ${source_sha}" >&2
+            exit 1
+          fi
+
+          release_tag="${INPUT_RELEASE_TAG}"
+          if [[ -z "${release_tag}" ]]; then
+            release_tag="vibecad-macos-$(date -u +%Y%m%d)-${source_sha:0:12}"
+          fi
+          if [[ ! "${release_tag}" =~ ^[A-Za-z0-9._-]+$ ]]; then
+            echo "Release tag contains unsupported characters: ${release_tag}" >&2
+            exit 1
+          fi
+
+          arm64='{"target":"osx-arm64","runner":"macos-15","arch":"arm64"}'
+          x86_64='{"target":"osx-64","runner":"macos-15-intel","arch":"x86_64"}'
+          case "${ARCHITECTURE}" in
+            arm64)
+              matrix="{\"include\":[${arm64}]}"
+              ;;
+            x86_64)
+              matrix="{\"include\":[${x86_64}]}"
+              ;;
+            both)
+              matrix="{\"include\":[${arm64},${x86_64}]}"
+              ;;
+            *)
+              echo "Unsupported architecture selection: ${ARCHITECTURE}" >&2
+              exit 1
+              ;;
+          esac
+
+          echo "source_sha=${source_sha}" >> "${GITHUB_OUTPUT}"
+          echo "build_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+          echo "matrix=${matrix}" >> "${GITHUB_OUTPUT}"
+
+          cat >> "${GITHUB_STEP_SUMMARY}" <<EOF
+          Source: ${SOURCE_REF} @ ${source_sha}
+
+          Architecture: ${ARCHITECTURE}
+
+          Release tag: ${release_tag}
+
+          Publish release: ${{ inputs.publish_release }}
+          EOF
+
+  macos:
+    name: macOS ${{ matrix.arch }} DMG
+    needs: prepare
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.matrix) }}
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Check out source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.source_sha }}
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Install Pixi
+        shell: bash
+        run: |
+          set -euo pipefail
+          curl -fsSL https://pixi.sh/install.sh | bash
+          echo "${HOME}/.pixi/bin" >> "${GITHUB_PATH}"
+
+      - name: Restore Pixi and runtime caches
+        id: cache-pixi
+        uses: actions/cache/restore@v4
+        with:
+          path: |
+            package/rattler-build/.pixi
+            package/rattler-build/.download-cache
+            ~/.cache/pixi
+            ~/.cache/rattler
+            ~/Library/Caches/pip
+          key: pixi-${{ matrix.target }}-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'src/Mod/VibeCAD/build123d-requirements.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_build123d_runtime.sh', 'package/rattler-build/scripts/install_vibecad_openscad_runtime.sh', 'package/rattler-build/scripts/write_vibecad_build123d_manifest.py') }}
+          restore-keys: |
+            pixi-${{ matrix.target }}-
+
+      - name: Restore ccache
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-${{ matrix.target }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: |
+            ccache-${{ matrix.target }}-
+
+      - name: Build package environment
+        shell: bash
+        working-directory: package/rattler-build
+        env:
+          CCACHE_DIR: ${{ runner.temp }}/ccache
+          CCACHE_MAXSIZE: "2G"
+          MACOS_DEPLOYMENT_TARGET: "12.0"
+        run: |
+          set -euo pipefail
+          pixi install -e default
+          pixi install -e package
+
+      - name: Create and validate VibeCAD DMG
+        shell: bash
+        working-directory: package/rattler-build
+        env:
+          BUILD_TAG: ${{ needs.prepare.outputs.build_tag }}
+          MACOS_DEPLOYMENT_TARGET: "12.0"
+          MACOS_SIGN_RELEASE: "false"
+          UPLOAD_RELEASE: "false"
+        run: |
+          set -euo pipefail
+          pixi run -e package create_bundle
+
+      - name: Save ccache
+        if: always()
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ runner.temp }}/ccache
+          key: ccache-${{ matrix.target }}-${{ github.run_id }}-${{ github.run_attempt }}
+
+      - name: Save Pixi and runtime caches
+        if: always() && steps.cache-pixi.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v4
+        with:
+          path: |
+            package/rattler-build/.pixi
+            package/rattler-build/.download-cache
+            ~/.cache/pixi
+            ~/.cache/rattler
+            ~/Library/Caches/pip
+          key: ${{ steps.cache-pixi.outputs.cache-primary-key }}
+
+      - name: Upload macOS artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vibecad-macos-${{ matrix.arch }}
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            package/rattler-build/osx/VibeCAD_*.dmg
+            package/rattler-build/osx/VibeCAD_*.dmg-SHA256.txt
+
+  publish:
+    name: Publish macOS Prerelease
+    needs:
+      - prepare
+      - macos
+    if: ${{ inputs.publish_release }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: vibecad-macos-*
+          path: release-assets
+          merge-multiple: true
+
+      - name: Verify and publish macOS-only release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+          SOURCE_SHA: ${{ needs.prepare.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+
+          cd release-assets
+          for checksum in *-SHA256.txt; do
+            sha256sum --check "${checksum}"
+          done
+
+          mapfile -t assets < <(find . -maxdepth 1 -type f -print | sort)
+          if [[ "${#assets[@]}" -eq 0 ]]; then
+            echo "No macOS release assets were downloaded." >&2
+            exit 1
+          fi
+
+          if gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${RELEASE_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --clobber \
+              "${assets[@]}"
+          else
+            gh release create "${RELEASE_TAG}" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --target "${SOURCE_SHA}" \
+              --title "VibeCAD macOS ${RELEASE_TAG}" \
+              --notes "Unsigned VibeCAD macOS test builds. This release contains macOS artifacts only." \
+              --prerelease \
+              "${assets[@]}"
+          fi


### PR DESCRIPTION
Adds an isolated manual workflow for ARM64 and optional Intel macOS DMG builds. It does not invoke the Linux or Windows release jobs, and publishing is disabled by default.