### PR TITLE
Bump VibeCAD release build to 2

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 1
+  number: 2
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC3",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 1,
+  "build_version": 2,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Outcome

Advances the canonical VibeCAD release identity from Build 1 to Build 2 so installed Build 1 clients can discover the updater UX release through the official `10-X-eng/vibecad` GitHub Releases feed.

## Compatibility

- [x] Existing public functions/APIs remain unchanged.
- [x] No preference keys, tool names, or schemas changed.
- [x] This is the normal additive build-number increment for the existing `26.3.1-RC3` version.
- [x] No breaking changes.

## Validation

- `python src/Tools/sync_version.py --check`: passed
- Release/update contract suite: 92 passed, 1 skipped
- `git diff --check`: passed

## AI assistance

Prepared with AI assistance and validated locally as described above.