### PR TITLE
Bump VibeCAD release build to 1

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 0
+  number: 1
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC3",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 0,
+  "build_version": 1,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Outcome

Advances the canonical VibeCAD release identity from Build 0 to Build 1 so the verified Build 0 Windows installer has a real newer version/build candidate to discover through GitHub Releases.

## Changes

- `version.json`: `build_version` 0 -> 1
- Rattler recipe build number synchronized to 1

## Test plan

- 92 focused release/updater tests pass.
- `sync_version.py --check` passes.
- Artifact identity resolves to `VibeCAD-26.3.1-RC3-build1` and tag `v26.3.1-RC3-build1` on the `preview` channel.
- All workflows pass `actionlint`.

## Compatibility checklist

- [x] Existing public functions/APIs remain unchanged.
- [x] No preference keys, tool names, or schemas changed.
- [x] Product version remains `26.3.1-RC3`; only the monotonic build number advances.
- [x] No breaking changes.

AI assistance was used to prepare and validate this release bump.