### PR TITLE
Fix Aero assistant document persistence

### DIFF
--- a/docs/vibecad-aero.md
+++ b/docs/vibecad-aero.md
@@ -113,8 +113,9 @@ the nose. Optional extra **aft** stagger is allowed. Analyze does not shove
 the upper wing toward the CAD nose. It re-solves at most twice and stops if
 the model is stable or no CAD/config change landed. The dialog and FreeCAD
 console list each change in plain sentences. `AeroReport.Corrections`,
-`AeroReport.RepairPasses`, and `document.AeroAssistantJson` carry the same
-list for the in-app assistant (`VibeCADCore.aero_summary`).
+`AeroReport.RepairPasses`, and the `Text` property of the document's named
+`AeroAssistantJson` object carry the same list for the in-app assistant
+(`VibeCADCore.aero_summary`).
 `VibeCADAero.run_analyze` returns `changes` and `user_message`.
 
 Section / VLM-only commands stay report-only (`repair=False`) unless they

--- a/package/rattler-build/scripts/build_vibecad_local_release.sh
+++ b/package/rattler-build/scripts/build_vibecad_local_release.sh
@@ -52,6 +52,8 @@ fi
 "${freecadcmd_executable}" --safe-mode -c \
     "import importlib.util, anthropic, jsonschema, keyring, mcp, mcp_types, numpy, neuralfoil, aerosandbox, jsbsim; assert int(numpy.__version__.split('.', 1)[0]) < 2; assert importlib.util.find_spec('openai') is None; assert importlib.util.find_spec('agents') is None; print('VibeCAD Python and Aero dependencies import ok')"
 "${freecadcmd_executable}" --safe-mode -c \
+    "import FreeCAD as App, AeroResults; from VibeCADAeroContext import document_aero_summary; doc=App.newDocument('VibeCADAeroReportSmoke'); AeroResults.write_report(doc, {'CL': 0.81, 'CD': 0.037, 'CM': -0.021, 'CLalpha': 5.1, 'Cmalpha': -0.4, 'PitchUnstable': False, 'source': 'smoke', 'corrections': ['Pitch stable.']}); assistant=doc.getObject('AeroAssistantJson'); assert assistant is not None; assert getattr(doc, 'AeroAssistantJson') is assistant; summary=document_aero_summary(doc); assert summary['assistant_json']['CL'] == 0.81; App.closeDocument(doc.Name); print('VibeCAD Aero report document smoke ok')"
+"${freecadcmd_executable}" --safe-mode -c \
     "from VibeCADProvider import _provider_subprocess_smoke; _provider_subprocess_smoke(); print('VibeCAD provider subprocess smoke ok')"
 "${freecadcmd_executable}" --safe-mode -c \
     "from VibeCADCodex import runtime_execution_smoke; result = runtime_execution_smoke(); print('VibeCAD Codex app-server smoke ok', result['version'])"

--- a/src/Mod/VibeCAD/VibeCADAeroContext.py
+++ b/src/Mod/VibeCAD/VibeCADAeroContext.py
@@ -96,17 +96,31 @@ def document_aero_summary(doc: Any | None) -> dict[str, Any]:
 
 
 def _assistant_json(doc: Any, report: Any | None) -> dict[str, Any]:
-    raw = getattr(doc, "AeroAssistantJson", None)
+    raw = _assistant_json_source(getattr(doc, "AeroAssistantJson", None))
     if raw in (None, ""):
         obj = _named(doc, "AeroAssistantJson")
         if obj is not None:
-            raw = getattr(obj, "Text", None) or getattr(obj, "AeroAssistantJson", None)
+            raw = _assistant_json_source(obj)
     if raw in (None, "") and report is not None:
-        raw = getattr(report, "AeroAssistantJson", None)
+        raw = _assistant_json_source(getattr(report, "AeroAssistantJson", None))
     parsed = _parse_assistant_json(raw)
     if parsed:
         return parsed
     return {}
+
+
+def _assistant_json_source(raw: Any) -> Any:
+    """Unwrap the named TextDocument used by real FreeCAD documents."""
+
+    if raw is None or isinstance(raw, (str, dict)):
+        return raw
+    text = getattr(raw, "Text", None)
+    if text not in (None, ""):
+        return text
+    nested = getattr(raw, "AeroAssistantJson", None)
+    if nested is not None and nested is not raw:
+        return nested
+    return raw
 
 
 def _parse_assistant_json(raw: Any) -> dict[str, Any]:
@@ -154,15 +168,15 @@ def _corrections(report: Any | None, doc: Any) -> list[str]:
         items = _bounded_corrections(getattr(report, "Corrections", None))
         if items:
             return items
-    assistant = _parse_assistant_json(getattr(doc, "AeroAssistantJson", None))
+    assistant = _parse_assistant_json(
+        _assistant_json_source(getattr(doc, "AeroAssistantJson", None))
+    )
     items = list(assistant.get("corrections") or [])
     if items:
         return items
     obj = _named(doc, "AeroAssistantJson")
     if obj is not None:
-        assistant = _parse_assistant_json(
-            getattr(obj, "Text", None) or getattr(obj, "AeroAssistantJson", None)
-        )
+        assistant = _parse_assistant_json(_assistant_json_source(obj))
         return list(assistant.get("corrections") or [])
     return []
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_aero_ribbon_and_context.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_aero_ribbon_and_context.py
@@ -373,6 +373,54 @@ def test_document_aero_summary_exposes_assistant_json_when_present() -> None:
     assert "Increase decalage" in summary["assistant_json"]["corrections"][0]
 
 
+def test_document_aero_summary_reads_freecad_named_assistant_object() -> None:
+    report = SimpleNamespace(
+        Name="AeroReport",
+        Label="AeroReport",
+        CL=0.81,
+        CD=0.037,
+        CM=-0.021,
+        CLalpha=5.1,
+        Cmalpha=-0.4,
+        PitchUnstable=False,
+        Re=42000.0,
+        V_loaf=7.4,
+        P_hover=18.2,
+        P_cruise=4.1,
+        Source="NeuralFoil",
+        Airfoil="e63",
+        GeometrySource="AeroConfig",
+        JSBSimPlantPath="",
+        Corrections="Pitch stable.",
+    )
+    assistant = SimpleNamespace(
+        Name="AeroAssistantJson",
+        Label="AeroAssistantJson",
+        Text=(
+            '{"CL":0.81,"CD":0.037,"Cmalpha":-0.4,'
+            '"PitchUnstable":false,"corrections":["Pitch stable."]}'
+        ),
+    )
+
+    def get_object(name: str):
+        return {"AeroReport": report, "AeroAssistantJson": assistant}.get(name)
+
+    doc = SimpleNamespace(
+        Name="Voider",
+        Objects=[report, assistant],
+        getObject=get_object,
+        AeroAssistantJson=assistant,
+    )
+
+    summary = document_aero_summary(doc)
+
+    assert summary["assistant_json"]["CL"] == 0.81
+    assert summary["assistant_json"]["CD"] == 0.037
+    assert summary["assistant_json"]["Cmalpha"] == -0.4
+    assert summary["assistant_json"]["PitchUnstable"] is False
+    assert summary["assistant_json"]["corrections"] == ["Pitch stable."]
+
+
 def test_session_and_provider_allowlists_keep_aero(monkeypatch) -> None:
     import VibeCADProvider as provider
     import VibeCADSession as session

--- a/src/Mod/VibeCADAero/AeroResults.py
+++ b/src/Mod/VibeCADAero/AeroResults.py
@@ -410,6 +410,15 @@ def _get_or_create(doc: Any, typ: str, name: str) -> Any:
 
 
 def _set_doc_attr(doc: Any, name: str, value: Any) -> None:
+    getter = getattr(doc, "getObject", None)
+    named_object = getter(name) if callable(getter) else None
+    try:
+        current = getattr(doc, name)
+    except (AttributeError, RuntimeError):
+        current = None
+    if named_object is not None and current is named_object:
+        return
+
     adder = getattr(doc, "addProperty", None)
     if callable(adder) and not hasattr(doc, name):
         try:

--- a/src/Mod/VibeCADAero/tests/test_results.py
+++ b/src/Mod/VibeCADAero/tests/test_results.py
@@ -52,6 +52,24 @@ class _Doc:
         self.recomputed = True
 
 
+class _FreeCADLikeDoc(_Doc):
+    """Expose named objects as attributes and reject overwriting them."""
+
+    def __getattr__(self, name):
+        obj = self.__dict__.get("_by_name", {}).get(name)
+        if obj is not None:
+            return obj
+        raise AttributeError(name)
+
+    def __setattr__(self, name, value):
+        obj = self.__dict__.get("_by_name", {}).get(name)
+        if obj is not None and value is not obj:
+            raise RuntimeError(
+                f"'Document' object attribute '{name}' must not be set this way"
+            )
+        super().__setattr__(name, value)
+
+
 def _payload():
     return {
         "CL": 0.81,
@@ -203,3 +221,16 @@ def test_report_writes_corrections_and_assistant_json():
     assert "0.81" in str(raw)
     assert "PitchUnstable" in str(raw)
     assert "Grew the horizontal tail span" in str(raw)
+
+
+def test_report_preserves_freecad_named_assistant_object_without_overwriting_it():
+    doc = _FreeCADLikeDoc()
+
+    obj = results.write_report(doc, _payload())
+
+    assistant = doc.getObject("AeroAssistantJson")
+    assert obj.Name == "AeroReport"
+    assert assistant is not None
+    assert getattr(doc, "AeroAssistantJson") is assistant
+    assert '"CL": 0.81' in assistant.Text
+    assert doc.recomputed is True

--- a/src/Mod/VibeCADAero/tests/test_workbench.py
+++ b/src/Mod/VibeCADAero/tests/test_workbench.py
@@ -158,6 +158,7 @@ def test_local_release_smoke_checks_aero_dependencies_inside_freecad():
     ).read_text(encoding="utf-8")
     for module in ("numpy", "neuralfoil", "aerosandbox", "jsbsim"):
         assert module in script
+    assert "AeroResults.write_report" in script
 
 
 def test_release_cache_keys_include_aero_requirements():


### PR DESCRIPTION
## Summary

- preserve the named `AeroAssistantJson` TextDocument instead of trying to overwrite it with a string
- teach the VibeCAD assistant context reader to consume the real FreeCAD object form while retaining the legacy string/dict paths
- add a release smoke check that writes and reads Aero report metadata through a compiled FreeCAD document
- document the persisted `AeroAssistantJson.Text` contract

This fixes the Aero Section dialog error: `'Document' object attribute 'AeroAssistantJson' must not be set this way`.

## Root cause

FreeCAD exposes a named document object as `document.<ObjectName>`. Aero created an `App::TextDocument` named `AeroAssistantJson`, successfully wrote its `Text`, and then attempted to replace `document.AeroAssistantJson` with the encoded string. Real FreeCAD rejects that collision. The test fake did not model FreeCAD's named-object attribute semantics, and the context reader also tried to parse the object itself instead of its `Text` property.

## Verification

- [x] A test failed before the implementation and passes afterward.
- [x] Exact build and test commands and results are listed below.

Red:

`%TEMP%\vibecad-test-env\Scripts\python.exe -m pytest src/Mod/VibeCADAero/tests/test_results.py::test_report_preserves_freecad_named_assistant_object_without_overwriting_it src/Mod/VibeCAD/vibecad_tests/test_aero_ribbon_and_context.py::test_document_aero_summary_reads_freecad_named_assistant_object src/Mod/VibeCADAero/tests/test_workbench.py::test_local_release_smoke_checks_aero_dependencies_inside_freecad -q` -> 3 failed

Green:

- same targeted command -> 3 passed
- `%TEMP%\vibecad-test-env\Scripts\python.exe -m pytest src/Mod/VibeCADAero/tests -q` -> 81 passed
- `%TEMP%\vibecad-test-env\Scripts\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_aero_ribbon_and_context.py -q` -> 10 passed
- `bash -n package/rattler-build/scripts/build_vibecad_local_release.sh` -> passed
- compiled Windows `FreeCADCmd --safe-mode` end-to-end probe -> real NeuralFoil Section solve, repeated report update, assistant context read, registered JSBSim property, FCStd save/close/reopen, and persisted context read all passed

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] Legacy string/dict assistant payload readers remain supported.
- [x] No preference keys, tool names, schemas, defaults, or wire formats changed.
- [x] No removals or breaking changes.

## Risk and non-goals

This is limited to Aero report metadata persistence and its release smoke coverage. It does not change aerodynamic calculations, repair behavior, UI layout, dependencies, signing, release naming, or CI gates.