### PR TITLE
Write portable Debian package checksums

### DIFF
--- a/package/linux/build_deb_from_appdir.sh
+++ b/package/linux/build_deb_from_appdir.sh
@@ -189,6 +189,10 @@ fi
 # Staying on xz (rather than switching to zstd) keeps the package installable by the
 # same set of dpkg/apt versions, so the supported OS list is unchanged.
 dpkg-deb -Zxz -z1 --build --root-owner-group "$pkgroot" "$deb_path"
-sha256sum "$deb_path" > "${deb_path}-SHA256.txt"
+deb_filename="$(basename "$deb_path")"
+(
+    cd "$output_dir"
+    sha256sum "$deb_filename" > "${deb_filename}-SHA256.txt"
+)
 
 echo "$deb_path"

--- a/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
@@ -831,6 +831,8 @@ def test_release_packages_share_canonical_artifact_basename() -> None:
         'deb_path="$output_dir/${artifact_basename}-Linux-${deb_arch}.deb"'
         in deb_builder
     )
+    assert 'sha256sum "$deb_filename" > "${deb_filename}-SHA256.txt"' in deb_builder
+    assert 'sha256sum "$deb_path" > "${deb_path}-SHA256.txt"' not in deb_builder
     assert "package/rattler-build/osx/VibeCAD-*.dmg" in macos_workflow
     assert "package/rattler-build/osx/VibeCAD_*.dmg" not in macos_workflow
 


### PR DESCRIPTION
## Outcome

Writes Debian SHA-256 sidecar files with the package basename instead of the runner's absolute output path. This lets the canonical release validator verify downloaded artifacts in its own workspace without weakening checksum validation.

## Risk

Low. The Debian package name and contents are unchanged; only the filename recorded inside its checksum sidecar changes.

## Test plan

- `bash -n package/linux/build_deb_from_appdir.sh package/rattler-build/linux/create_bundle.sh`
- `pytest` release/updater/branding contract suite: 72 passed, 5 platform skips
- `git diff --check`
- Full canonical release workflow after merge

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed or removed.
- [x] Defaults preserve previous behavior.
- [x] No deprecations or breaking changes.
- [x] Existing standalone Debian package naming remains supported.

- [x] This PR is not unverified AI output; the repository owner is directing and validating the work.

AI-assisted implementation: OpenAI Codex (GPT-5 family).