### PR TITLE
Bump VibeCAD RC4 to Build 1

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 0
+  number: 1
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC4",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 0,
+  "build_version": 1,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Summary

- advance the immutable RC4 identity from Build 0 to Build 1
- synchronize the Rattler package build number
- prepare canonical preview tag `v26.3.1-RC4-build1`

## Why

Build 1 ships the verified Windows updater correction merged in #45: packages download to the user's real Downloads folder and the Windows installer launches normally with zero arguments after VibeCAD exits.

## Risk

Low. This PR changes only the public build number and generated Rattler build number. The updater behavior is reviewed separately in #45.

## Test plan

- `python src/Tools/sync_version.py --check`
- `python -m unittest discover -s src/Tools/tests` (103 passed)
- canonical title: `VibeCAD 26.3.1-RC4 (Build 1)`
- canonical tag: `v26.3.1-RC4-build1`

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Runtime defaults are unchanged by this metadata-only PR.
- [x] No deprecations were introduced.
- [x] No breaking changes are included.

## AI assistance

Prepared and verified with Codex assistance; the repository owner retains responsibility for the change.

- [x] This PR is not unverified AI output, I take responsibility for it.