### PR TITLE
Preserve Sketcher preferences and improve its defaults

### DIFF
--- a/src/Gui/ThemeManager.cpp
+++ b/src/Gui/ThemeManager.cpp
@@ -90,6 +90,24 @@ Gui::ThemeManager::Mode Gui::ThemeManager::modeFromStoredValues(
     return Mode::Dark;
 }
 
+Gui::ThemeManager::StartupPlan Gui::ThemeManager::startupPlanFromStoredValues(
+    std::string_view appearanceMode,
+    std::string_view legacyTheme,
+    std::string_view legacyStyleSheet
+)
+{
+    if (matches(appearanceMode, {"Light"})) {
+        return {Mode::Light, false};
+    }
+    if (matches(appearanceMode, {"Dark"})) {
+        return {Mode::Dark, false};
+    }
+    return {
+        modeFromStoredValues(appearanceMode, legacyTheme, legacyStyleSheet),
+        true,
+    };
+}
+
 const char* Gui::ThemeManager::modeName(Mode mode)
 {
     return mode == Mode::Light ? "Light" : "Dark";
@@ -107,31 +125,38 @@ const char* Gui::ThemeManager::overlayStyleSheetName(Mode mode)
 
 bool Gui::ThemeManager::apply(Mode mode, bool refreshGui)
 {
-    bool loaded = false;
+    return applyImpl(mode, refreshGui, true);
+}
+
+bool Gui::ThemeManager::applyImpl(Mode mode, bool refreshGui, bool loadProfile)
+{
+    bool applied = !loadProfile;
     const fs::path path = profilePath(mode);
 
-    try {
-        if (fs::is_regular_file(path)) {
-            auto profile = ParameterManager::Create();
-            profile->LoadDocument(Base::FileInfo::pathToString(path).c_str());
-            profile->GetGroup("BaseApp")
-                ->insertTo(App::GetApplication().GetUserParameter().GetGroup("BaseApp"));
-            loaded = true;
+    if (loadProfile) {
+        try {
+            if (fs::is_regular_file(path)) {
+                auto profile = ParameterManager::Create();
+                profile->LoadDocument(Base::FileInfo::pathToString(path).c_str());
+                profile->GetGroup("BaseApp")
+                    ->insertTo(App::GetApplication().GetUserParameter().GetGroup("BaseApp"));
+                applied = true;
+            }
+            else {
+                Base::Console().error(
+                    "VibeCAD %s theme profile is missing: %s\n",
+                    modeName(mode),
+                    Base::FileInfo::pathToString(path).c_str()
+                );
+            }
         }
-        else {
+        catch (const std::exception& error) {
             Base::Console().error(
-                "VibeCAD %s theme profile is missing: %s\n",
+                "VibeCAD could not load the %s theme profile: %s\n",
                 modeName(mode),
-                Base::FileInfo::pathToString(path).c_str()
+                error.what()
             );
         }
-    }
-    catch (const std::exception& error) {
-        Base::Console().error(
-            "VibeCAD could not load the %s theme profile: %s\n",
-            modeName(mode),
-            error.what()
-        );
     }
 
     // These values are the stable public appearance contract. Set them even
@@ -166,10 +191,16 @@ bool Gui::ThemeManager::apply(Mode mode, bool refreshGui)
     }
 
     Q_EMIT modeChanged(mode);
-    return loaded;
+    return applied;
 }
 
 bool Gui::ThemeManager::applyCurrent(bool refreshGui)
 {
-    return apply(currentMode(), refreshGui);
+    const auto parameters = mainWindowParameters();
+    const auto plan = startupPlanFromStoredValues(
+        parameters->GetASCII("AppearanceMode"),
+        parameters->GetASCII("Theme"),
+        parameters->GetASCII("StyleSheet")
+    );
+    return applyImpl(plan.mode, refreshGui, plan.loadProfile);
 }

--- a/src/Gui/ThemeManager.h
+++ b/src/Gui/ThemeManager.h
@@ -46,11 +46,22 @@ public:
         Dark
     };
 
+    struct StartupPlan
+    {
+        Mode mode;
+        bool loadProfile;
+    };
+
     ThemeManager() = default;
     ~ThemeManager() override = default;
 
     [[nodiscard]] Mode currentMode() const;
     [[nodiscard]] static Mode modeFromStoredValues(
+        std::string_view appearanceMode,
+        std::string_view legacyTheme,
+        std::string_view legacyStyleSheet
+    );
+    [[nodiscard]] static StartupPlan startupPlanFromStoredValues(
         std::string_view appearanceMode,
         std::string_view legacyTheme,
         std::string_view legacyStyleSheet
@@ -70,6 +81,9 @@ public:
 
 Q_SIGNALS:
     void modeChanged(Mode mode);
+
+private:
+    bool applyImpl(Mode mode, bool refreshGui, bool loadProfile);
 };
 
 }  // namespace Gui

--- a/src/Gui/Themes/Dark.cfg
+++ b/src/Gui/Themes/Dark.cfg
@@ -7,25 +7,28 @@
           <FCUInt Name="AxisLetterColor" Value="2914369023"/>
           <FCUInt Name="SketchEdgeColor" Value="4059297279"/>
           <FCUInt Name="SketchVertexColor" Value="4059297279"/>
-          <FCUInt Name="EditedEdgeColor" Value="4059297279"/>
-          <FCUInt Name="EditedVertexColor" Value="4199699199"/>
-          <FCUInt Name="ConstructionColor" Value="865792255"/>
-          <FCUInt Name="ExternalColor" Value="3428706559"/>
-          <FCUInt Name="InvalidSketchColor" Value="4252898559"/>
-          <FCUInt Name="FullyConstrainedColor" Value="1958221567"/>
-          <FCUInt Name="InternalAlignedGeoColor" Value="865792255"/>
-          <FCUInt Name="FullyConstraintElementColor" Value="11173887"/>
-          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2462511359"/>
-          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="2462511359"/>
-          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4205291519"/>
-          <FCUInt Name="ConstrainedIcoColor" Value="4199699199"/>
-          <FCUInt Name="NonDrivingConstrDimColor" Value="865792255"/>
-          <FCUInt Name="ConstrainedDimColor" Value="4199699199"/>
-          <FCUInt Name="ExprBasedConstrDimColor" Value="4252898559"/>
-          <FCUInt Name="DeactivatedConstrDimColor" Value="2257491711"/>
-          <FCUInt Name="CursorTextColor" Value="2914369023"/>
+          <FCUInt Name="EditedEdgeColor" Value="1303115775"/>
+          <FCUInt Name="EditedVertexColor" Value="1303115775"/>
+          <FCUInt Name="ConstructionColor" Value="4240710143"/>
+          <FCUInt Name="ExternalColor" Value="4240710143"/>
+          <FCUInt Name="ExternalDefiningColor" Value="4240710143"/>
+          <FCUInt Name="InvalidSketchColor" Value="4285230079"/>
+          <FCUInt Name="FullyConstrainedColor" Value="4059297279"/>
+          <FCUInt Name="InternalAlignedGeoColor" Value="4240710143"/>
+          <FCUInt Name="FullyConstraintElementColor" Value="4059297279"/>
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="4240710143"/>
+          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="4240710143"/>
+          <FCUInt Name="FullyConstraintConstructionPointColor" Value="4240710143"/>
+          <FCUInt Name="ConstrainedIcoColor" Value="2914369023"/>
+          <FCUInt Name="NonDrivingConstrDimColor" Value="2914369023"/>
+          <FCUInt Name="ConstrainedDimColor" Value="2914369023"/>
+          <FCUInt Name="ExprBasedConstrDimColor" Value="2914369023"/>
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2914369023"/>
+          <FCUInt Name="CursorTextColor" Value="4059297279"/>
           <FCUInt Name="CursorCrosshairColor" Value="4059297279"/>
           <FCUInt Name="CreateLineColor" Value="4059297279"/>
+          <FCInt Name="DefaultShapePointSize" Value="3"/>
+          <FCInt Name="MarkerSize" Value="5"/>
           <FCUInt Name="AnnotationTextColor" Value="2914369023"/>
           <FCBool Name="UseBackgroundColorMid" Value="0"/>
           <FCUInt Name="BackgroundColor" Value="556083711"/>
@@ -157,6 +160,11 @@
               <FCInt Name="GridLinePattern" Value="43690"/>
             </FCParamGroup>
             <FCParamGroup Name="View">
+              <FCInt Name="EdgeWidth" Value="1"/>
+              <FCInt Name="ConstructionWidth" Value="1"/>
+              <FCInt Name="InternalWidth" Value="1"/>
+              <FCInt Name="ExternalWidth" Value="1"/>
+              <FCInt Name="ExternalDefiningWidth" Value="1"/>
               <FCInt Name="EdgePattern" Value="65535"/>
               <FCInt Name="ConstructionPattern" Value="64764"/>
               <FCInt Name="InternalPattern" Value="61166"/>

--- a/src/Gui/Themes/Light.cfg
+++ b/src/Gui/Themes/Light.cfg
@@ -5,27 +5,30 @@
       <FCParamGroup Name="Preferences">
         <FCParamGroup Name="View">
           <FCUInt Name="AxisLetterColor" Value="556083711"/>
-          <FCUInt Name="SketchEdgeColor" Value="556083711"/>
-          <FCUInt Name="SketchVertexColor" Value="556083711"/>
-          <FCUInt Name="EditedEdgeColor" Value="1230002175"/>
-          <FCUInt Name="EditedVertexColor" Value="556083711"/>
-          <FCUInt Name="ConstructionColor" Value="995875839"/>
-          <FCUInt Name="ExternalColor" Value="2923350527"/>
-          <FCUInt Name="InvalidSketchColor" Value="4252898559"/>
-          <FCUInt Name="FullyConstrainedColor" Value="798901503"/>
-          <FCUInt Name="InternalAlignedGeoColor" Value="995875839"/>
-          <FCUInt Name="FullyConstraintElementColor" Value="798901503"/>
-          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2443706367"/>
-          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="2443706367"/>
-          <FCUInt Name="FullyConstraintConstructionPointColor" Value="730480383"/>
-          <FCUInt Name="ConstrainedIcoColor" Value="3761320447"/>
-          <FCUInt Name="NonDrivingConstrDimColor" Value="2257491711"/>
-          <FCUInt Name="ConstrainedDimColor" Value="3761320447"/>
-          <FCUInt Name="ExprBasedConstrDimColor" Value="3761320447"/>
-          <FCUInt Name="DeactivatedConstrDimColor" Value="2257491711"/>
-          <FCUInt Name="CursorTextColor" Value="556083711"/>
-          <FCUInt Name="CursorCrosshairColor" Value="556083711"/>
-          <FCUInt Name="CreateLineColor" Value="556083711"/>
+          <FCUInt Name="SketchEdgeColor" Value="255"/>
+          <FCUInt Name="SketchVertexColor" Value="255"/>
+          <FCUInt Name="EditedEdgeColor" Value="65535"/>
+          <FCUInt Name="EditedVertexColor" Value="65535"/>
+          <FCUInt Name="ConstructionColor" Value="2692874495"/>
+          <FCUInt Name="ExternalColor" Value="2692874495"/>
+          <FCUInt Name="ExternalDefiningColor" Value="2692874495"/>
+          <FCUInt Name="InvalidSketchColor" Value="3761320447"/>
+          <FCUInt Name="FullyConstrainedColor" Value="255"/>
+          <FCUInt Name="InternalAlignedGeoColor" Value="2692874495"/>
+          <FCUInt Name="FullyConstraintElementColor" Value="255"/>
+          <FCUInt Name="FullyConstraintConstructionElementColor" Value="2692874495"/>
+          <FCUInt Name="FullyConstraintInternalAlignmentColor" Value="2692874495"/>
+          <FCUInt Name="FullyConstraintConstructionPointColor" Value="2692874495"/>
+          <FCUInt Name="ConstrainedIcoColor" Value="2442236415"/>
+          <FCUInt Name="NonDrivingConstrDimColor" Value="2442236415"/>
+          <FCUInt Name="ConstrainedDimColor" Value="2442236415"/>
+          <FCUInt Name="ExprBasedConstrDimColor" Value="2442236415"/>
+          <FCUInt Name="DeactivatedConstrDimColor" Value="2442236415"/>
+          <FCUInt Name="CursorTextColor" Value="255"/>
+          <FCUInt Name="CursorCrosshairColor" Value="255"/>
+          <FCUInt Name="CreateLineColor" Value="255"/>
+          <FCInt Name="DefaultShapePointSize" Value="3"/>
+          <FCInt Name="MarkerSize" Value="5"/>
           <FCUInt Name="AnnotationTextColor" Value="876232959"/>
           <FCBool Name="UseBackgroundColorMid" Value="0"/>
           <FCUInt Name="BackgroundColor" Value="3470056191"/>
@@ -157,6 +160,11 @@
               <FCInt Name="GridLinePattern" Value="43690"/>
             </FCParamGroup>
             <FCParamGroup Name="View">
+              <FCInt Name="EdgeWidth" Value="1"/>
+              <FCInt Name="ConstructionWidth" Value="1"/>
+              <FCInt Name="InternalWidth" Value="1"/>
+              <FCInt Name="ExternalWidth" Value="1"/>
+              <FCInt Name="ExternalDefiningWidth" Value="1"/>
               <FCInt Name="EdgePattern" Value="65535"/>
               <FCInt Name="ConstructionPattern" Value="64764"/>
               <FCInt Name="InternalPattern" Value="61166"/>

--- a/src/Gui/resource.cpp
+++ b/src/Gui/resource.cpp
@@ -42,7 +42,6 @@
 #include "PreferencePages/DlgSettingsSelection.h"
 #include "PreferencePages/DlgSettingsUI.h"
 #include "PreferencePages/DlgSettingsViewColor.h"
-#include "PreferencePages/DlgSettingsWorkbenchesImp.h"
 #include "PreferencePages/DlgSettingsAdvanced.h"
 #include "PreferencePages/DlgSettingsPDF.h"
 
@@ -86,7 +85,6 @@ WidgetFactorySupplier::WidgetFactorySupplier()
     new PrefPageProducer<DlgSettingsNavigation>       ( QT_TRANSLATE_NOOP("QObject","Display") );
     new PrefPageProducer<DlgSettingsViewColor>        ( QT_TRANSLATE_NOOP("QObject","Display") );
     new PrefPageProducer<DlgSettingsAdvanced>         ( QT_TRANSLATE_NOOP("QObject","Display") );
-    new PrefPageProducer<DlgSettingsWorkbenchesImp>   ( QT_TRANSLATE_NOOP("QObject","Workbenches") );
     new PrefPageProducer<DlgSettingsPDF>              ( QT_TRANSLATE_NOOP("QObject","Import-Export") );
     new PrefPageProducer<DlgSettingsMacroImp>         ( QT_TRANSLATE_NOOP("QObject", "Python"));
     new PrefPageProducer<DlgSettingsPythonConsole>    ( QT_TRANSLATE_NOOP("QObject", "Python"));

--- a/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
@@ -1000,6 +1000,93 @@ def test_vibecad_ships_exactly_two_constrained_appearance_profiles() -> None:
     assert schemas["Light"] == schemas["Dark"]
 
 
+def test_vibecad_sketcher_profiles_use_clear_semantic_palettes() -> None:
+    profile_values = {
+        "Light": {
+            "primary": 0x000000FF,
+            "unconstrained": 0x0000FFFF,
+            "auxiliary": 0xA08200FF,
+            "constraint": 0x919191FF,
+            "invalid": 0xE03131FF,
+        },
+        "Dark": {
+            "primary": 0xF1F3F5FF,
+            "unconstrained": 0x4DABF7FF,
+            "auxiliary": 0xFCC419FF,
+            "constraint": 0xADB5BDFF,
+            "invalid": 0xFF6B6BFF,
+        },
+    }
+
+    for mode, palette in profile_values.items():
+        profile = ET.parse(ROOT / f"src/Gui/Themes/{mode}.cfg").getroot()
+        preferences = profile.find(
+            "./FCParamGroup[@Name='Root']/FCParamGroup[@Name='BaseApp']"
+            "/FCParamGroup[@Name='Preferences']"
+        )
+        assert preferences is not None
+        view = preferences.find("./FCParamGroup[@Name='View']")
+        sketch_view = preferences.find(
+            "./FCParamGroup[@Name='Mod']/FCParamGroup[@Name='Sketcher']"
+            "/FCParamGroup[@Name='View']"
+        )
+        assert view is not None
+        assert sketch_view is not None
+        view_values = {
+            item.get("Name"): int(item.get("Value", "0")) for item in view
+        }
+        sketch_values = {
+            item.get("Name"): int(item.get("Value", "0")) for item in sketch_view
+        }
+
+        for key in (
+            "SketchEdgeColor",
+            "SketchVertexColor",
+            "FullyConstrainedColor",
+            "FullyConstraintElementColor",
+        ):
+            assert view_values[key] == palette["primary"]
+        for key in ("EditedEdgeColor", "EditedVertexColor"):
+            assert view_values[key] == palette["unconstrained"]
+        for key in (
+            "ConstructionColor",
+            "ExternalColor",
+            "ExternalDefiningColor",
+            "InternalAlignedGeoColor",
+            "FullyConstraintConstructionElementColor",
+            "FullyConstraintInternalAlignmentColor",
+            "FullyConstraintConstructionPointColor",
+        ):
+            assert view_values[key] == palette["auxiliary"]
+        for key in (
+            "ConstrainedIcoColor",
+            "NonDrivingConstrDimColor",
+            "ConstrainedDimColor",
+            "ExprBasedConstrDimColor",
+            "DeactivatedConstrDimColor",
+        ):
+            assert view_values[key] == palette["constraint"]
+        for key in ("CreateLineColor", "CursorTextColor", "CursorCrosshairColor"):
+            assert view_values[key] == palette["primary"]
+        assert view_values["InvalidSketchColor"] == palette["invalid"]
+        assert view_values["DefaultShapePointSize"] == 3
+        assert view_values["MarkerSize"] == 5
+        for key in (
+            "EdgeWidth",
+            "ConstructionWidth",
+            "InternalWidth",
+            "ExternalWidth",
+            "ExternalDefiningWidth",
+        ):
+            assert sketch_values[key] == 1
+
+
+def test_vibecad_does_not_expose_the_legacy_workbench_preferences_page() -> None:
+    resource = _source("src/Gui/resource.cpp")
+
+    assert "PrefPageProducer<DlgSettingsWorkbenchesImp>" not in resource
+
+
 def test_vibecad_removes_theme_and_preference_pack_escape_hatches() -> None:
     gui_cmake = _source("src/Gui/CMakeLists.txt")
     stylesheet_cmake = _source("src/Gui/Stylesheets/CMakeLists.txt")

--- a/tests/src/Gui/ThemeManagerTest.cpp
+++ b/tests/src/Gui/ThemeManagerTest.cpp
@@ -79,3 +79,26 @@ TEST(ThemeManagerTest, ExposesStableModeAndResourceNames)
         "VibeDark_Overlay.qss"
     );
 }
+
+TEST(ThemeManagerTest, StartupPreservesOverridesAfterAProductModeWasStored)
+{
+    const auto light = ThemeManager::startupPlanFromStoredValues("Light", "", "");
+    EXPECT_EQ(light.mode, ThemeManager::Mode::Light);
+    EXPECT_FALSE(light.loadProfile);
+
+    const auto dark = ThemeManager::startupPlanFromStoredValues("Dark", "", "");
+    EXPECT_EQ(dark.mode, ThemeManager::Mode::Dark);
+    EXPECT_FALSE(dark.loadProfile);
+}
+
+TEST(ThemeManagerTest, StartupLoadsAProfileForFirstRunAndLegacyMigration)
+{
+    const auto firstRun = ThemeManager::startupPlanFromStoredValues("", "", "");
+    EXPECT_EQ(firstRun.mode, ThemeManager::Mode::Dark);
+    EXPECT_TRUE(firstRun.loadProfile);
+
+    const auto legacyLight =
+        ThemeManager::startupPlanFromStoredValues("", "VibeLight", "");
+    EXPECT_EQ(legacyLight.mode, ThemeManager::Mode::Light);
+    EXPECT_TRUE(legacyLight.loadProfile);
+}


### PR DESCRIPTION
## Summary

- stop normal startup from reloading the complete product theme profile over saved user preferences
- continue loading a complete profile on first run, legacy migration, and explicit Light/Dark theme selection
- update Light and Dark Sketcher colors, line widths, and marker sizes to clearer product defaults based on the feedback in #42
- remove the obsolete Workbenches preference page because VibeCAD ribbons own the available work surfaces

Closes #42.

## Root cause

`ThemeManager::applyCurrent()` called the same full-profile import path used for an explicit theme change. Every launch therefore merged `Light.cfg` or `Dark.cfg` into the user parameter tree and overwrote Sketcher appearance values saved through Preferences.

The startup path now derives a small plan from stored values. A recognized VibeCAD appearance mode applies only the stable stylesheet contract and preserves all user overrides. First run and legacy identifiers still receive a complete profile so migration remains deterministic.

## Verification

- [x] Red: after adding the startup contract, `cmake --build build/release -j2 --target Gui_tests_run` failed against the old implementation because `startupPlanFromStoredValues` did not exist.
- [x] Red: the focused profile contract failed against the previous theme files and registered Workbenches preference page.
- [x] `cmake --build build/release -j2 --target Gui_tests_run` — passed.
- [x] `ctest --test-dir build/release -R "^ThemeManagerTest\." --output-on-failure` — 6 passed, 0 failed.
- [x] `python3 -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py` — 31 passed, 5 skipped.
- [x] `git diff --check` — passed.

AI-assisted implementation used red/green TDD as described above. The palette values and preference-page scope follow the repository owner and reporter feedback in #42.

## Compatibility

- [x] Existing public ThemeManager functions and preference keys remain present.
- [x] Existing Light/Dark appearance identifiers and legacy migration remain supported.
- [x] User-authored Sketcher preferences are preserved on normal startup.
- [x] No document schema, tool schema, or wire format changes.
- [x] Deliberate UI change: the obsolete Workbenches preference page is no longer registered, as approved for the ribbon-owned VibeCAD work surfaces.
- [x] Deliberate default change: first-run and explicitly reset theme profiles use the revised Sketcher palettes.

## Before and after

The prior palette and requested direction are shown in the screenshots and detailed color feedback on #42. This PR changes defaults only; existing users keep their saved overrides after startup.

## Risk and rollback

Risk is limited to startup theme application and profile defaults. Explicit theme changes still load the selected full profile. Reverting this commit restores the former startup/profile behavior without migrating any document data.

## Non-goals

- no ribbon layout changes
- no fix for sketch rename editor painting or Sketch Properties
- no removal of underlying workbench implementations