### PR TITLE
Promote VibeCAD 26.3.1-RC3 Build 4

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 3
+  number: 4
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC3",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 3,
+  "build_version": 4,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
Promotes the canonical Build 4 identity to main after the clean Windows installer upgrade implementation was validated and merged. Build 4 is the newer update target for installed Build 3 clients. Validation: canonical version sync passed; all 95 release/update contract tests passed (one platform-specific skip); protected dev PR check passed. Compatibility: no APIs, preferences, schemas, or defaults are removed or renamed. AI assistance was used to prepare and validate this release promotion.