### PR TITLE
Prepare VibeCAD 26.3.1-RC4 Build 4

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 3
+  number: 4
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
@@ -1201,9 +1201,9 @@ def test_vibecad_ribbon_has_explicit_domains_and_legacy_fallback() -> None:
         "VibeCADCommandSearch",
         "VibeCADThemeToggle",
         "VibeCADRibbonTabs",
-        "VibeCADAeroWorkspaceHost",
     ):
         assert f'QStringLiteral("{object_name}")' in ribbon
+    assert 'QStringLiteral("VibeCADAeroWorkspaceHost")' not in ribbon
 
     assert "workbench->getToolbarItems()" in ribbon
     assert "command->getAction()->action()" in ribbon

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC4",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 3,
+  "build_version": 4,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Summary

- remove the stale branding-test requirement for the retired Aero workspace header
- bump the canonical VibeCAD RC4 build identity from Build 3 to Build 4
- synchronize the Rattler recipe build number

## Red / green evidence

After the Build 4 metadata change, the canonical sync check failed because package/rattler-build/recipe.yaml still declared build number 3. Running the repository sync tool updated it to 4.

The release/branding suite then exposed a stale assertion requiring VibeCADAeroWorkspaceHost, which the merged Aero correction intentionally removed. The contract now asserts that header is absent.

## Tests

    .pixi/envs/default/python.exe src/Tools/sync_version.py --check
    All files are in sync.

    .pixi/envs/default/python.exe -m pytest -q src/Tools/tests/test_sync_version.py src/Tools/tests/test_release_artifact_name.py src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
    88 passed, 5 skipped in 1.46s

Resolved release identity: v26.3.1-RC4-build4.

GitHub release and Git tag checks confirmed that Build 4 does not already exist.

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Runtime defaults are unchanged.
- [x] No breaking changes.