### PR TITLE
Fix VibeScript deletion on long Windows paths

### DIFF
--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
@@ -15,6 +15,7 @@ import ast
 import base64
 import binascii
 from dataclasses import dataclass
+import errno
 import hashlib
 import inspect
 import json
@@ -17038,11 +17039,69 @@ def restore_prepared_delete(prepared: Mapping[str, Any]) -> None:
         trash.replace(original)
 
 
+def _ignore_missing_artifact_cleanup_error(
+    _function: Callable[..., Any],
+    _path: str,
+    exc_info: tuple[type[BaseException], BaseException, Any],
+) -> None:
+    error = exc_info[1]
+    if isinstance(error, FileNotFoundError):
+        return
+    raise error.with_traceback(exc_info[2])
+
+
+def _deleted_program_cleanup_path(trash: Path) -> str | Path:
+    if os.name != "nt":
+        return trash
+    # Packaged Windows Python can report WinError 3 for descendants beyond
+    # MAX_PATH unless recursive cleanup starts from an extended-length path.
+    absolute = os.path.abspath(os.fspath(trash))
+    if absolute.startswith("\\\\?\\"):
+        return absolute
+    if absolute.startswith("\\\\"):
+        return f"\\\\?\\UNC\\{absolute[2:]}"
+    return f"\\\\?\\{absolute}"
+
+
+def _remove_deleted_program_artifacts(trash: Path) -> None:
+    cleanup_path = _deleted_program_cleanup_path(trash)
+    last_transient_error: OSError | None = None
+    # A worker or filesystem scanner can still create a final cache entry
+    # between rmtree's directory scan and its parent-directory removal.
+    for attempt in range(5):
+        try:
+            shutil.rmtree(
+                cleanup_path,
+                onerror=_ignore_missing_artifact_cleanup_error,
+            )
+        except OSError as exc:
+            retryable = isinstance(exc, FileNotFoundError) or (
+                exc.errno == errno.ENOTEMPTY or getattr(exc, "winerror", None) == 145
+            )
+            if not retryable:
+                raise
+            if not os.path.exists(cleanup_path):
+                return
+            last_transient_error = exc
+        else:
+            if not os.path.exists(cleanup_path):
+                return
+            last_transient_error = OSError(
+                errno.ENOTEMPTY,
+                "Deleted-program artifacts remain after cleanup",
+                trash,
+            )
+        if attempt < 4:
+            time.sleep(0.05 * (attempt + 1))
+    assert last_transient_error is not None
+    raise last_transient_error
+
+
 def finish_delete(
     prepared: Mapping[str, Any], publication: Mapping[str, Any]
 ) -> dict[str, Any]:
     trash = Path(str(prepared["trash_directory"]))
-    shutil.rmtree(trash)
+    _remove_deleted_program_artifacts(trash)
     deleted_objects = list(publication.get("deleted_objects") or [])
     return {
         "ok": True,

--- a/src/Mod/VibeCAD/vibecad_tests/test_scripted_editor_architecture.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_scripted_editor_architecture.py
@@ -4,8 +4,11 @@
 
 from __future__ import annotations
 
+import errno
 import json
 from pathlib import Path
+
+import pytest
 
 import VibeCADVibeScriptDomains as domains
 import VibeCADVibeScriptDomainRuntime as runtime
@@ -49,6 +52,18 @@ class _Service:
     @staticmethod
     def _active_document() -> _Document:
         return _Document()
+
+
+def _finish_delete_fixture(pack, trash: Path, program_id: str) -> dict:
+    return runtime.finish_delete(
+        {
+            "trash_directory": str(trash),
+            "program_id": program_id,
+            "pack": pack,
+            "arguments": {"reason": "Deleted from Model Code Editor"},
+        },
+        {"deleted_objects": []},
+    )
 
 
 def test_editor_program_index_never_captures_domain_geometry() -> None:
@@ -230,3 +245,129 @@ def test_editor_delete_lifecycle_accepts_a_failed_source_only_program(
         "artifacts_deleted": True,
     }
     assert not Path(prepared["trash_directory"]).exists()
+
+
+def test_editor_delete_lifecycle_tolerates_a_disappearing_trash_child(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    pack = domains.get_vibescript_pack("PartDesignWorkbench")
+    assert pack is not None
+    trash = tmp_path / ".trash" / f"{'2' * 32}-pending"
+    outputs = trash / "attempts" / "attempt-1" / "outputs"
+    outputs.mkdir(parents=True)
+    (outputs / "partdesign-native-history.json").write_text(
+        "{}",
+        encoding="utf-8",
+    )
+    real_rmtree = runtime.shutil.rmtree
+    cleanup_calls: list[str] = []
+
+    def racing_rmtree(path, *args, **kwargs) -> None:
+        cleanup_calls.append(str(path))
+        if len(cleanup_calls) == 1:
+            missing = outputs / "partdesign-native-history.json"
+            missing.unlink()
+            raise FileNotFoundError(3, "The system cannot find the path specified", missing)
+        real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(runtime.shutil, "rmtree", racing_rmtree)
+
+    deleted = _finish_delete_fixture(pack, trash, "2" * 32)
+
+    assert deleted["artifacts_deleted"] is True
+    assert len(cleanup_calls) == 2
+    assert all(call.endswith(str(trash)) for call in cleanup_calls)
+    assert not trash.exists()
+
+
+def test_editor_delete_lifecycle_uses_extended_windows_cleanup_paths(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    if runtime.os.name != "nt":
+        pytest.skip("Windows extended-length path behavior")
+    pack = domains.get_vibescript_pack("PartDesignWorkbench")
+    assert pack is not None
+    trash = tmp_path / ".trash" / f"{'5' * 32}-pending"
+    trash.mkdir(parents=True)
+    long_child = (
+        trash
+        / "attempts"
+        / ("6" * 96)
+        / "outputs"
+        / "partdesign-native-history.json"
+    )
+    assert len(str(long_child)) > 260
+    real_rmtree = runtime.shutil.rmtree
+    cleanup_calls: list[str] = []
+
+    def long_path_sensitive_rmtree(path, *args, **kwargs) -> None:
+        cleanup_calls.append(str(path))
+        if not str(path).startswith("\\\\?\\"):
+            raise FileNotFoundError(3, "The system cannot find the path specified", long_child)
+        real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(runtime.shutil, "rmtree", long_path_sensitive_rmtree)
+
+    deleted = _finish_delete_fixture(pack, trash, "5" * 32)
+
+    assert deleted["artifacts_deleted"] is True
+    assert cleanup_calls == [f"\\\\?\\{trash}"]
+    assert not trash.exists()
+
+
+def test_editor_delete_lifecycle_retries_a_transient_nonempty_directory(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    pack = domains.get_vibescript_pack("PartDesignWorkbench")
+    assert pack is not None
+    trash = tmp_path / ".trash" / f"{'4' * 32}-pending"
+    trash.mkdir(parents=True)
+    real_rmtree = runtime.shutil.rmtree
+    cleanup_calls: list[str] = []
+
+    def racing_rmtree(path, *args, **kwargs) -> None:
+        cleanup_calls.append(str(path))
+        if len(cleanup_calls) == 1:
+            raise OSError(errno.ENOTEMPTY, "The directory is not empty", path)
+        real_rmtree(path, *args, **kwargs)
+
+    monkeypatch.setattr(runtime.shutil, "rmtree", racing_rmtree)
+
+    deleted = _finish_delete_fixture(pack, trash, "4" * 32)
+
+    assert deleted["artifacts_deleted"] is True
+    assert len(cleanup_calls) == 2
+    assert all(call.endswith(str(trash)) for call in cleanup_calls)
+    assert not trash.exists()
+
+
+def test_editor_delete_lifecycle_preserves_real_cleanup_failures(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    pack = domains.get_vibescript_pack("PartDesignWorkbench")
+    assert pack is not None
+    trash = tmp_path / ".trash" / f"{'3' * 32}-pending"
+    trash.mkdir(parents=True)
+    denied = PermissionError(13, "Access is denied", trash / "locked.json")
+
+    def denied_rmtree(path, *args, **kwargs) -> None:
+        onerror = kwargs["onerror"]
+        onerror(
+            Path.unlink,
+            str(Path(path) / "locked.json"),
+            (PermissionError, denied, None),
+        )
+
+    monkeypatch.setattr(runtime.shutil, "rmtree", denied_rmtree)
+
+    try:
+        _finish_delete_fixture(pack, trash, "3" * 32)
+    except PermissionError as exc:
+        assert exc is denied
+    else:
+        raise AssertionError("A real artifact-cleanup failure was hidden")
+    assert trash.exists()


### PR DESCRIPTION
﻿## Summary

Fix VibeScript program deletion on Windows when retained attempt artifacts exceed the legacy path limit or change during recursive cleanup.

- start recursive deletion from a Windows extended-length path, including UNC handling
- tolerate descendants that are already gone
- retry bounded `ENOTEMPTY` / WinError 145 races
- verify the trash root is absent before returning `artifacts_deleted: true`
- continue to propagate access-denied and other genuine filesystem errors

Fixes #69.

## Why

The failing paths reported as WinError 3 were still present and measured 269-271 characters. The packaged Windows Python runtime therefore could not reliably traverse them with a normal `shutil.rmtree()` root. A real Part Design lifecycle run also reproduced WinError 145 when `__pycache__` content remained between enumeration and directory removal.

## TDD verification

Red tests were added and observed failing before their corresponding implementation changes:

```powershell
$env:PYTHONPATH=(Resolve-Path 'src\Mod\VibeCAD').Path
.\.pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_scripted_editor_architecture.py -k "tolerates_a_disappearing_trash_child"
# 1 failed, 5 deselected

.\.pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_scripted_editor_architecture.py -k "transient_nonempty_directory"
# 1 failed, 7 deselected

.\.pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_scripted_editor_architecture.py -k "uses_extended_windows_cleanup_paths"
# 1 failed, 8 deselected
```

Green focused suite:

```powershell
$env:PYTHONPATH=(Resolve-Path 'src\Mod\VibeCAD').Path
.\.pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_scripted_editor_architecture.py
# 9 passed
```

Real installed VibeCAD/FreeCADCmd lifecycle verification against the patched source:

```powershell
$script = (Resolve-Path 'src\Mod\VibeCAD\vibecad_tests\partdesign_vibescript_api_integration.py').Path
$code = "import pathlib, runpy, tempfile; ns = runpy.run_path(r'$script'); root_context = tempfile.TemporaryDirectory(prefix='vibecad-delete-fix-'); root = pathlib.Path(root_context.name); pack = ns['get_vibescript_pack']('PartDesignWorkbench'); print(ns['_exercise_lifecycle'](root, pack)); print(ns['_exercise_provider_failed_source_lifecycle'](root, pack)); root_context.cleanup()"
& 'C:\Program Files\VibeCAD 26.3\bin\freecadcmd.exe' --safe-mode -c $code
# exit 0; normal lifecycle deleted all owned CAD objects
# failed-source lifecycle: read, edit, and delete all true
```

Related regression set:

```powershell
$env:PYTHONPATH=(Resolve-Path 'src\Mod\VibeCAD').Path
.\.pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_scripted_editor_architecture.py src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py src/Mod/VibeCAD/vibecad_tests/test_tool_surface_guardrails.py src/Mod/VibeCAD/vibecad_tests/test_vibescript_timeline_publication.py
# 247 passed, 8 failed
```

The same eight unrelated `test_modeling_surface_architecture.py` failures were reproduced from untouched `main` in a detached worktree (`243 passed, 8 failed`): Windows path-format expectation, API-description size/content drift, `read_api` response drift, component-catalog description drift, stale schema hashes, and two stale `_execute_source` calls.

Syntax and whitespace checks:

```powershell
.\.pixi\envs\default\python.exe -m py_compile src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py src/Mod/VibeCAD/vibecad_tests/test_scripted_editor_architecture.py
git diff --check
# both passed
```

No rebuild was required for this pure-Python change; the native lifecycle was exercised through the installed VibeCAD 26.3.1 RC4 Build 5 command runtime while importing the patched repository source.

## Risk and non-goals

The extended path is used only for deleted-program artifact cleanup on Windows. Retries are limited to five attempts and only missing-path or non-empty-directory conditions; all other filesystem errors still propagate. This PR does not remove orphaned trash directories left by earlier failed releases.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields are renamed or removed.
- [x] Defaults and response fields preserve prior behavior.
- [x] No deprecations are introduced.
- [x] No breaking changes are included.

## Verification checklist

- [x] A test failed before the implementation and passes afterward.
- [x] Exact build and test commands and results are listed above.

## Issues

Closes #69.

## Before and After Images

Not applicable; there is no UI change.
