### PR TITLE
Welcome AI contributors with required TDD evidence

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,10 @@
 <!-- Include a brief summary of the changes. -->
 
+## Verification
+
+- [ ] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
+- [ ] The PR lists the exact build and test commands and their results.
+
 <!--
 The FreeCAD community thanks you for your contribution!
 By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -9,27 +9,6 @@ This template provides guidance on creating a PR that can be reviewed and approv
 Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled.  This will allow maintainers to help you.
 -->
 
-<!--
-FreeCAD does not accept raw and unverified AI output in PRs and no AI output in issues, PRs and their comments.
-Please check the following box:
--->
-
-- [ ] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.
-
-<!--
-If your work has been assisted by AI, please disclose the used technology in the PR description (in natural language) and with git trailers in the commit messages:
-
-Assisted-by [Model-Family] ([Version/ID])
-
-Examples:
-
-Assisted-by: gemini-2.5-pro (rev-1)
-Assisted-by: GPT-4o-2024-08-06
-
-The complete AI policy can be found in the root of the source tree (AI_POLICY.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md.
--->
-
-
 ## Issues
 <!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions for VibeCAD
 
-These rules apply to coding agents and automated assistants working in this repository. Follow them in addition to `CONTRIBUTING.md`, `AI_POLICY.md`, and the project PR template.
+These rules apply to coding agents and automated assistants working in this repository. Follow them in addition to `CONTRIBUTING.md` and the project PR template.
 
 ## Goals
 
@@ -68,7 +68,7 @@ Every PR an agent prepares SHOULD be something the owner can merge with high con
 2. Title and description explain **user-visible outcome** and **why**.
 3. Link related issues when they exist.
 4. Call out risk, test plan, and any deliberate non-goals.
-5. Disclose AI assistance per `AI_POLICY.md` when applicable.
+5. AI agents may author code and repository communication; their work must meet the same review and verification standards as any other contribution.
 6. Do not mix unrelated refactors, formatting sweeps, or dependency upgrades with feature work.
 
 ### Compatibility checklist (required in the PR body when relevant)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Every PR an agent prepares SHOULD be something the owner can merge with high con
 2. Title and description explain **user-visible outcome** and **why**.
 3. Link related issues when they exist.
 4. Call out risk, test plan, and any deliberate non-goals.
-5. AI agents may author code and repository communication; their work must meet the same review and verification standards as any other contribution.
+5. AI agents may author code and repository communication. For code changes, they must use red/green test-driven development and report the exact build and test commands and results in the PR.
 6. Do not mix unrelated refactors, formatting sweeps, or dependency upgrades with feature work.
 
 ### Compatibility checklist (required in the PR body when relevant)
@@ -82,7 +82,7 @@ Every PR an agent prepares SHOULD be something the owner can merge with high con
 ### Quality bar before asking for merge
 
 1. Builds for the touched area (or full project when CMake/public headers change).
-2. Relevant tests pass; add tests for new behavior when practical.
+2. For code changes, add or update a failing test before the implementation, then make it pass. Report the exact build and test commands and results in the PR. For non-code changes, state why TDD does not apply.
 3. No secrets, credentials, or local machine paths committed.
 4. Diff is reviewable: avoid generated noise and drive-by edits.
 5. Commit history is intentional (no “WIP / fixup later” left on the branch tip).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ The FreeCAD Contribution Process is expressed here with the following specific g
     1. the PR description MUST contain proper attribution as the first line, for example: "This is work of XYZ cherry-picked from <link>";
     2. all commits MUST have proper authorship, i.e. be authored by the original author and committed by the author of the PR;
     3. if changes to cherry-picked commits are necessary they SHOULD be done as follow-up commits. If it is not possible to do so, then the modified commits MUST contain a `Co-Authored-By` trailer in their commit message.
-14. Contributions must meet existing quality standards and comply with the [AI Policy](https://github.com/FreeCAD/FreeCAD/blob/main/AI_POLICY.md): All communication should be done by contributors (people), AI is only used in an assistive way, contributors fully understand their contributions, and people are fully in the driver seat.
+14. AI-authored and AI-assisted contributions are welcome and MUST meet the same quality, testing, review, attribution, copyright, and licensing requirements as every other contribution.
 15. The contributor provides reasonable assurance that the contribution does not infringe third-party copyrights or license terms.
 16. A “Valid PR” is one which satisfies the above requirements.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ The FreeCAD Contribution Process is expressed here with the following specific g
     1. the PR description MUST contain proper attribution as the first line, for example: "This is work of XYZ cherry-picked from <link>";
     2. all commits MUST have proper authorship, i.e. be authored by the original author and committed by the author of the PR;
     3. if changes to cherry-picked commits are necessary they SHOULD be done as follow-up commits. If it is not possible to do so, then the modified commits MUST contain a `Co-Authored-By` trailer in their commit message.
-14. AI-authored and AI-assisted contributions are welcome and MUST meet the same quality, testing, review, attribution, copyright, and licensing requirements as every other contribution.
+14. AI-authored and AI-assisted contributions are welcome. AI-authored code changes MUST use red/green test-driven development: add or update a failing test before the implementation, then make it pass. The PR MUST report the exact build and test commands and results. Non-code changes MUST state why TDD does not apply. All contributions remain subject to the same quality, review, attribution, copyright, and licensing requirements.
 15. The contributor provides reasonable assurance that the contribution does not infringe third-party copyrights or license terms.
 16. A “Valid PR” is one which satisfies the above requirements.
 


### PR DESCRIPTION
## Summary

- remove the inherited FreeCAD human-only AI restriction and references to the absent `AI_POLICY.md`
- explicitly welcome AI-authored and AI-assisted contributions
- require red/green TDD for AI-authored code changes
- require PRs to report exact build/test commands and results
- add the verification requirements directly to the PR template

## Why

VibeCAD intentionally uses AI agents to develop the platform. The inherited policy contradicted that workflow. AI contributors are welcome, but their work must be demonstrably tested and held to the same quality, review, attribution, copyright, and licensing standards as every other contribution.

## Verification

TDD does not apply because this PR only changes repository contribution policy and the PR template; it has no runtime code path.

Commands and results:

- `rg -n -i "AI_POLICY|unverified AI|assisted-by|AI output" AGENTS.md CONTRIBUTING.md .github/pull_request_template.md` — no stale policy references remain
- `git diff --check` — passed

## Compatibility

No product APIs, schemas, preferences, packaging, or runtime behavior change.
