### PR TITLE
Cut VibeCAD 26.3.1-RC3 Build 4

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 3
+  number: 4
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC3",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 3,
+  "build_version": 4,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
Advances the canonical VibeCAD build identity from Build 3 to Build 4 and keeps the rattler package build number synchronized. This creates an update target newer than the published Build 3 installer. Validation: version synchronization check passed; all 95 release/update contract tests passed (one platform-specific skip). Compatibility: no APIs, preferences, schemas, defaults, or packaging behavior are removed or changed. AI assistance was used to prepare and validate the build bump.