### PR TITLE
fix(mcp): keep uvicorn console logging from killing the windowless child

### DIFF
--- a/src/Mod/VibeCAD/VibeCADMCP.py
+++ b/src/Mod/VibeCAD/VibeCADMCP.py
@@ -754,6 +754,13 @@ def _mcp_server_process_main(
                 port=port,
                 log_level="warning",
                 access_log=False,
+                # The MCP child runs windowless (pythonw.exe on Windows), so
+                # sys.stdout/sys.stderr are None and uvicorn's default
+                # dictConfig fails with "Unable to configure formatter
+                # 'default'" before the server ever binds. Status already
+                # travels over the status pipe, so no console logging is
+                # needed here.
+                log_config=None,
             )
         )
 


### PR DESCRIPTION
## What

External MCP control never reached a listening state on Windows. Enabling **External MCP control** in Preferences asked for a restart; after restarting, the setting was back to disabled, **MCP state** sat at `stopping_mcp`, and the report view showed only this:

```
Exception in thread VibeCAD-MCP-Monitor:
  File "...\Mod\VibeCAD\VibeCADMCP.py", line 1253, in _monitor_process
    while process.is_alive() or status_connection.poll(0.1):
  File "...\multiprocessing\connection.py", line 344, in _poll
    _winapi.PeekNamedPipe(self._handle)[0] != 0):
BrokenPipeError: [WinError 109] The pipe has been ended
```

That `BrokenPipeError` is a symptom, not the cause — the monitor thread was polling a pipe whose child had already exited.

## Why

`_provider_spawn_python_executable()` prefers **`pythonw.exe`** in a GUI session (`_provider_windows_gui_session()` → `use_windowless`), which is correct — it avoids a console window flashing up. But `pythonw.exe` leaves `sys.stdout`, `sys.stderr` and `sys.stdin` as `None`.

Uvicorn's default logging config binds its handlers to `ext://sys.stderr`, so `dictConfig` fails before the server ever binds the port:

```
ValueError: Unable to configure formatter 'default'
```

Because the child is windowless, that traceback goes nowhere. The child dies, and the broken pipe in the host is the only thing the user ever sees.

This is why the failure is GUI-only: a console host resolves to `python.exe`, which has a real `stderr`, and the same code path works fine there.

## Fix

Pass `log_config=None` to `uvicorn.Config` so uvicorn skips `dictConfig` entirely.

Nothing is lost. `access_log` is already `False`, `log_level` still applies, and every status transition (`listening`, `error`, `stopped`, `client_activity`) already travels over the status pipe to the host. The child has no console to log to in the first place.

## Scope

Additive and minimal — one keyword argument plus a comment explaining why it must stay. No public surface, signature, schema, preference key, or tool contract is touched, per `AGENTS.md`.

## Impact

Affects **packaged Windows releases as well as local dev builds** — the shipped application is also a GUI host that prefers `pythonw.exe`, so external MCP control could not start there either.

## Verification

Windows 10, local `conda-windows-debug` build (`pixi run build`), Python 3.11, `mcp==2.0.0`, `uvicorn==0.52.1`.

**1. Child entrypoint under `pythonw.exe`** — ran `_mcp_server_process_main` directly with real pipes, logging to a file (no reassignment of `sys.stdout`/`sys.stderr`, so the real windowless condition is preserved).

Before:
```
sys.stdout : None
sys.stderr : None
STATUS: {'event': 'error', 'error': "ValueError: Unable to configure formatter 'default'"}
```

After:
```
sys.stdout : None
sys.stderr : None
STATUS: {'event': 'listening', 'endpoint': 'http://127.0.0.1:8765/mcp', 'pid': 11468}
STATUS: {'event': 'stopped'}
```

**2. End to end in the GUI** — enabled `MCPEnabled`, launched the GUI:

- Port bound: `127.0.0.1:8765` (`Listen`), owning process `pythonw.exe`
- No `Authorization` header → `HTTP 401`
- Wrong bearer token → `HTTP 401`
- Correct token → `initialize` returns `HTTP 200` with a session id, `serverInfo: VibeCAD 26.3.1`
- `tools/list` returns `HTTP 200`, 12 tools (`vibecad.read_workbench`, `vibecad.switch_workbench`, `vibescript.read_api`, `vibescript.read_source`, `vibescript.read_geometry`, `vibescript.read_placement`, `core.set_view`, `core.capture_view_screenshot`, `component_catalog.search`, `fastener_catalog.search`, `material_catalog.search`, `conversation.ask_user`)

## Note for maintainers (separate issue, not fixed here)

While testing I noticed the MCP child can outlive the host: after closing the GUI via `CloseMainWindow`, the `pythonw.exe` child was still listening on `127.0.0.1:8765` and had to be killed manually. `process.daemon = True` is set, but the child appears to survive host shutdown in at least some paths. That's unrelated to this change and left alone deliberately — happy to open a separate issue if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
