### PR TITLE
Make Windows upgrades clean and version-aware

### DIFF
--- a/.github/workflows/vibecad-release.yml
+++ b/.github/workflows/vibecad-release.yml
@@ -307,6 +307,17 @@ jobs:
           set -euo pipefail
           pixi run -e package create_bundle
 
+      - name: Verify clean installer upgrade from the previous build
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          ./package/WindowsInstaller/test_clean_upgrade.ps1
+          -CurrentInstaller "package/rattler-build/windows/VibeCAD-${{ needs.prepare.outputs.release_version }}-build${{ needs.prepare.outputs.build }}-Windows-x86_64-installer.exe"
+          -Repository "${{ github.repository }}"
+          -ReleaseVersion "${{ needs.prepare.outputs.release_version }}"
+          -Build ${{ needs.prepare.outputs.build }}
+
       - name: Save Pixi and Python caches
         if: always() && steps.cache-pixi-windows.outputs.cache-hit != 'true'
         uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4

--- a/.github/workflows/vibecad-windows-installer.yml
+++ b/.github/workflows/vibecad-windows-installer.yml
@@ -21,7 +21,9 @@ jobs:
     name: Resolve Canonical Metadata
     runs-on: ubuntu-24.04
     outputs:
+      build: ${{ steps.meta.outputs.build }}
       build_tag: ${{ steps.meta.outputs.build_tag }}
+      release_version: ${{ steps.meta.outputs.release_version }}
       release_title: ${{ steps.meta.outputs.release_title }}
       source_sha: ${{ steps.meta.outputs.source_sha }}
     steps:
@@ -39,10 +41,14 @@ jobs:
           set -euo pipefail
           python src/Tools/sync_version.py --check
           source_sha="$(git rev-parse --verify HEAD)"
+          build="$(python src/Tools/resolve_release_artifact_name.py . --component build)"
           build_tag="$(python src/Tools/resolve_release_artifact_name.py . --component release-tag)"
+          release_version="$(python src/Tools/resolve_release_artifact_name.py . --component release-version)"
           release_title="$(python src/Tools/resolve_release_artifact_name.py . --component release-title)"
           {
+            echo "build=${build}"
             echo "build_tag=${build_tag}"
+            echo "release_version=${release_version}"
             echo "release_title=${release_title}"
             echo "source_sha=${source_sha}"
           } >> "${GITHUB_OUTPUT}"
@@ -121,6 +127,17 @@ jobs:
         run: |
           set -euo pipefail
           pixi run -e package create_bundle
+
+      - name: Verify clean installer upgrade from the previous build
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: >-
+          ./package/WindowsInstaller/test_clean_upgrade.ps1
+          -CurrentInstaller "package/rattler-build/windows/VibeCAD-${{ needs.metadata.outputs.release_version }}-build${{ needs.metadata.outputs.build }}-Windows-x86_64-installer.exe"
+          -Repository "${{ github.repository }}"
+          -ReleaseVersion "${{ needs.metadata.outputs.release_version }}"
+          -Build ${{ needs.metadata.outputs.build }}
 
       - name: Save Pixi and Python caches
         if: always() && steps.cache-pixi-windows.outputs.cache-hit != 'true'

--- a/docs/vibecad-release-packaging.md
+++ b/docs/vibecad-release-packaging.md
@@ -57,8 +57,11 @@ The workflow:
 2. Pins every job to the same source commit.
 3. Builds the Linux AppImage and Debian package and the Windows installer.
 4. Verifies every package checksum and generates the strict update manifest.
-5. Creates GitHub build-provenance attestations.
-6. Creates a draft release, uploads the complete asset set, and publishes it
+5. On Windows, installs the previous published build and proves that the new
+   installer removes a stale program-tree marker while retaining the old tree
+   as the rollback snapshot.
+6. Creates GitHub build-provenance attestations.
+7. Creates a draft release, uploads the complete asset set, and publishes it
    only after all gates pass.
 
 Publishing is allowed only from the current `main` commit. The canonical tag
@@ -148,6 +151,13 @@ last-known-good tree, installs into a clean directory, imports the updater in
 survives startup. A failed install, import, crash, or health timeout restores
 the previous installation and registry state. One healthy Windows rollback
 tree is retained until the next update or uninstall.
+
+Running a newer Windows installer directly uses the same clean replacement
+transaction instead of overlaying files. The installer compares the canonical
+semantic version, prerelease rank, and build stored in the registry: an older
+installed identity is presented as an update, the same identity as a repair,
+and a newer identity blocks an accidental downgrade. Documents and preferences
+remain outside the replaced program tree.
 
 AppImage updates copy the verified package beside the running AppImage, atomically
 swap the files after exit, perform a command-line import check, and start the new

--- a/package/WindowsInstaller/FreeCAD-installer.nsi
+++ b/package/WindowsInstaller/FreeCAD-installer.nsi
@@ -48,6 +48,7 @@ ManifestDPIAware true
 !include MUI2.nsh
 !include MultiUser.nsh
 !include Sections.nsh
+!include WordFunc.nsh
 !include WinVer.nsh
 !include x64.nsh
 

--- a/package/WindowsInstaller/Settings.nsh
+++ b/package/WindowsInstaller/Settings.nsh
@@ -55,6 +55,7 @@ These typically need to be modified for each FreeCAD release
     !define APP_RELEASE_VERSION "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}-${APP_VERSION_SUFFIX}"
 !endif
 !define APP_VERSION "${APP_RELEASE_VERSION} (Build ${APP_VERSION_BUILD})" # Version to display
+!define APP_UPDATE_VERSION "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}.${APP_VERSION_RELEASE_RANK}.${APP_VERSION_BUILD}"
 
 #--------------------------------
 # Installer file name

--- a/package/WindowsInstaller/include/declarations.nsh
+++ b/package/WindowsInstaller/include/declarations.nsh
@@ -81,5 +81,13 @@ Var VibeCADUpdateBackupDir
 Var VibeCADUpdateFailedDir
 Var VibeCADUpdateInstallRoot
 Var VibeCADUpdateMode
+Var VibeCADInstalledBuild
+Var VibeCADInstalledDisplayVersion
+Var VibeCADInstalledDisposition
+Var VibeCADInstalledInstallRoot
+Var VibeCADInstalledPatch
+Var VibeCADInstalledReleaseVersion
+Var VibeCADInstalledUninstallString
+Var VibeCADInstalledUpdateVersion
 Var UserList
 Var LangName

--- a/package/WindowsInstaller/include/gui.nsh
+++ b/package/WindowsInstaller/include/gui.nsh
@@ -44,6 +44,7 @@ BrandingText " "
 !insertmacro MULTIUSER_PAGE_INSTALLMODE
 
 # Specify the installation directory.
+!define MUI_PAGE_CUSTOMFUNCTION_PRE VibeCADDirectoryPagePre
 !insertmacro MUI_PAGE_DIRECTORY
 
 # Define which components to install.

--- a/package/WindowsInstaller/include/init.nsh
+++ b/package/WindowsInstaller/include/init.nsh
@@ -22,62 +22,226 @@ Function InitUser
 FunctionEnd
 
 #--------------------------------
+# Installed-version discovery and clean replacement
+
+Function FindInstalledVibeCAD
+
+  StrCpy $OldVersionNumber ""
+  StrCpy $VibeCADInstalledBuild ""
+  StrCpy $VibeCADInstalledDisplayVersion ""
+  StrCpy $VibeCADInstalledDisposition "none"
+  StrCpy $VibeCADInstalledInstallRoot ""
+  StrCpy $VibeCADInstalledPatch ""
+  StrCpy $VibeCADInstalledReleaseVersion ""
+  StrCpy $VibeCADInstalledUninstallString ""
+  StrCpy $VibeCADInstalledUpdateVersion ""
+
+  # Find the highest installed patch in this major/minor series. Historical
+  # VibeCAD/FreeCAD installers used one registry key per patch release.
+  IntOp $4 ${APP_VERSION_PATCH} + 20
+  ${for} $5 0 $4
+    StrCpy $R0 "${APP_VERSION_MAJOR}${APP_VERSION_MINOR}$5"
+    StrCpy $R2 "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}$R0"
+    ReadRegStr $0 SHCTX "$R2" "DisplayVersion"
+    ${if} $0 == ""
+      # Preserve discovery of the legacy emergency-release key shape.
+      StrCpy $R0 "${APP_VERSION_MAJOR}${APP_VERSION_MINOR}$51"
+      StrCpy $R2 "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}$R0"
+      ReadRegStr $0 SHCTX "$R2" "DisplayVersion"
+    ${endif}
+    ${if} $0 != ""
+      StrCpy $OldVersionNumber $R0
+      StrCpy $VibeCADInstalledPatch $5
+      StrCpy $VibeCADInstalledDisplayVersion $0
+      ReadRegStr $VibeCADInstalledUninstallString SHCTX "$R2" "UninstallString"
+      StrCpy $R3 "SOFTWARE\${APP_NAME}$OldVersionNumber"
+      ReadRegStr $VibeCADInstalledInstallRoot SHCTX "$R3" ""
+      ReadRegStr $VibeCADInstalledReleaseVersion SHCTX "$R3" "ReleaseVersion"
+      ReadRegStr $VibeCADInstalledUpdateVersion SHCTX "$R3" "UpdateVersion"
+      ClearErrors
+      ReadRegDWORD $1 SHCTX "$R3" "Build"
+      ${if} ${Errors}
+        StrCpy $VibeCADInstalledBuild ""
+        ClearErrors
+      ${else}
+        StrCpy $VibeCADInstalledBuild $1
+      ${endif}
+    ${endif}
+  ${next}
+
+FunctionEnd
+
+Function SelectExistingVibeCADInstallMode
+
+  # The MultiUser plug-in normally restores the install scope from the target
+  # patch's registry key. Search the entire major/minor series as a migration
+  # fallback so a new patch still updates the existing per-user/per-machine
+  # installation instead of creating a second copy in another scope.
+  StrCpy $6 ""
+  StrCpy $7 ""
+  IntOp $4 ${APP_VERSION_PATCH} + 20
+  ${for} $5 0 $4
+    StrCpy $R0 "${APP_VERSION_MAJOR}${APP_VERSION_MINOR}$5"
+    ReadRegStr $0 HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}$R0" "DisplayVersion"
+    ${if} $0 != ""
+      ReadRegStr $6 HKLM "SOFTWARE\${APP_NAME}$R0" ""
+    ${endif}
+    ReadRegStr $0 HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}$R0" "DisplayVersion"
+    ${if} $0 != ""
+      ReadRegStr $7 HKCU "SOFTWARE\${APP_NAME}$R0" ""
+    ${endif}
+  ${next}
+
+  ${if} $6 != ""
+  ${andif} $7 == ""
+    Call MultiUser.InstallMode.AllUsers
+  ${elseif} $7 != ""
+  ${andif} $6 == ""
+    Call MultiUser.InstallMode.CurrentUser
+  ${elseif} $6 != ""
+  ${andif} $7 != ""
+  ${andif} $VibeCADUpdateInstallRoot != ""
+    GetFullPathName $6 "$6"
+    GetFullPathName $7 "$7"
+    GetFullPathName $0 "$VibeCADUpdateInstallRoot"
+    ${if} $0 == $6
+      Call MultiUser.InstallMode.AllUsers
+    ${elseif} $0 == $7
+      Call MultiUser.InstallMode.CurrentUser
+    ${endif}
+  ${endif}
+
+FunctionEnd
+
+Function ClassifyInstalledVibeCAD
+
+  StrCpy $VibeCADInstalledDisposition "unknown"
+
+  # Installers produced after this change persist a fully sortable numeric
+  # identity. It includes semantic version, prerelease rank, and build.
+  !if "${APP_VERSION_ORDER_KNOWN}" == "1"
+    ${if} $VibeCADInstalledUpdateVersion != ""
+      ${VersionCompare} "${APP_UPDATE_VERSION}" "$VibeCADInstalledUpdateVersion" $0
+      ${if} $0 == "1"
+        StrCpy $VibeCADInstalledDisposition "upgrade"
+      ${elseif} $0 == "0"
+        StrCpy $VibeCADInstalledDisposition "repair"
+      ${else}
+        StrCpy $VibeCADInstalledDisposition "downgrade"
+      ${endif}
+      Return
+    ${endif}
+  !endif
+
+  # Compatibility with already-published installers: exact public releases
+  # have always persisted ReleaseVersion and Build separately.
+  ${if} $VibeCADInstalledReleaseVersion == "${APP_RELEASE_VERSION}"
+  ${andif} $VibeCADInstalledBuild != ""
+    ${if} $VibeCADInstalledBuild < ${APP_VERSION_BUILD}
+      StrCpy $VibeCADInstalledDisposition "upgrade"
+    ${elseif} $VibeCADInstalledBuild == ${APP_VERSION_BUILD}
+      StrCpy $VibeCADInstalledDisposition "repair"
+    ${else}
+      StrCpy $VibeCADInstalledDisposition "downgrade"
+    ${endif}
+    Return
+  ${endif}
+
+  # Patch releases have an unambiguous order even for a legacy install.
+  ${if} $VibeCADInstalledPatch != ""
+    ${if} $VibeCADInstalledPatch < ${APP_VERSION_PATCH}
+      StrCpy $VibeCADInstalledDisposition "upgrade"
+      Return
+    ${elseif} $VibeCADInstalledPatch > ${APP_VERSION_PATCH}
+      StrCpy $VibeCADInstalledDisposition "downgrade"
+      Return
+    ${endif}
+  ${endif}
+
+  # A final release sorts after a legacy prerelease of the same patch. A
+  # prerelease must never replace an installed final release automatically.
+  !if "${APP_VERSION_SUFFIX}" == ""
+    ${if} $VibeCADInstalledReleaseVersion != ""
+    ${andif} $VibeCADInstalledReleaseVersion != "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}"
+      StrCpy $VibeCADInstalledDisposition "upgrade"
+    ${endif}
+  !else
+    ${if} $VibeCADInstalledReleaseVersion == "${APP_VERSION_MAJOR}.${APP_VERSION_MINOR}.${APP_VERSION_PATCH}"
+      StrCpy $VibeCADInstalledDisposition "downgrade"
+    ${endif}
+  !endif
+
+FunctionEnd
+
+Function BeginManualVibeCADReplacement
+
+  StrCpy $VibeCADUpdateMode "manual"
+  StrCpy $VibeCADUpdateInstallRoot $VibeCADInstalledInstallRoot
+  Call ValidateVibeCADUpdateInstallRoot
+  ${if} ${Errors}
+    StrCpy $VibeCADUpdateMode "false"
+    MessageBox MB_OK|MB_ICONSTOP "$(InvalidExistingInstall)" /SD IDOK
+    SetErrorLevel 28
+    Quit
+  ${endif}
+  ClearErrors
+
+FunctionEnd
+
+Function VibeCADDirectoryPagePre
+
+  # A replacement must use the registered installation root. Skipping the
+  # directory page prevents a clean upgrade from being redirected midway.
+  ${if} $VibeCADUpdateMode == "install"
+  ${orif} $VibeCADUpdateMode == "manual"
+    Abort
+  ${endif}
+
+FunctionEnd
+
+#--------------------------------
 # MultiUser custom method
 
 Function PostMultiUserPageInit
-  # check if this FreeCAD version is already installed
-  ReadRegStr $0 SHCTX "${APP_UNINST_KEY}" "UninstallString"
-  ${if} $0 != ""
-   ${if} $VibeCADUpdateMode != "false"
-    Goto ContinueInstall
-   ${endif}
-   # check if the uninstaller was accidentally deleted
-   # if so, don't bother the user if they really want to install a new FreeCAD over an existing one
-   # because they won't have a chance to deny this
+  Call FindInstalledVibeCAD
 
-   # remove quotes from uninstaller filename
-   ${TrimQuotes} $0 $0
-   # skip message box if uninstaller file is missing
-   IfFileExists $0 0 ContinueInstall
-
-   # installing over an existing installation of the same FreeCAD release is not necessary
-   # if the users does this, they most probably have a problem with FreeCAD that can better be solved
-   # by reinstalling FreeCAD
-   # for beta and other test releases over-installing can even cause errors
-   MessageBox MB_YESNOCANCEL "$(AlreadyInstalled)" /SD IDCANCEL IDYES ContinueInstall IDNO BackToMuiltUserPage
-   Quit
-   BackToMuiltUserPage:
-   Abort
-   ContinueInstall:
+  ${if} $OldVersionNumber == ""
+    Return
   ${endif}
 
-  # check if there is an existing FreeCAD installation of the same FreeCAD series
-  # we usually don't release more than 10 versions so with 20 we are safe to check if a newer version is installed
-  IntOp $4 ${APP_VERSION_PATCH} + 20
-  ${for} $5 0 $4
-   ReadRegStr $0 SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}${APP_VERSION_MAJOR}${APP_VERSION_MINOR}$5" "DisplayVersion"
-   # also check for an emergency release
-   ${if} $0 == ""
-    ReadRegStr $0 SHCTX "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}${APP_VERSION_MAJOR}${APP_VERSION_MINOR}$51" "DisplayVersion"
-   ${endif}
-   ${if} $0 != ""
-    StrCpy $R5 $0 # store the read version number
-    StrCpy $OldVersionNumber "${APP_VERSION_MAJOR}${APP_VERSION_MINOR}$5"
-    # we don't stop here because we want the latest installed version
-   ${endif}
-  ${next}
-
-  # NSIS cannot handle numbers with leading zero, thus cut it off before comparing
-  StrCpy $1 $OldVersionNumber "" 1
-  StrCpy $2 ${APP_SERIES_KEY} "" 1
-  ${if} $1 > $2
-   # store the version number and reformat it temporarily for the error message
-   StrCpy $R0 $OldVersionNumber
-   StrCpy $OldVersionNumber $R5
-   MessageBox MB_OK|MB_ICONSTOP "$(NewerInstalled)" /SD IDOK
-   StrCpy $OldVersionNumber $R0
-   Quit
+  # The verified in-app updater already supplies a silent, pinned install root.
+  # Preserve that path while sharing the same clean replacement sections.
+  ${if} $VibeCADUpdateMode != "false"
+    Return
   ${endif}
+
+  Call ClassifyInstalledVibeCAD
+
+  ${if} $VibeCADInstalledDisposition == "upgrade"
+    MessageBox MB_OKCANCEL|MB_ICONINFORMATION "$(UpgradeInstalled)" /SD IDOK IDOK AcceptManualReplacement
+    Goto CancelManualReplacement
+  ${elseif} $VibeCADInstalledDisposition == "repair"
+    MessageBox MB_YESNO|MB_ICONQUESTION "$(RepairInstalled)" /SD IDNO IDYES AcceptManualReplacement
+    Goto CancelManualReplacement
+  ${elseif} $VibeCADInstalledDisposition == "downgrade"
+    MessageBox MB_OK|MB_ICONSTOP "$(DowngradeBlocked)" /SD IDOK
+    SetErrorLevel 27
+    Quit
+  ${else}
+    MessageBox MB_YESNO|MB_ICONEXCLAMATION "$(ReplaceUnknownInstalled)" /SD IDNO IDYES AcceptManualReplacement
+    Goto CancelManualReplacement
+  ${endif}
+
+  AcceptManualReplacement:
+    Call BeginManualVibeCADReplacement
+    Return
+
+  CancelManualReplacement:
+    ${if} ${Silent}
+      Quit
+    ${else}
+      Abort
+    ${endif}
 FunctionEnd
 
 
@@ -110,6 +274,7 @@ Function .onInit
 
   StrCpy $VibeCADUpdateMode "false"
   StrCpy $VibeCADUpdateInstallRoot ""
+  StrCpy $OldVersionNumber ""
   ${GetParameters} $R8
   ClearErrors
   ${GetOptions} $R8 "/VIBECADUPDATE" $R9
@@ -172,6 +337,7 @@ Function .onInit
   
   # initialize the multi-user installer UI
   !insertmacro MULTIUSER_INIT
+  Call SelectExistingVibeCADInstallMode
 
   # this can be reset to "true" in section SecDesktop
   StrCpy $CreateDesktopIcon "false"
@@ -296,6 +462,12 @@ Function RestoreVibeCADUpdateBackup
   WriteRegStr SHCTX "$R3" "Version" "$R4"
   ReadINIStr $R4 "$INSTDIR\vibecad-update-registry.ini" "Registry" "ReleaseVersion"
   WriteRegStr SHCTX "$R3" "ReleaseVersion" "$R4"
+  ReadINIStr $R4 "$INSTDIR\vibecad-update-registry.ini" "Registry" "UpdateVersion"
+  ${if} $R4 == ""
+    DeleteRegValue SHCTX "$R3" "UpdateVersion"
+  ${else}
+    WriteRegStr SHCTX "$R3" "UpdateVersion" "$R4"
+  ${endif}
   ReadINIStr $R4 "$INSTDIR\vibecad-update-registry.ini" "Registry" "Build"
   WriteRegDWORD SHCTX "$R3" "Build" $R4
   Delete "$INSTDIR\vibecad-update-registry.ini"

--- a/package/WindowsInstaller/lang/english.nsh
+++ b/package/WindowsInstaller/lang/english.nsh
@@ -38,13 +38,28 @@ ${LangFileString} SecDesktopDescription "A VibeCAD icon on the desktop."
 
 #${LangFileString} RunConfigureFailed "Could not run configure script."
 ${LangFileString} InstallRunning "The installer is already running!"
-${LangFileString} AlreadyInstalled "VibeCAD ${APP_SERIES_KEY2} is already installed!$\r$\n\
-				Installing over existing installations is not recommended if the installed version$\r$\n\
-				is a test release or if you have problems with your existing VibeCAD installation.$\r$\n\
-				In these cases better reinstall VibeCAD.$\r$\n\
-				Do you nevertheless want to install VibeCAD over the existing version?"
-${LangFileString} NewerInstalled "You are trying to install an older version of VibeCAD than what you have installed.$\r$\n\
-				  If you really want this, you must uninstall the existing VibeCAD $OldVersionNumber before."
+${LangFileString} UpgradeInstalled "$VibeCADInstalledDisplayVersion is installed.$\r$\n\
+				This installer will update it to ${APP_VERSION} using a clean replacement of the program files.$\r$\n\
+				Your documents and preferences will be preserved.$\r$\n$\r$\n\
+				Continue with the update?"
+${LangFileString} RepairInstalled "VibeCAD ${APP_VERSION} is already installed.$\r$\n\
+				Would you like to repair it by cleanly replacing the program files?$\r$\n\
+				Your documents and preferences will be preserved."
+${LangFileString} DowngradeBlocked "A newer VibeCAD release is already installed:$\r$\n\
+				$VibeCADInstalledDisplayVersion$\r$\n$\r$\n\
+				This installer contains ${APP_VERSION} and will not downgrade it automatically.$\r$\n\
+				Uninstall the newer release first if you intentionally need to downgrade."
+${LangFileString} ReplaceUnknownInstalled "An existing VibeCAD installation was found:$\r$\n\
+				$VibeCADInstalledDisplayVersion$\r$\n$\r$\n\
+				Its complete version/build order cannot be determined. Continuing will cleanly replace its$\r$\n\
+				program files with ${APP_VERSION}; documents and preferences will be preserved.$\r$\n$\r$\n\
+				Continue?"
+${LangFileString} InvalidExistingInstall "The registered VibeCAD installation directory is missing or invalid.$\r$\n\
+				The installer stopped without changing it. Uninstall the damaged entry before reinstalling VibeCAD."
+# Retained for compatibility with downstream installer extensions that may
+# still reference the historical language identifiers.
+${LangFileString} AlreadyInstalled "VibeCAD ${APP_SERIES_KEY2} is already installed."
+${LangFileString} NewerInstalled "A newer VibeCAD installation already exists."
 
 #${LangFileString} FinishPageMessage "Congratulations! VibeCAD has been installed successfully.$\r$\n\
 #					$\r$\n\

--- a/package/WindowsInstaller/setup/configure.nsh
+++ b/package/WindowsInstaller/setup/configure.nsh
@@ -18,6 +18,11 @@ Section -InstallData
   WriteRegStr SHCTX ${APP_REGKEY} "Version" "${APP_VERSION_NUMBER}"
   WriteRegStr SHCTX ${APP_REGKEY} "ReleaseVersion" "${APP_RELEASE_VERSION}"
   WriteRegDWORD SHCTX ${APP_REGKEY} "Build" ${APP_VERSION_BUILD}
+  !if "${APP_VERSION_ORDER_KNOWN}" == "1"
+    WriteRegStr SHCTX ${APP_REGKEY} "UpdateVersion" "${APP_UPDATE_VERSION}"
+  !else
+    DeleteRegValue SHCTX ${APP_REGKEY} "UpdateVersion"
+  !endif
   
   # Start Menu shortcut
   SetOutPath "$INSTDIR\bin" # this is the folder in which the shortcut is executed

--- a/package/WindowsInstaller/setup/install.nsh
+++ b/package/WindowsInstaller/setup/install.nsh
@@ -13,6 +13,7 @@ Installation of program files, dictionaries and external components
 Section -PrepareVibeCADUpdate
 
   ${if} $VibeCADUpdateMode == "install"
+  ${orif} $VibeCADUpdateMode == "manual"
     StrCpy $VibeCADUpdateBackupDir "$INSTDIR.vibecad-rollback"
     IfFileExists "$VibeCADUpdateBackupDir\*.*" 0 PreviousRollbackRemoved
       RMDir /r "$VibeCADUpdateBackupDir"
@@ -33,29 +34,57 @@ Section -PrepareVibeCADUpdate
       IfErrors 0 +3
         SetErrorLevel 22
         Quit
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "UninstallKey" "$R2"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "AppKey" "$R3"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegStr $R4 SHCTX "$R2" "DisplayName"
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "DisplayName" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegStr $R4 SHCTX "$R2" "DisplayVersion"
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "DisplayVersion" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegStr $R4 SHCTX "$R2" "UninstallString"
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "UninstallString" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegStr $R4 SHCTX "$R2" "QuietUninstallString"
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "QuietUninstallString" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegStr $R4 SHCTX "$R2" "DisplayIcon"
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "DisplayIcon" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegStr $R4 SHCTX "$R2" "StartMenu"
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "StartMenu" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegStr $R4 SHCTX "$R3" ""
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "InstallPath" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegStr $R4 SHCTX "$R3" "Version"
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "Version" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegStr $R4 SHCTX "$R3" "ReleaseVersion"
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "ReleaseVersion" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
+      ReadRegStr $R4 SHCTX "$R3" "UpdateVersion"
+      ClearErrors
+      WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "UpdateVersion" "$R4"
+      IfErrors VibeCADUpdateRegistrySaveFailed
       ReadRegDWORD $R4 SHCTX "$R3" "Build"
+      ClearErrors
       WriteINIStr "$VibeCADUpdateBackupDir\vibecad-update-registry.ini" "Registry" "Build" "$R4"
-      IfErrors 0 VibeCADUpdateRegistrySaved
+      IfErrors VibeCADUpdateRegistrySaveFailed
+      Goto VibeCADUpdateRegistrySaved
+      VibeCADUpdateRegistrySaveFailed:
         ClearErrors
         Rename "$VibeCADUpdateBackupDir" "$INSTDIR"
         SetErrorLevel 26
@@ -129,6 +158,7 @@ SectionEnd
 Section -ValidateVibeCADUpdate
 
   ${if} $VibeCADUpdateMode == "install"
+  ${orif} $VibeCADUpdateMode == "manual"
     IfErrors RollbackVibeCADUpdate
     IfFileExists "$INSTDIR\bin\freecadcmd.exe" 0 RollbackVibeCADUpdate
     ExecWait '"$INSTDIR\bin\freecadcmd.exe" --safe-mode -c "import VibeCADUpdate"' $R0

--- a/package/WindowsInstaller/test_clean_upgrade.ps1
+++ b/package/WindowsInstaller/test_clean_upgrade.ps1
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$CurrentInstaller,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Repository,
+
+    [Parameter(Mandatory = $true)]
+    [string]$ReleaseVersion,
+
+    [Parameter(Mandatory = $true)]
+    [int]$Build,
+
+    [string]$PreviousInstaller = ""
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Invoke-Installer {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string]$Path,
+
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    $process = Start-Process -FilePath $Path -ArgumentList $Arguments -PassThru -Wait
+    if ($process.ExitCode -ne 0) {
+        throw "Installer '$Path' exited with code $($process.ExitCode)."
+    }
+}
+
+$current = (Resolve-Path -LiteralPath $CurrentInstaller).Path
+$majorMinorPatch = ($ReleaseVersion -split "-", 2)[0]
+$versionParts = $majorMinorPatch.Split(".")
+if ($versionParts.Count -ne 3) {
+    throw "Release version '$ReleaseVersion' does not contain major.minor.patch."
+}
+$seriesKey = "$($versionParts[0])$($versionParts[1])$($versionParts[2])"
+$appKey = "HKCU:\SOFTWARE\VibeCAD$seriesKey"
+$uninstallKey = "HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\VibeCAD$seriesKey"
+
+if ((Test-Path -LiteralPath $appKey) -or (Test-Path -LiteralPath $uninstallKey)) {
+    throw "The clean-upgrade smoke test requires a fresh Windows user registry."
+}
+
+$testRoot = Join-Path $env:RUNNER_TEMP "VibeCAD-clean-upgrade-$([guid]::NewGuid().ToString('N'))"
+$downloadRoot = Join-Path $testRoot "previous"
+New-Item -ItemType Directory -Path $downloadRoot -Force | Out-Null
+
+try {
+    if (-not $PreviousInstaller) {
+        $releases = gh release list --repo $Repository --limit 100 --json tagName,isDraft | ConvertFrom-Json
+        $candidates = foreach ($release in $releases) {
+            if ($release.isDraft -or $release.tagName -notmatch '^v(.+)-build(\d+)$') {
+                continue
+            }
+            if ($Matches[1] -eq $ReleaseVersion -and [int]$Matches[2] -lt $Build) {
+                [pscustomobject]@{
+                    Tag = $release.tagName
+                    Build = [int]$Matches[2]
+                }
+            }
+        }
+        $previousRelease = $candidates | Sort-Object Build -Descending | Select-Object -First 1
+        if (-not $previousRelease) {
+            Write-Host "No earlier published build of $ReleaseVersion exists; clean-upgrade smoke test is not applicable."
+            exit 0
+        }
+        $asset = "VibeCAD-$ReleaseVersion-build$($previousRelease.Build)-Windows-x86_64-installer.exe"
+        gh release download $previousRelease.Tag --repo $Repository --pattern $asset --dir $downloadRoot
+        if ($LASTEXITCODE -ne 0) {
+            throw "Could not download $asset from $($previousRelease.Tag)."
+        }
+        $PreviousInstaller = Join-Path $downloadRoot $asset
+    }
+
+    $previous = (Resolve-Path -LiteralPath $PreviousInstaller).Path
+    Invoke-Installer -Path $previous -Arguments @("/S", "/CurrentUser")
+
+    $installed = Get-ItemProperty -LiteralPath $appKey
+    $installRoot = [string]$installed.'(default)'
+    if (-not $installRoot -or -not (Test-Path -LiteralPath $installRoot)) {
+        throw "The previous installer did not register a valid installation root."
+    }
+    $oldBuild = $installed.Build
+    if ([int]$oldBuild -ge $Build) {
+        throw "Previous installer has Build $oldBuild; expected a build lower than $Build."
+    }
+
+    $marker = Join-Path $installRoot "must-not-survive-clean-upgrade.txt"
+    Set-Content -LiteralPath $marker -Value "stale program file" -Encoding ascii
+
+    # This deliberately exercises a normal, manually launched silent installer:
+    # no /VIBECADUPDATE flag and no explicit destination are supplied.
+    Invoke-Installer -Path $current -Arguments @("/S", "/CurrentUser")
+
+    $backupRoot = "$installRoot.vibecad-rollback"
+    if (Test-Path -LiteralPath $marker) {
+        throw "The old installation was overlaid; its stale marker remains in the live tree."
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $backupRoot "must-not-survive-clean-upgrade.txt"))) {
+        throw "The prior installation was not retained as the rollback tree."
+    }
+    if (-not (Test-Path -LiteralPath (Join-Path $installRoot "bin\VibeCAD.exe"))) {
+        throw "The replacement installation is missing bin\VibeCAD.exe."
+    }
+
+    $identity = Get-ItemProperty -LiteralPath $appKey
+    if ($identity.ReleaseVersion -ne $ReleaseVersion -or [int]$identity.Build -ne $Build) {
+        throw "Installed identity is '$($identity.ReleaseVersion)' Build $($identity.Build), expected '$ReleaseVersion' Build $Build."
+    }
+    if (-not $identity.UpdateVersion) {
+        throw "The sortable UpdateVersion registry identity was not written."
+    }
+
+    Write-Host "Clean Windows upgrade passed: Build $oldBuild -> Build $Build"
+}
+finally {
+    $registeredRoot = ""
+    if (Test-Path -LiteralPath $appKey) {
+        $registeredRoot = [string](Get-ItemProperty -LiteralPath $appKey).'(default)'
+    }
+    $uninstaller = if ($registeredRoot) { Join-Path $registeredRoot "Uninstall-VibeCAD.exe" } else { "" }
+    if ($uninstaller -and (Test-Path -LiteralPath $uninstaller)) {
+        try {
+            Invoke-Installer -Path $uninstaller -Arguments @("/S", "/CurrentUser")
+        }
+        catch {
+            Write-Warning $_
+        }
+    }
+    if (Test-Path -LiteralPath $appKey) {
+        Remove-Item -LiteralPath $appKey -Recurse -Force
+    }
+    if (Test-Path -LiteralPath $uninstallKey) {
+        Remove-Item -LiteralPath $uninstallKey -Recurse -Force
+    }
+    if (Test-Path -LiteralPath $testRoot) {
+        Remove-Item -LiteralPath $testRoot -Recurse -Force
+    }
+}

--- a/package/WindowsInstaller/write_version_nsh.py
+++ b/package/WindowsInstaller/write_version_nsh.py
@@ -5,6 +5,40 @@
 import datetime
 import os
 
+
+def release_rank(suffix: str) -> tuple[int, bool]:
+    """Return a sortable prerelease rank and whether its ordering is known."""
+
+    import re as regex
+
+    normalized = suffix.casefold()
+    if not normalized:
+        return 500_000, True
+
+    match = regex.fullmatch(r"(?:dev)(\d*)", normalized)
+    if match:
+        sequence = int(match.group(1) or 0)
+        if sequence < 100_000:
+            return 100_000 + sequence, True
+        return 0, False
+
+    for pattern, base in (
+        (r"(?:a|alpha)(\d+)", 200_000),
+        (r"(?:b|beta)(\d+)", 300_000),
+        (r"(?:rc)(\d+)", 400_000),
+    ):
+        match = regex.fullmatch(pattern, normalized)
+        if match:
+            sequence = int(match.group(1))
+            if sequence < 100_000:
+                return base + sequence, True
+            return 0, False
+
+    # Preserve support for custom suffixes while declining to guess their
+    # ordering. Exact custom releases can still be ordered by build number.
+    return 0, False
+
+
 def render_version_defines(version, *, suffix: str, build: str, year: int) -> str:
     # Keep the module reference local because importing FreeCAD mutates names in
     # the embedded interpreter's __main__ namespace.
@@ -15,6 +49,7 @@ def render_version_defines(version, *, suffix: str, build: str, year: int) -> st
     build_number = int(build)
     if build_number < 0:
         raise ValueError("VibeCAD build number must be non-negative")
+    rank, order_known = release_rank(suffix)
     return f'''\
 !define COPYRIGHT_YEAR {year}
 !define APP_VERSION_MAJOR "{version[0]}"
@@ -22,6 +57,8 @@ def render_version_defines(version, *, suffix: str, build: str, year: int) -> st
 !define APP_VERSION_PATCH "{version[2]}"
 !define APP_VERSION_SUFFIX "{suffix}"
 !define APP_VERSION_BUILD {build_number}
+!define APP_VERSION_RELEASE_RANK {rank}
+!define APP_VERSION_ORDER_KNOWN {int(order_known)}
 !define APP_VERSION_REVISION "{version[3].split()[0]}"
 '''
 

--- a/src/Tools/tests/test_windows_installer_version.py
+++ b/src/Tools/tests/test_windows_installer_version.py
@@ -11,6 +11,7 @@ SCRIPT_PATH = (
     / "WindowsInstaller"
     / "write_version_nsh.py"
 )
+INSTALLER_ROOT = SCRIPT_PATH.parent
 SPEC = importlib.util.spec_from_file_location("write_version_nsh", SCRIPT_PATH)
 assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -28,7 +29,50 @@ class TestWindowsInstallerVersion(unittest.TestCase):
 
         self.assertIn('!define APP_VERSION_SUFFIX "RC3"', content)
         self.assertIn("!define APP_VERSION_BUILD 17", content)
+        self.assertIn("!define APP_VERSION_RELEASE_RANK 400003", content)
+        self.assertIn("!define APP_VERSION_ORDER_KNOWN 1", content)
         self.assertIn('!define APP_VERSION_REVISION "41234"', content)
+
+    def test_release_rank_orders_supported_channels(self):
+        dev, dev_known = MODULE.release_rank("dev")
+        beta, beta_known = MODULE.release_rank("beta2")
+        rc, rc_known = MODULE.release_rank("RC3")
+        final, final_known = MODULE.release_rank("")
+
+        self.assertTrue(all((dev_known, beta_known, rc_known, final_known)))
+        self.assertLess(dev, beta)
+        self.assertLess(beta, rc)
+        self.assertLess(rc, final)
+
+    def test_custom_suffix_remains_buildable_without_guessing_order(self):
+        rank, known = MODULE.release_rank("enterprise-preview")
+        self.assertEqual(rank, 0)
+        self.assertFalse(known)
+
+        content = MODULE.render_version_defines(
+            ["26", "3", "1", "41234"],
+            suffix="enterprise-preview",
+            build="17",
+            year=2026,
+        )
+        self.assertIn("!define APP_VERSION_ORDER_KNOWN 0", content)
+
+    def test_manual_installs_share_the_clean_replacement_transaction(self):
+        init = (INSTALLER_ROOT / "include" / "init.nsh").read_text(encoding="utf-8")
+        install = (INSTALLER_ROOT / "setup" / "install.nsh").read_text(
+            encoding="utf-8"
+        )
+        configure = (INSTALLER_ROOT / "setup" / "configure.nsh").read_text(
+            encoding="utf-8"
+        )
+
+        self.assertIn('StrCpy $VibeCADUpdateMode "manual"', init)
+        self.assertIn("Function SelectExistingVibeCADInstallMode", init)
+        self.assertIn('StrCpy $VibeCADInstalledDisposition "upgrade"', init)
+        self.assertIn('${orif} $VibeCADUpdateMode == "manual"', install)
+        self.assertIn('Rename "$INSTDIR" "$VibeCADUpdateBackupDir"', install)
+        self.assertIn('"UpdateVersion" "${APP_UPDATE_VERSION}"', configure)
+        self.assertNotIn('$(AlreadyInstalled)', init)
 
     def test_rejects_negative_build(self):
         with self.assertRaisesRegex(ValueError, "non-negative"):


### PR DESCRIPTION
## Outcome

A manually launched newer Windows installer now performs the same clean program-tree replacement as the in-app updater instead of overlaying files.

## What changed

- Compare canonical semantic version, prerelease rank, and build from the registry.
- Present older installs as updates, identical installs as repairs, and block accidental downgrades.
- Preserve one complete rollback tree and restore registry identity if validation fails.
- Keep documents and preferences outside the replaced program tree.
- Preserve install scope across patch releases.
- Add a Windows release gate that installs the prior published build, injects a stale file, upgrades, and proves the stale file moved only to the rollback tree.

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing in-app `/VIBECADUPDATE` and rollback command-line contracts are unchanged.
- [x] Published installers without `UpdateVersion` remain supported through `ReleaseVersion` + `Build` fallback.
- [x] Custom suffixes remain buildable; unknown ordering is handled conservatively.

## Validation

- 95 release/update contract tests pass.
- PowerShell smoke-test script parses successfully.
- Both edited GitHub Actions workflows parse successfully.
- NSIS preprocessing succeeds for the complete installer.
- Isolated end-to-end test passed: legacy Build 3 -> Build 4 clean replacement, stale file absent from live tree and present in rollback tree.
- Isolated Build 4 -> Build 3 downgrade returned exit code 27 and preserved Build 4.

## Risk and rollback

Risk is limited to Windows installer discovery and replacement. The release workflow now exercises the exact manual-install path against the previous published installer before uploading assets. Reverting this commit restores the previous installer behavior.

AI assistance: implementation and validation were performed with Codex under owner direction.