### PR TITLE
Make planning a natural conversation flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ When using a `.env` file for this fallback, use `OPENAI_API_KEY`; VibeCAD resolv
 3. Open **View > Panels > VibeCAD Assistant** if the assistant is not visible.
 4. Describe the intended result, including the dimensions, interfaces, material, manufacturing process, and constraints that matter.
 5. Use **Attach Image** for a reference design, or paste an image into the message box with `Ctrl+V`. Use **Attach View** to include the current viewport in the next model request only; it is consumed after that delivery.
-6. Choose **Build** to let Codex edit the document, or **Plan** to let it inspect and propose work with only read/view CAD tools. Then click **Send**. While work is running, the same input becomes **Steer**, so corrections stay in the same conversation. **Stop** ends the run after the current provider or CAD step returns.
+6. Click **Send**. Ask for a plan when you want one, revise it in the same conversation, then say **Build it** when you are ready. While work is running, the same input becomes **Steer**, so corrections stay in that conversation. **Stop** ends the run after the current provider or CAD step returns.
 7. Save the CAD document normally. Reopening it restores the associated VibeCAD conversations and project records.
 
 Be explicit about functional intent, not only appearance. For an existing model, identify what should be preserved and what should change. For a new part, provide mating geometry and critical dimensions whenever they are known.

--- a/docs/vibecad-agent-control.md
+++ b/docs/vibecad-agent-control.md
@@ -28,7 +28,7 @@ The in-app Assistant already has a first-class **Grok (X / xAI)** provider:
 2. Enable **Use online provider** and select **Grok (X / xAI)**.
 3. Click **Sign in with X / Grok** (or **Use device code**).
 4. Click **Fetch models**, pick a Grok model, Apply.
-5. Build / Plan / Steer against the open document as with ChatGPT.
+5. Ask, plan, build, or steer against the open document as with ChatGPT.
 
 xAI publishes real OAuth at `https://auth.x.ai`. xAI does not publish a
 VibeCAD-specific OAuth app; VibeCAD reuses the official Grok CLI public

--- a/src/Mod/VibeCAD/VibeCADCodex.py
+++ b/src/Mod/VibeCAD/VibeCADCodex.py
@@ -111,7 +111,6 @@ def vibecad_thread_config(
     *,
     web_search_enabled: bool = False,
     skills_enabled: bool = False,
-    collaboration_mode_enabled: bool = False,
     openai_base_url: str | None = None,
     model_context_window: int | None = None,
     model_auto_compact_token_limit: int | None = None,
@@ -120,9 +119,7 @@ def vibecad_thread_config(
     config: dict[str, Any] = {
         "web_search": "live" if web_search_enabled else "disabled",
         "include_apps_instructions": False,
-        "include_collaboration_mode_instructions": bool(
-            collaboration_mode_enabled
-        ),
+        "include_collaboration_mode_instructions": False,
         "include_environment_context": False,
         "include_permissions_instructions": False,
         "orchestrator.mcp.enabled": False,

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -34,7 +34,6 @@ from VibeCADPromptStarters import (
 )
 from VibeCADSession import (
     _format_document_delta,
-    normalize_interaction_mode,
     rebuild_intent_memory,
     run_native_surface_continuation,
     run_prompt,
@@ -2832,7 +2831,6 @@ def _render_assistant_run_state(dock: Any, text: str | None = None) -> None:
     conversation_selector = _find_child("QComboBox", "VibeConversationSelector", dock)
     new_conversation = _find_child("QToolButton", "VibeNewConversation", dock)
     prompt_starters = _find_child("QToolButton", "VibePromptStarters", dock)
-    interaction_mode = _find_child("QComboBox", "VibeInteractionMode", dock)
     authoring_mode = _find_child("QComboBox", "VibeAuthoringMode", dock)
     composer_buttons = _find_child("QWidget", "VibeComposerButtons", dock)
 
@@ -2860,28 +2858,6 @@ def _render_assistant_run_state(dock: Any, text: str | None = None) -> None:
         new_conversation.setEnabled(internal_available and document_ready and not busy)
     if prompt_starters is not None:
         prompt_starters.setEnabled(internal_available and document_ready and not busy)
-    if interaction_mode is not None:
-        try:
-            supports_plan = get_service().provider_name() in {
-                "openai",
-                "chatgpt",
-                "grok",
-            }
-        except Exception:
-            supports_plan = False
-        if not supports_plan and interaction_mode.currentData() == "plan":
-            interaction_mode.setCurrentIndex(0)
-        interaction_mode.setEnabled(
-            internal_available and document_ready and not busy and supports_plan
-        )
-        interaction_mode.setToolTip(
-            (
-                "Build can change the active document; Plan inspects it without "
-                "making changes"
-            )
-            if supports_plan
-            else "Plan mode requires ChatGPT, OpenAI, or Grok running through Codex"
-        )
     if authoring_mode is not None:
         _refresh_authoring_mode_selector(dock)
     if composer_buttons is not None:
@@ -3028,7 +3004,6 @@ def start_aero_designer_turn(prompt: str) -> bool:
         dock,
         service,
         prompt=clean,
-        interaction_mode="build",
     )
     return True
 
@@ -3104,7 +3079,6 @@ def _execute_assistant_run(
     *,
     prompt: str | None = None,
     continuation_event: dict[str, Any] | None = None,
-    interaction_mode: str = "build",
 ) -> None:
     global _assistant_run_thread
     if not _internal_agent_allowed():
@@ -3119,11 +3093,6 @@ def _execute_assistant_run(
         )
         return
     clean_prompt = str(prompt or "").strip()
-    clean_interaction_mode = (
-        "build"
-        if continuation_event is not None
-        else normalize_interaction_mode(interaction_mode)
-    )
     if bool(clean_prompt) == bool(continuation_event):
         raise ValueError(
             "A VibeCAD run requires exactly one user prompt or continuation event."
@@ -3309,7 +3278,6 @@ def _execute_assistant_run(
             else:
                 response = run_prompt(
                     clean_prompt,
-                    interaction_mode=clean_interaction_mode,
                     **common_arguments,
                 )
         except BaseException as exc:
@@ -3528,17 +3496,12 @@ def _run_prompt_from_panel() -> None:
 
     # The background session persists the prompt after capturing only the
     # active document identity on the GUI thread.
-    interaction_mode = _find_child("QComboBox", "VibeInteractionMode", dock)
-    selected_mode = (
-        interaction_mode.currentData() if interaction_mode is not None else "build"
-    )
     _append_conversation("User", prompt)
     prompt_box.clear()
     _execute_assistant_run(
         dock,
         service,
         prompt=prompt,
-        interaction_mode=normalize_interaction_mode(selected_mode),
     )
 
 
@@ -4626,16 +4589,6 @@ def _build_panel_widget():
     )
     prompt_starters.setMenu(prompt_starter_menu)
 
-    interaction_mode = QtWidgets.QComboBox(composer_buttons)
-    interaction_mode.setObjectName("VibeInteractionMode")
-    interaction_mode.addItem("Build", "build")
-    interaction_mode.addItem("Plan", "plan")
-    interaction_mode.setToolTip(
-        "Build can change the active document; Plan inspects it without making changes"
-    )
-    interaction_mode.setAccessibleName("Interaction mode")
-    interaction_mode.setEnabled(False)
-
     send_button = QtWidgets.QPushButton("Send", composer_buttons)
     send_button.setObjectName("VibeSend")
     send_button.setIcon(QtGui.QIcon(_icon_path(ICON_SEND)))
@@ -4657,7 +4610,6 @@ def _build_panel_widget():
     buttons_layout.addWidget(attach_button)
     buttons_layout.addWidget(attach_image_button)
     buttons_layout.addStretch(1)
-    buttons_layout.addWidget(interaction_mode)
     buttons_layout.addWidget(send_button)
     buttons_layout.addWidget(stop_button)
     _install_composer_width_filter(composer_buttons)

--- a/src/Mod/VibeCAD/VibeCADMCP.py
+++ b/src/Mod/VibeCAD/VibeCADMCP.py
@@ -356,7 +356,6 @@ class _HostToolSession:
                 service,
                 workbench,
                 runtime_state=runtime_state,
-                interaction_mode="build",
             )
             document = getattr(App, "ActiveDocument", None)
             document_identity = ""
@@ -441,7 +440,6 @@ class _HostToolSession:
         context = _build_context_for_provider(
             service,
             None,
-            "build",
             self._dispatch,
         )
         self._runner = make_provider_tool_runner(
@@ -477,7 +475,6 @@ class _HostToolSession:
                 if isinstance(context.get("editable_sources"), dict)
                 else None
             ),
-            interaction_mode="build",
             provider_calls_allowed=False,
         )
         self._runner_signature = signature

--- a/src/Mod/VibeCAD/VibeCADNativeApplicationManifest.py
+++ b/src/Mod/VibeCAD/VibeCADNativeApplicationManifest.py
@@ -115,7 +115,6 @@ ASSISTANT_CHROME_IDS = frozenset(
         "VibeAttachImage",
         "VibePromptStarters",
         "VibePromptStarterMenu",
-        "VibeInteractionMode",
         "VibeSend",
         "VibeStop",
     }

--- a/src/Mod/VibeCAD/VibeCADNativeProviderContext.py
+++ b/src/Mod/VibeCAD/VibeCADNativeProviderContext.py
@@ -45,23 +45,13 @@ def resolve_production_native_surface(
     return registry, surface
 
 
-def native_provider_tool_schemas(
-    *,
-    interaction_mode: str,
-) -> list[dict[str, Any]]:
-    registry, surface = resolve_production_native_surface()
-    return schemas_for_native_provider_surface(
-        surface,
-        interaction_mode=interaction_mode,
-        registry=registry,
-    )
+def native_provider_tool_schemas() -> list[dict[str, Any]]:
+    _registry, surface = resolve_production_native_surface()
+    return schemas_for_native_provider_surface(surface)
 
 
 def schemas_for_native_provider_surface(
     surface: NativeProviderSurface,
-    *,
-    interaction_mode: str,
-    registry: NativeCapabilityRegistry | None = None,
 ) -> list[dict[str, Any]]:
     """Copy schemas from one already-resolved live manifest surface."""
 
@@ -69,31 +59,7 @@ def schemas_for_native_provider_surface(
         raise TypeError("surface must be a NativeProviderSurface")
     if not surface.available:
         return []
-    mode = str(interaction_mode or "build").strip().lower()
-    if mode == "build":
-        schemas = surface.schemas
-    elif mode == "plan":
-        if registry is None:
-            from VibeCADNativeRegistry import build_native_capability_registry
-
-            selected_registry = build_native_capability_registry()
-        else:
-            selected_registry = registry
-        schemas = []
-        for name, schema in zip(
-            surface.tool_names,
-            surface.schemas,
-            strict=True,
-        ):
-            definition = selected_registry.definition(name)
-            if (
-                definition is not None
-                and definition.primary_classification in {"read", "view"}
-            ):
-                schemas.append(schema)
-    else:
-        raise ValueError(f"Unknown Native interaction mode {mode!r}.")
-    return [provider_visible_native_schema(schema) for schema in schemas]
+    return [provider_visible_native_schema(schema) for schema in surface.schemas]
 
 
 def native_active_state(service: Any) -> dict[str, Any]:

--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -63,7 +63,7 @@ VIBECAD_SYSTEM_INSTRUCTIONS = """You are VibeCAD, the mechanical engineer for th
 
 CURRENT_USER_MESSAGE controls; RECENT_CONVERSATION_JSON resolves follow-ups. Meet explicit requirements; decide only ordinary details required for function. Ask only when an answer changes function or geometry. Build editable parametric geometry. Preserve existing identity and history unless replacement is requested; a correction changes only the named design. Search catalogs only for requested or required unspecified components; explicit dimensions are not catalog requests.
 
-Use only exposed tools and exact returned state. Never invent names, references, revisions, or API members. Act decisively; do not narrate plans or revisit settled arithmetic. Resolve a failed operation before dependent work and never repeat an unchanged failure. Verify requested and function-critical geometry, interfaces, clearances, motion, manufacture, and appearance before claiming completion. Before claiming appearance is good, capture at least isometric, front, and top via core.set_view, fit (frame='all' or fit_all/set_isometric), and core.capture_view_screenshot; one random view is not enough. Pixels never invent dimensions, clearance, or fit; cite the view and tag presentation_only vs needs_measurement. If the next screenshot is unchanged (same faceting, clipping, or lighting), stop retrying that view; change tessellation, display, or section, or measure. Do not claim STEP, STL, or export quality from a screenshot. Aero mass, CL, hover power, and stability come from aero.solve / aero.inspect / the aero flight card, never from screenshots. Those numbers are not airworthy. Never claim work or verification not performed."""
+Use only exposed tools and exact returned state. Never invent names, references, revisions, or API members. Act decisively; do not revisit settled arithmetic. Resolve a failed operation before dependent work and never repeat an unchanged failure. Verify requested and function-critical geometry, interfaces, clearances, motion, manufacture, and appearance before claiming completion. Before claiming appearance is good, capture at least isometric, front, and top via core.set_view, fit (frame='all' or fit_all/set_isometric), and core.capture_view_screenshot; one random view is not enough. Pixels never invent dimensions, clearance, or fit; cite the view and tag presentation_only vs needs_measurement. If the next screenshot is unchanged (same faceting, clipping, or lighting), stop retrying that view; change tessellation, display, or section, or measure. Do not claim STEP, STL, or export quality from a screenshot. Aero mass, CL, hover power, and stability come from aero.solve / aero.inspect / the aero flight card, never from screenshots. Those numbers are not airworthy. Never claim work or verification not performed."""
 
 
 ANTHROPIC_TURN_COMPACTION_INSTRUCTIONS = """You compact one unfinished VibeCAD agent turn.
@@ -827,38 +827,18 @@ class CodexProvider(BaseProvider):
                         ),
                     },
                 )
-        interaction_mode = (
-            str(live_context.get("_vibecad_interaction_mode") or "build")
-            .strip()
-            .lower()
-        )
-        if interaction_mode not in {"build", "plan"}:
-            raise ProviderUnavailable(
-                f"Unknown VibeCAD interaction mode {interaction_mode!r}."
-            )
-        plan_mode = interaction_mode == "plan"
         namespaced_tools = _codex_uses_namespaced_tools(
             auth_mode=self.auth_mode,
             base_url=self.base_url,
         )
-        current_dynamic_tools, dynamic_name_map = _codex_dynamic_tool_surface(
+        dynamic_tools, dynamic_name_map = _codex_dynamic_tool_surface(
             live_context,
             namespaced=namespaced_tools,
         )
-        if not current_dynamic_tools:
+        if not dynamic_tools:
             raise ProviderUnavailable(
                 "Codex mode has no declared VibeCAD tools for the current workbench."
             )
-        thread_surface = live_context.get("_vibecad_codex_thread_surface")
-        if isinstance(thread_surface, dict):
-            thread_context = dict(live_context)
-            thread_context.update(thread_surface)
-        else:
-            thread_context = live_context
-        thread_dynamic_tools, _thread_name_map = _codex_dynamic_tool_surface(
-            thread_context,
-            namespaced=namespaced_tools,
-        )
         skill_call_key = (
             ("skills", "read")
             if namespaced_tools
@@ -1037,12 +1017,6 @@ class CodexProvider(BaseProvider):
 
             tool_name = dynamic_name_map.get((namespace, function_name))
             if tool_name is None:
-                declared_name = _thread_name_map.get((namespace, function_name))
-                if declared_name is not None:
-                    raise CodexAppServerError(
-                        f"VibeCAD tool {declared_name} is not available in this "
-                        f"{interaction_mode} turn."
-                    )
                 raise CodexAppServerError(
                     f"Unknown VibeCAD dynamic tool {namespace}.{function_name}."
                 )
@@ -1170,7 +1144,7 @@ class CodexProvider(BaseProvider):
             else None
         )
         session_identity = live_context.get("_vibecad_codex_session")
-        thread_declaration = thread_context.get("provider_tool_surface")
+        thread_declaration = live_context.get("provider_tool_surface")
         managed = bool(
             isinstance(session_identity, dict)
             and str(session_identity.get("conversation_id") or "").strip()
@@ -1277,7 +1251,7 @@ class CodexProvider(BaseProvider):
                     cwd=codex_workspace(),
                 )
                 if skill_catalog:
-                    thread_dynamic_tools.append(
+                    dynamic_tools.append(
                         _codex_skill_read_tool(namespaced=namespaced_tools)
                     )
 
@@ -1310,11 +1284,10 @@ class CodexProvider(BaseProvider):
                 "developerInstructions": developer_instructions,
                 "ephemeral": not managed,
                 "environments": [],
-                "dynamicTools": thread_dynamic_tools,
+                "dynamicTools": dynamic_tools,
                 "config": vibecad_thread_config(
                     web_search_enabled=self.web_search_enabled,
                     skills_enabled=self.skills_enabled,
-                    collaboration_mode_enabled=plan_mode,
                     openai_base_url=(
                         (codex_base_url or "")
                         if self.auth_mode == "api_key"
@@ -1387,28 +1360,7 @@ class CodexProvider(BaseProvider):
                 "environments": [],
             }
             effort = _provider_reasoning_effort(self.reasoning_effort)
-            if plan_mode:
-                effective_model = str(
-                    thread_result.get("model")
-                    if isinstance(thread_result, dict)
-                    else ""
-                ).strip()
-                if not effective_model:
-                    effective_model = self.model
-                if not effective_model:
-                    raise ProviderUnavailable(
-                        "Codex did not report the model required for Plan mode."
-                    )
-                turn_request["collaborationMode"] = {
-                    "mode": "plan",
-                    "settings": {
-                        "model": effective_model,
-                        "reasoning_effort": effort or "medium",
-                        "developer_instructions": None,
-                    },
-                }
-                turn_request["summary"] = "auto"
-            elif effort:
+            if effort:
                 turn_request["effort"] = effort
                 turn_request["summary"] = "auto"
             else:
@@ -1477,7 +1429,6 @@ class CodexProvider(BaseProvider):
                     final_output="",
                     raw={
                         "thread_id": thread_id,
-                        "interaction_mode": interaction_mode,
                         "auth_mode": self.auth_mode,
                         "cad_transition": True,
                     },
@@ -1494,7 +1445,6 @@ class CodexProvider(BaseProvider):
                     final_output="",
                     raw={
                         "thread_id": thread_id,
-                        "interaction_mode": interaction_mode,
                         "auth_mode": self.auth_mode,
                         "cad_transition": True,
                     },
@@ -1514,7 +1464,6 @@ class CodexProvider(BaseProvider):
                 final_output=final_output,
                 raw={
                     "thread_id": thread_id,
-                    "interaction_mode": interaction_mode,
                     "auth_mode": self.auth_mode,
                     **(
                         {

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -62,30 +62,8 @@ PROVIDER_SAFE_LEVELS = {
     SafetyLevel.VIEW,
     SafetyLevel.SAFE_WRITE,
 }
-PLAN_PROVIDER_SAFE_LEVELS = {
-    SafetyLevel.READ,
-    SafetyLevel.VIEW,
-}
-INTERACTION_MODES = frozenset({"build", "plan"})
 
 CORE_PROVIDER_TOOLS = set(CORE_CONVERSATION_VIEW_TOOLS) | set(SHARED_CONTEXT_TOOLS)
-
-
-def normalize_interaction_mode(value: str | None) -> str:
-    clean = str(value or "build").strip().lower()
-    if clean not in INTERACTION_MODES:
-        raise ValueError(
-            f"Unknown VibeCAD interaction mode {clean!r}; expected build or plan."
-        )
-    return clean
-
-
-def _provider_safety_levels(interaction_mode: str) -> set[SafetyLevel]:
-    return (
-        PLAN_PROVIDER_SAFE_LEVELS
-        if normalize_interaction_mode(interaction_mode) == "plan"
-        else PROVIDER_SAFE_LEVELS
-    )
 
 
 VIBESCRIPT_PROVIDER_TOOLS = {
@@ -710,15 +688,13 @@ def _provider_safe_tool_names(
     service: VibeCADService,
     workbench: str | None,
     edit_mode: str,
-    interaction_mode: str = "build",
 ) -> list[str]:
     """Return live-callable names without serializing provider schemas."""
 
-    allowed_safety = _provider_safety_levels(interaction_mode)
     result: list[str] = []
     for name in sorted(_surface_tool_names(service, workbench)):
         tool = service.registry.get(name)
-        if tool.safety not in allowed_safety:
+        if tool.safety not in PROVIDER_SAFE_LEVELS:
             continue
         # A sketch task is transient, not a different Model/Assembly API.  The
         # runner returns EDIT_STATE_MISMATCH if a call cannot execute until the
@@ -735,8 +711,6 @@ def is_provider_safe_tool(
     service: VibeCADService,
     tool_name: str,
     workbench: str | None = None,
-    *,
-    interaction_mode: str = "build",
 ) -> bool:
     modeling_engine = getattr(service, "modeling_engine", None)
     if (
@@ -746,25 +720,19 @@ def is_provider_safe_tool(
         from VibeCADNativeProviderContext import resolve_production_native_surface
 
         try:
-            registry, surface = resolve_production_native_surface()
+            _registry, surface = resolve_production_native_surface()
         except Exception:
             return False
         clean_name = str(tool_name)
         if not surface.available or clean_name not in surface.tool_names:
             return False
-        if normalize_interaction_mode(interaction_mode) == "build":
-            return True
-        definition = registry.definition(clean_name)
-        return bool(
-            definition is not None
-            and definition.primary_classification in {"read", "view"}
-        )
+        return True
     try:
         tool = service.registry.get(tool_name)
     except KeyError:
         return False
     active = workbench or service.active_workbench_name()
-    if tool.safety not in _provider_safety_levels(interaction_mode):
+    if tool.safety not in PROVIDER_SAFE_LEVELS:
         return False
     if tool_name not in _surface_tool_names(service, active):
         return False
@@ -778,7 +746,6 @@ def provider_tool_schemas(
     workbench: str | None,
     *,
     runtime_state: dict[str, Any] | None = None,
-    interaction_mode: str = "build",
 ) -> list[dict[str, Any]]:
     modeling_engine = getattr(service, "modeling_engine", None)
     if (
@@ -787,7 +754,7 @@ def provider_tool_schemas(
     ):
         from VibeCADNativeProviderContext import native_provider_tool_schemas
 
-        return native_provider_tool_schemas(interaction_mode=interaction_mode)
+        return native_provider_tool_schemas()
     state = (
         runtime_state if runtime_state is not None else _minimal_runtime_state(service)
     )
@@ -795,7 +762,6 @@ def provider_tool_schemas(
         service,
         workbench,
         _edit_mode_from_runtime_state(state),
-        interaction_mode,
     )
     return [
         _provider_schema_copy(
@@ -807,7 +773,6 @@ def provider_tool_schemas(
 
 def _live_provider_surface_state(
     service: VibeCADService,
-    interaction_mode: str = "build",
 ) -> dict[str, Any]:
     """Capture one coherent authorization snapshot on the document thread."""
 
@@ -826,7 +791,6 @@ def _live_provider_surface_state(
             service,
             workbench,
             _edit_mode_from_runtime_state(runtime_state),
-            interaction_mode,
         ),
     }
 
@@ -1122,10 +1086,8 @@ def _rebase_unified_source_index(
 def _capture_context_for_provider(
     service: VibeCADService,
     session_trigger: dict[str, Any] | None = None,
-    interaction_mode: str = "build",
     prepared_component_catalog: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
-    clean_interaction_mode = normalize_interaction_mode(interaction_mode)
     raw_context = service.provider_context_summary()
     allowed_turn_facts = (
         "document",
@@ -1143,7 +1105,7 @@ def _capture_context_for_provider(
     if native_engine:
         from VibeCADNativeProviderContext import resolve_production_native_surface
 
-        _native_registry, native_provider_surface = resolve_production_native_surface()
+        _, native_provider_surface = resolve_production_native_surface()
         resolution = modeling_surface_from_native_provider(
             workbench,
             native_provider_surface,
@@ -1207,48 +1169,21 @@ def _capture_context_for_provider(
             schemas_for_native_provider_surface,
         )
 
-        schemas = schemas_for_native_provider_surface(
-            native_provider_surface,
-            interaction_mode=clean_interaction_mode,
-            registry=_native_registry,
-        )
-        codex_thread_schemas = schemas_for_native_provider_surface(
-            native_provider_surface,
-            interaction_mode="build",
-            registry=_native_registry,
-        )
+        schemas = schemas_for_native_provider_surface(native_provider_surface)
     elif not native_engine:
         schemas = provider_tool_schemas(
             service,
             workbench,
             runtime_state=runtime_state,
-            interaction_mode=clean_interaction_mode,
-        )
-        codex_thread_schemas = provider_tool_schemas(
-            service,
-            workbench,
-            runtime_state=runtime_state,
-            interaction_mode="build",
         )
     else:
         schemas = []
-        codex_thread_schemas = []
     context["provider_tool_schemas"] = schemas
-    context["_vibecad_interaction_mode"] = clean_interaction_mode
     context["provider_tool_surface"] = _turn_start_tool_surface(
         workbench,
         schemas,
         resolution=resolution,
     )
-    if codex_thread_schemas:
-        context["_vibecad_codex_thread_surface"] = {
-            "provider_tool_schemas": codex_thread_schemas,
-            "provider_tool_surface": _turn_start_tool_surface(
-                workbench,
-                codex_thread_schemas,
-                resolution=resolution,
-            ),
-        }
     if session_trigger:
         context["session_trigger"] = dict(session_trigger)
     return context
@@ -1341,7 +1276,6 @@ def _complete_context_for_provider(context: Mapping[str, Any]) -> dict[str, Any]
 def _context_for_provider(
     service: VibeCADService,
     session_trigger: dict[str, Any] | None = None,
-    interaction_mode: str = "build",
 ) -> dict[str, Any]:
     """Return completed provider context for synchronous compatibility callers."""
 
@@ -1349,7 +1283,6 @@ def _context_for_provider(
         _capture_context_for_provider(
             service,
             session_trigger,
-            interaction_mode,
         )
     )
 
@@ -1357,7 +1290,6 @@ def _context_for_provider(
 def _build_context_for_provider(
     service: VibeCADService,
     session_trigger: dict[str, Any] | None,
-    interaction_mode: str,
     document_thread_dispatch: DocumentThreadDispatch | None,
     prepared_component_catalog: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
@@ -1366,7 +1298,6 @@ def _build_context_for_provider(
         lambda: _capture_context_for_provider(
             service,
             session_trigger,
-            interaction_mode,
             prepared_component_catalog,
         ),
     )
@@ -4164,10 +4095,8 @@ def make_provider_tool_runner(
     turn_modeling_surface: dict[str, Any] | None = None,
     turn_component_catalog: Mapping[str, Any] | None = None,
     turn_editable_sources: Mapping[str, Any] | None = None,
-    interaction_mode: str = "build",
     provider_calls_allowed: bool = True,
 ):
-    clean_interaction_mode = normalize_interaction_mode(interaction_mode)
     if (
         isinstance(turn_surface, Mapping)
         and str(turn_surface.get("engine") or "") == "native"
@@ -4175,10 +4104,6 @@ def make_provider_tool_runner(
         from VibeCADNativeProviderRunner import NativeProviderToolRunner
         from VibeCADNativeSessionFactory import create_native_session_execution
 
-        if clean_interaction_mode != "build":
-            raise RuntimeError(
-                "Native Plan mode is unavailable until its read-only turn contract is complete."
-            )
         debug_config = service.provider_debug_config()
         debug_events: list[dict[str, Any]] | None = (
             [] if debug_config.get("enabled") else None
@@ -4204,7 +4129,6 @@ def make_provider_tool_runner(
             refresh_context=lambda: _build_context_for_provider(
                 service,
                 session_trigger,
-                clean_interaction_mode,
                 document_thread_dispatch,
             ),
             frozen_surface=dict(turn_surface),
@@ -4593,7 +4517,7 @@ def make_provider_tool_runner(
                 return finalize(payload)
         live_surface = _on_document_thread(
             document_thread_dispatch,
-            lambda: _live_provider_surface_state(service, clean_interaction_mode),
+            lambda: _live_provider_surface_state(service),
         )
         active_workbench = live_surface["workbench"]
         runtime_state = live_surface["runtime_state"]
@@ -4779,7 +4703,6 @@ def make_provider_tool_runner(
             review_context = _build_context_for_provider(
                 service,
                 session_trigger,
-                clean_interaction_mode,
                 document_thread_dispatch,
             )
             _emit(
@@ -5033,7 +4956,6 @@ def make_provider_tool_runner(
         refreshed = _build_context_for_provider(
             service,
             session_trigger,
-            clean_interaction_mode,
             document_thread_dispatch,
             (
                 None
@@ -5142,7 +5064,6 @@ def _run_session_turn(
     persist_input_as_user: bool,
     prompt_section: str,
     document_thread_dispatch: DocumentThreadDispatch | None,
-    interaction_mode: str,
 ) -> VibeCADResponse:
     from VibeCADMCP import require_internal_agent
 
@@ -5150,7 +5071,6 @@ def _run_session_turn(
     clean_prompt = str(prompt or "").strip()
     if not clean_prompt:
         raise ValueError("Prompt cannot be empty.")
-    clean_interaction_mode = normalize_interaction_mode(interaction_mode)
     active_service = service or _on_document_thread(
         document_thread_dispatch,
         get_service,
@@ -5203,7 +5123,6 @@ def _run_session_turn(
     context = _build_context_for_provider(
         active_service,
         session_trigger,
-        clean_interaction_mode,
         document_thread_dispatch,
     )
     if turn_conversation_id:
@@ -5228,15 +5147,8 @@ def _run_session_turn(
             prefer_online=prefer_online,
         ),
     )
-    if clean_interaction_mode == "plan" and not isinstance(
-        active_provider, CodexProvider
-    ):
-        raise ProviderUnavailable(
-            "Plan mode requires a Codex-backed provider (ChatGPT, OpenAI, or Grok)."
-        )
     provider_name = active_provider.__class__.__name__
     provider_runtime = provider_execution_identity(active_provider)
-    provider_runtime["interaction_mode"] = clean_interaction_mode
     tool_runner = make_provider_tool_runner(
         active_service,
         tool_trace=tool_trace,
@@ -5274,7 +5186,6 @@ def _run_session_turn(
             if isinstance(context.get("editable_sources"), Mapping)
             else None
         ),
-        interaction_mode=clean_interaction_mode,
     )
     _emit(
         progress_callback,
@@ -5329,7 +5240,6 @@ def _run_session_turn(
         final_context = _build_context_for_provider(
             active_service,
             session_trigger,
-            clean_interaction_mode,
             document_thread_dispatch,
         )
         _emit(
@@ -5365,7 +5275,6 @@ def _run_session_turn(
         failed_context = _build_context_for_provider(
             active_service,
             session_trigger,
-            clean_interaction_mode,
             document_thread_dispatch,
         )
         return VibeCADResponse(
@@ -5393,7 +5302,6 @@ def run_prompt(
     output_authorization_callback: NativeOutputAuthorizer | None = None,
     input_authorization_callback: NativeInputAuthorizer | None = None,
     document_thread_dispatch: DocumentThreadDispatch | None = None,
-    interaction_mode: str = "build",
 ) -> VibeCADResponse:
     return _run_session_turn(
         prompt,
@@ -5410,7 +5318,6 @@ def run_prompt(
         persist_input_as_user=True,
         prompt_section="CURRENT_USER_MESSAGE",
         document_thread_dispatch=document_thread_dispatch,
-        interaction_mode=interaction_mode,
     )
 
 
@@ -5571,7 +5478,6 @@ def run_sketch_close_continuation(
         persist_input_as_user=False,
         prompt_section="CURRENT_SESSION_EVENT",
         document_thread_dispatch=document_thread_dispatch,
-        interaction_mode="build",
     )
 
 
@@ -5651,7 +5557,6 @@ def run_native_surface_continuation(
         persist_input_as_user=False,
         prompt_section="CURRENT_SESSION_EVENT",
         document_thread_dispatch=document_thread_dispatch,
-        interaction_mode="build",
     )
 
 

--- a/src/Mod/VibeCAD/vibecad_tests/mcp_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/mcp_gui_integration.py
@@ -37,7 +37,6 @@ def _live_tool_contracts() -> list[dict[str, Any]]:
             service,
             workbench,
             runtime_state=_minimal_runtime_state(service),
-            interaction_mode="build",
         ),
         *controller_tool_schemas(),
     ]

--- a/src/Mod/VibeCAD/vibecad_tests/native_sketch_virtual_space_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_sketch_virtual_space_gui_integration.py
@@ -125,21 +125,10 @@ def _run() -> None:
         )
         assert "set_virtual_space" in json.dumps(constraint_schema, sort_keys=True)
 
-        plan_context = _capture_context_for_provider(
-            service,
-            interaction_mode="plan",
-        )
-        plan_names = plan_context["provider_tool_surface"]["tool_names"]
-        assert plan_names
-        assert set(plan_names) < set(production.tool_names)
-        assert "sketch.geometry" not in plan_names
-        assert "sketch.constraint" not in plan_names
-        assert plan_context["_vibecad_codex_thread_surface"][
-            "provider_tool_surface"
-        ]["tool_names"] == list(production.tool_names)
-
         _phase("provider_surface")
         context = _capture_context_for_provider(service)
+        assert "_vibecad_interaction_mode" not in context
+        assert "_vibecad_codex_thread_surface" not in context
         turn_surface = context["provider_tool_surface"]
         schemas = context["provider_tool_schemas"]
         assert turn_surface["kind"] == "turn_start_snapshot", turn_surface

--- a/src/Mod/VibeCAD/vibecad_tests/ollama_vibescript_live_acceptance.py
+++ b/src/Mod/VibeCAD/vibecad_tests/ollama_vibescript_live_acceptance.py
@@ -52,11 +52,6 @@ class _FilteredCodexProvider(CodexProvider):
             return result
 
         filtered.update(filter_surface(filtered))
-        thread_surface = filtered.get("_vibecad_codex_thread_surface")
-        if isinstance(thread_surface, dict):
-            filtered["_vibecad_codex_thread_surface"] = filter_surface(
-                thread_surface
-            )
         return filtered
 
     def run(self, prompt, context, *args, **kwargs):

--- a/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
@@ -192,20 +192,8 @@ class TestVibeCADResponsiveAssistant(unittest.TestCase):
                 "VibeComposerButtons",
             )
             self.assertIsNotNone(composer)
-            interaction_mode = root.findChild(
-                QtWidgets.QComboBox,
-                "VibeInteractionMode",
-            )
-            self.assertIsNotNone(interaction_mode)
-            self.assertEqual(
-                [
-                    (
-                        interaction_mode.itemText(index),
-                        interaction_mode.itemData(index),
-                    )
-                    for index in range(interaction_mode.count())
-                ],
-                [("Build", "build"), ("Plan", "plan")],
+            self.assertIsNone(
+                root.findChild(QtWidgets.QComboBox, "VibeInteractionMode")
             )
             self.assertLess(
                 composer.width(),
@@ -232,17 +220,18 @@ class TestVibeCADResponsiveAssistant(unittest.TestCase):
                 buttons["VibeAttachImage"].icon().cacheKey(),
             )
 
-            # This is the width from the reported dock screenshot: it exceeds
-            # the old 500 px guess but still cannot fit all four full labels.
+            # Removing the mode selector leaves enough room for all four
+            # actions at the width from the reported dock screenshot.
             root.resize(520, 800)
             application.processEvents()
-            self.assertLess(
+            self.assertGreaterEqual(
                 composer.width(),
                 int(composer.property("VibeFullLabelRequiredWidth")),
             )
-            for button in buttons.values():
-                self.assertEqual(button.text(), "")
-                self.assertTrue(button.property("VibeCompactMode"))
+            self.assertEqual(buttons["VibeAttachView"].text(), "Attach View")
+            self.assertEqual(buttons["VibeAttachImage"].text(), "Attach Image")
+            self.assertEqual(buttons["VibeSend"].text(), "Send")
+            self.assertEqual(buttons["VibeStop"].text(), "Stop")
 
             root.resize(760, 800)
             application.processEvents()

--- a/src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py
@@ -892,7 +892,7 @@ def test_tool_runner_revalidates_each_call_against_the_live_surface(
     monkeypatch.setattr(
         session,
         "_live_provider_surface_state",
-        lambda _service, _interaction_mode="build": {
+        lambda _service: {
             "workbench": "AssemblyWorkbench",
             "runtime_state": {"edit_mode": "none"},
             "tool_names": ["assembly.solve"],
@@ -1089,13 +1089,12 @@ def test_codex_thread_config_enables_only_web_and_skill_capabilities() -> None:
     assert config["features.plugins"] is False
 
 
-def test_codex_thread_config_enables_plan_and_api_key_provider() -> None:
+def test_codex_thread_config_keeps_one_conversation_mode_with_api_key_provider() -> None:
     config = codex.vibecad_thread_config(
-        collaboration_mode_enabled=True,
         openai_base_url="https://api.example.test/v1/",
     )
 
-    assert config["include_collaboration_mode_instructions"] is True
+    assert config["include_collaboration_mode_instructions"] is False
     assert config["model_provider"] == codex.CODEX_OPENAI_PROVIDER_ID
     prefix = f"model_providers.{codex.CODEX_OPENAI_PROVIDER_ID}"
     assert config[f"{prefix}.base_url"] == "https://api.example.test/v1"
@@ -1359,44 +1358,7 @@ def test_choose_provider_enables_web_search_for_api_providers(
         assert selected.compaction_model == "memory-model"
 
 
-def test_plan_surface_excludes_document_mutation_tools(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    class _Spec:
-        def supports_edit_mode(self, _edit_mode: str) -> bool:
-            return True
-
-    tools = {
-        "core.read": SimpleNamespace(
-            safety=SafetyLevel.READ,
-            spec=_Spec(),
-            to_schema=lambda **_kwargs: _tool_schema("core.read"),
-        ),
-        "core.view": SimpleNamespace(
-            safety=SafetyLevel.VIEW,
-            spec=_Spec(),
-            to_schema=lambda **_kwargs: _tool_schema("core.view"),
-        ),
-        "partdesign.write": SimpleNamespace(
-            safety=SafetyLevel.SAFE_WRITE,
-            spec=_Spec(),
-            to_schema=lambda **_kwargs: _tool_schema("partdesign.write"),
-        ),
-    }
-    service = SimpleNamespace(registry=SimpleNamespace(get=lambda name: tools[name]))
-    monkeypatch.setattr(session, "_surface_tool_names", lambda *_args: set(tools))
-
-    schemas = session.provider_tool_schemas(
-        service,
-        "PartDesignWorkbench",
-        runtime_state={"edit_mode": False, "active_sketch": None},
-        interaction_mode="plan",
-    )
-
-    assert [schema["name"] for schema in schemas] == ["core.read", "core.view"]
-
-
-def test_openai_api_key_and_plan_mode_run_through_codex(
+def test_natural_plan_request_uses_the_normal_codex_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _Client:
@@ -1433,7 +1395,10 @@ def test_openai_api_key_and_plan_mode_run_through_codex(
                     {
                         "threadId": "thread-1",
                         "turnId": "turn-1",
-                        "item": {"type": "plan", "text": "Inspect, then revise."},
+                        "item": {
+                            "type": "agentMessage",
+                            "text": "Inspect, then revise.",
+                        },
                     },
                 )
                 self.notification_handler(
@@ -1460,7 +1425,6 @@ def test_openai_api_key_and_plan_mode_run_through_codex(
         reasoning_effort="high",
     )
     context = _surface_context("core.set_view")
-    context["_vibecad_interaction_mode"] = "plan"
 
     result = active_provider.run("Plan the change.", context)
 
@@ -1472,7 +1436,7 @@ def test_openai_api_key_and_plan_mode_run_through_codex(
         params for method, params in client.requests if method == "thread/start"
     )
     assert thread_request["modelProvider"] == codex.CODEX_OPENAI_PROVIDER_ID
-    assert thread_request["config"]["include_collaboration_mode_instructions"] is True
+    assert thread_request["config"]["include_collaboration_mode_instructions"] is False
     assert "Operate only through the supplied VibeCAD tools" in thread_request[
         "developerInstructions"
     ]
@@ -1482,19 +1446,13 @@ def test_openai_api_key_and_plan_mode_run_through_codex(
     turn_request = next(
         params for method, params in client.requests if method == "turn/start"
     )
-    assert turn_request["collaborationMode"] == {
-        "mode": "plan",
-        "settings": {
-            "model": "gpt-test",
-            "reasoning_effort": "high",
-            "developer_instructions": None,
-        },
-    }
+    assert "collaborationMode" not in turn_request
+    assert turn_request["effort"] == "high"
     assert result.final_output == "Inspect, then revise."
-    assert result.raw["interaction_mode"] == "plan"
+    assert "interaction_mode" not in result.raw
 
 
-def test_codex_plan_and_build_resume_one_schema_thread_across_surface_revisions(
+def test_codex_plan_then_build_reuses_one_normal_conversation_thread(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     class _Client:
@@ -1541,15 +1499,18 @@ def test_codex_plan_and_build_resume_one_schema_thread_across_surface_revisions(
             if method == "turn/start":
                 self.turn_number += 1
                 turn_id = f"turn-{self.turn_number}"
-                item_type = "plan" if "collaborationMode" in params else "agentMessage"
                 self.notification_handler(
                     "item/completed",
                     {
                         "threadId": "shared-thread",
                         "turnId": turn_id,
                         "item": {
-                            "type": item_type,
-                            "text": "Plan saved." if item_type == "plan" else "Plan used.",
+                            "type": "agentMessage",
+                            "text": (
+                                "Plan saved."
+                                if self.turn_number == 1
+                                else "Plan used."
+                            ),
                         },
                     },
                 )
@@ -1570,28 +1531,9 @@ def test_codex_plan_and_build_resume_one_schema_thread_across_surface_revisions(
     codex.reset_managed_codex_sessions()
     monkeypatch.setattr(codex, "CodexAppServerClient", _Client)
     context = _surface_context("core.set_view")
-    context["_vibecad_codex_thread_surface"] = {
-        "provider_tool_schemas": list(context["provider_tool_schemas"]),
-        "provider_tool_surface": dict(context["provider_tool_surface"]),
-    }
     context["_vibecad_codex_session"] = {
         "conversation_id": "a" * 32,
         "conversation_path": "/project/conversations/" + "a" * 32 + ".json",
-    }
-    plan_context = dict(context)
-    plan_context["_vibecad_interaction_mode"] = "plan"
-    build_context = dict(context)
-    build_context["_vibecad_interaction_mode"] = "build"
-    build_context["_vibecad_codex_thread_surface"] = {
-        "provider_tool_schemas": list(context["provider_tool_schemas"]),
-        "provider_tool_surface": {
-            **dict(context["provider_tool_surface"]),
-            "surface_id": "vibecad/surface/native/model/revision-2",
-        },
-        "modeling_surface": {
-            **dict(context["modeling_surface"]),
-            "surface_id": "vibecad/surface/native/model/revision-2",
-        },
     }
     first_provider = provider.CodexProvider(
         model="gpt-test",
@@ -1603,10 +1545,10 @@ def test_codex_plan_and_build_resume_one_schema_thread_across_surface_revisions(
         api_key="test-key",
         auth_mode="api_key",
     )
-    first_prompt = session._provider_prompt("Make a plan.", plan_context)
+    first_prompt = session._provider_prompt("Make a plan.", context)
     second_prompt = session._provider_prompt(
         "Build it.",
-        build_context,
+        context,
         recent_conversation=[
             {"role": "user", "content": "Make a plan."},
             {"role": "assistant", "content": "Plan saved."},
@@ -1615,8 +1557,8 @@ def test_codex_plan_and_build_resume_one_schema_thread_across_surface_revisions(
 
     requests_before_cleanup: list[tuple[str, dict]] = []
     try:
-        planned = first_provider.run(first_prompt, plan_context)
-        built = second_provider.run(second_prompt, build_context)
+        planned = first_provider.run(first_prompt, context)
+        built = second_provider.run(second_prompt, context)
     finally:
         if _Client.instance is not None:
             requests_before_cleanup = list(_Client.instance.requests)
@@ -1631,14 +1573,20 @@ def test_codex_plan_and_build_resume_one_schema_thread_across_surface_revisions(
     assert methods.count("thread/resume") == 1
     assert methods.count("turn/start") == 2
     assert "thread/delete" not in methods
-    second_turn = [
+    turns = [
         params for method, params in requests_before_cleanup if method == "turn/start"
-    ][1]
+    ]
+    assert all("collaborationMode" not in turn for turn in turns)
+    second_turn = turns[1]
     text_input = next(
         item["text"] for item in second_turn["input"] if item["type"] == "text"
     )
     assert '"turns":[]' in text_input
     assert "Plan saved." not in text_input
+
+
+def test_system_instructions_do_not_forbid_requested_planning() -> None:
+    assert "do not narrate plans" not in provider.VIBECAD_SYSTEM_INSTRUCTIONS.lower()
 
 
 def test_codex_client_initializes_and_reads_account_from_json_rpc(

--- a/src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py
@@ -634,7 +634,7 @@ def test_unsaved_run_prompt_reaches_provider_and_includes_active_thread_once(
     monkeypatch.setattr(
         session,
         "_build_context_for_provider",
-        lambda active_service, trigger, interaction_mode, dispatch: dict(context),
+        lambda active_service, trigger, dispatch: dict(context),
     )
     monkeypatch.setattr(
         session,
@@ -671,7 +671,6 @@ def test_unsaved_run_prompt_reaches_provider_and_includes_active_thread_once(
                 "model_selection": "explicit",
                 "reasoning_effort": "xhigh",
                 "model_fallback_allowed": False,
-                "interaction_mode": "build",
             }
         },
     }

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_mode_surface.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_mode_surface.py
@@ -63,6 +63,9 @@ class _NativeService:
     def modeling_engine(self) -> str:
         return "native"
 
+    def provider_debug_config(self) -> dict:
+        return {}
+
 
 def test_native_schema_assembly_never_reads_the_legacy_service_registry(
     monkeypatch,
@@ -84,7 +87,7 @@ def test_native_schema_assembly_never_reads_the_legacy_service_registry(
     monkeypatch.setattr(
         provider_context,
         "native_provider_tool_schemas",
-        lambda *, interaction_mode: schemas if interaction_mode == "build" else [],
+        lambda: schemas,
     )
     monkeypatch.setattr(
         session,
@@ -128,19 +131,7 @@ def test_native_availability_queries_use_the_manifest_surface(
 
     assert session.is_provider_safe_tool(service, "model.feature") is True
     assert session.is_provider_safe_tool(service, "part.make_box") is False
-    assert (
-        session.is_provider_safe_tool(
-            service,
-            "state.read",
-            interaction_mode="plan",
-        )
-        is True
-    )
-    assert session.is_provider_safe_tool(
-        service,
-        "model.feature",
-        interaction_mode="plan",
-    ) is False
+    assert session.is_provider_safe_tool(service, "state.read") is True
 
 
 def test_native_runner_assembly_returns_before_the_vibescript_runner_path(

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_surface_continuation.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_surface_continuation.py
@@ -33,7 +33,7 @@ def test_native_surface_continuation_preserves_conversation_and_build_obligation
     assert captured["session_trigger"] == {"workspace": "assembly"}
     assert captured["persist_input_as_user"] is False
     assert captured["prompt_section"] == "CURRENT_SESSION_EVENT"
-    assert captured["interaction_mode"] == "build"
+    assert "interaction_mode" not in captured
     assert captured["prompt"] == (
         "Assembly work is now available. Continue the current design from its "
         "existing document state. Do not repeat completed operations."
@@ -62,4 +62,4 @@ def test_native_edit_continuation_accepts_exact_opened_sketch(monkeypatch) -> No
 
     assert captured["session_trigger"] == {"workspace": "sketching"}
     assert captured["persist_input_as_user"] is False
-    assert captured["interaction_mode"] == "build"
+    assert "interaction_mode" not in captured

--- a/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
@@ -1102,7 +1102,6 @@ def test_editable_source_manifests_complete_after_document_thread_capture(
     context = session._build_context_for_provider(
         service,
         None,
-        "build",
         dispatch,
     )
 


### PR DESCRIPTION
## Summary

- removes the Build/Plan dropdown from the Assistant;
- removes the legacy `interaction_mode` API, Plan-only tool filtering, private mode metadata, and alternate Codex thread surface;
- stops sending Codex collaboration-mode Plan turns;
- removes the normal prompt instruction that contradicted an explicit request for a plan; and
- documents the natural workflow: ask for a plan, revise it, then say “Build it” in the same conversation.

The human-selected ribbon still defines the complete tool surface. Planning is now ordinary user intent rather than a second application mode.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward.
- [x] The PR lists the exact build and test commands and their results.

### Red

Before the implementation:

```bash
PYTHONPATH=src/Mod/VibeCAD /usr/bin/python3.12 -m pytest -q \
  src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py \
  src/Mod/VibeCAD/vibecad_tests/test_native_mode_surface.py \
  -k 'one_conversation_mode or legacy_plan_argument or natural_plan_request or plan_then_build or system_instructions_do_not_forbid or native_availability'
```

Result: `4 failed, 2 passed`. The failures proved that Plan filtered writable tools, leaked mode metadata, and conflicted with the normal system prompt.

### Green

```bash
/usr/bin/python3.12 -m py_compile \
  src/Mod/VibeCAD/VibeCADGui.py \
  src/Mod/VibeCAD/VibeCADSession.py \
  src/Mod/VibeCAD/VibeCADProvider.py \
  src/Mod/VibeCAD/VibeCADCodex.py \
  src/Mod/VibeCAD/VibeCADNativeProviderContext.py \
  src/Mod/VibeCAD/VibeCADMCP.py

PYTHONPATH=src/Mod/VibeCAD:src/Mod/TechDraw /usr/bin/python3.12 -m pytest -q \
  src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py \
  src/Mod/VibeCAD/vibecad_tests/test_native_mode_surface.py \
  src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py \
  src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py \
  src/Mod/VibeCAD/vibecad_tests/test_native_surface_continuation.py \
  src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py \
  src/Mod/VibeCAD/vibecad_tests/test_aero_ribbon_and_context.py \
  src/Mod/VibeCAD/vibecad_tests/test_agent_control.py \
  src/Mod/VibeCAD/vibecad_tests/test_agent_control_grok_bot.py

cmake --build build/release -j2

build/release/bin/FreeCAD \
  -P "$PWD/src/Mod/VibeCAD/vibecad_tests" \
  -P "$PWD/src/Mod/VibeCAD" \
  -t test_branding_contract.TestVibeCADResponsiveAssistant.test_narrow_composer_uses_distinct_icons_without_words
```

Results:

- Python compilation passed.
- Focused suite passed twice after implementation: `179 passed, 5 skipped`.
- Release build passed, including a subsequent full App/GUI relink.
- Real Qt GUI test passed and confirmed `VibeInteractionMode` is absent at narrow and full-label panel widths.

### Live ChatGPT subscription acceptance

GPT-5.6 Terra at high reasoning ran three fresh Native Model conversations in real GUI processes. Each process used the supported GUI save and normal main-window close path.

1. **Plate revision**
   - Plan and revision created no objects.
   - All three turns reused one managed Codex thread.
   - “Build it” created one valid `72 × 48 × 12 mm` solid with exact `41,472 mm³` volume.

2. **Tube revision**
   - Plan and revision made zero tool calls and created no objects.
   - All three turns reused one managed Codex thread.
   - Build created one valid tube with `64 mm` OD, `36 mm` ID, `22 mm` height, and exact `48,380.52686528282 mm³` volume.

3. **Design pivot**
   - The first turn planned a plate without changing the document.
   - The second turn discarded that plan and planned a cylinder without changing the document.
   - “Build the revised design” created only one valid `24 mm × 30 mm` cylinder with exact `13,571.680263507906 mm³` volume.
   - All three turns reused one managed Codex thread.

Both additional live processes exited with zero unexpected dialogs and no crash. All three saved FCStd results were reopened independently; each contained one valid solid with the expected exact volume.

## Issues

Closes #71.

## Compatibility decision

This intentionally removes the old interaction-mode contract. The repository owner explicitly approved deleting the dropdown, call parameters, filtering, and metadata without a compatibility shim; issue #71 records that decision and migration behavior.

- [x] No unrelated public functions, preference keys, tool names, or schema fields changed.
- [x] Existing provider and ribbon selection behavior remains intact.
- [x] Existing user documents are unaffected.
- [x] The approved breaking surface is limited to the obsolete Build/Plan interaction mode.
- [x] Rollback is the single commit in this PR.

## Before and After Images

The visible change is removal of the Build/Plan selector from the Assistant composer. The real Qt layout test covers the resulting narrow and full-label states; no document rendering changes are included.

## Risk and non-goals

- The model receives the full human-selected ribbon surface on every turn. A request to plan remains non-mutating because the user requested a plan, not because VibeCAD swaps in a different schema.
- This PR does not change ribbon selection, CAD tool contracts, document persistence, provider selection, or active-turn surface freezing.
