### PR TITLE
Put update checks in the VibeCAD bar

### DIFF
--- a/docs/vibecad-release-packaging.md
+++ b/docs/vibecad-release-packaging.md
@@ -120,11 +120,12 @@ missing. It does not change the normal GitHub Releases flow.
 
 ## Application update flow
 
-The standard menu bar remains visible, and **Help > Check for Updates** opens the
-update flow and immediately checks the configured channel. The Updates
-preference page contains settings only. By default, VibeCAD checks once every 24
-hours on a background thread and shows a main-window notification only when an
-update is available.
+The persistent VibeCAD application bar includes a **Check for Updates** control.
+The standard menu bar also remains visible, with **Help > Check for Updates** as
+a secondary entry point. Either control opens the update flow and immediately
+checks the configured channel. The Updates preference page contains settings
+only. By default, VibeCAD checks once every 24 hours on a background thread and
+shows a main-window notification only when an update is available.
 
 The client:
 

--- a/src/Gui/VibeCADRibbon.cpp
+++ b/src/Gui/VibeCADRibbon.cpp
@@ -1352,6 +1352,11 @@ struct Gui::VibeCADRibbon::Private
             QStringLiteral("VibeCAD_OpenAssistant"),
             QStringLiteral("VibeCADRibbonAssistant")
         );
+        updateButton = addCommandButton(
+            trailingLayout,
+            QStringLiteral("VibeCAD_CheckForUpdates"),
+            QStringLiteral("VibeCADRibbonCheckForUpdates")
+        );
         settingsButton = addCommandButton(
             trailingLayout,
             QStringLiteral("VibeCAD_OpenPreferences"),
@@ -1889,6 +1894,7 @@ struct Gui::VibeCADRibbon::Private
     QAction* searchShortcut = nullptr;
     QToolButton* themeButton = nullptr;
     QToolButton* assistantButton = nullptr;
+    QToolButton* updateButton = nullptr;
     QToolButton* settingsButton = nullptr;
     QTabBar* tabs = nullptr;
     RibbonPage* page = nullptr;

--- a/src/Mod/VibeCAD/VibeCADUpdateGui.py
+++ b/src/Mod/VibeCAD/VibeCADUpdateGui.py
@@ -32,7 +32,7 @@ from VibeCADUpdate import (
 _PREFERENCE_PATH = "User parameter:BaseApp/Preferences/Mod/VibeCAD/Updates"
 _COMMAND_NAME = "VibeCAD_CheckForUpdates"
 _LEGACY_COMMAND_NAME = "VibeCAD_UpdateCenter"
-_ICON = "preferences-vibecad.svg"
+_ICON = "view-refresh.svg"
 _registered = False
 _controller: "UpdateController | None" = None
 _update_center: "UpdateCenterDialog | None" = None
@@ -720,6 +720,28 @@ def get_update_controller() -> UpdateController:
     return _controller
 
 
+def _find_help_menu(main_window: Any) -> Any | None:
+    menu_bar = main_window.menuBar()
+    candidates = list(menu_bar.findChildren(QtWidgets.QMenu))
+    candidates.extend(main_window.findChildren(QtWidgets.QMenu))
+    for menu_action in menu_bar.actions():
+        try:
+            menu = menu_action.menu()
+        except RuntimeError:
+            continue
+        if menu is not None:
+            candidates.append(menu)
+    for menu in candidates:
+        try:
+            title = menu.title()
+            menu.actions()
+        except RuntimeError:
+            continue
+        if title.replace("&", "").strip().casefold() == "help":
+            return menu
+    return None
+
+
 def _add_help_menu_action() -> None:
     main_window = Gui.getMainWindow()
     command = Gui.Command.get(_COMMAND_NAME)
@@ -730,15 +752,20 @@ def _add_help_menu_action() -> None:
     action.setObjectName("VibeCADCheckForUpdatesAction")
     action.setProperty("VibeCADCheckForUpdates", True)
     action.setProperty("VibeCADUpdateCenter", True)
-    for menu in main_window.menuBar().findChildren(QtWidgets.QMenu):
-        if menu.title().replace("&", "").strip().casefold() == "help":
-            if action not in menu.actions():
-                menu.addSeparator()
-                menu.addAction(action)
-            if not menu.property("VibeCADCheckForUpdatesHooked"):
-                menu.aboutToShow.connect(_add_help_menu_action)
-                menu.setProperty("VibeCADCheckForUpdatesHooked", True)
-            return
+    menu = _find_help_menu(main_window)
+    if menu is None:
+        return
+    try:
+        if action not in menu.actions():
+            menu.addSeparator()
+            menu.addAction(action)
+        if not menu.property("VibeCADCheckForUpdatesHooked"):
+            menu.aboutToShow.connect(_add_help_menu_action)
+            menu.setProperty("VibeCADCheckForUpdatesHooked", True)
+    except RuntimeError:
+        # Workbench activation can replace FreeCAD's menus between discovery
+        # and insertion. A later scheduled/workbench callback will retry.
+        return
 
 
 def _schedule_help_menu_action(*_args: Any) -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/qt_ribbon_theme_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/qt_ribbon_theme_integration.py
@@ -792,6 +792,7 @@ def _assert_application_strip_actions(main_window):
         "VibeCADRibbonRedo": "Std_Redo",
         "VibeCADRibbonNew": "Std_New",
         "VibeCADRibbonAssistant": "VibeCAD_OpenAssistant",
+        "VibeCADRibbonCheckForUpdates": "VibeCAD_CheckForUpdates",
         "VibeCADRibbonSettings": "VibeCAD_OpenPreferences",
     }
     command_ids = []
@@ -1202,6 +1203,9 @@ def _run():
         assistant_button = main_window.findChild(
             QtWidgets.QToolButton, "VibeCADRibbonAssistant"
         )
+        update_button = main_window.findChild(
+            QtWidgets.QToolButton, "VibeCADRibbonCheckForUpdates"
+        )
         settings_button = main_window.findChild(
             QtWidgets.QToolButton, "VibeCADRibbonSettings"
         )
@@ -1227,20 +1231,39 @@ def _run():
         assert new_document_button is not None and new_document_button.isVisible()
         assert search is not None and search.completer() is not None
         _assert_visible_inside(assistant_button, root)
+        _assert_visible_inside(update_button, root)
         _assert_visible_inside(settings_button, root)
         _assert_visible_inside(document_tabs, root)
         _assert_visible_inside(search_button, root)
         _assert_visible_inside(new_document_button, root)
         assert assistant_button.toolButtonStyle() == QtCore.Qt.ToolButtonIconOnly
+        assert update_button.toolButtonStyle() == QtCore.Qt.ToolButtonIconOnly
         assert settings_button.toolButtonStyle() == QtCore.Qt.ToolButtonIconOnly
         assert (
             assistant_button.defaultAction().property("VibeCADCommandId")
             == "VibeCAD_OpenAssistant"
         )
         assert (
+            update_button.defaultAction().property("VibeCADCommandId")
+            == "VibeCAD_CheckForUpdates"
+        )
+        assert (
             settings_button.defaultAction().property("VibeCADCommandId")
             == "VibeCAD_OpenPreferences"
         )
+        import VibeCADUpdateGui
+
+        update_calls = []
+        original_show_check = VibeCADUpdateGui.show_check_for_updates
+        VibeCADUpdateGui.show_check_for_updates = lambda **kwargs: update_calls.append(
+            kwargs
+        )
+        try:
+            update_button.click()
+            _process_events()
+        finally:
+            VibeCADUpdateGui.show_check_for_updates = original_show_check
+        assert update_calls == [{}]
         assert main_window.menuBar().isVisible()
         assert _visible_main_window_toolbars(main_window) == [ribbon]
         _assert_application_strip_actions(main_window)
@@ -1663,11 +1686,13 @@ def _run():
         main_window.resize(850, 760)
         _process_events()
         assert assistant_button.toolButtonStyle() == QtCore.Qt.ToolButtonIconOnly
+        assert update_button.toolButtonStyle() == QtCore.Qt.ToolButtonIconOnly
         assert settings_button.toolButtonStyle() == QtCore.Qt.ToolButtonIconOnly
         assert not search.isVisible()
         _assert_visible_inside(search_button, root)
         _assert_visible_inside(document_tabs, root)
         _assert_visible_inside(assistant_button, root)
+        _assert_visible_inside(update_button, root)
         _assert_visible_inside(settings_button, root)
         assert not source_document_tabs.isVisible()
         saw_collapsed_group = False
@@ -2072,18 +2097,8 @@ def _run():
         print("VIBECAD_RIBBON_STAGE draft-compatibility", flush=True)
 
         assert main_window.menuBar().isVisible()
-        import VibeCADUpdateGui
-
         VibeCADUpdateGui.ensure_registered()
-        VibeCADUpdateGui._add_help_menu_action()
-        help_menu = next(
-            (
-                menu
-                for menu in main_window.menuBar().findChildren(QtWidgets.QMenu)
-                if menu.title().replace("&", "").strip().casefold() == "help"
-            ),
-            None,
-        )
+        help_menu = VibeCADUpdateGui._find_help_menu(main_window)
         assert help_menu is not None
         update_actions = [
             action

--- a/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
@@ -837,7 +837,7 @@ def test_release_packages_share_canonical_artifact_basename() -> None:
     assert "package/rattler-build/osx/VibeCAD_*.dmg" not in macos_workflow
 
 
-def test_update_ui_uses_the_standard_menu_and_keeps_preferences_for_settings() -> None:
+def test_update_ui_uses_the_vibecad_bar_and_keeps_preferences_for_settings() -> None:
     update_gui = _source("src/Mod/VibeCAD/VibeCADUpdateGui.py")
     preferences = update_gui.split("class VibeCADUpdatePreferencesPage", 1)[1].split(
         "class UpdateCenterDialog", 1
@@ -845,8 +845,11 @@ def test_update_ui_uses_the_standard_menu_and_keeps_preferences_for_settings() -
 
     assert '_COMMAND_NAME = "VibeCAD_CheckForUpdates"' in update_gui
     assert '_LEGACY_COMMAND_NAME = "VibeCAD_UpdateCenter"' in update_gui
+    assert '_ICON = "view-refresh.svg"' in update_gui
     assert '"MenuText": "Check for Updates"' in update_gui
     assert 'action.setProperty("VibeCADCheckForUpdates", True)' in update_gui
+    assert "def _find_help_menu(main_window: Any)" in update_gui
+    assert "for menu_action in menu_bar.actions():" in update_gui
     assert "main_window.workbenchActivated.connect(_schedule_help_menu_action)" in update_gui
     assert "for delay in (0, 250, 1000, 5000):" in update_gui
     assert "Open Update Center" not in update_gui
@@ -1031,6 +1034,7 @@ def test_vibecad_ribbon_has_explicit_domains_and_legacy_fallback() -> None:
         "VibeCADTrailingTools",
         "VibeCADRibbonGroupMenu",
         "VibeCADRibbonSearch",
+        "VibeCADRibbonCheckForUpdates",
         "VibeCADCommandSearch",
         "VibeCADThemeToggle",
         "VibeCADRibbonTabs",
@@ -1053,6 +1057,7 @@ def test_vibecad_ribbon_has_explicit_domains_and_legacy_fallback() -> None:
     assert '<< "MeshPart_ShapeFromMesh"' in mesh_workbench
     assert '<< "MeshPart_CurveOnMesh"' in mesh_workbench
     assert 'QStringLiteral("VibeCAD_OpenPreferences")' in ribbon
+    assert 'QStringLiteral("VibeCAD_CheckForUpdates")' in ribbon
     assert "VibeCADRibbon::install(mainWindow);" in startup
 
 


### PR DESCRIPTION
## Outcome

Makes update checks directly and persistently accessible from the VibeCAD application bar.

- adds a visible refresh-icon control wired to `VibeCAD_CheckForUpdates`
- keeps Help > Check for Updates as a secondary path
- fixes Help-menu discovery across FreeCAD menu rebuilds
- safely ignores stale Qt menu wrappers during workbench activation
- replaces the previous manual-injection assertion with real startup visibility and click coverage

## Compatibility

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] The legacy `VibeCAD_UpdateCenter` command and `show_update_center()` entry point remain supported.
- [x] No preference keys, tool names, schemas, or updater backend behavior changed.
- [x] Preferences remain settings-only.
- [x] No breaking changes.

## Validation

- Native Windows incremental build: passed
- Live compiled GUI activation: `VIBECAD_UPDATE_BAR_GUI_OK`
- Visual 1400x900 application-bar inspection: passed
- Focused Python tests: 73 passed, 5 skipped
- Python bytecode compile: passed
- `git diff --check`: passed

## Risk

Low and UI-scoped. Release discovery, trust verification, download, install, restart, rollback, and policy behavior are unchanged.

## AI assistance

Prepared with AI assistance and validated locally as described above.