### PR TITLE
Link geometry worker with platform threads

### DIFF
--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -187,6 +187,8 @@ install(
         PATTERN "*.py"
 )
 
+find_package(Threads REQUIRED)
+
 add_executable(VibeCADGeometryWorker
     VibeCADGeometryWorker.cpp
 )
@@ -206,6 +208,7 @@ target_link_libraries(VibeCADGeometryWorker
     PRIVATE
         ${OCC_LIBRARIES}
         ${OCC_DEBUG_LIBRARIES}
+        Threads::Threads
 )
 
 if(FREECAD_WARN_ERROR)


### PR DESCRIPTION
## Outcome

Fixes the Linux release build for `VibeCADGeometryWorker`.

## Cause and change

The worker uses the C++ threading runtime, but its target did not link the platform thread library. Linux failed with undefined `pthread_create` and `pthread_join`; Windows linked successfully. This adds CMake's portable `Threads::Threads` target to only `VibeCADGeometryWorker`.

## Test plan

- The failed official release log identifies the missing pthread symbols at this target's link step.
- The same release run completed the Windows package and installer successfully.
- 92 focused release/updater tests pass.
- `sync_version.py --check` and `git diff --check` pass.
- The next official Linux build is the authoritative link validation.

## Compatibility checklist

- [x] Existing public functions/APIs remain unchanged.
- [x] No preferences, tool names, schemas, or defaults changed.
- [x] The target remains additive and cross-platform.
- [x] No breaking changes.

AI assistance was used to diagnose the CI link log and validate this focused fix.