### PR TITLE
Fix Codex stop and shutdown lifecycle

### DIFF
--- a/src/Mod/VibeCAD/VibeCADCodex.py
+++ b/src/Mod/VibeCAD/VibeCADCodex.py
@@ -30,6 +30,7 @@ CODEX_HOME_ENV = "VIBECAD_CODEX_HOME"
 CODEX_RUNTIME_DIRECTORY = "codex_runtime"
 CODEX_RUNTIME_MANIFEST = "runtime.json"
 DEFAULT_RPC_TIMEOUT_SECONDS = 30.0
+SERVER_REQUEST_SHUTDOWN_GRACE_SECONDS = 0.25
 LOGIN_TIMEOUT_SECONDS = 15.0 * 60.0
 MAX_SKILL_RESOURCE_BYTES = 256 * 1024
 CODEX_OPENAI_PROVIDER_ID = "vibecad_openai"
@@ -132,13 +133,12 @@ def vibecad_thread_config(
     for feature in DISABLED_CODEX_FEATURES:
         config[f"features.{feature}"] = False
     # Current Codex model catalogs can select code-mode-only tool dispatch even
-    # when the local feature toggle is false.  Core tools must remain direct:
-    # in particular, wrapping capture_view_screenshot in exec makes the model
-    # forward the whole dynamic-tool result through image(), which produces an
-    # invalid outer image_url instead of forwarding the valid inline image.
+    # when the local feature toggle is false. Core and interactive conversation
+    # tools must remain direct: viewport images cannot be wrapped in exec, and
+    # a user question must never be held inside a long-running exec cell.
     config["features.code_mode"] = {
         "enabled": False,
-        "direct_only_tool_namespaces": ["core"],
+        "direct_only_tool_namespaces": ["core", "conversation"],
     }
     if openai_base_url is not None:
         config.update(codex_openai_provider_config(openai_base_url))
@@ -310,11 +310,39 @@ class CodexAppServerClient:
         self._next_request_id = 1
         self._closed = threading.Event()
         self._stderr_lines: deque[str] = deque(maxlen=80)
+        self._server_request_threads: set[threading.Thread] = set()
+        self._shutdown_reason = ""
+        self._process_exit_code: int | None = None
+        self._late_server_response_count = 0
+        self._discarded_server_request_count = 0
 
     @property
     def stderr_tail(self) -> list[str]:
         with self._state_lock:
             return list(self._stderr_lines)
+
+    @property
+    def shutdown_details(self) -> dict[str, Any]:
+        """Return bounded transport lifecycle diagnostics."""
+
+        with self._state_lock:
+            exit_code = self._process_exit_code
+            if exit_code is None and self._process is not None:
+                exit_code = self._process.poll()
+            reason = self._shutdown_reason
+            if not reason and exit_code is not None:
+                reason = "app-server process exited"
+            return {
+                "closed": self._closed.is_set(),
+                "reason": reason,
+                "process_exit_code": exit_code,
+                "active_server_request_count": len(self._server_request_threads),
+                "late_server_response_count": self._late_server_response_count,
+                "discarded_server_request_count": (
+                    self._discarded_server_request_count
+                ),
+                "stderr_tail": list(self._stderr_lines)[-3:],
+            }
 
     @property
     def alive(self) -> bool:
@@ -445,16 +473,20 @@ class CodexAppServerClient:
             self._notification_handler = notification_handler
             self._server_request_handler = server_request_handler
 
-    def close(self) -> None:
+    def close(self, *, reason: str = "client shutdown") -> None:
         process = self._process
         if process is None:
             return
-        self._closed.set()
-        try:
-            if process.stdin is not None:
-                process.stdin.close()
-        except Exception:
-            pass
+        with self._state_lock:
+            if not self._shutdown_reason:
+                self._shutdown_reason = str(reason or "client shutdown")
+            self._closed.set()
+        with self._write_lock:
+            try:
+                if process.stdin is not None:
+                    process.stdin.close()
+            except Exception:
+                pass
         if process.poll() is None:
             process.terminate()
             try:
@@ -462,14 +494,22 @@ class CodexAppServerClient:
             except subprocess.TimeoutExpired:
                 process.kill()
                 process.wait(timeout=2.0)
+        with self._state_lock:
+            self._process_exit_code = process.poll()
         self._fail_pending("Codex app-server connection closed.")
+        self._wait_for_server_requests(SERVER_REQUEST_SHUTDOWN_GRACE_SECONDS)
 
     def _write_message(self, message: dict[str, Any]) -> None:
-        process = self._process
-        if process is None or process.stdin is None or process.poll() is not None:
-            raise CodexAppServerError("Codex app-server input is unavailable.")
         encoded = json.dumps(message, ensure_ascii=True, separators=(",", ":"))
         with self._write_lock:
+            process = self._process
+            if (
+                self._closed.is_set()
+                or process is None
+                or process.stdin is None
+                or process.poll() is not None
+            ):
+                raise CodexAppServerError("Codex app-server input is unavailable.")
             try:
                 process.stdin.write(encoded + "\n")
                 process.stdin.flush()
@@ -502,12 +542,16 @@ class CodexAppServerClient:
                     continue
                 self._dispatch_message(message)
         finally:
-            self._closed.set()
             code = process.poll() if process is not None else None
             tail = " | ".join(self.stderr_tail[-3:])
             detail = f"Codex app-server exited with code {code}."
             if tail:
                 detail += f" {tail}"
+            with self._state_lock:
+                if not self._shutdown_reason:
+                    self._shutdown_reason = "app-server output stream closed"
+                self._process_exit_code = code
+                self._closed.set()
             self._fail_pending(detail)
 
     def _read_stderr(self) -> None:
@@ -553,7 +597,19 @@ class CodexAppServerClient:
                 name=f"VibeCAD-Codex-request-{method}",
                 daemon=True,
             )
-            thread.start()
+            with self._state_lock:
+                if self._closed.is_set():
+                    self._discarded_server_request_count += 1
+                    self._stderr_lines.append(
+                        f"Discarded {method} request after transport shutdown."
+                    )
+                    return
+                self._server_request_threads.add(thread)
+                try:
+                    thread.start()
+                except Exception:
+                    self._server_request_threads.discard(thread)
+                    raise
             return
         with self._state_lock:
             notification_handler = self._notification_handler
@@ -569,29 +625,91 @@ class CodexAppServerClient:
         method: str,
         params: dict[str, Any],
     ) -> None:
-        with self._state_lock:
-            server_request_handler = self._server_request_handler
-        if server_request_handler is None:
-            self._write_message(
-                {
-                    "id": request_id,
-                    "error": {
-                        "code": -32601,
-                        "message": f"VibeCAD does not handle {method}.",
-                    },
-                }
-            )
-            return
         try:
-            result = server_request_handler(method, params)
-            self._write_message({"id": request_id, "result": result})
-        except Exception as exc:
-            self._write_message(
-                {
-                    "id": request_id,
-                    "error": {"code": -32000, "message": str(exc)},
-                }
+            with self._state_lock:
+                if self._closed.is_set():
+                    self._discarded_server_request_count += 1
+                    self._stderr_lines.append(
+                        f"Discarded {method} request after transport shutdown."
+                    )
+                    return
+                server_request_handler = self._server_request_handler
+            if server_request_handler is None:
+                self._send_server_response(
+                    {
+                        "id": request_id,
+                        "error": {
+                            "code": -32601,
+                            "message": f"VibeCAD does not handle {method}.",
+                        },
+                    },
+                    method=method,
+                )
+                return
+            try:
+                result = server_request_handler(method, params)
+            except Exception as exc:
+                self._send_server_response(
+                    {
+                        "id": request_id,
+                        "error": {"code": -32000, "message": str(exc)},
+                    },
+                    method=method,
+                )
+                return
+            self._send_server_response(
+                {"id": request_id, "result": result},
+                method=method,
             )
+        finally:
+            current = threading.current_thread()
+            with self._state_lock:
+                self._server_request_threads.discard(current)
+
+    def _send_server_response(
+        self,
+        message: dict[str, Any],
+        *,
+        method: str,
+    ) -> bool:
+        """Send one server-request reply or quietly retire it after shutdown."""
+
+        with self._state_lock:
+            if self._closed.is_set():
+                self._late_server_response_count += 1
+                self._stderr_lines.append(
+                    f"Discarded late {method} response after transport shutdown."
+                )
+                return False
+        try:
+            self._write_message(message)
+        except CodexAppServerError as exc:
+            with self._state_lock:
+                self._late_server_response_count += 1
+                self._stderr_lines.append(
+                    f"Discarded unsendable {method} response: {exc}"
+                )
+            return False
+        return True
+
+    def _wait_for_server_requests(self, timeout: float) -> None:
+        """Give detached request handlers a bounded chance to retire."""
+
+        deadline = time.monotonic() + max(0.0, float(timeout))
+        current = threading.current_thread()
+        while True:
+            with self._state_lock:
+                threads = [
+                    thread
+                    for thread in self._server_request_threads
+                    if thread is not current and thread.is_alive()
+                ]
+            if not threads:
+                return
+            remaining = deadline - time.monotonic()
+            if remaining <= 0.0:
+                return
+            threads[0].join(timeout=remaining)
 
     def _fail_pending(self, message: str) -> None:
         with self._state_lock:
@@ -604,7 +722,8 @@ class CodexAppServerClient:
 
 @dataclass(slots=True)
 class _ManagedCodexRuntime:
-    lock: threading.RLock
+    lease_lock: threading.RLock
+    state_lock: threading.RLock
     client: Any = None
     thread_ids: dict[str, str] = field(default_factory=dict)
 
@@ -622,8 +741,9 @@ class ManagedCodexSession:
         clean = str(thread_id or "").strip()
         if not clean:
             raise ValueError("Codex thread id cannot be empty.")
-        self._runtime.thread_ids[self._thread_key] = clean
-        self.thread_id = clean
+        with self._runtime.state_lock:
+            self._runtime.thread_ids[self._thread_key] = clean
+            self.thread_id = clean
 
 
 _managed_codex_lock = threading.RLock()
@@ -671,10 +791,14 @@ def managed_codex_session(
     with _managed_codex_lock:
         runtime = _managed_codex_runtimes.setdefault(
             key,
-            _ManagedCodexRuntime(lock=threading.RLock()),
+            _ManagedCodexRuntime(
+                lease_lock=threading.RLock(),
+                state_lock=threading.RLock(),
+            ),
         )
-    with runtime.lock:
-        client = runtime.client
+    with runtime.lease_lock:
+        with runtime.state_lock:
+            client = runtime.client
         if client is None or not bool(getattr(client, "alive", False)):
             client = client_factory(
                 notification_handler=notification_handler,
@@ -682,12 +806,15 @@ def managed_codex_session(
                 environment=environment,
             )
             client.start()
-            runtime.client = client
+            with runtime.state_lock:
+                runtime.client = client
         else:
             _set_client_handlers(client, notification_handler, server_request_handler)
+        with runtime.state_lock:
+            remembered_thread_id = str(runtime.thread_ids.get(clean_thread) or "")
         lease = ManagedCodexSession(
             client=client,
-            thread_id=str(runtime.thread_ids.get(clean_thread) or ""),
+            thread_id=remembered_thread_id,
             _runtime=runtime,
             _thread_key=clean_thread,
         )
@@ -697,6 +824,24 @@ def managed_codex_session(
             _set_client_handlers(client, None, None)
 
 
+def _take_managed_codex_runtimes() -> list[tuple[Any, tuple[str, ...]]]:
+    """Detach managed clients without waiting for an in-flight turn lease."""
+
+    with _managed_codex_lock:
+        runtimes = list(_managed_codex_runtimes.values())
+        _managed_codex_runtimes.clear()
+    detached: list[tuple[Any, tuple[str, ...]]] = []
+    for runtime in runtimes:
+        with runtime.state_lock:
+            client = runtime.client
+            thread_ids = tuple(dict.fromkeys(runtime.thread_ids.values()))
+            runtime.client = None
+            runtime.thread_ids.clear()
+        if client is not None:
+            detached.append((client, thread_ids))
+    return detached
+
+
 def reset_managed_codex_sessions() -> None:
     """Close managed transports and forget their in-process thread mapping."""
 
@@ -704,29 +849,44 @@ def reset_managed_codex_sessions() -> None:
         runtimes = list(_managed_codex_runtimes.values())
         _managed_codex_runtimes.clear()
     for runtime in runtimes:
-        with runtime.lock:
-            client = runtime.client
-            thread_ids = tuple(dict.fromkeys(runtime.thread_ids.values()))
-            runtime.client = None
-            runtime.thread_ids.clear()
-            if client is not None:
-                try:
-                    if bool(getattr(client, "alive", False)):
-                        for thread_id in thread_ids:
-                            try:
-                                client.request(
-                                    "thread/delete",
-                                    {"threadId": thread_id},
-                                    timeout=5.0,
-                                )
-                            except Exception:
-                                pass
-                    client.close()
-                except Exception:
-                    pass
+        # Explicit reset preserves its graceful behavior and waits for the
+        # exclusive turn lease. Application shutdown uses the force-close path
+        # below and must never wait here.
+        with runtime.lease_lock:
+            with runtime.state_lock:
+                client = runtime.client
+                thread_ids = tuple(dict.fromkeys(runtime.thread_ids.values()))
+                runtime.client = None
+                runtime.thread_ids.clear()
+            if client is None:
+                continue
+            try:
+                if bool(getattr(client, "alive", False)):
+                    for thread_id in thread_ids:
+                        try:
+                            client.request(
+                                "thread/delete",
+                                {"threadId": thread_id},
+                                timeout=5.0,
+                            )
+                        except Exception:
+                            pass
+                client.close()
+            except Exception:
+                pass
 
 
-atexit.register(reset_managed_codex_sessions)
+def shutdown_managed_codex_sessions() -> None:
+    """Force-close managed transports without waiting on active turn ownership."""
+
+    for client, _thread_ids in _take_managed_codex_runtimes():
+        try:
+            client.close()
+        except Exception:
+            pass
+
+
+atexit.register(shutdown_managed_codex_sessions)
 
 
 def load_codex_skill_catalog(

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -78,6 +78,8 @@ _PANEL_SPLITTER_PARAMETER = "PanelSplitterState"
 _PREFERENCES_PATH = "User parameter:BaseApp/Preferences/VibeCAD"
 _COMPOSER_ICON_ONLY_BREAKPOINT = 500
 _QT_WIDGET_MAXIMUM_SIZE = 16777215
+_DOCUMENT_THREAD_DISPATCH_POLL_SECONDS = 0.05
+_ASSISTANT_SHUTDOWN_JOIN_SECONDS = 1.0
 
 
 class _AssistantRunController:
@@ -129,10 +131,14 @@ class _DocumentThreadCall:
     def __init__(self, operation: Any) -> None:
         self.operation = operation
         self.completed = threading.Event()
+        self.cancelled = threading.Event()
         self.result: Any = None
         self.error: BaseException | None = None
 
     def execute(self) -> None:
+        if self.cancelled.is_set():
+            self.completed.set()
+            return
         try:
             self.result = self.operation()
         except BaseException as exc:
@@ -161,6 +167,8 @@ _document_thread_invoker: Any | None = None
 _pending_question_waiter: _QuestionWaiter | None = None
 _control_modes_initialized = False
 _control_mode_shutdown_connected = False
+_internal_agent_shutdown_connected = False
+_application_shutting_down = threading.Event()
 
 
 def _is_intent_memory_rebuild_active() -> bool:
@@ -172,6 +180,8 @@ def _is_intent_memory_rebuild_active() -> bool:
 
 def _ensure_document_thread_invoker() -> Any:
     """Create the queued Qt dispatcher while running on FreeCAD's GUI thread."""
+    if _application_shutting_down.is_set():
+        raise RuntimeError("VibeCAD is shutting down; Qt dispatch is unavailable.")
     global _document_thread_invoker
     if threading.current_thread() is not threading.main_thread():
         raise RuntimeError("The VibeCAD document-thread dispatcher must start on Qt.")
@@ -201,15 +211,46 @@ def _dispatch_to_document_thread(operation: Any) -> Any:
     """Synchronously execute a short GUI/document operation on FreeCAD's thread."""
     if threading.current_thread() is threading.main_thread():
         return operation()
+    if _application_shutting_down.is_set():
+        raise RuntimeError("VibeCAD is shutting down; Qt dispatch is unavailable.")
     invoker = _document_thread_invoker
     if invoker is None:
         raise RuntimeError("The VibeCAD document-thread dispatcher is not initialized.")
     request = _DocumentThreadCall(operation)
     invoker.requested.emit(request)
-    request.completed.wait()
+    while not request.completed.wait(_DOCUMENT_THREAD_DISPATCH_POLL_SECONDS):
+        if _application_shutting_down.is_set():
+            request.cancelled.set()
+            raise RuntimeError(
+                "VibeCAD shut down before the queued Qt operation could complete."
+            )
     if request.error is not None:
         raise request.error
     return request.result
+
+
+def _shutdown_internal_assistant() -> None:
+    """Cancel active internal work before Qt stops servicing queued calls."""
+
+    if _application_shutting_down.is_set():
+        return
+    _application_shutting_down.set()
+    _assistant_run_controller.request_cancel()
+    _intent_memory_rebuild_cancel_event.set()
+    _cancel_question_round()
+
+    try:
+        from VibeCADCodex import shutdown_managed_codex_sessions
+
+        shutdown_managed_codex_sessions()
+    except Exception as exc:
+        _warn(f"VibeCAD Codex shutdown failed: {exc}")
+
+    current = threading.current_thread()
+    for worker in (_assistant_run_thread, _intent_memory_rebuild_thread):
+        if worker is None or worker is current or not worker.is_alive():
+            continue
+        worker.join(timeout=_ASSISTANT_SHUTDOWN_JOIN_SECONDS)
 
 
 def _internal_agent_allowed() -> bool:
@@ -236,7 +277,8 @@ def _cancel_internal_agent_for_mcp() -> None:
 def _initialize_control_modes() -> None:
     """Bind the single control-mode state machine to the live Qt host once."""
 
-    global _control_modes_initialized, _control_mode_shutdown_connected
+    global _control_modes_initialized
+    global _control_mode_shutdown_connected, _internal_agent_shutdown_connected
     _ensure_document_thread_invoker()
     from PySide import QtWidgets
     from VibeCADMCP import get_control_mode_controller
@@ -273,9 +315,12 @@ def _initialize_control_modes() -> None:
             event_callback=handle_event,
         )
         _control_modes_initialized = True
-    if not _control_mode_shutdown_connected:
-        application = QtWidgets.QApplication.instance()
-        if application is not None:
+    application = QtWidgets.QApplication.instance()
+    if application is not None:
+        if not _internal_agent_shutdown_connected:
+            application.aboutToQuit.connect(_shutdown_internal_assistant)
+            _internal_agent_shutdown_connected = True
+        if not _control_mode_shutdown_connected:
             application.aboutToQuit.connect(
                 lambda: get_control_mode_controller().shutdown(wait=True)
             )
@@ -1029,9 +1074,17 @@ def _turn_image_paths(entry: dict[str, Any]) -> list[str]:
 
 def _append_transcript_block(output: Any, block_html: str) -> None:
     """Append one HTML block, preserving a blank line between turns."""
+    from PySide import QtGui
+
+    cursor = output.textCursor()
+    cursor.movePosition(QtGui.QTextCursor.End)
     if output.toPlainText().strip():
-        output.append("")
-    output.append(block_html)
+        neutral = QtGui.QTextBlockFormat()
+        neutral.setObjectIndex(-1)
+        cursor.insertBlock(neutral, QtGui.QTextCharFormat())
+        cursor.insertBlock(neutral, QtGui.QTextCharFormat())
+    cursor.insertFragment(QtGui.QTextDocumentFragment.fromHtml(block_html))
+    output.setTextCursor(cursor)
 
 
 def _append_output(
@@ -2341,7 +2394,7 @@ def _install_prompt_paste_filter(prompt: Any) -> None:
 
 
 def _install_prompt_submit_filter(prompt: Any) -> None:
-    """Submit the assistant composer on exactly Shift+Enter."""
+    """Submit the assistant composer on exactly Ctrl+Enter."""
 
     try:
         from PySide import QtCore
@@ -2354,7 +2407,7 @@ def _install_prompt_submit_filter(prompt: Any) -> None:
                 if (
                     event.type() == QtCore.QEvent.KeyPress
                     and event.key() in {QtCore.Qt.Key_Return, QtCore.Qt.Key_Enter}
-                    and event.modifiers() == QtCore.Qt.ShiftModifier
+                    and event.modifiers() == QtCore.Qt.ControlModifier
                 ):
                     _run_prompt_from_panel()
                     return True
@@ -2411,9 +2464,9 @@ def _apply_composer_button_presentation(
         "VibeSend": (
             "Steer" if is_busy else "Send",
             (
-                "Steer the current CAD run (Shift+Enter)"
+                "Steer the current CAD run (Ctrl+Enter)"
                 if is_busy
-                else "Send this message to VibeCAD (Shift+Enter)"
+                else "Send this message to VibeCAD (Ctrl+Enter)"
             ),
         ),
         "VibeStop": (
@@ -2668,13 +2721,14 @@ def _render_assistant_run_state(dock: Any, text: str | None = None) -> None:
     if dock is None:
         return
     busy = _is_assistant_run_active()
+    cancel_requested = _is_assistant_cancel_requested()
     control = _control_mode_snapshot()
     internal_available = bool(control.get("internal_agent_enabled"))
     persistence = _document_persistence_state()
     document_ready = bool(persistence.get("enabled"))
     pending_sketch = _sketch_close_continuation_controller.snapshot()
     dock.setProperty("VibeRunActive", busy)
-    dock.setProperty("VibeCancelRequested", _is_assistant_cancel_requested())
+    dock.setProperty("VibeCancelRequested", cancel_requested)
     dock.setProperty("VibeDocumentReady", document_ready)
 
     send_button = _find_child("QPushButton", "VibeSend", dock)
@@ -2691,9 +2745,13 @@ def _render_assistant_run_state(dock: Any, text: str | None = None) -> None:
     composer_buttons = _find_child("QWidget", "VibeComposerButtons", dock)
 
     if send_button is not None:
-        send_button.setEnabled(internal_available and (busy or document_ready))
+        send_button.setEnabled(
+            internal_available
+            and not cancel_requested
+            and (busy or document_ready)
+        )
     if stop_button is not None:
-        stop_button.setEnabled(busy)
+        stop_button.setEnabled(busy and not cancel_requested)
     if attach_button is not None:
         attach_button.setEnabled(internal_available and document_ready and not busy)
     if attach_image_button is not None:
@@ -2737,7 +2795,9 @@ def _render_assistant_run_state(dock: Any, text: str | None = None) -> None:
         )
     if prompt_box is not None:
         prompt_box.setReadOnly(
-            not internal_available or (not busy and not document_ready)
+            not internal_available
+            or cancel_requested
+            or (not busy and not document_ready)
         )
         if not internal_available:
             placeholder = "VibeCAD is controlled by an external MCP client."
@@ -2791,7 +2851,9 @@ def _stop_prompt_from_panel() -> None:
     if not _is_assistant_run_active():
         _render_assistant_run_state(dock)
         return
-    _assistant_run_controller.request_cancel()
+    if not _assistant_run_controller.request_cancel():
+        _render_assistant_run_state(dock)
+        return
     _cancel_question_round()
     _render_assistant_run_state(
         dock, text="Stopping after the current provider/tool step..."
@@ -2946,7 +3008,10 @@ def _execute_assistant_run(
         current_dock = _find_dock() or dock
         run_succeeded = False
         terminal_status = ""
-        if failure is not None:
+        run_cancelled = _cancelled()
+        if run_cancelled:
+            terminal_status = "Stopped."
+        elif failure is not None:
             terminal_status = f"The CAD run failed: {failure}"
             _append_conversation(
                 "System",
@@ -2980,7 +3045,7 @@ def _execute_assistant_run(
                     "Intent Memory update failed; uncovered turns were retained"
                     f" | {memory_update.get('error', 'unknown error')}"
                 )
-            run_succeeded = response.error is None and not _cancelled()
+            run_succeeded = response.error is None
 
         _assistant_run_controller.finish(run_id)
         _cancel_question_round()
@@ -3033,13 +3098,29 @@ def _execute_assistant_run(
                     **common_arguments,
                 )
         except BaseException as exc:
-            _dispatch_to_document_thread(
-                lambda failure=exc: _complete_run(None, failure)
-            )
+            if _application_shutting_down.is_set():
+                _assistant_run_controller.finish(run_id)
+                return
+            try:
+                _dispatch_to_document_thread(
+                    lambda failure=exc: _complete_run(None, failure)
+                )
+            except RuntimeError:
+                if not _application_shutting_down.is_set():
+                    raise
+                _assistant_run_controller.finish(run_id)
             return
-        _dispatch_to_document_thread(
-            lambda result=response: _complete_run(result, None)
-        )
+        if _application_shutting_down.is_set():
+            _assistant_run_controller.finish(run_id)
+            return
+        try:
+            _dispatch_to_document_thread(
+                lambda result=response: _complete_run(result, None)
+            )
+        except RuntimeError:
+            if not _application_shutting_down.is_set():
+                raise
+            _assistant_run_controller.finish(run_id)
 
     _assistant_run_thread = threading.Thread(
         target=_run_in_background,
@@ -4199,7 +4280,7 @@ def _build_panel_widget():
     send_button.setObjectName("VibeSend")
     send_button.setIcon(QtGui.QIcon(_icon_path(ICON_SEND)))
     send_button.setIconSize(icon_size)
-    send_button.setToolTip("Send this message to VibeCAD (Shift+Enter)")
+    send_button.setToolTip("Send this message to VibeCAD (Ctrl+Enter)")
     send_button.setDefault(True)
     send_button.clicked.connect(_run_prompt_from_panel)
 

--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -585,6 +585,30 @@ def _codex_tool_image_steer_input(
     )
 
 
+def _codex_shutdown_summary(client: Any) -> str:
+    """Return concise app-server lifecycle state for provider failures."""
+
+    details = getattr(client, "shutdown_details", None)
+    if callable(details):
+        details = details()
+    if not isinstance(details, dict):
+        return ""
+    values: list[str] = []
+    reason = str(details.get("reason") or "").strip()
+    if reason:
+        values.append(f"reason={reason}")
+    exit_code = details.get("process_exit_code")
+    if exit_code is not None:
+        values.append(f"exit_code={exit_code}")
+    active = details.get("active_server_request_count")
+    if isinstance(active, int) and active > 0:
+        values.append(f"active_tool_calls={active}")
+    late = details.get("late_server_response_count")
+    if isinstance(late, int) and late > 0:
+        values.append(f"discarded_late_replies={late}")
+    return ", ".join(values)
+
+
 def _codex_context_screenshot_steer_input(
     context: dict[str, Any],
 ) -> list[dict[str, Any]]:
@@ -1239,9 +1263,11 @@ class CodexProvider(BaseProvider):
                     finally:
                         raise TimeoutError
                 if not client.alive:
+                    shutdown = _codex_shutdown_summary(client)
                     tail = " | ".join(client.stderr_tail[-3:])
                     raise ProviderUnavailable(
                         "Codex app-server stopped during the VibeCAD turn"
+                        + (f" ({shutdown})" if shutdown else "")
                         + (f": {tail}" if tail else ".")
                     )
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
@@ -87,7 +87,7 @@ class TestVibeCADNativePanelStartup(unittest.TestCase):
 class TestVibeCADResponsiveAssistant(unittest.TestCase):
     """Exercise the compact composer against the real Qt layout engine."""
 
-    def test_shift_enter_sends_while_plain_enter_edits(self) -> None:
+    def test_ctrl_enter_sends_while_plain_enter_edits(self) -> None:
         import FreeCAD as App
 
         if not App.GuiUp:
@@ -112,15 +112,15 @@ class TestVibeCADResponsiveAssistant(unittest.TestCase):
             self.assertTrue(prompt.property("VibeSubmitFilterInstalled"))
             send_button = root.findChild(QtWidgets.QPushButton, "VibeSend")
             self.assertIsNotNone(send_button)
-            self.assertIn("Shift+Enter", send_button.toolTip())
+            self.assertIn("Ctrl+Enter", send_button.toolTip())
             prompt.setPlainText("Build the mounting bracket")
 
-            shift_enter = QtGui.QKeyEvent(
+            ctrl_enter = QtGui.QKeyEvent(
                 QtCore.QEvent.KeyPress,
                 QtCore.Qt.Key_Return,
-                QtCore.Qt.ShiftModifier,
+                QtCore.Qt.ControlModifier,
             )
-            application.sendEvent(prompt, shift_enter)
+            application.sendEvent(prompt, ctrl_enter)
             self.assertEqual(submitted, ["Build the mounting bracket"])
             self.assertEqual(prompt.toPlainText(), "Build the mounting bracket")
 
@@ -138,6 +138,36 @@ class TestVibeCADResponsiveAssistant(unittest.TestCase):
                 root.close()
                 root.deleteLater()
                 application.processEvents()
+
+    def test_transcript_turn_starts_outside_prior_markdown_list(self) -> None:
+        import FreeCAD as App
+
+        if not App.GuiUp:
+            self.skipTest("FreeCAD GUI mode is required")
+
+        from PySide import QtWidgets
+
+        import VibeCADGui
+
+        output = QtWidgets.QTextBrowser()
+        VibeCADGui._append_transcript_block(
+            output,
+            VibeCADGui._transcript_block_html(
+                "VibeCAD:\nFinished:\n\n- Added slots\n- Added fillets"
+            ),
+        )
+        VibeCADGui._append_transcript_block(
+            output,
+            VibeCADGui._transcript_block_html("User:\nMake the slots longer"),
+        )
+
+        self.assertIn("Added fillets\n\nUser:", output.toPlainText())
+        rendered = output.document().toHtml()
+        user_position = rendered.index("User:</span>")
+        self.assertGreater(
+            rendered.rfind("</ul>", 0, user_position),
+            rendered.rfind("<ul", 0, user_position),
+        )
 
     def test_narrow_composer_uses_distinct_icons_without_words(self) -> None:
         import FreeCAD as App

--- a/src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py
@@ -797,7 +797,7 @@ def test_codex_thread_config_disables_non_vibecad_tool_surfaces() -> None:
     assert config["include_collaboration_mode_instructions"] is False
     assert config["features.code_mode"] == {
         "enabled": False,
-        "direct_only_tool_namespaces": ["core"],
+        "direct_only_tool_namespaces": ["core", "conversation"],
     }
 
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_codex_transport_lifecycle.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_codex_transport_lifecycle.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Codex stdio lifecycle regressions independent of a live provider."""
+
+from __future__ import annotations
+
+import json
+import threading
+import time
+from typing import Any
+
+import pytest
+
+import VibeCADCodex as codex
+
+
+class _InputPipe:
+    def __init__(self) -> None:
+        self.closed = False
+        self.messages: list[str] = []
+
+    def write(self, value: str) -> None:
+        if self.closed:
+            raise BrokenPipeError("closed test pipe")
+        self.messages.append(value)
+
+    def flush(self) -> None:
+        if self.closed:
+            raise BrokenPipeError("closed test pipe")
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _Process:
+    def __init__(self) -> None:
+        self.stdin = _InputPipe()
+        self.returncode: int | None = None
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+    def terminate(self) -> None:
+        self.returncode = -15
+
+    def wait(self, timeout: float | None = None) -> int:
+        del timeout
+        assert self.returncode is not None
+        return self.returncode
+
+    def kill(self) -> None:
+        self.returncode = -9
+
+
+def _wait_until(predicate, *, timeout: float = 1.0) -> None:
+    deadline = time.monotonic() + timeout
+    while not predicate():
+        if time.monotonic() >= deadline:
+            raise AssertionError("Timed out waiting for Codex transport state.")
+        time.sleep(0.005)
+
+
+@pytest.mark.parametrize("handler_fails", [False, True])
+def test_close_discards_late_server_request_reply_without_thread_exception(
+    monkeypatch: pytest.MonkeyPatch,
+    handler_fails: bool,
+) -> None:
+    started = threading.Event()
+    release = threading.Event()
+    uncaught: list[BaseException] = []
+
+    def handler(_method: str, _params: dict[str, Any]) -> dict[str, bool]:
+        started.set()
+        assert release.wait(2.0)
+        if handler_fails:
+            raise RuntimeError("late tool failure")
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        threading,
+        "excepthook",
+        lambda args: uncaught.append(args.exc_value),
+    )
+    client = codex.CodexAppServerClient(server_request_handler=handler)
+    process = _Process()
+    client._process = process
+
+    client._dispatch_message(
+        {
+            "id": 7,
+            "method": "item/tool/call",
+            "params": {"tool": "conversation.ask_user"},
+        }
+    )
+    assert started.wait(1.0)
+
+    before = time.monotonic()
+    client.close(reason="test cancellation during interactive tool")
+    elapsed = time.monotonic() - before
+    release.set()
+    _wait_until(
+        lambda: client.shutdown_details["active_server_request_count"] == 0
+    )
+
+    assert elapsed < 1.0
+    assert uncaught == []
+    assert process.stdin.messages == []
+    assert client.shutdown_details == {
+        "closed": True,
+        "reason": "test cancellation during interactive tool",
+        "process_exit_code": -15,
+        "active_server_request_count": 0,
+        "late_server_response_count": 1,
+        "discarded_server_request_count": 0,
+        "stderr_tail": [
+            "Discarded late item/tool/call response after transport shutdown."
+        ],
+    }
+
+
+def test_live_server_request_failure_sends_one_error_reply() -> None:
+    def handler(_method: str, _params: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("question UI failed")
+
+    client = codex.CodexAppServerClient(server_request_handler=handler)
+    process = _Process()
+    client._process = process
+
+    client._dispatch_message(
+        {"id": 9, "method": "item/tool/call", "params": {}}
+    )
+    _wait_until(lambda: bool(process.stdin.messages))
+    _wait_until(
+        lambda: client.shutdown_details["active_server_request_count"] == 0
+    )
+
+    messages = [
+        json.loads(line)
+        for payload in process.stdin.messages
+        for line in payload.splitlines()
+        if line
+    ]
+    assert messages == [
+        {
+            "id": 9,
+            "error": {"code": -32000, "message": "question UI failed"},
+        }
+    ]
+    assert client.shutdown_details["late_server_response_count"] == 0
+    client.close(reason="test complete")
+
+
+def test_managed_shutdown_does_not_wait_for_active_turn_lease() -> None:
+    entered = threading.Event()
+    closed = threading.Event()
+    released = threading.Event()
+
+    class _ManagedClient:
+        def __init__(
+            self,
+            *,
+            notification_handler,
+            server_request_handler,
+            environment=None,
+        ) -> None:
+            del environment
+            self.notification_handler = notification_handler
+            self.server_request_handler = server_request_handler
+            self.alive = True
+
+        def start(self) -> None:
+            return None
+
+        def set_handlers(
+            self,
+            *,
+            notification_handler,
+            server_request_handler,
+        ) -> None:
+            self.notification_handler = notification_handler
+            self.server_request_handler = server_request_handler
+
+        def close(self) -> None:
+            self.alive = False
+            closed.set()
+
+    codex.shutdown_managed_codex_sessions()
+
+    def hold_turn_lease() -> None:
+        with codex.managed_codex_session(
+            runtime_key="shutdown-runtime",
+            thread_key="shutdown-thread",
+            client_factory=_ManagedClient,
+            notification_handler=lambda _method, _params: None,
+            server_request_handler=lambda _method, _params: {},
+        ):
+            entered.set()
+            assert closed.wait(2.0)
+        released.set()
+
+    worker = threading.Thread(target=hold_turn_lease, daemon=True)
+    worker.start()
+    assert entered.wait(1.0)
+
+    before = time.monotonic()
+    codex.shutdown_managed_codex_sessions()
+    elapsed = time.monotonic() - before
+
+    assert elapsed < 0.5
+    assert closed.is_set()
+    assert released.wait(1.0)
+    worker.join(timeout=1.0)
+    assert not worker.is_alive()


### PR DESCRIPTION
## Summary

- synchronize Codex request replies with transport shutdown so late tool-call responses cannot write to a closed app-server pipe
- make Stop cancel pending questions and active assistant work cleanly, with bounded worker and managed-session retirement during application exit
- add concise shutdown diagnostics for provider failures without leaking noisy transport details
- use Ctrl+Enter for Send and isolate transcript turns so later user messages cannot inherit prior Markdown list formatting

## Issues

Closes #22

## Verification

- `python3 -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_codex_transport_lifecycle.py src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py`
  - 74 passed, 5 skipped
- `VibeCADScripts` target built successfully during implementation
- real bundled-Codex/Qt checks covered Stop during `conversation.ask_user`, live-window shutdown with a pending question, and Markdown turn boundaries
- `git diff --check`

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing defaults remain unchanged outside the corrected Stop/shutdown behavior and requested Send shortcut.
- [x] No deprecations or breaking changes are introduced.

## Before and After Images

Not applicable: this corrects lifecycle, keyboard, and transcript-boundary behavior without changing the panel layout.

## AI assistance

Implementation and verification were assisted by OpenAI Codex (GPT-5). The repository owner should review and take responsibility for the final change before merge.

- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.