### PR TITLE
Bundle Aero solver dependencies in release artifacts

### DIFF
--- a/.github/workflows/vibecad-macos.yml
+++ b/.github/workflows/vibecad-macos.yml
@@ -123,7 +123,7 @@ jobs:
             ~/.cache/pixi
             ~/.cache/rattler
             ~/Library/Caches/pip
-          key: pixi-${{ matrix.target }}-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh', 'package/rattler-build/scripts/relocate_conda_environment.py') }}
+          key: pixi-${{ matrix.target }}-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'src/Mod/VibeCADAero/requirements-aero.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh', 'package/rattler-build/scripts/relocate_conda_environment.py') }}
           restore-keys: |
             pixi-${{ matrix.target }}-
 

--- a/.github/workflows/vibecad-release.yml
+++ b/.github/workflows/vibecad-release.yml
@@ -143,7 +143,7 @@ jobs:
             ~/.cache/pixi
             ~/.cache/rattler
             ~/.cache/pip
-          key: pixi-linux-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh') }}
+          key: pixi-linux-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'src/Mod/VibeCADAero/requirements-aero.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh') }}
           restore-keys: |
             pixi-linux-
 
@@ -265,7 +265,7 @@ jobs:
             ~\AppData\Local\pixi
             ~\AppData\Local\rattler
             ~\AppData\Local\pip\Cache
-          key: pixi-windows-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh') }}
+          key: pixi-windows-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'src/Mod/VibeCADAero/requirements-aero.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh') }}
           restore-keys: |
             pixi-windows-
 
@@ -383,7 +383,7 @@ jobs:
             ~/.cache/pixi
             ~/.cache/rattler
             ~/Library/Caches/pip
-          key: pixi-${{ matrix.target }}-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh', 'package/rattler-build/scripts/relocate_conda_environment.py') }}
+          key: pixi-${{ matrix.target }}-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'src/Mod/VibeCADAero/requirements-aero.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh', 'package/rattler-build/scripts/relocate_conda_environment.py') }}
           restore-keys: |
             pixi-${{ matrix.target }}-
 

--- a/.github/workflows/vibecad-windows-installer.yml
+++ b/.github/workflows/vibecad-windows-installer.yml
@@ -83,7 +83,7 @@ jobs:
             ~\AppData\Local\pixi
             ~\AppData\Local\rattler
             ~\AppData\Local\pip\Cache
-          key: pixi-windows-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh') }}
+          key: pixi-windows-${{ hashFiles('package/rattler-build/pixi.lock', 'package/rattler-build/pixi.toml', 'package/rattler-build/recipe.yaml', 'src/Mod/VibeCAD/requirements.txt', 'src/Mod/VibeCADAero/requirements-aero.txt', 'package/rattler-build/scripts/install_vibecad_provider_deps.sh', 'package/rattler-build/scripts/install_vibecad_codex_runtime.sh', 'package/rattler-build/scripts/purge_vibecad_retired_authoring_artifacts.sh') }}
           restore-keys: |
             pixi-windows-
 

--- a/package/rattler-build/scripts/build_vibecad_local_release.sh
+++ b/package/rattler-build/scripts/build_vibecad_local_release.sh
@@ -50,7 +50,7 @@ fi
 
 "${freecadcmd_executable}" --safe-mode --version
 "${freecadcmd_executable}" --safe-mode -c \
-    "import importlib.util, anthropic, jsonschema, keyring, mcp, mcp_types; assert importlib.util.find_spec('openai') is None; assert importlib.util.find_spec('agents') is None; print('VibeCAD Python dependencies import ok')"
+    "import importlib.util, anthropic, jsonschema, keyring, mcp, mcp_types, numpy, neuralfoil, aerosandbox, jsbsim; assert int(numpy.__version__.split('.', 1)[0]) < 2; assert importlib.util.find_spec('openai') is None; assert importlib.util.find_spec('agents') is None; print('VibeCAD Python and Aero dependencies import ok')"
 "${freecadcmd_executable}" --safe-mode -c \
     "from VibeCADProvider import _provider_subprocess_smoke; _provider_subprocess_smoke(); print('VibeCAD provider subprocess smoke ok')"
 "${freecadcmd_executable}" --safe-mode -c \

--- a/package/rattler-build/scripts/install_vibecad_provider_deps.sh
+++ b/package/rattler-build/scripts/install_vibecad_provider_deps.sh
@@ -24,28 +24,49 @@ else
 fi
 
 requirements="${repo_root}/src/Mod/VibeCAD/requirements.txt"
-if [[ ! -f "${requirements}" ]]; then
-    echo "VibeCAD provider requirements file not found: ${requirements}" >&2
-    exit 1
-fi
+aero_requirements="${repo_root}/src/Mod/VibeCADAero/requirements-aero.txt"
+for requirements_file in "${requirements}" "${aero_requirements}"; do
+    if [[ ! -f "${requirements_file}" ]]; then
+        echo "VibeCAD requirements file not found: ${requirements_file}" >&2
+        exit 1
+    fi
+done
 
 echo "Removing the retired direct OpenAI SDK from ${env_root}"
 "${python_exe}" -m pip uninstall --yes openai openai-agents
 
-echo "Installing VibeCAD Python dependencies into ${env_root}"
+echo "Installing VibeCAD Python and Aero dependencies into ${env_root}"
 "${python_exe}" -m pip install \
     --disable-pip-version-check \
     --upgrade \
     --prefer-binary \
-    -r "${requirements}"
+    -r "${requirements}" \
+    -r "${aero_requirements}"
 "${python_exe}" -m pip check
 "${python_exe}" - <<'PY'
 import importlib
 import importlib.util
 import sys
 
-for module_name in ("anthropic", "keyring", "jsonschema", "mcp", "mcp_types", "tuf"):
+for module_name in (
+    "anthropic",
+    "keyring",
+    "jsonschema",
+    "mcp",
+    "mcp_types",
+    "tuf",
+    "numpy",
+    "neuralfoil",
+    "aerosandbox",
+    "jsbsim",
+):
     importlib.import_module(module_name)
+
+numpy = importlib.import_module("numpy")
+if int(numpy.__version__.split(".", 1)[0]) >= 2:
+    raise RuntimeError(
+        f"NumPy 2 is not compatible with this VibeCAD runtime: {numpy.__version__}"
+    )
 
 if sys.platform == "win32":
     importlib.import_module("keyring.backends.Windows")
@@ -63,5 +84,5 @@ for removed_module in ("openai", "agents"):
             f"The retired direct OpenAI module {removed_module!r} is still present."
         )
 
-print("VibeCAD Python dependencies and OS keyring backend import ok")
+print("VibeCAD Python, Aero, and OS keyring dependencies import ok")
 PY

--- a/src/Mod/VibeCADAero/README.md
+++ b/src/Mod/VibeCADAero/README.md
@@ -13,4 +13,5 @@ Analyze defaults to repairing pitch-unstable geometry (tail volume, boom,
 avionics CG, upper-wing stagger/decalage) and tells the user and assistant
 what changed. User guide: [`docs/vibecad-aero.md`](../../../docs/vibecad-aero.md)
 
-Optional packages: [`requirements-aero.txt`](requirements-aero.txt)
+Release builds install these dependencies automatically into VibeCAD's bundled
+Python: [`requirements-aero.txt`](requirements-aero.txt)

--- a/src/Mod/VibeCADAero/requirements-aero.txt
+++ b/src/Mod/VibeCADAero/requirements-aero.txt
@@ -1,11 +1,9 @@
-# Optional Aero workbench dependencies.
-# Install them into VibeCAD's bundled interpreter, not a system Python:
-#
-#   "<VibeCAD>\bin\python.exe" -m pip install -r requirements-aero.txt
-#
-# On macOS/Linux the bundled binary is usually `bin/python` next to FreeCAD.
-# Do not vendor wheels into git.
+# Aero workbench runtime dependencies bundled by the VibeCAD release scripts.
+# Keep NumPy below 2 because the packaged FreeCAD environment contains compiled
+# extensions built against the NumPy 1.x ABI. AeroSandbox 4.2.8 is the newest
+# release in the 4.2 line that does not require NumPy 2.
 
-neuralfoil
-aerosandbox
-jsbsim
+numpy>=1.26,<2
+neuralfoil==0.3.3
+aerosandbox==4.2.8
+jsbsim==1.3.1

--- a/src/Mod/VibeCADAero/tests/test_workbench.py
+++ b/src/Mod/VibeCADAero/tests/test_workbench.py
@@ -9,6 +9,7 @@ import ast
 from types import SimpleNamespace
 
 ROOT = Path(__file__).resolve().parents[1]
+REPO = ROOT.parents[2]
 
 
 def _top_level_imports(path: Path) -> set[str]:
@@ -118,10 +119,53 @@ def test_cmake_installs_mod_vibecadaero():
     assert "test_repair.py" in cmake
 
 
-def test_requirements_list_optional_pip_packages():
-    text = (ROOT / "requirements-aero.txt").read_text(encoding="utf-8")
-    assert "neuralfoil" in text
-    assert "aerosandbox" in text
-    assert "jsbsim" in text
-    assert "python.exe" in text
-    assert "wheel" not in text.lower() or "do not vendor" in text.lower()
+def test_requirements_pin_bundled_aero_runtime_without_numpy_2():
+    requirements = [
+        line.strip()
+        for line in (ROOT / "requirements-aero.txt")
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    assert requirements == [
+        "numpy>=1.26,<2",
+        "neuralfoil==0.3.3",
+        "aerosandbox==4.2.8",
+        "jsbsim==1.3.1",
+    ]
+
+
+def test_readme_says_release_builds_bundle_aero_dependencies():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "Release builds install these dependencies automatically" in readme
+    assert "Optional packages" not in readme
+
+
+def test_shared_release_installer_installs_and_imports_aero_dependencies():
+    script = (
+        REPO / "package" / "rattler-build" / "scripts" / "install_vibecad_provider_deps.sh"
+    ).read_text(encoding="utf-8")
+    assert "src/Mod/VibeCADAero/requirements-aero.txt" in script
+    assert '-r "${aero_requirements}"' in script
+    for module in ("numpy", "neuralfoil", "aerosandbox", "jsbsim"):
+        assert f'"{module}"' in script
+    assert "NumPy 2" in script
+
+
+def test_local_release_smoke_checks_aero_dependencies_inside_freecad():
+    script = (
+        REPO / "package" / "rattler-build" / "scripts" / "build_vibecad_local_release.sh"
+    ).read_text(encoding="utf-8")
+    for module in ("numpy", "neuralfoil", "aerosandbox", "jsbsim"):
+        assert module in script
+
+
+def test_release_cache_keys_include_aero_requirements():
+    workflows = {
+        "vibecad-release.yml": 3,
+        "vibecad-windows-installer.yml": 1,
+        "vibecad-macos.yml": 1,
+    }
+    for name, expected_count in workflows.items():
+        source = (REPO / ".github" / "workflows" / name).read_text(encoding="utf-8")
+        assert source.count("'src/Mod/VibeCADAero/requirements-aero.txt'") == expected_count


### PR DESCRIPTION
## Summary

- Install the pinned Aero runtime requirements in the shared release dependency step used by Windows, Linux, macOS, and local release builds.
- Hold NumPy below 2 and pin AeroSandbox to the newest compatible 4.2 release so pip cannot replace FreeCAD's NumPy 1.x ABI at packaging time.
- Import-smoke the Aero dependencies, invalidate release caches when the Aero requirements change, and document that release builds bundle them.

The previous build copied `requirements-aero.txt` into the application but no packaging path ever installed it. This is an additive packaging fix; Aero keeps its existing lazy imports and missing-dependency fallback.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
- [x] The PR lists the exact build and test commands and their results.

Red:

- `%TEMP%\vibecad-test-env\Scripts\python.exe -m pytest src/Mod/VibeCADAero/tests/test_workbench.py -q` -> `4 failed, 6 passed` before implementation.
- `%TEMP%\vibecad-test-env\Scripts\python.exe -m pytest src/Mod/VibeCADAero/tests/test_workbench.py::test_readme_says_release_builds_bundle_aero_dependencies -q` -> `1 failed` before the documentation update.

Green:

- `%TEMP%\vibecad-test-env\Scripts\python.exe -m pytest src/Mod/VibeCADAero/tests -q` -> `80 passed`.
- `%TEMP%\vibecad-test-env\Scripts\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py -q` -> `32 passed, 5 skipped`.
- `package/rattler-build/.pixi/envs/package/Library/bin/bash.exe package/rattler-build/scripts/install_vibecad_provider_deps.sh package/rattler-build/.pixi/envs/default` -> dependencies installed; `pip check` clean; Python, Aero, and Windows keyring imports passed.
- Bundled Python E63 smoke solve using production `AeroSolvers.run_section` -> `Aero runtime smoke ok bundled:e63 NeuralFoil 0.775084`.
- MSYS bash `-n` on both touched scripts -> passed.
- PyYAML parse of all three touched workflows -> passed.
- `git diff --check` -> passed.

Wheel availability was checked for CPython 3.11 on Windows x64, Linux x86_64, macOS x86_64, and macOS arm64. The compiled transitive dependencies (`casadi` and `jsbsim`) publish wheels for every current release target; JSBSim's macOS wheel is universal2.

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed or removed.
- [x] Defaults preserve existing workbench lazy-loading behavior.
- [x] No deprecations or breaking changes.

## Risk and non-goals

The release artifacts grow by the solver runtime, primarily CasADi. This PR does not alter Aero calculations, commands, UI, update behavior, signing, artifact naming, or release version metadata.

## Issues

No linked issue; this fixes the release-blocking packaging gap found while preparing RC4 Build4.

## Before and After Images

Not applicable; no GUI changes.