### PR TITLE
Fix macOS startup segfault in PythonWrapper::setParent (issue #15)

### DIFF
--- a/cMake/FreeCAD_Helpers/SetupJSON.cmake
+++ b/cMake/FreeCAD_Helpers/SetupJSON.cmake
@@ -2,6 +2,8 @@ macro(SetupJSON)
 
     if(FREECAD_USE_EXTERNAL_JSON)
         find_package(nlohmann_json REQUIRED)
+        get_target_property(nlohmann_json_INCLUDE_DIRS
+            nlohmann_json::nlohmann_json INTERFACE_INCLUDE_DIRECTORIES)
     else(FREECAD_USE_EXTERNAL_JSON)
         set(nlohmann_json_INCLUDE_DIRS ${CMAKE_SOURCE_DIR}/src/3rdParty/json/single_include)
     endif(FREECAD_USE_EXTERNAL_JSON)

--- a/src/Gui/PythonWrapper.cpp
+++ b/src/Gui/PythonWrapper.cpp
@@ -872,7 +872,7 @@ Py::Object PythonWrapper::fromQWidget(QWidget* widget, const char* className)
     throw Py::RuntimeError("Failed to wrap widget");
 }
 
-const char* PythonWrapper::getWrapperName(QObject* obj) const
+const char* PythonWrapper::getWrapperName(QObject* obj)
 {
 #if defined(HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
     const QMetaObject* meta = obj->metaObject();
@@ -964,8 +964,18 @@ void PythonWrapper::setParent(PyObject* pyWdg, QObject* parent)
 {
 #if defined(HAVE_SHIBOKEN) && defined(HAVE_PYSIDE)
     if (parent) {
+        auto type = getPyTypeObjectForTypeName<QWidget>();
+        if (!type) {
+            // Some Shiboken builds do not resolve Qt widget classes via typeid().name().
+            // Fall back to PySide type names, mirroring fromQWidget().
+            type = getPyTypeObjectForPySideTypeName(getWrapperName(parent));
+        }
+        if (!type) {
+            // Leave the widget unparented on the Python side rather than crash.
+            return;
+        }
         Shiboken::AutoDecRef pyParent(
-            Shiboken::Conversions::pointerToPython(getPyTypeObjectForTypeName<QWidget>(), parent)
+            Shiboken::Conversions::pointerToPython(type, parent)
         );
         Shiboken::Object::setParent(pyParent, pyWdg);
     }

--- a/src/Gui/PythonWrapper.h
+++ b/src/Gui/PythonWrapper.h
@@ -66,7 +66,7 @@ public:
     Py::Object fromQPrinter(QPrinter*);
     Py::Object fromQObject(QObject*, const char* className = nullptr);
     Py::Object fromQWidget(QWidget*, const char* className = nullptr);
-    const char* getWrapperName(QObject*) const;
+    static const char* getWrapperName(QObject*);
 
     Py::Object fromQImage(const QImage&);
     QImage* toQImage(PyObject* pyobj);


### PR DESCRIPTION
Fixes #15.

## The crash

On the macOS prerelease (`vibecad-macos-20260717-5bd9b3593fbb`), the app segfaults on startup while the VibeCAD assistant panel registers itself via `MainWindow.addDockWindow`.

`PythonWrapper::setParent` calls `getPyTypeObjectForTypeName<QWidget>()` and passes the result straight to `Shiboken::Conversions::pointerToPython`. In the bundled macOS runtime, Shiboken cannot resolve Qt classes via `typeid().name()`, so the lookup returns null and `pointerToPython` dereferences it.

## The fix

Reuse the PySide type-name fallback that `fromQWidget()` already applies (`getPyTypeObjectForPySideTypeName`), and if no type can be resolved at all, leave the widget unparented on the Python side instead of crashing.

Also includes a small CMake fix hit while building on macOS with `FREECAD_USE_EXTERNAL_JSON=ON`: `find_package(nlohmann_json)` only defines the imported target, so `nlohmann_json_INCLUDE_DIRS` (used by the standalone `VibeCADGeometryWorker`) was empty; derive it from the imported target. Happy to split this into a separate PR if you prefer.

## Testing

Built locally on an M4 via pixi (`pixi run configure-release` / `build-release`). Without the fix the bundled app segfaults at startup exactly as in the issue #15 log; with it, the app launches, the assistant panel docks, and it runs stably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)