### PR TITLE
Launch Windows updates as normal installers

### DIFF
--- a/docs/vibecad-release-packaging.md
+++ b/docs/vibecad-release-packaging.md
@@ -151,17 +151,19 @@ The client:
 5. Selects only the native Windows installer or Linux AppImage for the current
    architecture. macOS DMGs are published for manual installation; automatic
    macOS installation is not implemented yet.
-6. Resumes interrupted downloads with HTTP Range and ETag state.
+6. Downloads packages to the user's visible Downloads directory and resumes
+   interrupted downloads with HTTP Range and ETag state.
 7. Verifies the authorized size and SHA-256 before using the package.
 8. Stages installation on explicit request or, when policy allows, on exit.
 
-Windows updates run the installer silently after VibeCAD exits. The installer
-waits for the process to stop, renames the old installation to a sibling
-last-known-good tree, installs into a clean directory, imports the updater in
-`freecadcmd`, and starts the new GUI. The GUI commits a health receipt after it
-survives startup. A failed install, import, crash, or health timeout restores
-the previous installation and registry state. One healthy Windows rollback
-tree is retained until the next update or uninstall.
+Windows updates wait for VibeCAD to exit and then launch the verified installer
+normally, exactly as if the user opened it from Downloads. The updater supplies
+no silent, private-update, destination, or install-scope flags. The normal
+installer UI performs the clean replacement, imports the updater in
+`freecadcmd`, and restores the previous installation if installation or import
+validation fails. The new GUI commits a health receipt when the user launches
+it. One healthy Windows rollback tree is retained until the next update or
+uninstall.
 
 Running a newer Windows installer directly uses the same clean replacement
 transaction instead of overlaying files. The installer compares the canonical
@@ -175,9 +177,11 @@ swap the files after exit, perform a command-line import check, and start the ne
 GUI. A failed check, crash, or health timeout atomically restores the previous
 AppImage. A successful health receipt removes its rollback copy.
 
-Updater state, partial downloads, and receipts live in the `updates` child of
-the user application-data directory reported by VibeCAD. Command-line test
-environments without the application runtime fall back to `~/.vibecad/updates`.
+Updater state and receipts live in the `updates` child of the user
+application-data directory reported by VibeCAD. Packages, partial downloads,
+and their resume metadata live in the user's Downloads directory, and verified
+packages are retained there after installation. Command-line test environments
+without the application runtime fall back to `~/.vibecad/updates` for state.
 
 ## Enterprise policy
 

--- a/src/Mod/VibeCAD/VibeCADUpdate.py
+++ b/src/Mod/VibeCAD/VibeCADUpdate.py
@@ -565,6 +565,29 @@ def default_update_directory() -> Path:
     return base / "updates"
 
 
+def default_download_directory() -> Path:
+    """Return the user's visible Downloads directory for update packages."""
+
+    if os.name == "nt":
+        try:
+            import winreg
+
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Explorer\User Shell Folders",
+            ) as key:
+                value, _value_type = winreg.QueryValueEx(
+                    key,
+                    "{374DE290-123F-4565-9164-39C4925E467B}",
+                )
+            expanded = os.path.expandvars(str(value)).strip()
+            if expanded:
+                return Path(expanded).expanduser().resolve()
+        except (ImportError, OSError):
+            pass
+    return (Path.home() / "Downloads").resolve()
+
+
 def _atomic_json_write(path: Path, payload: Mapping[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     handle, temporary_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=path.parent)
@@ -587,6 +610,7 @@ class UpdateService:
         policy: UpdatePolicy,
         *,
         update_directory: Path | None = None,
+        download_directory: Path | None = None,
         system: str | None = None,
         machine: str | None = None,
         clock: Callable[[], float] = time.time,
@@ -595,6 +619,13 @@ class UpdateService:
         self.current = current
         self.policy = policy
         self.update_directory = (update_directory or default_update_directory()).resolve()
+        if download_directory is None:
+            download_directory = (
+                Path(update_directory) / "downloads"
+                if update_directory is not None
+                else default_download_directory()
+            )
+        self.download_directory = download_directory.resolve()
         self.system = system or platform.system()
         self.machine = machine or platform.machine()
         self.clock = clock
@@ -867,7 +898,7 @@ class UpdateService:
         cancelled: Callable[[], bool] | None = None,
         timeout: float = 60.0,
     ) -> Path:
-        downloads = self.update_directory / "downloads"
+        downloads = self.download_directory
         downloads.mkdir(parents=True, exist_ok=True)
         destination = downloads / asset.name
         partial = downloads / f"{asset.name}.part"
@@ -1076,12 +1107,7 @@ def create_install_plan(
         return InstallPlan(
             "windows-installer",
             package,
-            (
-                str(package),
-                "/S",
-                "/VIBECADUPDATE",
-                f"/VIBECADINSTALLROOT={install_root.resolve(strict=True)}",
-            ),
+            (str(package),),
             current_install_root=install_root.resolve(strict=True),
         )
     if asset.platform == "linux" and asset.kind == "appimage":
@@ -1107,9 +1133,12 @@ def record_pending_install(
 
     root = (update_directory or default_update_directory()).resolve()
     package = plan.package.resolve(strict=True)
-    downloads = (root / "downloads").resolve()
-    if downloads not in package.parents:
-        raise UpdateError("The staged package is outside the update cache.")
+    downloads = {
+        default_download_directory().resolve(),
+        (root / "downloads").resolve(),
+    }
+    if not any(directory in package.parents for directory in downloads):
+        raise UpdateError("The staged package is outside the Downloads directory.")
     payload: dict[str, object] = {
         "schema": 1,
         "status": "pending",
@@ -1204,10 +1233,13 @@ def complete_pending_install_health(
     package_value = str(payload.get("package") or "")
     if package_value:
         package = Path(package_value).resolve()
-        downloads = (root / "downloads").resolve()
-        if downloads not in package.parents:
-            raise UpdateError("Pending install package is outside the update cache.")
-        package.unlink(missing_ok=True)
+        visible_downloads = default_download_directory().resolve()
+        legacy_downloads = (root / "downloads").resolve()
+        downloads = {visible_downloads, legacy_downloads}
+        if not any(directory in package.parents for directory in downloads):
+            raise UpdateError("Pending install package is outside the Downloads directory.")
+        if legacy_downloads in package.parents:
+            package.unlink(missing_ok=True)
 
     receipt = {
         "schema": 1,

--- a/src/Mod/VibeCAD/VibeCADUpdateGui.py
+++ b/src/Mod/VibeCAD/VibeCADUpdateGui.py
@@ -265,68 +265,20 @@ class UpdateController(QtCore.QObject):
 
 
 def _launch_windows_install_helper(plan: InstallPlan) -> None:
-    install_root = plan.current_install_root
-    if install_root is None:
-        raise RuntimeError("The staged Windows plan has no install directory.")
     helper_dir = default_update_directory() / "install-helper"
     helper_dir.mkdir(parents=True, exist_ok=True)
     helper = helper_dir / "install-windows-update.ps1"
     helper.write_text(
         """param(
     [Parameter(Mandatory=$true)][string]$Installer,
-    [Parameter(Mandatory=$true)][string]$InstallRoot,
-    [Parameter(Mandatory=$true)][string]$PendingReceipt
+    [Parameter(Mandatory=$true)][int]$VibeCADProcessId
 )
 $ErrorActionPreference = 'Stop'
-$exitCode = 1
-try {
-    if ($InstallRoot.Contains('"')) {
-        throw 'The VibeCAD install path contains an unsupported quote character.'
-    }
-    $installArguments = '/S /VIBECADUPDATE /VIBECADINSTALLROOT="' + $InstallRoot + '"'
-    $process = Start-Process -FilePath $Installer -ArgumentList $installArguments -PassThru -Wait
-    $exitCode = $process.ExitCode
-    $application = Join-Path $InstallRoot 'bin\\VibeCAD.exe'
-    if ($exitCode -ne 0) {
-        exit $exitCode
-    }
-    if (-not (Test-Path -LiteralPath $application)) {
-        throw 'The updated VibeCAD executable is missing.'
-    }
-    $applicationProcess = Start-Process -FilePath $application -PassThru
-    $healthy = $false
-    for ($attempt = 0; $attempt -lt 120; $attempt++) {
-        if (-not (Test-Path -LiteralPath $PendingReceipt)) {
-            $healthy = $true
-            break
-        }
-        if ($applicationProcess.HasExited) {
-            break
-        }
-        Start-Sleep -Seconds 1
-        $applicationProcess.Refresh()
-    }
-    if ($healthy) {
-        exit 0
-    }
-    if (-not $applicationProcess.HasExited) {
-        Stop-Process -Id $applicationProcess.Id -Force
-        $applicationProcess.WaitForExit()
-    }
-    $rollbackArguments = '/S /VIBECADROLLBACK /VIBECADINSTALLROOT="' + $InstallRoot + '"'
-    $rollback = Start-Process -FilePath $Installer -ArgumentList $rollbackArguments -PassThru -Wait
-    $exitCode = $rollback.ExitCode
-    if ($exitCode -eq 0 -and (Test-Path -LiteralPath $application)) {
-        Start-Process -FilePath $application
-    }
+$vibecad = Get-Process -Id $VibeCADProcessId -ErrorAction SilentlyContinue
+if ($null -ne $vibecad) {
+    $vibecad | Wait-Process
 }
-finally {
-    $application = Join-Path $InstallRoot 'bin\\VibeCAD.exe'
-    if ($exitCode -ne 0 -and (Test-Path -LiteralPath $application)) {
-        Start-Process -FilePath $application
-    }
-}
-exit $exitCode
+Start-Process -FilePath $Installer
 """,
         encoding="utf-8",
         newline="\n",
@@ -342,8 +294,7 @@ exit $exitCode
             "-File",
             str(helper),
             str(plan.package),
-            str(install_root),
-            str(default_update_directory() / "pending-install.json"),
+            str(os.getpid()),
         ],
         close_fds=True,
         creationflags=(
@@ -639,7 +590,9 @@ class UpdateCenterDialog(QtWidgets.QDialog):
 
     @QtCore.Slot(object)
     def _install_staged(self, _plan: InstallPlan) -> None:
-        self.status.setText("The verified update is staged and will install as VibeCAD exits.")
+        self.status.setText(
+            "VibeCAD will close, then open the verified installer normally."
+        )
         self._refresh_buttons()
 
     def _install_and_restart(self) -> None:

--- a/src/Tools/tests/test_vibecad_update.py
+++ b/src/Tools/tests/test_vibecad_update.py
@@ -27,6 +27,7 @@ from VibeCADUpdate import (  # noqa: E402
     UpdateService,
     UpdateTrustError,
     current_release_identity,
+    default_download_directory,
     complete_pending_install_health,
     create_install_plan,
     load_update_policy,
@@ -307,6 +308,29 @@ class UpdateServiceTests(unittest.TestCase):
                 result = service.download_asset(asset)
         self.assertEqual(result, cached)
         verify.assert_not_called()
+
+    def test_default_download_directory_is_user_visible(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            home = Path(temp_dir)
+            with (
+                mock.patch("VibeCADUpdate.os.name", "posix"),
+                mock.patch("VibeCADUpdate.Path.home", return_value=home),
+            ):
+                downloads = default_download_directory()
+        self.assertEqual(downloads, (home / "Downloads").resolve())
+
+    def test_default_service_downloads_packages_to_user_downloads(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            downloads = Path(temp_dir) / "Downloads"
+            with mock.patch(
+                "VibeCADUpdate.default_download_directory",
+                return_value=downloads,
+            ):
+                service = UpdateService(
+                    ReleaseIdentity("26.3.1-RC3", 1),
+                    UpdatePolicy(),
+                )
+        self.assertEqual(service.download_directory, downloads.resolve())
 
     def test_tampered_cached_windows_installer_is_not_reused(self) -> None:
         asset = self._windows_asset(b"authorized installer fixture")
@@ -813,11 +837,7 @@ class UpdateServiceTests(unittest.TestCase):
                 asset,
                 install_root=install_root,
             )
-            self.assertEqual(plan.command[1:3], ("/S", "/VIBECADUPDATE"))
-            self.assertEqual(
-                plan.command[3],
-                f"/VIBECADINSTALLROOT={install_root.resolve()}",
-            )
+            self.assertEqual(plan.command, (str(package.resolve()),))
             record_pending_install(
                 plan,
                 original,
@@ -831,6 +851,47 @@ class UpdateServiceTests(unittest.TestCase):
             backup_exists = backup.exists()
         self.assertEqual(status, "healthy")
         self.assertTrue(backup_exists)
+
+    def test_health_receipt_keeps_installer_in_user_downloads(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir) / "state"
+            downloads = Path(temp_dir) / "Downloads"
+            root.mkdir()
+            downloads.mkdir()
+            package = downloads / "VibeCAD-installer.exe"
+            package.write_bytes(b"installer")
+            install_root = Path(temp_dir) / "VibeCAD 26.3"
+            install_root.mkdir()
+            original = ReleaseIdentity("26.3.1-RC3", 1)
+            target = ReleaseIdentity("26.3.1-RC3", 2)
+            asset = UpdateAsset(
+                "windows",
+                "x86_64",
+                "installer",
+                package.name,
+                "https://github.com/10-X-eng/vibecad/releases/download/"
+                f"{target.tag}/{package.name}",
+                package.stat().st_size,
+                hashlib.sha256(package.read_bytes()).hexdigest(),
+            )
+            with mock.patch(
+                "VibeCADUpdate.default_download_directory",
+                return_value=downloads,
+            ):
+                plan = create_install_plan(package, asset, install_root=install_root)
+                record_pending_install(
+                    plan,
+                    original,
+                    target,
+                    update_directory=root,
+                )
+                status = complete_pending_install_health(
+                    target,
+                    update_directory=root,
+                )
+            package_exists = package.exists()
+        self.assertEqual(status, "healthy")
+        self.assertTrue(package_exists)
 
 
 if __name__ == "__main__":

--- a/src/Tools/tests/test_windows_installer_version.py
+++ b/src/Tools/tests/test_windows_installer_version.py
@@ -74,6 +74,25 @@ class TestWindowsInstallerVersion(unittest.TestCase):
         self.assertIn('"UpdateVersion" "${APP_UPDATE_VERSION}"', configure)
         self.assertNotIn('$(AlreadyInstalled)', init)
 
+    def test_in_app_updater_launches_normal_installer_without_flags(self):
+        update_gui = (
+            INSTALLER_ROOT.parents[1]
+            / "src"
+            / "Mod"
+            / "VibeCAD"
+            / "VibeCADUpdateGui.py"
+        ).read_text(encoding="utf-8")
+        helper = update_gui.split(
+            "def _launch_windows_install_helper", 1
+        )[1].split("def _launch_appimage_install_helper", 1)[0]
+
+        self.assertIn("$vibecad | Wait-Process", helper)
+        self.assertIn("Start-Process -FilePath $Installer", helper)
+        self.assertNotIn("-ArgumentList", helper)
+        self.assertNotIn("/S", helper)
+        self.assertNotIn("/VIBECADUPDATE", helper)
+        self.assertNotIn("/VIBECADINSTALLROOT", helper)
+
     def test_rejects_negative_build(self):
         with self.assertRaisesRegex(ValueError, "non-negative"):
             MODULE.render_version_defines(


### PR DESCRIPTION
## Summary

- download update packages and resume files to the user's real Downloads folder
- wait for VibeCAD to exit, then launch the verified Windows installer normally with zero arguments
- retain the downloaded package in Downloads after successful installation
- keep only updater state and health receipts in application data

## Why

The special silent updater path (`/S /VIBECADUPDATE /VIBECADINSTALLROOT=...`) rolls back on this machine even though the exact same verified installer succeeds when launched normally. The updater state recorded the failed transition as `rolled-back`.

## Risk

Low and Windows-focused. Package discovery, manifest verification, size/SHA-256 authorization, clean replacement inside the installer, Linux AppImage handling, and existing private installer compatibility remain intact. Only the default package location and Windows launch behavior change.

## Test plan

- `python src/Tools/sync_version.py --check`
- `python -m unittest discover -s src/Tools/tests -v` (103 passed)
- confirmed Windows Known Folder lookup resolves to `C:\Users\robit\Downloads`
- regression contract proves the helper waits for VibeCAD and launches the installer without `ArgumentList`, `/S`, `/VIBECADUPDATE`, or `/VIBECADINSTALLROOT`

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing managed policy and update verification defaults remain intact.
- [x] Legacy cached-package paths remain accepted for pending receipts.
- [x] No breaking API changes are included.

## AI assistance

Prepared and verified with Codex assistance; the repository owner retains responsibility for the change.

- [x] This PR is not unverified AI output, I take responsibility for it.