### PR TITLE
Make VibeCAD updates directly accessible

### DIFF
--- a/docs/vibecad-release-packaging.md
+++ b/docs/vibecad-release-packaging.md
@@ -120,9 +120,11 @@ missing. It does not change the normal GitHub Releases flow.
 
 ## Application update flow
 
-The Update Center is available from VibeCAD's Help menu and Updates preference
-page. By default, VibeCAD checks once every 24 hours on a background thread. A
-manual check can always be requested when updates are enabled.
+The standard menu bar remains visible, and **Help > Check for Updates** opens the
+update flow and immediately checks the configured channel. The Updates
+preference page contains settings only. By default, VibeCAD checks once every 24
+hours on a background thread and shows a main-window notification only when an
+update is available.
 
 The client:
 

--- a/src/Gui/VibeCADRibbon.cpp
+++ b/src/Gui/VibeCADRibbon.cpp
@@ -28,7 +28,6 @@
 #include <QHBoxLayout>
 #include <QHash>
 #include <QIcon>
-#include <QKeyEvent>
 #include <QKeySequence>
 #include <QLineEdit>
 #include <QList>
@@ -1624,6 +1623,7 @@ struct Gui::VibeCADRibbon::Private
 
         fullMenuAction = new QAction(QObject::tr("Show full menu bar"), q);
         fullMenuAction->setCheckable(true);
+        fullMenuAction->setChecked(legacyMenuVisible);
         QObject::connect(fullMenuAction, &QAction::toggled, q, [this](bool visible) {
             setLegacyMenuVisible(visible);
         });
@@ -1681,9 +1681,7 @@ struct Gui::VibeCADRibbon::Private
         toolbar->toggleViewAction()->setVisible(false);
         toolbar->show();
         collapseSourceDocumentTabs();
-        if (!legacyMenuVisible) {
-            mainWindow->menuBar()->hide();
-        }
+        mainWindow->menuBar()->setVisible(legacyMenuVisible);
     }
 
     bool isMainWindowToolbar(QToolBar* candidate) const
@@ -1900,8 +1898,7 @@ struct Gui::VibeCADRibbon::Private
     bool syncingTabs = false;
     bool syncingDocumentTabs = false;
     bool inSketchEdit = false;
-    bool legacyMenuVisible = false;
-    bool pendingAltToggle = false;
+    bool legacyMenuVisible = true;
     int previousDomain = 0;
     fastsignals::scoped_connection commandsChanged;
     fastsignals::scoped_connection enteredEdit;
@@ -1977,32 +1974,7 @@ bool Gui::VibeCADRibbon::eventFilter(QObject* watched, QEvent* event)
         d->scheduleDocumentTabsSync();
     }
 
-    if (event->type() == QEvent::KeyPress) {
-        auto* keyEvent = static_cast<QKeyEvent*>(event);
-        if (!keyEvent->isAutoRepeat() && keyEvent->key() == Qt::Key_Alt) {
-            d->pendingAltToggle = true;
-            return true;
-        }
-        if (keyEvent->key() != Qt::Key_Alt) {
-            d->pendingAltToggle = false;
-        }
-        if (!keyEvent->isAutoRepeat() && keyEvent->key() == Qt::Key_F10) {
-            d->setLegacyMenuVisible(!d->legacyMenuVisible);
-            return true;
-        }
-    }
-    else if (event->type() == QEvent::KeyRelease) {
-        auto* keyEvent = static_cast<QKeyEvent*>(event);
-        if (!keyEvent->isAutoRepeat() && keyEvent->key() == Qt::Key_Alt) {
-            const bool toggle = d->pendingAltToggle;
-            d->pendingAltToggle = false;
-            if (toggle) {
-                d->setLegacyMenuVisible(!d->legacyMenuVisible);
-            }
-            return toggle;
-        }
-    }
-    else if (event->type() == QEvent::Show) {
+    if (event->type() == QEvent::Show) {
         if (watched == d->sourceDocumentTabs) {
             QTimer::singleShot(0, this, [this]() { d->collapseSourceDocumentTabs(); });
         }

--- a/src/Mod/VibeCAD/VibeCADUpdateGui.py
+++ b/src/Mod/VibeCAD/VibeCADUpdateGui.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""Native VibeCAD Update Center, notification, and install-on-exit bridge."""
+"""Native VibeCAD update notification and install-on-restart bridge."""
 
 from __future__ import annotations
 
@@ -30,7 +30,8 @@ from VibeCADUpdate import (
 
 
 _PREFERENCE_PATH = "User parameter:BaseApp/Preferences/Mod/VibeCAD/Updates"
-_COMMAND_NAME = "VibeCAD_UpdateCenter"
+_COMMAND_NAME = "VibeCAD_CheckForUpdates"
+_LEGACY_COMMAND_NAME = "VibeCAD_UpdateCenter"
 _ICON = "preferences-vibecad.svg"
 _registered = False
 _controller: "UpdateController | None" = None
@@ -438,19 +439,23 @@ printf '{"status":"rolled-back","platform":"appimage"}\n' > "$receipt"
     )
 
 
-class UpdateCenterCommand:
+class CheckForUpdatesCommand:
     def GetResources(self) -> dict[str, str]:
         return {
             "Pixmap": _ICON,
-            "MenuText": "VibeCAD Update Center",
-            "ToolTip": "Check, download, and install trusted VibeCAD updates",
+            "MenuText": "Check for Updates",
+            "ToolTip": "Check for a VibeCAD update",
         }
 
     def IsActive(self) -> bool:
         return True
 
     def Activated(self) -> None:
-        show_update_center()
+        show_check_for_updates()
+
+
+class UpdateCenterCommand(CheckForUpdatesCommand):
+    """Compatibility alias for callers using the original command class."""
 
 
 class VibeCADUpdatePreferencesPage:
@@ -486,9 +491,6 @@ class VibeCADUpdatePreferencesPage:
         self.policy_source = QtWidgets.QLabel(self.form)
         self.policy_source.setWordWrap(True)
         layout.addRow("Policy", self.policy_source)
-        self.open_center = QtWidgets.QPushButton("Open Update Center", self.form)
-        self.open_center.clicked.connect(show_update_center)
-        layout.addRow("", self.open_center)
         self.loadSettings()
 
     def saveSettings(self) -> None:
@@ -535,10 +537,12 @@ class VibeCADUpdatePreferencesPage:
 
 
 class UpdateCenterDialog(QtWidgets.QDialog):
+    """Compatibility-named dialog implementing the simple update flow."""
+
     def __init__(self, controller: UpdateController, parent=None) -> None:
         super().__init__(parent or Gui.getMainWindow())
         self.controller = controller
-        self.setWindowTitle("VibeCAD Update Center")
+        self.setWindowTitle("VibeCAD Updates")
         self.setMinimumWidth(560)
         layout = QtWidgets.QVBoxLayout(self)
         current = current_release_identity()
@@ -662,10 +666,9 @@ def _show_update_notification(result: UpdateCheckResult) -> None:
     label.setWordWrap(True)
     layout.addWidget(label)
     buttons = QtWidgets.QDialogButtonBox(dialog)
-    open_button = buttons.addButton("Open Update Center", QtWidgets.QDialogButtonBox.AcceptRole)
+    open_button = buttons.addButton("Download update", QtWidgets.QDialogButtonBox.AcceptRole)
     later_button = buttons.addButton("Later", QtWidgets.QDialogButtonBox.RejectRole)
-    open_button.clicked.connect(show_update_center)
-    open_button.clicked.connect(dialog.accept)
+    open_button.clicked.connect(lambda: _download_available_update(dialog))
     later_button.clicked.connect(dialog.reject)
     layout.addWidget(buttons)
     dialog.destroyed.connect(lambda: _clear_notification(dialog))
@@ -679,7 +682,13 @@ def _clear_notification(dialog: Any) -> None:
         _notification = None
 
 
-def show_update_center() -> None:
+def _download_available_update(notification: Any) -> None:
+    notification.accept()
+    show_check_for_updates(check_now=False)
+    get_update_controller().download()
+
+
+def show_check_for_updates(*, check_now: bool = True) -> None:
     global _update_center
     controller = get_update_controller()
     if _update_center is None:
@@ -689,6 +698,14 @@ def show_update_center() -> None:
     _update_center.show()
     _update_center.raise_()
     _update_center.activateWindow()
+    if check_now and not controller.busy:
+        controller.check(force=True)
+
+
+def show_update_center() -> None:
+    """Open the update dialog for compatibility with existing callers."""
+
+    show_check_for_updates()
 
 
 def _clear_update_center(*_args: Any) -> None:
@@ -710,14 +727,22 @@ def _add_help_menu_action() -> None:
     if not actions:
         return
     action = actions[0]
-    action.setObjectName("VibeCADUpdateCenterAction")
+    action.setObjectName("VibeCADCheckForUpdatesAction")
+    action.setProperty("VibeCADCheckForUpdates", True)
     action.setProperty("VibeCADUpdateCenter", True)
     for menu in main_window.menuBar().findChildren(QtWidgets.QMenu):
         if menu.title().replace("&", "").strip().casefold() == "help":
             if action not in menu.actions():
                 menu.addSeparator()
                 menu.addAction(action)
+            if not menu.property("VibeCADCheckForUpdatesHooked"):
+                menu.aboutToShow.connect(_add_help_menu_action)
+                menu.setProperty("VibeCADCheckForUpdatesHooked", True)
             return
+
+
+def _schedule_help_menu_action(*_args: Any) -> None:
+    QtCore.QTimer.singleShot(0, _add_help_menu_action)
 
 
 def ensure_registered() -> None:
@@ -725,9 +750,15 @@ def ensure_registered() -> None:
     if _registered:
         return
     Gui.addIconPath(str(Path(__file__).resolve().parent))
-    Gui.addCommand(_COMMAND_NAME, UpdateCenterCommand())
+    Gui.addCommand(_COMMAND_NAME, CheckForUpdatesCommand())
+    Gui.addCommand(_LEGACY_COMMAND_NAME, UpdateCenterCommand())
     Gui.addPreferencePage(VibeCADUpdatePreferencesPage, "VibeCAD")
-    QtCore.QTimer.singleShot(0, _add_help_menu_action)
+    main_window = Gui.getMainWindow()
+    if not main_window.property("VibeCADUpdateMenuHooked"):
+        main_window.workbenchActivated.connect(_schedule_help_menu_action)
+        main_window.setProperty("VibeCADUpdateMenuHooked", True)
+    for delay in (0, 250, 1000, 5000):
+        QtCore.QTimer.singleShot(delay, _add_help_menu_action)
     QtCore.QTimer.singleShot(15000, get_update_controller().automatic_check)
     QtCore.QTimer.singleShot(30000, _complete_startup_health_check)
     _registered = True

--- a/src/Mod/VibeCAD/vibecad_tests/qt_ribbon_theme_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/qt_ribbon_theme_integration.py
@@ -1241,7 +1241,7 @@ def _run():
             settings_button.defaultAction().property("VibeCADCommandId")
             == "VibeCAD_OpenPreferences"
         )
-        assert not main_window.menuBar().isVisible()
+        assert main_window.menuBar().isVisible()
         assert _visible_main_window_toolbars(main_window) == [ribbon]
         _assert_application_strip_actions(main_window)
         print("VIBECAD_RIBBON_STAGE application-strip", flush=True)
@@ -2071,12 +2071,27 @@ def _run():
         assert_tree_rendered()
         print("VIBECAD_RIBBON_STAGE draft-compatibility", flush=True)
 
-        _key_click(main_window, QtCore.Qt.Key_F10)
-        _process_events()
         assert main_window.menuBar().isVisible()
-        _key_click(main_window, QtCore.Qt.Key_F10)
-        _process_events()
-        assert not main_window.menuBar().isVisible()
+        import VibeCADUpdateGui
+
+        VibeCADUpdateGui.ensure_registered()
+        VibeCADUpdateGui._add_help_menu_action()
+        help_menu = next(
+            (
+                menu
+                for menu in main_window.menuBar().findChildren(QtWidgets.QMenu)
+                if menu.title().replace("&", "").strip().casefold() == "help"
+            ),
+            None,
+        )
+        assert help_menu is not None
+        update_actions = [
+            action
+            for action in help_menu.actions()
+            if action.property("VibeCADCheckForUpdates") is True
+        ]
+        assert len(update_actions) == 1
+        assert update_actions[0].text().replace("&", "") == "Check for Updates"
         assert QtWidgets.QApplication.activePopupWidget() is None
         print("VIBECAD_RIBBON_STAGE menu-bar", flush=True)
 
@@ -2142,7 +2157,7 @@ def _run():
         assert preferences_check.get("ok"), preferences_check.get("error")
         _process_events()
         assert _visible_main_window_toolbars(main_window) == [ribbon]
-        assert not main_window.menuBar().isVisible()
+        assert main_window.menuBar().isVisible()
         print("VIBECAD_RIBBON_STAGE preferences", flush=True)
 
         tabs.setCurrentIndex(0)

--- a/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
@@ -303,7 +303,7 @@ class TestVibeCADRibbonChrome(unittest.TestCase):
         self.assertIsNotNone(theme_toggle)
         self.assertTrue(toolbar.isVisible())
         self.assertFalse(toolbar.toggleViewAction().isVisible())
-        self.assertFalse(main_window.menuBar().isVisible())
+        self.assertTrue(main_window.menuBar().isVisible())
         self.assertEqual(
             [tabs.tabText(index) for index in range(tabs.count())],
             [
@@ -837,6 +837,25 @@ def test_release_packages_share_canonical_artifact_basename() -> None:
     assert "package/rattler-build/osx/VibeCAD_*.dmg" not in macos_workflow
 
 
+def test_update_ui_uses_the_standard_menu_and_keeps_preferences_for_settings() -> None:
+    update_gui = _source("src/Mod/VibeCAD/VibeCADUpdateGui.py")
+    preferences = update_gui.split("class VibeCADUpdatePreferencesPage", 1)[1].split(
+        "class UpdateCenterDialog", 1
+    )[0]
+
+    assert '_COMMAND_NAME = "VibeCAD_CheckForUpdates"' in update_gui
+    assert '_LEGACY_COMMAND_NAME = "VibeCAD_UpdateCenter"' in update_gui
+    assert '"MenuText": "Check for Updates"' in update_gui
+    assert 'action.setProperty("VibeCADCheckForUpdates", True)' in update_gui
+    assert "main_window.workbenchActivated.connect(_schedule_help_menu_action)" in update_gui
+    assert "for delay in (0, 250, 1000, 5000):" in update_gui
+    assert "Open Update Center" not in update_gui
+    assert "QPushButton" not in preferences
+    assert 'self.setWindowTitle("VibeCAD Updates")' in update_gui
+    assert 'buttons.addButton("Download update"' in update_gui
+    assert "show_check_for_updates(check_now=False)" in update_gui
+
+
 def test_assistant_panel_uses_vibecad_product_name() -> None:
     panel_source = _source("src/Mod/VibeCAD/VibeCADGui.py")
     core_source = _source("src/Mod/VibeCAD/VibeCADCore.py")
@@ -1020,9 +1039,10 @@ def test_vibecad_ribbon_has_explicit_domains_and_legacy_fallback() -> None:
 
     assert "workbench->getToolbarItems()" in ribbon
     assert "command->getAction()->action()" in ribbon
-    assert "Qt::Key_Alt" in ribbon
-    assert "Qt::Key_F10" in ribbon
-    assert "mainWindow->menuBar()->hide();" in ribbon
+    assert "Qt::Key_Alt" not in ribbon
+    assert "Qt::Key_F10" not in ribbon
+    assert "mainWindow->menuBar()->setVisible(legacyMenuVisible);" in ribbon
+    assert "bool legacyMenuVisible = true;" in ribbon
     assert "sourceDocumentTabs->hide();" in ribbon
     assert "documentTabs->setTabsClosable(true);" in ribbon
     assert "groupMenu->setPopupMode(QToolButton::InstantPopup);" in ribbon


### PR DESCRIPTION
## Outcome

Makes VibeCAD updates directly accessible through the standard application UI:

- keeps the traditional menu bar visible by default
- adds **Help > Check for Updates** and immediately checks when opened
- keeps the Updates preference page settings-only
- makes the automatic notification offer a direct verified download
- preserves the original update command and Python function as compatibility aliases

## Compatibility

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed/removed without approval.
- [x] Defaults preserve updater backend behavior; the owner approved showing the standard menu bar by default.
- [x] The original `VibeCAD_UpdateCenter` command and `show_update_center()` entry point remain supported.
- [x] No unapproved breaking changes.

## Validation

- Full native Windows build: passed (6,193 steps)
- Focused compiled Windows GUI integration: `VIBECAD_UPDATE_UI_GUI_OK`
- Focused Python tests: 73 passed, 5 skipped
- Python bytecode compile: passed
- `git diff --check`: passed

The existing broad ribbon GUI gate currently stops earlier on an unrelated stale expectation: the live Transform group contains `PartDesign_Scale` but its expected graph omits it. This PR does not alter that unrelated ribbon command graph.

## Risk

Low and UI-scoped. Update discovery, trust verification, download, installation, restart, rollback, policy keys, and release formats are unchanged.

## AI assistance

Prepared with AI assistance and validated locally as described above.