### PR TITLE
Remove inherited AI contribution restrictions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,27 +9,6 @@ This template provides guidance on creating a PR that can be reviewed and approv
 Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
 -->
 
-<!--
-FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
-Please check the following box:
--->
-
-- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
-
-<!--
-If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:
-
-Assisted-by [Model-Family] ([Version/ID])
-
-Examples:
-
-Assisted-by: gemini-2.5-pro (rev-1)
-Assisted-by: GPT-4o-2024-08-06
-
-The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
--->
-
-
 ## Issues
 <!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions for VibeCAD
 
-These rules apply to coding agents and automated assistants working in this repository. Follow them in addition to `CONTRIBUTING.md`, `AI_POLICY.md`, and the project PR template.
+These rules apply to coding agents and automated assistants working in this repository. Follow them in addition to `CONTRIBUTING.md` and the project PR template.
 
 ## Goals
 
@@ -68,8 +68,7 @@ Every PR an agent prepares SHOULD be something the owner can merge with high con
 2. Title and description explain **user-visible outcome** and **why**.
 3. Link related issues when they exist.
 4. Call out risk, test plan, and any deliberate non-goals.
-5. Disclose AI assistance per `AI_POLICY.md` when applicable.
-6. Do not mix unrelated refactors, formatting sweeps, or dependency upgrades with feature work.
+5. Do not mix unrelated refactors, formatting sweeps, or dependency upgrades with feature work.
 
 ### Compatibility checklist (required in the PR body when relevant)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,9 +62,8 @@ The FreeCAD Contribution Process is expressed here with the following specific g
     1. the PR description MUST contain proper attribution as the first line, for example: "This is work of XYZ cherry-picked from <link>";
     2. all commits MUST have proper authorship, i.e. be authored by the original author and committed by the author of the PR;
     3. if changes to cherry-picked commits are necessary they SHOULD be done as follow-up commits. If it is not possible to do so, then the modified commits MUST contain a `Co-Authored-By` trailer in their commit message.
-14. Contributions must meet existing quality standards and comply with the [AI Policy](https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md): All communication should be done by contributors (people), AI is only used in an assistive way, contributors fully understand their contributions, and people are fully in the driver seat.
-15. The contributor provides reasonable assurance that the contribution does not infringe third-party copyrights or license terms.
-16. A “Valid PR” is one which satisfies the above requirements.
+14. The contributor provides reasonable assurance that the contribution does not infringe third-party copyrights or license terms.
+15. A “Valid PR” is one which satisfies the above requirements.
 
 ## 6. Process
 


### PR DESCRIPTION
## Summary

- remove the inherited FreeCAD restriction on AI-assisted contributions
- remove the nonexistent `AI_POLICY.md` references from contributor and agent guidance
- remove the AI disclosure checkbox and trailer instructions from the PR template
- retain the normal code-quality, licensing, review, and compatibility requirements

## Validation

- [x] Repository-wide search finds no remaining AI-policy or disclosure references
- [x] Markdown diff passes `git diff --check`

The repository owner explicitly requested removal of this policy. Assisted by GPT-5.