### PR TITLE
Simplify the problem report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-FUNCTIONAL_PROBLEM_REPORT.yml
+++ b/.github/ISSUE_TEMPLATE/1-FUNCTIONAL_PROBLEM_REPORT.yml
@@ -1,22 +1,20 @@
 name: Report a Problem
-description: Have you found something that does not work well, is too hard to do or is missing altogether? Please create a Problem Report.
-labels: ["Status: Needs triage","Status: Needs confirmation"]
+description: Tell us about something that is broken, difficult to use, or missing.
+labels: ["Status: Needs triage", "Status: Needs confirmation"]
 body:
   - type: markdown
     attributes:
       value: |
-        
-        > [!TIP]
-        > If this is your first time, read [how to report an issue to FreeCAD][Guide].
-        
-        [Guide]: https://github.com/FreeCAD/FreeCAD?tab=readme-ov-file#reporting-issues
+        Thanks for helping improve VibeCAD. Describe the problem in your own words.
+        Screenshots, recordings, CAD files, and logs are useful when available, but
+        you do not need to install another build or know a version number to report an issue.
 
   - type: textarea
     id: description
     attributes:
       label: Problem description
-      description: Describe the problem and how it impacts user experience, workflow, maintainability or performance. You can attach images or log files by clicking this area to highlight it and then dragging files in. To attach a FCStd file, ZIP it first.
-      placeholder: Describe your problem briefly.
+      description: Tell us what happened, what you were trying to do, and what you expected instead. Drag images, videos, logs, or ZIP archives into this field to attach them.
+      placeholder: What went wrong, or what is unnecessarily difficult or missing?
     validations:
       required: true
 
@@ -44,53 +42,29 @@ body:
   - type: textarea
     id: steps_to_reproduce
     attributes:
-      label: Steps to reproduce
-      description: If the problem appears to be a bug with the current functionality, provide a test case or recipe that reliably reproduces the issue. Ideally [record a macro](https://wiki.freecad.org/Std_DlgMacroRecord) and attach it. Please also add an example file as ZIP.
+      label: Steps to reproduce (optional)
+      description: If the problem is repeatable, list the shortest sequence that causes it. Attach a ZIP of the affected CAD document when it helps.
       placeholder: |
-        Drag an example file as ZIP into this textbox to attach it.
-
-        Steps to reproduce the behavior:
-        1. Open my example file
-        2. Go to '...'
-        3. Click on '...'
-    validations:
-      required: true
+        1. Open ...
+        2. Select ...
+        3. Ask VibeCAD to ...
+        4. The problem appears when ...
 
   - type: textarea
-    id: expected_behavior
+    id: diagnostics
     attributes:
-      label: Expected behavior
-      description: A clear and concise description of what you expected to happen when following the provided steps above.
-      placeholder: What is the expected behavior?
-    validations:
-      required: true
+      label: Logs or error messages (optional)
+      description: Paste relevant Report view, provider, terminal, or crash output. Remove API keys and other secrets first.
+      placeholder: Paste the relevant error text here.
+      render: text
 
   - type: textarea
-    id: actual_behavior
+    id: environment
     attributes:
-      label: Actual behavior
-      description: A clear and concise description of what actually happens. If applicable, add screenshots to help explain the problem.
-      placeholder: What is actually happening? You can add screenshorts or videos by dragging them into this textbox.
-    validations:
-      required: true
-
-  - type: textarea
-    id: dev_version
-    attributes:
-      label: Development version About Info (in Safe Mode)
-      description: Download the latest weekly [development release](https://github.com/FreeCAD/FreeCAD/releases) and try reproducing the issue in safe mode (Help → Restart in Safe Mode). Use the [About FreeCAD](https://wiki.freecad.org/About) dialog to copy your full version information and paste it here.
+      label: Environment details (optional)
+      description: Add anything relevant that you already know, such as operating system, VibeCAD build, AI provider/model, modeling engine, or whether this worked previously.
       placeholder: |
-        1. Download the latest weekly development version (link above).
-        2. Make sure to run in Safe Mode (Help -> Restart in Safe Mode) to exclude interference from 3rd party addons.
-        3. If the issue is still reproducible, open the About FreeCAD dialog and copy the full version info here.
-      render: shell
-    validations:
-      required: true
-
-  - type: textarea
-    id: good_version
-    attributes:
-      label: Last known good version (optional)
-      description: If this is a regression, paste the [About FreeCAD](https://wiki.freecad.org/About) info from the last known working version.
-      placeholder: If the problem did not exist in a previous version, paste the About FreeCAD info from that version here.
-      render: shell
+        OS:
+        VibeCAD build, if known:
+        Provider and model, if relevant:
+        Modeling engine, if relevant:


### PR DESCRIPTION
## Summary
- remove the required latest-development-build and Safe Mode retest
- make version and environment details optional
- reduce the form to one required problem-description field
- keep optional reproduction steps, logs, attachments, and relevant environment details
- replace inherited FreeCAD-specific instructions with concise VibeCAD guidance

## Verification
- issue form parses as valid YAML
- git diff --check