### PR TITLE
Bump VibeCAD RC4 to Build 2

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 1
+  number: 2
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC4",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 1,
+  "build_version": 2,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Summary

- advance the immutable RC4 identity from Build 1 to Build 2
- synchronize the Rattler package build number
- prepare canonical preview tag `v26.3.1-RC4-build2`

## Why

Build 2 packages the changes merged in #49, #51, #52, and #53, including Codex shutdown lifecycle fixes, Ollama/MCP/Responses compatibility, tool sharpening, and the updated AI contribution policy.

## Risk

Low. This PR changes only release metadata. It does not alter runtime code, APIs, preferences, schemas, or packaging behavior.

## Verification

- [x] TDD does not apply because this is a metadata-only build-number bump with no code behavior change.
- [x] Exact commands and results:
  - `package/rattler-build/.pixi/envs/default/python.exe src/Tools/sync_version.py --update` — synchronized `package/rattler-build/recipe.yaml`
  - `package/rattler-build/.pixi/envs/default/python.exe src/Tools/sync_version.py --check` — all version consumers in sync
  - `package/rattler-build/.pixi/envs/default/python.exe -m unittest discover -s src/Tools/tests` — 103 tests passed
  - `git diff --check` — passed

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Runtime defaults are unchanged.
- [x] No deprecations were introduced.
- [x] No breaking changes are included.