### PR TITLE
Bump VibeCAD to RC4 Build 0

### DIFF
--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -16,7 +16,7 @@
 
 Name:           vibecad
 Epoch:          1
-Version:        26.3.1~RC3
+Version:        26.3.1~RC4
 Release:        1%{?dist}
 
 Summary:        A general purpose 3D CAD modeler

--- a/package/rattler-build/pixi.toml
+++ b/package/rattler-build/pixi.toml
@@ -8,7 +8,7 @@ preview = ["pixi-build"]
 
 [package]
 name = "vibecad"
-version = "26.3.1RC3"
+version = "26.3.1RC4"
 homepage = "https://freecad.org"
 repository = "https://github.com/FreeCAD/FreeCAD"
 description = "VibeCAD"

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "26.3.1RC3"
+  version: "26.3.1RC4"
 
 package:
   name: vibecad
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 4
+  number: 0
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -4,8 +4,8 @@
   "version_minor": 3,
   "version_patch": 1,
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
-  "version_suffix": "RC3",
+  "version_suffix": "RC4",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 4,
+  "build_version": 0,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Summary

- advance the release identity from 26.3.1-RC3 Build 4 to 26.3.1-RC4 Build 0
- synchronize the Rattler and Fedora package metadata from `version.json`
- prepare the canonical preview tag `v26.3.1-RC4-build0`

## Why

The large Native AI authoring feature merge is now on `main` and needs a distinct RC4 prerelease identity.

## Risk

Low. This changes release/package metadata only; application APIs and runtime behavior are unchanged.

## Test plan

- `python src/Tools/sync_version.py --check`
- `python -m unittest discover -s src/Tools/tests -v` (99 passed)
- resolved release title, tag, and channel from the canonical metadata tools

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults and runtime behavior are unchanged.
- [x] No deprecations were introduced.
- [x] No breaking changes are included.

## AI assistance

Prepared and verified with Codex assistance; the repository owner retains responsibility for the change.

- [x] This PR is not unverified AI output, I take responsibility for it.