### PR TITLE
Prepare VibeCAD 26.3.1-RC4 Build 5

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 4
+  number: 5
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC4",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 4,
+  "build_version": 5,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
﻿## Summary

- advance the canonical VibeCAD release identity from RC4 Build 4 to RC4 Build 5
- synchronize the Rattler recipe build number
- prepare the newly merged Native CAD modeling work for an immutable all-platform prerelease

## Why

Build 4 is already published and immutable. The release workflow derives package names, update ordering, tags, and release metadata from `version.json`, so the new source on `main` requires a new monotonic build number before it can be published.

## Red / green evidence

After changing `version.json` to Build 5, the canonical sync check failed as expected because `package/rattler-build/recipe.yaml` still declared Build 4:

```
.\.pixi\envs\default\python.exe src\Tools\sync_version.py --check
```

Result: expected failure, `package/rattler-build/recipe.yaml` out of sync.

The repository synchronization tool updated the recipe, after which the same check passed:

```
.\.pixi\envs\default\python.exe src\Tools\sync_version.py --update
.\.pixi\envs\default\python.exe src\Tools\sync_version.py --check
```

Result: all canonical version files in sync.

## Tests

Exact release/update contract suite used by CI:

```
.\.pixi\envs\default\python.exe -m unittest src.Tools.tests.test_sync_version src.Tools.tests.test_release_artifact_name src.Tools.tests.test_windows_installer_version src.Tools.tests.test_generate_update_manifest src.Tools.tests.test_release_workflow src.Tools.tests.test_vibecad_update
```

Result: **103 tests passed, 1 skipped**.

`git diff --check`: clean.

Resolved release identity: `v26.3.1-RC4-build5`.

GitHub release and tag checks confirmed that Build 5 does not already exist.

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Runtime defaults are unchanged.
- [x] No breaking changes.
