### PR TITLE
Fix release immutability preflight

### DIFF
--- a/.github/workflows/vibecad-release.yml
+++ b/.github/workflows/vibecad-release.yml
@@ -84,14 +84,6 @@ jobs:
               echo "Tag ${release_tag} already exists and will not be moved or reused." >&2
               exit 1
             fi
-            immutable_enabled="$(gh api \
-              -H "X-GitHub-Api-Version: 2026-03-10" \
-              "repos/${GITHUB_REPOSITORY}/immutable-releases" \
-              --jq '.enabled // false')"
-            if [[ "${immutable_enabled}" != "true" ]]; then
-              echo "GitHub release immutability must be enabled before publishing." >&2
-              exit 1
-            fi
           fi
 
           retention_days="14"

--- a/docs/vibecad-release-packaging.md
+++ b/docs/vibecad-release-packaging.md
@@ -72,8 +72,11 @@ official release uses `source_ref=main` and `publish_release=true`.
 No additional repository token, external update repository, Microsoft account,
 or code-signing certificate is required. Publishing uses the workflow's scoped
 GitHub token. Production publication is fail-closed on the current `main`
-commit, version synchronization, unique tag and release identity, immutable
-release configuration, package checksums, and the canonical update manifest.
+commit, version synchronization, unique tag and release identity, package
+checksums, and the canonical update manifest. Repository owners must keep
+GitHub's immutable-releases setting enabled; the standard workflow token cannot
+read repository-administration settings, while GitHub enforces that setting on
+the release once it is published.
 
 ## Release assets
 


### PR DESCRIPTION
## Outcome

Fixes the official release preflight after the standard GitHub Actions token received HTTP 403 from the repository-administration `immutable-releases` endpoint.

## Change

Remove only the impossible self-query. The release still requires current `main`, synchronized version/build metadata, an unused canonical tag and release, exact package checksums, and the canonical update manifest. GitHub immutable releases are already enabled and remain enforced by GitHub after publication. No personal token or new secret is introduced.

## Test plan

- 92 focused release/updater tests pass.
- All workflows pass `actionlint`.
- Version consumers pass `sync_version.py --check`.
- The original failed before any package build or release publication, with HTTP 403 on this exact API call.

## Compatibility checklist

- [x] Existing public functions/APIs remain unchanged.
- [x] No preference keys, tool names, or schemas changed.
- [x] No release identity or package contract changed.
- [x] No breaking changes.

AI assistance was used to diagnose and validate this workflow fix.