### PR TITLE
Sharpen VibeScript modeling and add stable planar face edits

### DIFF
--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
@@ -17969,8 +17969,10 @@ class PartDesignDomainAdapter(DeclarativeDomainAdapter):
                 "add/remove features: pass the exact prior feature as base."
             ),
             "standalone": (
-                "new_solid is standalone. api.publish keeps it standalone; api.body "
-                "promotes supported sketch extrusions/revolutions/lofts to Body history."
+                "new_solid is standalone. For extrude, pass distance_mm; vector is an "
+                "optional normalized direction, not displacement. api.publish keeps "
+                "standalone topology standalone; api.body promotes supported sketch "
+                "extrusions/revolutions/lofts to Body history."
             ),
         }
         selector_schema = {

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
@@ -11,6 +11,7 @@ inspection, and deletion adapters must all be registered.
 from __future__ import annotations
 
 import ast
+import copy
 from dataclasses import dataclass
 import hashlib
 import inspect
@@ -184,6 +185,7 @@ _API_GROUPS_BY_DOMAIN: dict[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
                 "fillet",
                 "chamfer",
                 "thickness",
+                "move_planar_faces",
                 "hole",
                 "holes",
                 "bosses",
@@ -305,6 +307,7 @@ _API_GROUPS_BY_DOMAIN: dict[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
 # context stays small without asking a model to guess primitive contracts.
 _CORE_API_EXPORTS_BY_DOMAIN: dict[str, tuple[str, ...]] = {
     "partdesign": (
+        "from_object",
         "box",
         "wedge",
         "plane",
@@ -320,6 +323,7 @@ _CORE_API_EXPORTS_BY_DOMAIN: dict[str, tuple[str, ...]] = {
         "holes",
         "bosses",
         "find_subelements",
+        "move_planar_faces",
         "fillet",
         "chamfer",
         "transform",
@@ -607,6 +611,7 @@ VIBESCRIPT_WORKBENCH_PACKS: dict[str, VibeScriptWorkbenchPack] = {
             "fillet",
             "chamfer",
             "thickness",
+            "move_planar_faces",
             "hole",
             "holes",
             "bosses",
@@ -5252,8 +5257,36 @@ def validate_program_contract(
     adapter = get_domain_adapter(pack.domain)
     if adapter is not None:
         adapter.validate_source(source)
-    clean_schema = validate_input_schema(input_schema)
     clean_inputs = validate_inputs(inputs)
+    normalized_schema = copy.deepcopy(input_schema)
+    if isinstance(normalized_schema, dict):
+        properties = normalized_schema.get("properties")
+        if isinstance(properties, dict):
+            for name, value in clean_inputs.items():
+                property_schema = properties.get(name)
+                if (
+                    is_document_reference(value)
+                    and isinstance(property_schema, dict)
+                    and property_schema.get("x-vibecad-reference") is True
+                ):
+                    property_schema.setdefault("type", "object")
+                    reference_properties = property_schema.setdefault("properties", {})
+                    if isinstance(reference_properties, dict):
+                        reference_properties.setdefault(
+                            "document_uid", {"type": "string"}
+                        )
+                        reference_properties.setdefault(
+                            "object_name", {"type": "string"}
+                        )
+                        if "document_path" in value:
+                            reference_properties.setdefault(
+                                "document_path", {"type": "string"}
+                            )
+                    property_schema.setdefault(
+                        "required", ["document_uid", "object_name"]
+                    )
+                    property_schema.setdefault("additionalProperties", False)
+    clean_schema = validate_input_schema(normalized_schema)
     errors = sorted(
         Draft202012Validator(clean_schema).iter_errors(clean_inputs),
         key=lambda error: tuple(str(item) for item in error.absolute_path),

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
@@ -410,11 +410,11 @@ def _core_api_snapshot(pack: "VibeScriptWorkbenchPack") -> dict[str, Any]:
             },
             "output_types": list(pack.output_types),
             "result_rule": (
-                "One output: result=final_api_value. Multiple outputs: result is an ordered "
-                "mapping whose keys exactly equal expected_outputs names. VibeCAD publishes "
-                "a solid/feature as its stable Design Body and other matching topology as "
-                "its stable output. api.body/api.publish are optional only for interfaces, "
-                "checks, material, or appearance."
+                "Output names are identifiers; human text belongs in api labels. One "
+                "output: result=final_api_value. Multiple outputs: ordered mapping with keys "
+                "exactly matching expected_outputs. VibeCAD publishes solid/features as "
+                "Design Bodies and matching topology directly. Use api.body/api.publish "
+                "only for interfaces, checks, material, or appearance."
             ),
         },
         "api": calls,
@@ -5828,10 +5828,10 @@ def universal_tool_specs() -> tuple[dict[str, Any], ...]:
     )
     outputs = _property_schema(
         (
-            "Only user-requested final deliverables, never intermediate bases, cutters, "
-            "sketches, or selectors. A requested single part is exactly one solid output. "
-            "Names equal final result keys; types are active-domain output types, never "
-            "class names such as Body or Sketch."
+            "Final deliverables only; no intermediate bases, cutters, sketches, or "
+            "selectors. One requested part is one solid output. Names are 1-64 character "
+            "identifiers and equal final result keys; types are active-domain output types, "
+            "not class names such as Body or Sketch."
         ),
         type="array",
         minItems=1,
@@ -6082,7 +6082,7 @@ def universal_tool_specs() -> tuple[dict[str, Any], ...]:
                         type="boolean",
                     ),
                     "max_subelements": _property_schema(
-                        "Maximum faces and edges returned.",
+                        "Returned faces and edges; omit for 32, maximum 32.",
                         type="integer",
                         minimum=1,
                         maximum=32,
@@ -6167,7 +6167,7 @@ def universal_tool_specs() -> tuple[dict[str, Any], ...]:
                         items={"type": "number"},
                     ),
                     "x_direction": _property_schema(
-                        "Primitive local +X; sets roll.",
+                        "Primitive local +X; sets roll and cannot be parallel to direction.",
                         type="array",
                         minItems=3,
                         maxItems=3,

--- a/src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py
@@ -754,6 +754,29 @@ def test_topology_editing_accepts_stable_queries_and_keeps_index_compatibility()
     assert (legacy.operation, legacy.output_type) == ("subshape", "face")
 
 
+def test_move_planar_faces_uses_stable_queries_and_signed_distance() -> None:
+    api = PartDesignDomainAPI(PartDesignDomainAPI.exported_names, OUTPUT_TYPES)
+    base = api.box(10, 20, 30)
+    positive_x = api.find_subelements(
+        element_type="face",
+        expected_count=1,
+        geometry_type="Plane",
+        normal=[1, 0, 0],
+    )
+
+    moved = api.move_planar_faces(base, positive_x, 2)
+    payload = moved.to_payload()
+
+    assert (moved.operation, moved.output_type) == (
+        "model_move_planar_faces",
+        "solid",
+    )
+    assert payload["arguments"][1] == [positive_x]
+    assert payload["arguments"][2] == 2.0
+    with pytest.raises(ValueError, match="distance_mm must be non-zero"):
+        api.move_planar_faces(base, positive_x, 0)
+
+
 def test_body_and_standalone_options_are_never_silently_reinterpreted() -> None:
     api = PartDesignDomainAPI(PartDesignDomainAPI.exported_names, OUTPUT_TYPES)
     feature = api.extrude(

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_document_portability.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_document_portability.py
@@ -149,6 +149,35 @@ def test_edited_input_values_keep_existing_constraints() -> None:
     assert synchronized["required"] == ["width"]
 
 
+def test_program_contract_completes_a_marked_stable_reference_schema() -> None:
+    reference = {"document_uid": "document", "object_name": "Source"}
+    contract = domains.validate_program_contract(
+        _pack(),
+        source="result = {'Result': api.from_object(inputs['source'], output_type='solid')}\n",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "source": {"type": "object", "x-vibecad-reference": True}
+            },
+            "required": ["source"],
+            "additionalProperties": False,
+        },
+        inputs={"source": reference},
+        expected_outputs=EXPECTED_OUTPUTS,
+    )
+
+    assert contract["input_schema"]["properties"]["source"] == {
+        "type": "object",
+        "x-vibecad-reference": True,
+        "properties": {
+            "document_uid": {"type": "string"},
+            "object_name": {"type": "string"},
+        },
+        "required": ["document_uid", "object_name"],
+        "additionalProperties": False,
+    }
+
+
 def test_runtime_hydrates_missing_local_artifact_from_document(
     tmp_path: Path,
 ) -> None:

--- a/src/Mod/VibeCAD/vibescript_part_api.py
+++ b/src/Mod/VibeCAD/vibescript_part_api.py
@@ -325,7 +325,7 @@ class PartDomainAPI:
         output_type: str,
         label: str = "",
     ) -> DomainValue:
-        """Snapshot a referenced live object's exact Shape for isolated Part operations."""
+        """Snapshot a live object's exact Shape; reference must be a validated inputs value marked x-vibecad-reference."""
 
         operation = "from_object"
         return self._value(

--- a/src/Mod/VibeCAD/vibescript_part_api.py
+++ b/src/Mod/VibeCAD/vibescript_part_api.py
@@ -346,7 +346,7 @@ class PartDomainAPI:
         x_direction: Sequence[float] | None = None,
         label: str = "",
     ) -> DomainValue:
-        """Solid box in mm; exact size keywords are length, width, and height. Its origin is the minimum corner. With default axes it occupies X=[origin[0], origin[0]+length], Y=[origin[1], origin[1]+width], Z=[origin[2], origin[2]+height]; direction sets local +Z and x_direction sets local +X."""
+        """Solid box in mm; exact size keywords are length, width, and height. Its origin is the minimum corner. With default axes it occupies X=[origin[0], origin[0]+length], Y=[origin[1], origin[1]+width], Z=[origin[2], origin[2]+height]; direction sets local +Z and x_direction sets local +X; they cannot be parallel."""
 
         operation = "box"
         clean_direction = _vector(

--- a/src/Mod/VibeCAD/vibescript_partdesign_api.py
+++ b/src/Mod/VibeCAD/vibescript_partdesign_api.py
@@ -965,6 +965,7 @@ class PartDesignDomainAPI:
         "fillet",
         "chamfer",
         "thickness",
+        "move_planar_faces",
         "hole",
         "holes",
         "bosses",
@@ -2750,6 +2751,52 @@ class PartDesignDomainAPI:
             inward=bool(inward),
             join=clean_join,
             label=_label("thickness", label),
+        )
+
+    def move_planar_faces(
+        self,
+        base: DomainValue,
+        selection: Mapping[str, Any] | Sequence[Mapping[str, Any]],
+        distance_mm: float,
+        *,
+        label: str = "",
+    ) -> DomainValue:
+        """Move selected planar faces along their outward normals; positive grows the solid, negative removes material. Pass one exact face query or a list of queries."""
+
+        clean_base = _topology(
+            "move_planar_faces", "base", base, allowed={"solid"}
+        )
+        raw_selections = (
+            [selection] if isinstance(selection, Mapping) else selection
+        )
+        if (
+            not isinstance(raw_selections, (list, tuple))
+            or not raw_selections
+            or len(raw_selections) > 64
+        ):
+            raise _error(
+                "move_planar_faces",
+                "selection",
+                "must be one face query or a list of 1 to 64 face queries",
+            )
+        selections = [
+            _selection("move_planar_faces", item, element_type="face")
+            for item in raw_selections
+        ]
+        distance = _number(
+            "move_planar_faces", "distance_mm", distance_mm
+        )
+        if abs(distance) <= 1.0e-12:
+            raise _error(
+                "move_planar_faces", "distance_mm", "must be non-zero", distance_mm
+            )
+        return self._graph(
+            "model_move_planar_faces",
+            "solid",
+            clean_base,
+            selections,
+            distance,
+            label=_label("move_planar_faces", label),
         )
 
     def hole(

--- a/src/Mod/VibeCAD/vibescript_partdesign_api.py
+++ b/src/Mod/VibeCAD/vibescript_partdesign_api.py
@@ -1736,11 +1736,12 @@ class PartDesignDomainAPI:
     ) -> DomainValue:
         """Extrude when the cross-section stays constant.
 
-        For Body features use add_material or remove_material with base as needed.
-        direction is along_normal, opposite_normal, or symmetric; it has the
-        same meaning for additions and cuts. A cut needs distance_mm or through_all.
-        new_solid/new_surface create standalone geometry; vector and output_type
-        apply only there.
+        Body features use add_material/remove_material and base after the first
+        addition. direction has the same meaning for additions and cuts:
+        along_normal, opposite_normal, or symmetric. Cuts need distance_mm or
+        through_all. Standalone new_solid/new_surface always need distance_mm;
+        vector optionally overrides the profile normal and is normalized, not a
+        displacement. Omit output_type; it is inferred from the source.
         """
 
         intent = _operation_intent("extrude", operation, allow_creation=True)
@@ -2191,7 +2192,7 @@ class PartDesignDomainAPI:
         refine: bool = True,
         label: str = "",
     ) -> DomainValue:
-        """Union/intersect all shapes; subtract uses the first as base and the rest as tools. output_type='solid' requires one connected result; 'compound' permits separate pieces."""
+        """Union/intersect all shapes; subtract uses the first as base. A solid union needs positive-volume overlap at each operand; face/edge contact is invalid. compound permits separate pieces."""
 
         intent = str(operation or "").strip().lower()
         if intent not in {"union", "subtract", "intersect"}:
@@ -2236,7 +2237,7 @@ class PartDesignDomainAPI:
         refine: bool = True,
         label: str = "",
     ) -> DomainValue:
-        """Fuse two or more solids; output_type='solid' requires one connected result."""
+        """Fuse solids. A solid result needs positive-volume overlap at each operand; face/edge contact is invalid. compound permits separate pieces."""
 
         return self.boolean(
             shapes,

--- a/src/Mod/VibeCAD/vibescript_partdesign_worker.py
+++ b/src/Mod/VibeCAD/vibescript_partdesign_worker.py
@@ -1534,6 +1534,8 @@ def _build_model_shape(
         "model_thickness",
     }:
         return _build_direct_dressup_shape(body, payload, memo, sketch_evidence)
+    if operation == "model_move_planar_faces":
+        return _build_move_planar_faces_shape(body, payload, memo, sketch_evidence)
     raise PartDesignCandidateError(
         f"Unsupported consolidated modeling operation {operation!r}.",
         details={"stage": "operation_dispatch", "operation": operation},
@@ -1724,6 +1726,103 @@ def _build_direct_dressup_shape(
         "api.draft requires a Body feature base.",
         details={"stage": "draft_base_contract"},
     )
+
+
+def _build_move_planar_faces_shape(
+    body: Any,
+    payload: Mapping[str, Any],
+    memo: dict[str, Any],
+    sketch_evidence: list[dict[str, Any]],
+) -> Any:
+    import FreeCAD as App
+
+    base = _build_model_shape(
+        body,
+        _payload(
+            _argument(payload, 0, context="api.move_planar_faces"),
+            context="api.move_planar_faces.base",
+        ),
+        memo,
+        sketch_evidence,
+    )
+    raw_selections = _argument(payload, 1, context="api.move_planar_faces")
+    if not isinstance(raw_selections, list) or not raw_selections:
+        raise PartDesignCandidateError(
+            "api.move_planar_faces.selection must contain at least one face query."
+        )
+    face_names: list[str] = []
+    for index, selection in enumerate(raw_selections):
+        names, _details = _query_subelements(base, selection)
+        invalid = [name for name in names if not str(name).startswith("Face")]
+        if invalid:
+            raise PartDesignCandidateError(
+                f"api.move_planar_faces.selection[{index}] resolved non-face topology.",
+                details={
+                    "stage": "move_planar_faces_selection",
+                    "selection_index": index,
+                    "invalid_subelements": invalid,
+                },
+            )
+        face_names.extend(str(name) for name in names)
+    duplicates = sorted(
+        name for name in set(face_names) if face_names.count(name) > 1
+    )
+    if duplicates:
+        raise PartDesignCandidateError(
+            "api.move_planar_faces selections overlap.",
+            details={
+                "stage": "move_planar_faces_selection",
+                "duplicate_faces": duplicates,
+                "correction": "Make each selected face match exactly one query.",
+            },
+        )
+
+    distance = float(_argument(payload, 2, context="api.move_planar_faces"))
+    if abs(distance) <= 1.0e-12:
+        raise PartDesignCandidateError(
+            "api.move_planar_faces.distance_mm must be non-zero."
+        )
+    prisms = []
+    for name in face_names:
+        face = base.getElement(name)
+        if type(face.Surface).__name__ != "Plane":
+            raise PartDesignCandidateError(
+                f"api.move_planar_faces supports planar faces; {name} is "
+                f"{type(face.Surface).__name__}.",
+                details={
+                    "stage": "move_planar_faces_geometry",
+                    "face": name,
+                    "geometry_type": type(face.Surface).__name__,
+                },
+            )
+        u_min, u_max, v_min, v_max = face.ParameterRange
+        normal = face.normalAt(
+            (float(u_min) + float(u_max)) * 0.5,
+            (float(v_min) + float(v_max)) * 0.5,
+        )
+        if normal.Length <= 1.0e-12:
+            raise PartDesignCandidateError(
+                f"api.move_planar_faces could not resolve the outward normal of {name}."
+            )
+        normal.normalize()
+        prisms.append(face.extrude(App.Vector(normal) * distance))
+
+    result = _boolean_sequence(
+        [base, *prisms],
+        intent="union" if distance > 0.0 else "subtract",
+        tolerance=0.0,
+        context="api.move_planar_faces",
+    )
+    result = _normalized_solid_orientation(_refined(result, True))
+    if result.isNull() or not result.isValid() or len(result.Solids) != 1:
+        raise PartDesignCandidateError(
+            "api.move_planar_faces did not produce one valid solid.",
+            details={
+                "stage": "move_planar_faces_result",
+                "solid_count": int(len(result.Solids)),
+            },
+        )
+    return result
 
 
 def _build_feature(


### PR DESCRIPTION
## Summary

- sharpen compact VibeScript guidance for extrusion, oriented boxes, boolean intent, inspection limits, and output identifiers
- add `api.move_planar_faces(...)` for signed, query-based planar face movement without fragile topology indices or primitive reconstruction
- expose `from_object` in the compact Part Design authoring surface and complete explicitly marked stable-reference input schemas
- preserve every existing API, tool name, schema field, and default

## Why

CADGenBench editing exposed a missing direct operation: moving pocket walls required the model to reconstruct material with boxes and wedges. The new operation accepts stable face queries and moves all matched planar faces atomically. The accompanying wording changes remove recurring, avoidable argument errors while keeping the model-facing surface compact.

## Validation

- full release build: `cmake --build build/release -j2` — passed
- focused contract tests: 2 passed
- manual kernel checks: signed +2 mm and -2 mm movements produced one valid solid with the expected bounds and volumes
- live CADGenBench edit: reduced the task from 47 calls with reconstructed primitives to 20 calls using direct face movement
- live Terra xhigh PW4000 cutaway stress test: 14 successful tool calls, zero rejected calls, 347 unique valid solids; exported STEP reopened without invalid topology

## Risk and non-goals

The new path is additive. It supports planar faces only and deliberately rejects ambiguous, overlapping, non-planar, zero-distance, or multi-solid results. This PR does not rename or remove tools, add model-specific heuristics, or change existing defaults.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults preserve previous behavior.
- [x] No deprecations or breaking changes are introduced.
- [x] No breaking-change approval is required.
