### PR TITLE
Add McMaster-Carr catalog insert workbench

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 6
+  number: 7
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/package/rattler-build/windows/create_bundle.sh
+++ b/package/rattler-build/windows/create_bundle.sh
@@ -228,6 +228,14 @@ if ! "$SIGN_DIR/FreeCADCmd.exe" --safe-mode --version; then
   echo "VibeCAD portable command-line launcher smoke test failed."
   exit 1
 fi
+if [[ ! -x "$SIGN_DIR/Mod/McMasterInsert/McMasterCatalogWebView2.exe" ]]; then
+  echo "VibeCAD McMaster WebView2 helper is missing from the Windows bundle."
+  exit 1
+fi
+if ! "$SIGN_DIR/Mod/McMasterInsert/McMasterCatalogWebView2.exe" --smoke-test; then
+  echo "VibeCAD McMaster WebView2 helper could not find the Edge WebView2 Runtime."
+  exit 1
+fi
 if ! "$SIGN_DIR/bin/freecadcmd.exe" --safe-mode -c "import importlib.util, anthropic, keyring, jsonschema, mcp, mcp_types, tuf; import keyring.backends.Windows; assert importlib.util.find_spec('openai') is None; assert importlib.util.find_spec('agents') is None; print('VibeCAD Python dependencies and OS keyring backend import ok')"; then
   echo "VibeCAD Python dependency/keyring smoke test failed; the Windows bundle is incomplete."
   exit 1

--- a/src/Mod/CMakeLists.txt
+++ b/src/Mod/CMakeLists.txt
@@ -167,6 +167,7 @@ endif(BUILD_TECHDRAW)
 
 add_subdirectory(VibeCAD)
 add_subdirectory(VibeCADAero)
+add_subdirectory(McMasterInsert)
 
 #add_subdirectory(TemplatePyMod)
 

--- a/src/Mod/McMasterInsert/CMakeLists.txt
+++ b/src/Mod/McMasterInsert/CMakeLists.txt
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+SET(McMasterInsert_SRCS
+    Init.py
+    InitGui.py
+    Commands.py
+    InstallUI.py
+    McMasterInsert.py
+    package.xml
+    README.md
+    McMasterWebKit.swift
+    McMasterCatalog.swift
+    McMasterCatalog.entitlements
+)
+
+SET(McMasterInsert_Icons
+    icons/catalog.svg
+    icons/import.svg
+    icons/cache.svg
+    icons/mcmaster-workbench.svg
+)
+
+SET(McMasterInsert_Tests
+    tests/__init__.py
+    tests/test_catalog.py
+    tests/test_ribbon.py
+)
+
+SET(McMasterInsert_All
+    ${McMasterInsert_SRCS}
+    ${McMasterInsert_Icons}
+    ${McMasterInsert_Tests}
+)
+
+SOURCE_GROUP("" FILES ${McMasterInsert_SRCS})
+
+ADD_CUSTOM_TARGET(McMasterInsert ALL
+    SOURCES ${McMasterInsert_All}
+)
+
+fc_copy_sources(McMasterInsert "${CMAKE_BINARY_DIR}/Mod/McMasterInsert" ${McMasterInsert_All})
+
+INSTALL(
+    FILES
+        ${McMasterInsert_SRCS}
+    DESTINATION
+        Mod/McMasterInsert
+)
+
+INSTALL(
+    FILES
+        ${McMasterInsert_Icons}
+    DESTINATION
+        Mod/McMasterInsert/icons
+)
+
+if(BUILD_TEST)
+    INSTALL(
+        FILES
+            ${McMasterInsert_Tests}
+        DESTINATION
+            Mod/McMasterInsert/tests
+    )
+endif()

--- a/src/Mod/McMasterInsert/CMakeLists.txt
+++ b/src/Mod/McMasterInsert/CMakeLists.txt
@@ -13,6 +13,93 @@ SET(McMasterInsert_SRCS
     McMasterCatalog.entitlements
 )
 
+if(WIN32 AND BUILD_GUI)
+    # WebView2 is kept out of the main VibeCAD process. This small native
+    # helper uses the installed Evergreen Edge runtime and a VibeCAD-owned
+    # profile, avoiding any changes to FreeCAD's Qt/PySide dependency graph.
+    set(MCMASTER_WEBVIEW2_VERSION "1.0.4129.50")
+    set(MCMASTER_WEBVIEW2_SHA256
+        "d3934f482d484b89fb4825df720c710664e1143a1e90f7b3a60794ef33f473d2"
+    )
+    set(MCMASTER_WEBVIEW2_ROOT
+        "${CMAKE_BINARY_DIR}/_deps/mcmaster-webview2-${MCMASTER_WEBVIEW2_VERSION}"
+    )
+    set(MCMASTER_WEBVIEW2_PACKAGE
+        "${MCMASTER_WEBVIEW2_ROOT}/microsoft.web.webview2.nupkg"
+    )
+    set(MCMASTER_WEBVIEW2_HEADER
+        "${MCMASTER_WEBVIEW2_ROOT}/build/native/include/WebView2.h"
+    )
+    string(CONCAT MCMASTER_WEBVIEW2_URL
+        "https://api.nuget.org/v3-flatcontainer/microsoft.web.webview2/"
+        "${MCMASTER_WEBVIEW2_VERSION}/microsoft.web.webview2."
+        "${MCMASTER_WEBVIEW2_VERSION}.nupkg"
+    )
+    if(NOT EXISTS "${MCMASTER_WEBVIEW2_HEADER}")
+        file(MAKE_DIRECTORY "${MCMASTER_WEBVIEW2_ROOT}")
+        file(DOWNLOAD
+            "${MCMASTER_WEBVIEW2_URL}"
+            "${MCMASTER_WEBVIEW2_PACKAGE}"
+            EXPECTED_HASH "SHA256=${MCMASTER_WEBVIEW2_SHA256}"
+            STATUS MCMASTER_WEBVIEW2_DOWNLOAD_STATUS
+            TLS_VERIFY ON
+        )
+        list(GET MCMASTER_WEBVIEW2_DOWNLOAD_STATUS 0 MCMASTER_WEBVIEW2_DOWNLOAD_CODE)
+        if(NOT MCMASTER_WEBVIEW2_DOWNLOAD_CODE EQUAL 0)
+            list(GET MCMASTER_WEBVIEW2_DOWNLOAD_STATUS 1 MCMASTER_WEBVIEW2_DOWNLOAD_ERROR)
+            message(FATAL_ERROR "Could not download the pinned Microsoft WebView2 SDK: "
+                "${MCMASTER_WEBVIEW2_DOWNLOAD_ERROR}")
+        endif()
+        file(ARCHIVE_EXTRACT
+            INPUT "${MCMASTER_WEBVIEW2_PACKAGE}"
+            DESTINATION "${MCMASTER_WEBVIEW2_ROOT}"
+        )
+    endif()
+
+    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+        set(MCMASTER_WEBVIEW2_ARCH "x86")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "^(ARM64|arm64|aarch64)$")
+        set(MCMASTER_WEBVIEW2_ARCH "arm64")
+    else()
+        set(MCMASTER_WEBVIEW2_ARCH "x64")
+    endif()
+
+    set(VIBECAD_ICON_PATH "${CMAKE_SOURCE_DIR}/src/Main/vibecad.ico")
+    configure_file(
+        McMasterCatalogWebView2.rc.cmake
+        "${CMAKE_CURRENT_BINARY_DIR}/McMasterCatalogWebView2.rc"
+    )
+    add_executable(McMasterCatalogWebView2 WIN32
+        McMasterCatalogWebView2.cpp
+        "${CMAKE_CURRENT_BINARY_DIR}/McMasterCatalogWebView2.rc"
+    )
+    target_include_directories(McMasterCatalogWebView2 PRIVATE
+        "${MCMASTER_WEBVIEW2_ROOT}/build/native/include"
+    )
+    target_link_libraries(McMasterCatalogWebView2 PRIVATE
+        "${MCMASTER_WEBVIEW2_ROOT}/build/native/${MCMASTER_WEBVIEW2_ARCH}/WebView2LoaderStatic.lib"
+        advapi32
+        gdi32
+        ole32
+        shell32
+        shlwapi
+        user32
+    )
+    target_compile_definitions(McMasterCatalogWebView2 PRIVATE UNICODE _UNICODE)
+    set_target_properties(McMasterCatalogWebView2 PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/Mod/McMasterInsert"
+    )
+    foreach(config DEBUG RELEASE RELWITHDEBINFO MINSIZEREL)
+        set_target_properties(McMasterCatalogWebView2 PROPERTIES
+            "RUNTIME_OUTPUT_DIRECTORY_${config}"
+            "${CMAKE_BINARY_DIR}/Mod/McMasterInsert"
+        )
+    endforeach()
+    INSTALL(TARGETS McMasterCatalogWebView2
+        RUNTIME DESTINATION Mod/McMasterInsert
+    )
+endif()
+
 SET(McMasterInsert_Icons
     icons/catalog.svg
     icons/import.svg

--- a/src/Mod/McMasterInsert/Commands.py
+++ b/src/Mod/McMasterInsert/Commands.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Workbench commands for McMaster-Carr."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ICON_DIR = Path(__file__).resolve().parent / "icons"
+ICON = str(ICON_DIR / "mcmaster-workbench.svg")
+
+
+class BrowseCatalogCommand:
+    def GetResources(self):
+        return {
+            "Pixmap": str(ICON_DIR / "catalog.svg"),
+            "MenuText": "Browse Catalog",
+            "ToolTip": "Open the McMaster-Carr catalog and auto-import 3-D STEP.",
+        }
+
+    def IsActive(self):
+        return True
+
+    def Activated(self):
+        try:
+            from McMasterInsert import run
+
+            run()
+        except Exception as exc:
+            import FreeCAD as App
+
+            App.Console.PrintError(f"McMaster Catalog failed: {exc}\n")
+
+
+class ImportFileCommand:
+    def GetResources(self):
+        return {
+            "Pixmap": str(ICON_DIR / "import.svg"),
+            "MenuText": "Import CAD File",
+            "ToolTip": "Import a McMaster STEP/IGES/SAT file you already downloaded.",
+        }
+
+    def IsActive(self):
+        return True
+
+    def Activated(self):
+        from McMasterInsert import import_file
+
+        import_file()
+
+
+class OpenCacheCommand:
+    def GetResources(self):
+        return {
+            "Pixmap": str(ICON_DIR / "cache.svg"),
+            "MenuText": "Open Cache Folder",
+            "ToolTip": "Open the local McMaster CAD cache.",
+        }
+
+    def IsActive(self):
+        return True
+
+    def Activated(self):
+        from McMasterInsert import open_cache
+
+        open_cache()
+
+
+COMMANDS = (
+    "McMaster_BrowseCatalog",
+    "McMaster_ImportFile",
+    "McMaster_OpenCache",
+)
+
+
+def register(gui=None) -> None:
+    if gui is None:
+        import FreeCADGui as gui  # type: ignore[no-redef]
+    existing = set(gui.listCommands())
+    mapping = {
+        "McMaster_BrowseCatalog": BrowseCatalogCommand,
+        "McMaster_ImportFile": ImportFileCommand,
+        "McMaster_OpenCache": OpenCacheCommand,
+    }
+    for name, cls in mapping.items():
+        if name not in existing:
+            gui.addCommand(name, cls())

--- a/src/Mod/McMasterInsert/Init.py
+++ b/src/Mod/McMasterInsert/Init.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""McMaster-Carr workbench (FreeCAD / VibeCAD)."""
+
+try:
+    import FreeCAD
+
+    FreeCAD.Console.PrintMessage("McMasterInsert module discovered\n")
+except Exception:
+    pass
+
+

--- a/src/Mod/McMasterInsert/InitGui.py
+++ b/src/Mod/McMasterInsert/InitGui.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""McMaster-Carr workbench for VibeCAD.
+
+VibeCAD does not show extra workbenches on its ribbon selector. This file
+still registers a real Python workbench, then InstallUI pins Catalog/Import
+onto a toolbar, the McMaster-Carr menu, and the ribbon.
+"""
+
+import os
+
+import FreeCAD
+import FreeCADGui as Gui
+
+
+class McMasterWorkbench(Workbench):
+    """Browse McMaster-Carr and import 3-D CAD."""
+
+    MenuText = "McMaster-Carr"
+    ToolTip = "Browse the McMaster-Carr catalog and import 3-D STEP"
+
+    def __init__(self):
+        self.__class__.Icon = os.path.join(
+            os.path.dirname(__file__),
+            "icons",
+            "mcmaster-workbench.svg",
+        )
+
+    def Initialize(self):
+        import Commands
+        import InstallUI
+
+        Commands.register(Gui)
+        self.appendToolbar(
+            "McMaster-Carr",
+            ["McMaster_BrowseCatalog", "McMaster_ImportFile"],
+        )
+        self.appendMenu("McMaster-Carr", list(Commands.COMMANDS))
+        InstallUI.install_with_retry()
+        Log("Loading McMaster-Carr workbench... done\n")
+
+    def Activated(self):
+        try:
+            import InstallUI
+
+            InstallUI.install_once()
+        except Exception:
+            pass
+        Msg("McMasterWorkbench::Activated()\n")
+
+    def Deactivated(self):
+        Msg("McMasterWorkbench::Deactivated()\n")
+
+    def GetClassName(self):
+        return "Gui::PythonWorkbench"
+
+
+try:
+    Gui.addWorkbench(McMasterWorkbench())
+    FreeCAD.Console.PrintMessage("McMaster-Carr workbench registered\n")
+except Exception as exc:
+    FreeCAD.Console.PrintError(f"McMaster-Carr workbench failed to register: {exc}\n")
+
+try:
+    from PySide import QtCore
+    import InstallUI
+
+    QtCore.QTimer.singleShot(0, InstallUI.install_with_retry)
+except Exception as exc:
+    FreeCAD.Console.PrintWarning(f"McMaster-Carr UI install deferred: {exc}\n")

--- a/src/Mod/McMasterInsert/InitGui.py
+++ b/src/Mod/McMasterInsert/InitGui.py
@@ -20,7 +20,9 @@ class McMasterWorkbench(Workbench):
 
     def __init__(self):
         self.__class__.Icon = os.path.join(
-            os.path.dirname(__file__),
+            FreeCAD.getResourceDir(),
+            "Mod",
+            "McMasterInsert",
             "icons",
             "mcmaster-workbench.svg",
         )

--- a/src/Mod/McMasterInsert/InstallUI.py
+++ b/src/Mod/McMasterInsert/InstallUI.py
@@ -1,0 +1,434 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Make McMaster commands visible in VibeCAD (ribbon, toolbar, and Tools menu).
+
+VibeCAD hides the classic workbench combo. A Python workbench alone is
+invisible. This installer puts Catalog / Import on:
+- a permanent main-window toolbar
+- Tools → McMaster-Carr
+- a McMaster ribbon tab, retried until the native ribbon exists
+- a button group on the live ribbon page so it is visible on Model too
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+ICON = str(Path(__file__).resolve().parent / "icons" / "mcmaster-workbench.svg")
+TOOLBAR_NAME = "McMaster-Carr"
+MENU_NAME = "McMaster-Carr"
+GROUP_NAME = "VibeCADRibbonGroup_McMaster"
+RIBBON_TABS = "VibeCADRibbonTabs"
+RIBBON_PAGE = "VibeCADRibbonPage"
+TAB_LABEL = "McMaster"
+TAB_DATA = "McMasterWorkbench"
+RIBBON_GROUP_VERSION = 7
+ICON_DIR = Path(__file__).resolve().parent / "icons"
+BUTTONS = (
+    ("Catalog", "McMaster_BrowseCatalog", "catalog.svg"),
+    ("Import", "McMaster_ImportFile", "import.svg"),
+)
+
+
+def _log(message: str) -> None:
+    try:
+        import FreeCAD as App
+
+        App.Console.PrintMessage(f"McMaster-Carr: {message}\n")
+    except Exception:
+        pass
+
+
+def _warn(message: str) -> None:
+    try:
+        import FreeCAD as App
+
+        App.Console.PrintWarning(f"McMaster-Carr: {message}\n")
+    except Exception:
+        pass
+
+
+def _qt():
+    from PySide import QtCore, QtGui, QtWidgets
+
+    return QtCore, QtGui, QtWidgets
+
+
+def _gui():
+    import FreeCADGui as Gui
+
+    return Gui
+
+
+def _icon(qt_gui: Any, filename: str = "mcmaster-workbench.svg"):
+    icon_type = getattr(qt_gui, "QIcon", None)
+    if icon_type is None:
+        return None
+    try:
+        return icon_type(str(ICON_DIR / filename))
+    except Exception:
+        return None
+
+
+def _run_command(gui: Any, command_id: str):
+    def _run(_checked=False) -> None:
+        runner = getattr(gui, "runCommand", None)
+        if callable(runner):
+            try:
+                runner(command_id, 0)
+            except TypeError:
+                runner(command_id)
+
+    return _run
+
+
+def install_toolbar(gui: Any, qt_widgets: Any, qt_gui: Any) -> bool:
+    mw = gui.getMainWindow()
+    if mw is None:
+        return False
+    existing = mw.findChild(qt_widgets.QToolBar, "McMasterCarrToolbar")
+    if existing is not None:
+        existing.show()
+        return True
+    bar = mw.addToolBar(TOOLBAR_NAME)
+    bar.setObjectName("McMasterCarrToolbar")
+    bar.setMovable(True)
+    for label, command_id, icon_name in BUTTONS:
+        action = bar.addAction(label)
+        icon = _icon(qt_gui, icon_name)
+        if icon is not None:
+            action.setIcon(icon)
+        action.setToolTip(command_id)
+        action.triggered.connect(_run_command(gui, command_id))
+    bar.show()
+    _log("toolbar installed")
+    return True
+
+
+def install_menu(gui: Any, qt_widgets: Any) -> bool:
+    mw = gui.getMainWindow()
+    if mw is None:
+        return False
+    bar = mw.menuBar()
+    menu = None
+    for action in bar.actions():
+        title = (action.text() or "").replace("&", "")
+        if title == MENU_NAME:
+            menu = action.menu()
+            break
+    if menu is None:
+        menu = bar.addMenu(MENU_NAME)
+    have = {(action.text() or "") for action in menu.actions()}
+    added = False
+    for label, command_id in (
+        ("Browse Catalog", "McMaster_BrowseCatalog"),
+        ("Import CAD File", "McMaster_ImportFile"),
+        ("Open Cache Folder", "McMaster_OpenCache"),
+    ):
+        if label in have:
+            continue
+        action = menu.addAction(label)
+        action.triggered.connect(_run_command(gui, command_id))
+        added = True
+    if added:
+        _log("Tools/menu installed")
+    return True
+
+
+def _tab_index(tabs: Any, label: str) -> int:
+    for index in range(tabs.count()):
+        if tabs.tabText(index) == label:
+            return index
+    return -1
+
+
+def install_ribbon_tab(gui: Any, qt_widgets: Any) -> bool:
+    mw = gui.getMainWindow()
+    if mw is None:
+        return False
+    tabs = mw.findChild(qt_widgets.QTabBar, RIBBON_TABS)
+    if tabs is None:
+        return False
+    if _tab_index(tabs, TAB_LABEL) >= 0:
+        return True
+    insert_at = tabs.count()
+    blocker = getattr(tabs, "blockSignals", None)
+    if callable(blocker):
+        blocker(True)
+    try:
+        tabs.insertTab(insert_at, TAB_LABEL)
+        if hasattr(tabs, "setTabData"):
+            tabs.setTabData(insert_at, TAB_DATA)
+    finally:
+        if callable(blocker):
+            blocker(False)
+    _log("ribbon tab installed")
+    return True
+
+
+def _is_mcmaster_tab(tabs: Any, index: int) -> bool:
+    if index < 0 or index >= tabs.count():
+        return False
+    if tabs.tabText(index) == TAB_LABEL:
+        return True
+    return str(tabs.tabData(index) or "") in {TAB_DATA, "mcmaster"}
+
+
+def _iter_ribbon_groups(root: Any) -> list[Any]:
+    groups = []
+    find_children = getattr(root, "findChildren", None)
+    if find_children is None:
+        return groups
+    try:
+        children = find_children(object)
+    except TypeError:
+        children = find_children(None)
+    except Exception:
+        children = []
+    for child in children or []:
+        name = str(getattr(child, "objectName", lambda: "")() or "")
+        if name.startswith("VibeCADRibbonGroup_"):
+            groups.append(child)
+    return groups
+
+
+def _remove_overlay_strip(gui: Any, qt_widgets: Any) -> None:
+    mw = gui.getMainWindow()
+    if mw is None:
+        return
+    for name in ("McMasterRibbonStrip", "McMasterCarrToolbar"):
+        widget = mw.findChild(qt_widgets.QWidget, name)
+        if widget is not None:
+            widget.hide()
+            widget.setParent(None)
+            widget.deleteLater()
+
+
+def _ribbon_page(gui: Any, qt_widgets: Any):
+    mw = gui.getMainWindow()
+    if mw is None:
+        return None
+    return mw.findChild(qt_widgets.QWidget, RIBBON_PAGE)
+
+
+def _set_mcmaster_page_active(gui: Any, qt_widgets: Any, qt_gui: Any, active: bool) -> None:
+    page = _ribbon_page(gui, qt_widgets)
+    if page is None:
+        return
+    if active:
+        install_ribbon_group(gui, qt_widgets, qt_gui, page)
+        for group in _iter_ribbon_groups(page):
+            name = str(group.objectName() or "")
+            if name == GROUP_NAME:
+                group.show()
+            else:
+                group.hide()
+    else:
+        for group in _iter_ribbon_groups(page):
+            name = str(group.objectName() or "")
+            if name == GROUP_NAME:
+                group.hide()
+
+
+def _ribbon_group_version(group: Any) -> int:
+    try:
+        return int(group.property("McMasterRibbonVersion") or 0)
+    except Exception:
+        return 0
+
+
+def _discard_ribbon_group(page: Any, group: Any) -> None:
+    try:
+        group.setObjectName(GROUP_NAME + "_old")
+    except Exception:
+        pass
+    layout = getattr(page, "layout", lambda: None)()
+    if layout is not None and hasattr(layout, "removeWidget"):
+        try:
+            layout.removeWidget(group)
+        except Exception:
+            pass
+    try:
+        group.hide()
+        group.setParent(None)
+        group.deleteLater()
+    except Exception:
+        pass
+
+
+def install_ribbon_group(gui: Any, qt_widgets: Any, qt_gui: Any, page: Any) -> bool:
+    """Match native VibeCAD groups: transparent strip, icon-over-label commands."""
+    leftovers = [
+        group
+        for group in _iter_ribbon_groups(page)
+        if str(group.objectName() or "").startswith(GROUP_NAME)
+    ]
+    reusable = None
+    for group in leftovers:
+        if (
+            group.objectName() == GROUP_NAME
+            and _ribbon_group_version(group) >= RIBBON_GROUP_VERSION
+            and not (group.styleSheet() or "").strip()
+        ):
+            reusable = group
+        else:
+            _discard_ribbon_group(page, group)
+    if reusable is not None:
+        reusable.show()
+        return True
+
+    from PySide import QtCore as _qc
+
+    frame_type = getattr(qt_widgets, "QFrame", None) or qt_widgets.QWidget
+    group = frame_type(page)
+    group.setObjectName(GROUP_NAME)
+    group.setProperty("ribbonGroup", True)
+    group.setProperty("McMasterRibbonVersion", RIBBON_GROUP_VERSION)
+    group.setStyleSheet("")
+    layout = qt_widgets.QHBoxLayout(group)
+    layout.setContentsMargins(6, 4, 10, 4)
+    layout.setSpacing(4)
+    style = getattr(_qc.Qt, "ToolButtonTextUnderIcon", None)
+    if style is None:
+        style = getattr(getattr(qt_widgets, "Qt", None), "ToolButtonTextUnderIcon", None)
+    icon_size = _qc.QSize(24, 24)
+    tooltips = {
+        "McMaster_BrowseCatalog": "Browse McMaster-Carr and insert 3-D STEP",
+        "McMaster_ImportFile": "Import a STEP file you already downloaded",
+        "McMaster_OpenCache": "Open the local McMaster CAD cache",
+    }
+    for label, command_id, icon_name in BUTTONS:
+        button = qt_widgets.QToolButton(group)
+        button.setText(label)
+        icon = _icon(qt_gui, icon_name)
+        if icon is not None:
+            button.setIcon(icon)
+        button.setIconSize(icon_size)
+        if style is not None:
+            button.setToolButtonStyle(style)
+        button.setAutoRaise(True)
+        button.setToolTip(tooltips.get(command_id, command_id))
+        button.setProperty("VibeCADCommandId", command_id)
+        button.setMinimumSize(48, 48)
+        button.clicked.connect(_run_command(gui, command_id))
+        layout.addWidget(button)
+    try:
+        group.setSizePolicy(
+            qt_widgets.QSizePolicy.Maximum,
+            qt_widgets.QSizePolicy.Preferred,
+        )
+    except Exception:
+        pass
+
+    page_layout = page.layout()
+    if page_layout is not None:
+        if hasattr(page_layout, "insertWidget"):
+            page_layout.insertWidget(0, group)
+        elif hasattr(page_layout, "addWidget"):
+            page_layout.addWidget(group)
+        try:
+            page_layout.setAlignment(group, getattr(_qc.Qt, "AlignLeft"))
+        except Exception:
+            pass
+    group.show()
+    _log("native-style ribbon group installed")
+    return True
+
+
+def _on_tab_changed(index: int, tabs: Any, gui: Any, qt_widgets: Any, qt_gui: Any, qt_core: Any) -> None:
+    mcmaster = _is_mcmaster_tab(tabs, index)
+    if mcmaster:
+        try:
+            gui.activateWorkbench("McMasterWorkbench")
+        except Exception:
+            pass
+
+    def _apply() -> None:
+        _set_mcmaster_page_active(gui, qt_widgets, qt_gui, mcmaster)
+
+    timer = getattr(qt_core, "QTimer", None)
+    if timer is not None and hasattr(timer, "singleShot"):
+        timer.singleShot(0, _apply)
+        timer.singleShot(80, _apply)
+        timer.singleShot(250, _apply)
+    else:
+        _apply()
+
+
+def hook_ribbon_tab_changes(gui: Any, qt_widgets: Any, qt_gui: Any, qt_core: Any) -> bool:
+    mw = gui.getMainWindow()
+    if mw is None:
+        return False
+    tabs = mw.findChild(qt_widgets.QTabBar, RIBBON_TABS)
+    if tabs is None:
+        return False
+    _remove_overlay_strip(gui, qt_widgets)
+    if not getattr(tabs, "_mcmasterTabHooked", False):
+        tabs.currentChanged.connect(
+            lambda i, bar=tabs: _on_tab_changed(i, bar, gui, qt_widgets, qt_gui, qt_core)
+        )
+        try:
+            setattr(tabs, "_mcmasterTabHooked", True)
+        except Exception:
+            pass
+        _log("ribbon tab change hooked")
+    if _is_mcmaster_tab(tabs, tabs.currentIndex()):
+        _on_tab_changed(tabs.currentIndex(), tabs, gui, qt_widgets, qt_gui, qt_core)
+    else:
+        _set_mcmaster_page_active(gui, qt_widgets, qt_gui, False)
+    return True
+
+
+def install_once() -> dict[str, bool]:
+    from Commands import register
+
+    gui = _gui()
+    QtCore, QtGui, QtWidgets = _qt()
+    register(gui)
+    _remove_overlay_strip(gui, QtWidgets)
+    return {
+        "menu": install_menu(gui, QtWidgets),
+        "ribbon_tab": install_ribbon_tab(gui, QtWidgets),
+        "ribbon_hook": hook_ribbon_tab_changes(gui, QtWidgets, QtGui, QtCore),
+    }
+
+
+_retry_count = 0
+_timer = None
+
+
+def install_with_retry(max_tries: int = 40, interval_ms: int = 500) -> None:
+    """Keep trying until VibeCAD's native ribbon/main window exists."""
+
+    global _retry_count, _timer
+    from PySide import QtCore
+
+    def _tick() -> None:
+        global _retry_count, _timer
+        _retry_count += 1
+        try:
+            result = install_once()
+        except Exception as exc:
+            _warn(f"install attempt {_retry_count} failed: {exc}")
+            result = {}
+        if result.get("ribbon_hook") and result.get("ribbon_tab") and result.get("menu"):
+            if _timer is not None:
+                _timer.stop()
+            _log("UI ready")
+            return
+        if _retry_count >= max_tries:
+            if _timer is not None:
+                _timer.stop()
+            _warn(
+                "could not fully hook VibeCAD's ribbon. "
+                "Use menu McMaster-Carr → Browse Catalog, or run Macro InsertMcMaster."
+            )
+
+    if _timer is None:
+        _timer = QtCore.QTimer()
+        _timer.setInterval(interval_ms)
+        _timer.timeout.connect(_tick)
+    _retry_count = 0
+    _tick()
+    if _retry_count < max_tries:
+        _timer.start()

--- a/src/Mod/McMasterInsert/McMasterCatalog.entitlements
+++ b/src/Mod/McMasterInsert/McMasterCatalog.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.network.client</key>
+	<true/>
+</dict>
+</plist>

--- a/src/Mod/McMasterInsert/McMasterCatalog.swift
+++ b/src/Mod/McMasterInsert/McMasterCatalog.swift
@@ -1,0 +1,286 @@
+import Cocoa
+import CoreGraphics
+import WebKit
+
+/// Overlay catalog for VibeCAD. Runs as a separate process so WebKit cannot
+/// crash VibeCAD. Intercepts CAD downloads (no Save dialog) and writes them
+/// into --out-dir for VibeCAD to import.
+
+final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, WKDownloadDelegate, WKUIDelegate {
+    var window: NSWindow!
+    var webView: WKWebView!
+    var status: NSTextField!
+    var outDir: URL
+    var loadAttempts = 0
+    let cadExtensions: Set<String> = [
+        "step", "stp", "stpz", "iges", "igs", "sat", "sab", "x_t", "x_b", "sldprt", "zip",
+    ]
+
+    init(outDir: URL) {
+        self.outDir = outDir
+        super.init()
+    }
+
+    static let raiseName = Notification.Name("com.vibecad.McMasterCatalog.raise")
+    static let catalogURL = URL(string: "https://www.mcmaster.com/")!
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        buildUI()
+    }
+
+    func buildUI() {
+        guard window == nil else {
+            raiseCatalog()
+            return
+        }
+        try? FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+
+        DistributedNotificationCenter.default().addObserver(
+            forName: AppDelegate.raiseName,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.raiseCatalog()
+        }
+
+        let screen = NSScreen.main?.visibleFrame ?? NSRect(x: 80, y: 80, width: 1200, height: 800)
+        let width = min(1040, screen.width - 120)
+        let height = min(740, screen.height - 120)
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: width, height: height),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "McMaster-Carr Catalog"
+        window.isReleasedWhenClosed = false
+        window.hidesOnDeactivate = false
+        window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.popUpMenuWindow)))
+        window.collectionBehavior = [
+            .canJoinAllSpaces,
+            .fullScreenAuxiliary,
+        ]
+        window.center()
+
+        let root = NSView(frame: NSRect(x: 0, y: 0, width: width, height: height))
+        status = NSTextField(labelWithString: "Loading McMaster-Carr…")
+        status.translatesAutoresizingMaskIntoConstraints = false
+        status.textColor = .secondaryLabelColor
+        root.addSubview(status)
+
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = WKWebsiteDataStore.default()
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+        config.preferences.javaScriptCanOpenWindowsAutomatically = true
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        webView.navigationDelegate = self
+        webView.uiDelegate = self
+        webView.customUserAgent =
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.6 Safari/605.1.15"
+        root.addSubview(webView)
+        NSLayoutConstraint.activate([
+            status.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: 12),
+            status.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -12),
+            status.topAnchor.constraint(equalTo: root.topAnchor, constant: 6),
+            webView.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            webView.topAnchor.constraint(equalTo: status.bottomAnchor, constant: 6),
+            webView.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+        ])
+        window.contentView = root
+        raiseCatalog()
+        loadCatalog()
+        for delay in [0.15, 0.4, 0.9, 1.6, 2.5] {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.raiseCatalog()
+            }
+        }
+        NSLog("McMasterCatalog window shown")
+    }
+
+    func loadCatalog() {
+        loadAttempts += 1
+        status.stringValue = "Loading McMaster-Carr…"
+        let request = URLRequest(
+            url: AppDelegate.catalogURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 30
+        )
+        webView.load(request)
+    }
+
+    func raiseCatalog() {
+        window.collectionBehavior.insert(.canJoinAllSpaces)
+        window.collectionBehavior.insert(.fullScreenAuxiliary)
+        window.level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.popUpMenuWindow)))
+        window.orderFrontRegardless()
+        window.makeKeyAndOrderFront(nil)
+        if #available(macOS 14.0, *) {
+            NSApp.activate()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+
+    func isCADResponse(_ response: URLResponse) -> Bool {
+        let name = response.suggestedFilename?.lowercased() ?? ""
+        let ext = (name as NSString).pathExtension
+        if cadExtensions.contains(ext) { return true }
+        if let mime = response.mimeType?.lowercased(),
+           mime.contains("step") || mime.contains("iges") || mime.contains("acad")
+        {
+            return true
+        }
+        if let url = response.url, cadExtensions.contains(url.pathExtension.lowercased()) {
+            return true
+        }
+        return false
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        if let url = navigationAction.request.url,
+           cadExtensions.contains(url.pathExtension.lowercased()),
+           #available(macOS 11.3, *)
+        {
+            decisionHandler(.download)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
+        if isCADResponse(navigationResponse.response), #available(macOS 11.3, *) {
+            decisionHandler(.download)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    @available(macOS 11.3, *)
+    func webView(
+        _ webView: WKWebView,
+        navigationAction: WKNavigationAction,
+        didBecome download: WKDownload
+    ) {
+        download.delegate = self
+    }
+
+    @available(macOS 11.3, *)
+    func webView(
+        _ webView: WKWebView,
+        navigationResponse: WKNavigationResponse,
+        didBecome download: WKDownload
+    ) {
+        download.delegate = self
+    }
+
+    @available(macOS 11.3, *)
+    func download(
+        _ download: WKDownload,
+        decideDestinationUsing response: URLResponse,
+        suggestedFilename: String,
+        completionHandler: @escaping (URL?) -> Void
+    ) {
+        let safe = suggestedFilename.replacingOccurrences(of: "/", with: "_")
+        let dest = outDir.appendingPathComponent(safe)
+        try? FileManager.default.removeItem(at: dest)
+        completionHandler(dest)
+    }
+
+    @available(macOS 11.3, *)
+    func downloadDidFinish(_ download: WKDownload) {}
+
+    @available(macOS 11.3, *)
+    func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {}
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        status.stringValue = "McMaster-Carr — download 3-D STEP to import into VibeCAD"
+        raiseCatalog()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        handleLoadFailure(error)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        handleLoadFailure(error)
+    }
+
+    func handleLoadFailure(_ error: Error) {
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+            return
+        }
+        NSLog("McMasterCatalog load failed: \(error)")
+        status.stringValue = "Could not load McMaster-Carr (\(nsError.localizedDescription)). Retrying…"
+        if loadAttempts < 3 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
+                self?.loadCatalog()
+            }
+        } else {
+            status.stringValue = "Could not reach McMaster-Carr. Check the network, then click Catalog again."
+        }
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        if navigationAction.targetFrame == nil, let url = navigationAction.request.url {
+            webView.load(URLRequest(url: url))
+        }
+        return nil
+    }
+}
+
+let args = CommandLine.arguments
+var out = FileManager.default.temporaryDirectory.appendingPathComponent("McMasterInbox")
+if let idx = args.firstIndex(of: "--out-dir"), idx + 1 < args.count {
+    out = URL(fileURLWithPath: args[idx + 1], isDirectory: true)
+}
+
+let logDir = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first?
+    .appendingPathComponent("Logs", isDirectory: true)
+if let logDir {
+    try? FileManager.default.createDirectory(at: logDir, withIntermediateDirectories: true)
+    let logFile = logDir.appendingPathComponent("McMasterCatalog.log")
+    let line = "launch \(Date()) out=\(out.path)\n"
+    if let data = line.data(using: .utf8) {
+        if FileManager.default.fileExists(atPath: logFile.path) {
+            if let handle = try? FileHandle(forWritingTo: logFile) {
+                handle.seekToEndOfFile()
+                handle.write(data)
+                try? handle.close()
+            }
+        } else {
+            try? data.write(to: logFile)
+        }
+    }
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+let delegate = AppDelegate(outDir: out)
+app.delegate = delegate
+delegate.buildUI()
+app.finishLaunching()
+app.run()

--- a/src/Mod/McMasterInsert/McMasterCatalogWebView2.cpp
+++ b/src/Mod/McMasterInsert/McMasterCatalogWebView2.cpp
@@ -1,0 +1,620 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <shellapi.h>
+#include <wrl.h>
+
+#include <WebView2.h>
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <vector>
+
+using Microsoft::WRL::Callback;
+using Microsoft::WRL::ComPtr;
+
+namespace
+{
+constexpr wchar_t WindowClass[] = L"VibeCADMcMasterWebView2";
+constexpr wchar_t WindowTitle[] = L"Insert McMaster-Carr Component - VibeCAD";
+constexpr wchar_t InstanceMutex[] = L"Local\\VibeCADMcMasterCatalogWebView2";
+constexpr wchar_t RuntimeDownloadUrl[] =
+    L"https://go.microsoft.com/fwlink/p/?LinkId=2124703";
+constexpr int ToolbarHeight = 44;
+constexpr int StatusHeight = 28;
+constexpr int ButtonBack = 1001;
+constexpr int ButtonForward = 1002;
+constexpr int ButtonReload = 1003;
+constexpr int ButtonExternal = 1004;
+constexpr UINT_PTR ParentTimer = 2001;
+constexpr UINT_PTR CloseAfterDownloadTimer = 2002;
+
+HWND windowHandle = nullptr;
+HWND backButton = nullptr;
+HWND forwardButton = nullptr;
+HWND reloadButton = nullptr;
+HWND externalButton = nullptr;
+HWND statusLabel = nullptr;
+HANDLE instanceMutex = nullptr;
+DWORD parentProcessId = 0;
+std::filesystem::path inboxPath;
+std::wstring profilePath;
+std::wstring initialUrl = L"https://www.mcmaster.com/";
+ComPtr<ICoreWebView2Controller> webViewController;
+ComPtr<ICoreWebView2> webView;
+
+void setStatus(const std::wstring& text)
+{
+    if (statusLabel) {
+        SetWindowTextW(statusLabel, text.c_str());
+    }
+}
+
+void showWebViewError(const std::wstring& message)
+{
+    setStatus(message);
+    MessageBoxW(windowHandle, message.c_str(), L"VibeCAD McMaster Catalog", MB_OK | MB_ICONERROR);
+}
+
+std::wstring argumentValue(const std::vector<std::wstring>& arguments, const wchar_t* name)
+{
+    for (std::size_t index = 0; index + 1 < arguments.size(); ++index) {
+        if (arguments[index] == name) {
+            return arguments[index + 1];
+        }
+    }
+    return {};
+}
+
+bool hasArgument(const std::vector<std::wstring>& arguments, const wchar_t* name)
+{
+    for (const auto& argument : arguments) {
+        if (argument == name) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool downloadPathAvailable(const std::filesystem::path& path)
+{
+    std::error_code error;
+    auto staging = path;
+    staging += L".download";
+    return !std::filesystem::exists(path, error)
+        && !std::filesystem::exists(staging, error);
+}
+
+std::filesystem::path uniqueDownloadPath(const std::filesystem::path& suggested)
+{
+    std::filesystem::path filename = suggested.filename();
+    if (filename.empty() || filename == L"." || filename == L"..") {
+        filename = L"McMaster-CAD.step";
+    }
+    std::filesystem::path result = inboxPath / filename;
+    if (downloadPathAvailable(result)) {
+        return result;
+    }
+    const auto stem = filename.stem().wstring();
+    const auto extension = filename.extension().wstring();
+    for (unsigned int suffix = 1; suffix < 10000; ++suffix) {
+        result = inboxPath / (stem + L"-" + std::to_wstring(suffix) + extension);
+        if (downloadPathAvailable(result)) {
+            return result;
+        }
+    }
+    return inboxPath / (stem + L"-" + std::to_wstring(GetTickCount64()) + extension);
+}
+
+void updateHistoryButtons()
+{
+    if (!webView) {
+        return;
+    }
+    BOOL canGoBack = FALSE;
+    BOOL canGoForward = FALSE;
+    webView->get_CanGoBack(&canGoBack);
+    webView->get_CanGoForward(&canGoForward);
+    EnableWindow(backButton, canGoBack);
+    EnableWindow(forwardButton, canGoForward);
+}
+
+void resizeWebView()
+{
+    if (!windowHandle) {
+        return;
+    }
+    RECT client{};
+    GetClientRect(windowHandle, &client);
+    const int width = client.right - client.left;
+    const int height = client.bottom - client.top;
+    const int padding = 8;
+    const int smallButtonWidth = 74;
+    const int externalButtonWidth = 132;
+
+    MoveWindow(backButton, padding, 7, smallButtonWidth, 30, TRUE);
+    MoveWindow(forwardButton, padding + 80, 7, smallButtonWidth, 30, TRUE);
+    MoveWindow(reloadButton, padding + 160, 7, smallButtonWidth, 30, TRUE);
+    MoveWindow(
+        externalButton,
+        width - externalButtonWidth - padding,
+        7,
+        externalButtonWidth,
+        30,
+        TRUE
+    );
+    MoveWindow(
+        statusLabel,
+        padding,
+        height - StatusHeight,
+        width - 2 * padding,
+        StatusHeight,
+        TRUE
+    );
+
+    if (webViewController) {
+        RECT bounds{0, ToolbarHeight, width, height - StatusHeight};
+        webViewController->put_Bounds(bounds);
+    }
+}
+
+void openCurrentPageExternally()
+{
+    std::wstring url = initialUrl;
+    if (webView) {
+        LPWSTR source = nullptr;
+        if (SUCCEEDED(webView->get_Source(&source)) && source) {
+            url = source;
+            CoTaskMemFree(source);
+        }
+    }
+    ShellExecuteW(windowHandle, L"open", url.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
+}
+
+HRESULT registerWebViewEvents()
+{
+    EventRegistrationToken token{};
+    HRESULT result = webView->add_NavigationStarting(
+        Callback<ICoreWebView2NavigationStartingEventHandler>(
+            [](ICoreWebView2*, ICoreWebView2NavigationStartingEventArgs*) -> HRESULT {
+                setStatus(L"Loading McMaster-Carr...");
+                return S_OK;
+            }
+        ).Get(),
+        &token
+    );
+    if (FAILED(result)) {
+        return result;
+    }
+    result = webView->add_NavigationCompleted(
+        Callback<ICoreWebView2NavigationCompletedEventHandler>(
+            [](ICoreWebView2*, ICoreWebView2NavigationCompletedEventArgs* args) -> HRESULT {
+                BOOL success = FALSE;
+                args->get_IsSuccess(&success);
+                setStatus(
+                    success
+                        ? L"Choose a part and download 3-D STEP; VibeCAD imports it automatically."
+                        : L"McMaster-Carr did not load. Reload or use Open in Browser."
+                );
+                updateHistoryButtons();
+                return S_OK;
+            }
+        ).Get(),
+        &token
+    );
+    if (FAILED(result)) {
+        return result;
+    }
+    result = webView->add_HistoryChanged(
+        Callback<ICoreWebView2HistoryChangedEventHandler>(
+            [](ICoreWebView2*, IUnknown*) -> HRESULT {
+                updateHistoryButtons();
+                return S_OK;
+            }
+        ).Get(),
+        &token
+    );
+    if (FAILED(result)) {
+        return result;
+    }
+    ComPtr<ICoreWebView2_4> downloadWebView;
+    result = webView.As(&downloadWebView);
+    if (FAILED(result)) {
+        return result;
+    }
+    return downloadWebView->add_DownloadStarting(
+        Callback<ICoreWebView2DownloadStartingEventHandler>(
+            [](ICoreWebView2*, ICoreWebView2DownloadStartingEventArgs* args) -> HRESULT {
+                LPWSTR originalPath = nullptr;
+                args->get_ResultFilePath(&originalPath);
+                const auto target = uniqueDownloadPath(
+                    originalPath ? std::filesystem::path(originalPath)
+                                 : std::filesystem::path(L"McMaster-CAD.step")
+                );
+                CoTaskMemFree(originalPath);
+                auto staging = target;
+                staging += L".download";
+
+                HRESULT pathResult = args->put_ResultFilePath(staging.c_str());
+                if (FAILED(pathResult)) {
+                    setStatus(L"Could not send the download to VibeCAD's McMaster inbox.");
+                    return pathResult;
+                }
+                args->put_Handled(TRUE);
+                setStatus(L"Downloading " + target.filename().wstring() + L"...");
+
+                ComPtr<ICoreWebView2DownloadOperation> operation;
+                if (SUCCEEDED(args->get_DownloadOperation(&operation)) && operation) {
+                    EventRegistrationToken stateToken{};
+                    operation->add_StateChanged(
+                        Callback<ICoreWebView2StateChangedEventHandler>(
+                            [staging, target](
+                                ICoreWebView2DownloadOperation* sender,
+                                IUnknown*
+                            ) -> HRESULT {
+                                COREWEBVIEW2_DOWNLOAD_STATE state{};
+                                sender->get_State(&state);
+                                if (state == COREWEBVIEW2_DOWNLOAD_STATE_COMPLETED) {
+                                    std::error_code moveError;
+                                    std::filesystem::rename(staging, target, moveError);
+                                    if (moveError) {
+                                        setStatus(
+                                            L"Download completed, but VibeCAD could not move it "
+                                            L"into the McMaster inbox."
+                                        );
+                                    }
+                                    else {
+                                        setStatus(
+                                            L"Downloaded " + target.filename().wstring()
+                                            + L". VibeCAD is importing it now."
+                                        );
+                                        SetTimer(
+                                            windowHandle,
+                                            CloseAfterDownloadTimer,
+                                            1200,
+                                            nullptr
+                                        );
+                                    }
+                                }
+                                else if (state == COREWEBVIEW2_DOWNLOAD_STATE_INTERRUPTED) {
+                                    std::error_code removeError;
+                                    std::filesystem::remove(staging, removeError);
+                                    setStatus(L"The McMaster CAD download was interrupted.");
+                                }
+                                return S_OK;
+                            }
+                        ).Get(),
+                        &stateToken
+                    );
+                }
+                return S_OK;
+            }
+        ).Get(),
+        &token
+    );
+}
+
+void initializeWebView()
+{
+    setStatus(L"Starting Microsoft Edge WebView2...");
+    HRESULT result = CreateCoreWebView2EnvironmentWithOptions(
+        nullptr,
+        profilePath.c_str(),
+        nullptr,
+        Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
+            [](HRESULT environmentResult, ICoreWebView2Environment* environment) -> HRESULT {
+                if (FAILED(environmentResult) || !environment) {
+                    showWebViewError(
+                        L"Microsoft Edge WebView2 Runtime is unavailable. "
+                        L"Install the Evergreen Runtime and try again."
+                    );
+                    return environmentResult;
+                }
+                return environment->CreateCoreWebView2Controller(
+                    windowHandle,
+                    Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
+                        [](
+                            HRESULT controllerResult,
+                            ICoreWebView2Controller* controller
+                        ) -> HRESULT {
+                            if (FAILED(controllerResult) || !controller) {
+                                showWebViewError(
+                                    L"VibeCAD could not create the WebView2 catalog window."
+                                );
+                                return controllerResult;
+                            }
+                            webViewController = controller;
+                            HRESULT coreResult = controller->get_CoreWebView2(&webView);
+                            if (FAILED(coreResult) || !webView) {
+                                showWebViewError(
+                                    L"VibeCAD could not initialize the WebView2 browser."
+                                );
+                                return coreResult;
+                            }
+                            ComPtr<ICoreWebView2Settings> settings;
+                            if (SUCCEEDED(webView->get_Settings(&settings)) && settings) {
+                                settings->put_IsStatusBarEnabled(FALSE);
+                                settings->put_AreDevToolsEnabled(FALSE);
+                            }
+                            HRESULT eventResult = registerWebViewEvents();
+                            if (FAILED(eventResult)) {
+                                showWebViewError(
+                                    L"VibeCAD could not attach WebView2 browser events."
+                                );
+                                return eventResult;
+                            }
+                            resizeWebView();
+                            updateHistoryButtons();
+                            return webView->Navigate(initialUrl.c_str());
+                        }
+                    ).Get()
+                );
+            }
+        ).Get()
+    );
+    if (FAILED(result)) {
+        showWebViewError(L"VibeCAD could not start the Microsoft Edge WebView2 Runtime.");
+    }
+}
+
+bool parentIsRunning()
+{
+    if (!parentProcessId) {
+        return true;
+    }
+    HANDLE process = OpenProcess(SYNCHRONIZE, FALSE, parentProcessId);
+    if (!process) {
+        return false;
+    }
+    const bool running = WaitForSingleObject(process, 0) == WAIT_TIMEOUT;
+    CloseHandle(process);
+    return running;
+}
+
+LRESULT CALLBACK windowProcedure(HWND handle, UINT message, WPARAM wParam, LPARAM lParam)
+{
+    switch (message) {
+    case WM_CREATE: {
+        HFONT font = static_cast<HFONT>(GetStockObject(DEFAULT_GUI_FONT));
+        backButton = CreateWindowW(
+            L"BUTTON", L"Back", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+            0, 0, 0, 0, handle,
+            reinterpret_cast<HMENU>(static_cast<INT_PTR>(ButtonBack)), nullptr, nullptr
+        );
+        forwardButton = CreateWindowW(
+            L"BUTTON", L"Forward", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+            0, 0, 0, 0, handle,
+            reinterpret_cast<HMENU>(static_cast<INT_PTR>(ButtonForward)), nullptr, nullptr
+        );
+        reloadButton = CreateWindowW(
+            L"BUTTON", L"Reload", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+            0, 0, 0, 0, handle,
+            reinterpret_cast<HMENU>(static_cast<INT_PTR>(ButtonReload)), nullptr, nullptr
+        );
+        externalButton = CreateWindowW(
+            L"BUTTON", L"Open in Browser", WS_CHILD | WS_VISIBLE | BS_PUSHBUTTON,
+            0, 0, 0, 0, handle,
+            reinterpret_cast<HMENU>(static_cast<INT_PTR>(ButtonExternal)), nullptr, nullptr
+        );
+        statusLabel = CreateWindowW(
+            L"STATIC", L"Starting McMaster-Carr...", WS_CHILD | WS_VISIBLE | SS_LEFT,
+            0, 0, 0, 0, handle, nullptr, nullptr, nullptr
+        );
+        for (HWND control : {
+                 backButton,
+                 forwardButton,
+                 reloadButton,
+                 externalButton,
+                 statusLabel,
+             }) {
+            SendMessageW(control, WM_SETFONT, reinterpret_cast<WPARAM>(font), TRUE);
+        }
+        SetTimer(handle, ParentTimer, 2000, nullptr);
+        return 0;
+    }
+    case WM_SIZE:
+        resizeWebView();
+        return 0;
+    case WM_COMMAND:
+        switch (LOWORD(wParam)) {
+        case ButtonBack:
+            if (webView) {
+                webView->GoBack();
+            }
+            break;
+        case ButtonForward:
+            if (webView) {
+                webView->GoForward();
+            }
+            break;
+        case ButtonReload:
+            if (webView) {
+                webView->Reload();
+            }
+            break;
+        case ButtonExternal:
+            openCurrentPageExternally();
+            break;
+        default:
+            break;
+        }
+        return 0;
+    case WM_TIMER:
+        if (wParam == ParentTimer && !parentIsRunning()) {
+            DestroyWindow(handle);
+        }
+        else if (wParam == CloseAfterDownloadTimer) {
+            KillTimer(handle, CloseAfterDownloadTimer);
+            DestroyWindow(handle);
+        }
+        return 0;
+    case WM_DPICHANGED: {
+        const auto* suggested = reinterpret_cast<RECT*>(lParam);
+        SetWindowPos(
+            handle,
+            nullptr,
+            suggested->left,
+            suggested->top,
+            suggested->right - suggested->left,
+            suggested->bottom - suggested->top,
+            SWP_NOACTIVATE | SWP_NOZORDER
+        );
+        return 0;
+    }
+    case WM_DESTROY:
+        KillTimer(handle, ParentTimer);
+        KillTimer(handle, CloseAfterDownloadTimer);
+        if (webViewController) {
+            webViewController->Close();
+        }
+        webView.Reset();
+        webViewController.Reset();
+        PostQuitMessage(0);
+        return 0;
+    default:
+        return DefWindowProcW(handle, message, wParam, lParam);
+    }
+}
+
+bool webView2RuntimeAvailable()
+{
+    LPWSTR version = nullptr;
+    const HRESULT result = GetAvailableCoreWebView2BrowserVersionString(nullptr, &version);
+    CoTaskMemFree(version);
+    return SUCCEEDED(result);
+}
+}  // namespace
+
+int WINAPI wWinMain(HINSTANCE instance, HINSTANCE, PWSTR, int commandShow)
+{
+    SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    if (FAILED(CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED))) {
+        return 1;
+    }
+
+    int argumentCount = 0;
+    LPWSTR* rawArguments = CommandLineToArgvW(GetCommandLineW(), &argumentCount);
+    std::vector<std::wstring> arguments;
+    for (int index = 0; rawArguments && index < argumentCount; ++index) {
+        arguments.emplace_back(rawArguments[index]);
+    }
+    LocalFree(rawArguments);
+
+    if (hasArgument(arguments, L"--smoke-test")) {
+        const bool available = webView2RuntimeAvailable();
+        CoUninitialize();
+        return available ? 0 : 2;
+    }
+
+    inboxPath = argumentValue(arguments, L"--inbox");
+    profilePath = argumentValue(arguments, L"--profile");
+    const auto requestedUrl = argumentValue(arguments, L"--url");
+    if (!requestedUrl.empty()) {
+        initialUrl = requestedUrl;
+    }
+    const auto parent = argumentValue(arguments, L"--parent-pid");
+    if (!parent.empty()) {
+        try {
+            parentProcessId = static_cast<DWORD>(std::stoul(parent));
+        }
+        catch (...) {
+            parentProcessId = 0;
+        }
+    }
+    if (inboxPath.empty() || profilePath.empty()) {
+        MessageBoxW(
+            nullptr,
+            L"VibeCAD did not provide the McMaster inbox and browser profile paths.",
+            L"VibeCAD McMaster Catalog",
+            MB_OK | MB_ICONERROR
+        );
+        CoUninitialize();
+        return 3;
+    }
+
+    std::error_code directoryError;
+    std::filesystem::create_directories(inboxPath, directoryError);
+    std::filesystem::create_directories(profilePath, directoryError);
+
+    instanceMutex = CreateMutexW(nullptr, TRUE, InstanceMutex);
+    if (instanceMutex && GetLastError() == ERROR_ALREADY_EXISTS) {
+        if (HWND existing = FindWindowW(WindowClass, nullptr)) {
+            ShowWindow(existing, SW_RESTORE);
+            SetForegroundWindow(existing);
+        }
+        CloseHandle(instanceMutex);
+        CoUninitialize();
+        return 0;
+    }
+
+    WNDCLASSEXW windowClass{};
+    windowClass.cbSize = sizeof(windowClass);
+    windowClass.hInstance = instance;
+    windowClass.lpfnWndProc = windowProcedure;
+    windowClass.lpszClassName = WindowClass;
+    windowClass.hCursor = LoadCursorW(nullptr, IDC_ARROW);
+    windowClass.hIcon = LoadIconW(instance, MAKEINTRESOURCEW(101));
+    windowClass.hIconSm = windowClass.hIcon;
+    windowClass.hbrBackground = reinterpret_cast<HBRUSH>(COLOR_WINDOW + 1);
+    if (!RegisterClassExW(&windowClass)) {
+        CloseHandle(instanceMutex);
+        CoUninitialize();
+        return 4;
+    }
+
+    windowHandle = CreateWindowExW(
+        0,
+        WindowClass,
+        WindowTitle,
+        WS_OVERLAPPEDWINDOW,
+        CW_USEDEFAULT,
+        CW_USEDEFAULT,
+        1180,
+        820,
+        nullptr,
+        nullptr,
+        instance,
+        nullptr
+    );
+    if (!windowHandle) {
+        CloseHandle(instanceMutex);
+        CoUninitialize();
+        return 5;
+    }
+    ShowWindow(windowHandle, commandShow);
+    UpdateWindow(windowHandle);
+
+    if (!webView2RuntimeAvailable()) {
+        const int choice = MessageBoxW(
+            windowHandle,
+            L"Microsoft Edge WebView2 Runtime is required for the VibeCAD McMaster catalog. "
+            L"Open Microsoft's installer page now?",
+            L"VibeCAD McMaster Catalog",
+            MB_YESNO | MB_ICONINFORMATION
+        );
+        if (choice == IDYES) {
+            ShellExecuteW(
+                windowHandle, L"open", RuntimeDownloadUrl, nullptr, nullptr, SW_SHOWNORMAL
+            );
+        }
+        DestroyWindow(windowHandle);
+    }
+    else {
+        initializeWebView();
+    }
+
+    MSG message{};
+    while (GetMessageW(&message, nullptr, 0, 0) > 0) {
+        TranslateMessage(&message);
+        DispatchMessageW(&message);
+    }
+
+    if (instanceMutex) {
+        ReleaseMutex(instanceMutex);
+        CloseHandle(instanceMutex);
+    }
+    CoUninitialize();
+    return static_cast<int>(message.wParam);
+}

--- a/src/Mod/McMasterInsert/McMasterCatalogWebView2.rc.cmake
+++ b/src/Mod/McMasterInsert/McMasterCatalogWebView2.rc.cmake
@@ -1,0 +1,3 @@
+#include <windows.h>
+
+101 ICON "@VIBECAD_ICON_PATH@"

--- a/src/Mod/McMasterInsert/McMasterInsert.py
+++ b/src/Mod/McMasterInsert/McMasterInsert.py
@@ -827,6 +827,21 @@ def close_catalog_panel() -> None:
     Gui.McMasterCatalogPanel = None
 
 
+def _open_system_url(url: str) -> bool:
+    from PySide import QtCore, QtGui
+
+    return bool(QtGui.QDesktopServices.openUrl(QtCore.QUrl(url)))
+
+
+def open_external_catalog() -> bool:
+    """Open the live catalog in the user's browser when no embedded backend exists."""
+    try:
+        return _open_system_url(CATALOG_URL)
+    except Exception as exc:
+        App.Console.PrintError(f"McMaster-Carr: could not open {CATALOG_URL}: {exc}\n")
+        return False
+
+
 def attach_webkit(widget, out_dir: Path) -> bool:
     lib = _webkit_dylib()
     if lib is None:
@@ -932,6 +947,24 @@ def show_catalog_window() -> bool:
     return True
 
 
+def open_catalog() -> str:
+    """Open the best available catalog backend and return its mode."""
+    try:
+        if _webkit_dylib() is not None and show_catalog_window():
+            return "embedded"
+    except Exception as exc:
+        try:
+            App.Console.PrintWarning(
+                f"McMaster-Carr: embedded catalog unavailable ({exc}); "
+                "using the system browser\n"
+            )
+        except Exception:
+            pass
+    if open_external_catalog():
+        return "external"
+    return ""
+
+
 def _ensure_import_watcher() -> None:
     from PySide import QtCore
     import FreeCADGui as Gui
@@ -1007,10 +1040,18 @@ def run() -> None:
     if not App.GuiUp:
         raise RuntimeError("McMaster catalog requires the VibeCAD GUI")
     _ensure_import_watcher()
-    if show_catalog_window():
+    mode = open_catalog()
+    if mode == "embedded":
         App.Console.PrintMessage(
             "McMaster-Carr catalog overlay opened. "
             "Download 3-D STEP — it imports automatically (no Save dialog).\n"
+        )
+        return
+    if mode == "external":
+        App.Console.PrintMessage(
+            "McMaster-Carr opened in your browser. Download 3-D STEP to your "
+            "Downloads folder and VibeCAD will import it automatically; use "
+            "Import if you save it somewhere else.\n"
         )
         return
     App.Console.PrintError("McMaster-Carr: could not open https://www.mcmaster.com/\n")

--- a/src/Mod/McMasterInsert/McMasterInsert.py
+++ b/src/Mod/McMasterInsert/McMasterInsert.py
@@ -289,126 +289,163 @@ def _import_roots(created: list) -> list:
     return roots
 
 
-def _ensure_body(doc, obj):
-    tid = _type_id(obj)
-    if tid == "PartDesign::Body":
-        return obj
-    if tid == "PartDesign::Component":
-        return obj
+def _parent_of(obj):
     try:
-        parent = obj.getParentGeoFeatureGroup()
-        if parent is not None and _type_id(parent) == "PartDesign::Body":
-            return parent
+        return obj.getParentGeoFeatureGroup()
     except Exception:
-        pass
-    body = doc.addObject("PartDesign::Body", "Body")
-    _classify_structure(doc, body)
-    try:
-        body.addObject(obj)
-    except Exception:
-        pass
-    try:
-        if getattr(obj, "Shape", None) is not None:
-            body.Tip = obj
-    except Exception:
-        pass
-    return body
+        return None
 
 
-def _imported_bodies(doc, created: list) -> list:
-    bodies = []
-    seen = set()
-    for obj in created:
-        if obj is None or _is_origin_object(obj):
-            continue
-        body = None
-        tid = _type_id(obj)
-        if tid == "PartDesign::Body":
-            body = obj
-        elif tid == "PartDesign::Component":
-            continue
-        else:
-            try:
-                parent = obj.getParentGeoFeatureGroup()
-            except Exception:
-                parent = None
-            if parent is not None and _type_id(parent) == "PartDesign::Body":
-                body = parent
-            else:
-                body = _ensure_body(doc, obj)
-        if body is None or id(body) in seen:
-            continue
-        seen.add(id(body))
-        bodies.append(body)
-    return bodies
-
-
-def _component_only_holds(component, bodies: list) -> bool:
-    owned = [
-        child
-        for child in list(getattr(component, "Group", []) or [])
-        if not _is_origin_object(child)
-    ]
-    if not owned:
+def _adopt(container, obj) -> bool:
+    if obj is None or container is None or obj is container:
+        return False
+    current = _parent_of(obj)
+    if current is container:
         return True
-    imported = set(bodies)
-    return all(child in imported for child in owned)
+    if current is not None:
+        remover = getattr(current, "removeObject", None)
+        if callable(remover):
+            try:
+                remover(obj)
+            except Exception:
+                pass
+    try:
+        container.addObject(obj)
+    except Exception as exc:
+        App.Console.PrintWarning(
+            f"McMaster: {container.Name}.addObject({obj.Name}) failed: {exc}\n"
+        )
+        return _parent_of(obj) is container
+    return _parent_of(obj) is container
+
+
+def _shape_of(obj):
+    for candidate in (getattr(obj, "Tip", None), obj):
+        if candidate is None:
+            continue
+        shape = getattr(candidate, "Shape", None)
+        if shape is not None and not getattr(shape, "isNull", lambda: True)():
+            return candidate, shape
+    return None, None
+
+
+def _copy_into_body(body, source, part_number: str) -> bool:
+    _source_obj, shape = _shape_of(source)
+    if shape is None:
+        return False
+    feature = body.newObject(
+        "PartDesign::Feature",
+        _legal_object_name("Solid", part_number),
+    )
+    try:
+        feature.Shape = shape.copy() if hasattr(shape, "copy") else shape
+    except Exception:
+        feature.Shape = shape
+    try:
+        src_vo = getattr(_source_obj, "ViewObject", None)
+        dst_vo = getattr(feature, "ViewObject", None)
+        if src_vo is not None and dst_vo is not None and hasattr(src_vo, "DiffuseColor"):
+            dst_vo.DiffuseColor = src_vo.DiffuseColor
+    except Exception:
+        pass
+    try:
+        body.Tip = feature
+    except Exception:
+        pass
+    return True
+
+
+def _discard(doc, obj) -> None:
+    if obj is None:
+        return
+    try:
+        if getattr(obj, "ViewObject", None) is not None:
+            obj.ViewObject.Visibility = False
+    except Exception:
+        pass
+    try:
+        doc.removeObject(obj.Name)
+    except Exception:
+        pass
 
 
 def _promote_to_component(doc, created: list, part_number: str, source_path: Path):
+    """Always make a new PartDesign::Component and put the imported solid in it."""
     label = part_number or source_path.stem
-    created_components = [
-        obj for obj in created if _type_id(obj) == "PartDesign::Component"
-    ]
-    bodies = _imported_bodies(doc, created)
-
-    if len(created_components) == 1 and not bodies:
-        component = created_components[0]
-        _set_label(component, label)
-        return component
-
-    parents = []
-    for body in bodies:
-        try:
-            parent = body.getParentGeoFeatureGroup()
-        except Exception:
-            parent = None
-        if parent is not None and _type_id(parent) in (
-            "PartDesign::Component",
-            "App::Part",
-        ):
-            parents.append(parent)
-    unique_parents = []
-    seen = set()
-    for parent in parents:
-        if id(parent) in seen:
+    skip = set()
+    imported = []
+    for obj in created:
+        if obj is None or _is_origin_object(obj):
             continue
-        seen.add(id(parent))
-        unique_parents.append(parent)
+        if _type_id(obj) == "PartDesign::Component":
+            skip.add(obj)
+            continue
+        imported.append(obj)
 
-    component = None
-    if len(unique_parents) == 1 and _component_only_holds(unique_parents[0], bodies):
-        component = unique_parents[0]
-    elif len(created_components) == 1:
-        component = created_components[0]
-
-    if component is None:
-        component = doc.addObject(
-            "PartDesign::Component",
-            _legal_object_name("Component", part_number),
-        )
-        if component is None or _type_id(component) != "PartDesign::Component":
-            raise RuntimeError("VibeCAD did not create a PartDesign::Component")
-        _classify_structure(doc, component)
-
-    for body in bodies:
-        try:
-            if body.getParentGeoFeatureGroup() is not component:
-                component.addObject(body)
-        except Exception:
-            pass
-
+    component = doc.addObject(
+        "PartDesign::Component",
+        _legal_object_name("Component", part_number),
+    )
+    if component is None or _type_id(component) != "PartDesign::Component":
+        raise RuntimeError("VibeCAD did not create a PartDesign::Component")
+    _classify_structure(doc, component)
     _set_label(component, label)
+
+    placeholder = doc.addObject(
+        "PartDesign::Body",
+        _legal_object_name("Body", part_number),
+    )
+    _classify_structure(doc, placeholder)
+    if not _adopt(component, placeholder):
+        raise RuntimeError("could not add Body to Component")
+    _stamp_body(placeholder, part_number, source_path)
+
+    imported_bodies = [obj for obj in imported if _type_id(obj) == "PartDesign::Body"]
+    imported_other = [obj for obj in imported if _type_id(obj) != "PartDesign::Body"]
+    leftovers = []
+    kept_bodies = []
+
+    for obj in imported_bodies:
+        if _adopt(component, obj):
+            _stamp_body(obj, part_number, source_path)
+            kept_bodies.append(obj)
+        elif _copy_into_body(placeholder, obj, part_number):
+            leftovers.append(obj)
+        else:
+            App.Console.PrintWarning(f"McMaster: could not adopt body {obj.Name}\n")
+
+    if kept_bodies:
+        leftovers.append(placeholder)
+    else:
+        kept_bodies.append(placeholder)
+        for obj in imported_other:
+            if _parent_of(obj) in imported_bodies:
+                leftovers.append(obj)
+                continue
+            if _adopt(placeholder, obj):
+                try:
+                    placeholder.Tip = obj
+                except Exception:
+                    pass
+                _stamp_body(obj, part_number, source_path)
+            elif _copy_into_body(placeholder, obj, part_number):
+                leftovers.append(obj)
+
+    for obj in leftovers:
+        if obj not in (component,) and obj not in kept_bodies:
+            _discard(doc, obj)
+    for obj in skip:
+        if obj is not component and _component_is_empty(obj):
+            _discard(doc, obj)
+
+    owned_bodies = [
+        child
+        for child in list(getattr(component, "Group", []) or [])
+        if _type_id(child) == "PartDesign::Body"
+    ]
+    if not owned_bodies:
+        raise RuntimeError("imported geometry did not land inside the Component")
+
     try:
         import FreeCADGui as Gui
 
@@ -418,9 +455,19 @@ def _promote_to_component(doc, created: list, part_number: str, source_path: Pat
     except Exception:
         pass
     App.Console.PrintMessage(
-        f"McMaster: component {component.Name} Label={component.Label!r}\n"
+        f"McMaster: component {component.Name} Label={component.Label!r} "
+        f"bodies={[b.Name for b in owned_bodies]}\n"
     )
     return component
+
+
+def _component_is_empty(component) -> bool:
+    owned = [
+        child
+        for child in list(getattr(component, "Group", []) or [])
+        if not _is_origin_object(child)
+    ]
+    return not owned
 
 
 def _transform_target(objects: list):

--- a/src/Mod/McMasterInsert/McMasterInsert.py
+++ b/src/Mod/McMasterInsert/McMasterInsert.py
@@ -144,9 +144,39 @@ def catalog_description(part_number: str, source_path: Path) -> str:
 
 def _legal_object_name(prefix: str, part_number: str) -> str:
     raw = re.sub(r"[^0-9A-Za-z_]", "_", part_number or "Part")
-    if not raw or not raw[0].isalpha():
-        raw = f"{prefix}_{raw}"
+    if not raw:
+        raw = prefix
+    elif not raw[0].isalpha():
+        raw = f"_{raw}"
     return raw[:50]
+
+
+def _add_named_object(doc, type_id: str, visible_name: str, fallback_prefix: str):
+    """Create an object whose tree name is the catalog number when possible."""
+    visible = str(visible_name or fallback_prefix).strip()
+    candidates = []
+    if visible:
+        candidates.append(visible)
+        if visible[0].isdigit():
+            candidates.append(f"_{visible}")
+    candidates.append(_legal_object_name(fallback_prefix, visible))
+    candidates.append(fallback_prefix)
+    seen: set[str] = set()
+    obj = None
+    for name in candidates:
+        if not name or name in seen:
+            continue
+        seen.add(name)
+        try:
+            obj = doc.addObject(type_id, name)
+        except Exception:
+            obj = None
+        if obj is not None:
+            break
+    if obj is None:
+        raise RuntimeError(f"could not create {type_id}")
+    _set_label(obj, visible)
+    return obj
 
 
 def _set_label(obj, label: str) -> None:
@@ -158,9 +188,10 @@ def _set_label(obj, label: str) -> None:
     except Exception as exc:
         App.Console.PrintWarning(f"McMaster: could not set Label on {obj.Name}: {exc}\n")
         return
-    if str(getattr(obj, "Label", "") or "") != wanted:
+    actual = str(getattr(obj, "Label", "") or "")
+    if actual != wanted:
         App.Console.PrintWarning(
-            f"McMaster: {obj.Name} Label is {obj.Label!r}, wanted {wanted!r}\n"
+            f"McMaster: {obj.Name} Label is {actual!r}, wanted {wanted!r}\n"
         )
 
 
@@ -179,6 +210,12 @@ def _stamp_metadata(obj, part_number: str, source_path: Path) -> None:
     _set_label(obj, label)
     try:
         obj.Label2 = description
+    except Exception:
+        pass
+    try:
+        view = getattr(obj, "ViewObject", None)
+        if view is not None:
+            view.ToolTip = description
     except Exception:
         pass
     group = "McMaster"
@@ -382,18 +419,23 @@ def _promote_to_component(doc, created: list, part_number: str, source_path: Pat
             continue
         imported.append(obj)
 
-    component = doc.addObject(
+    component = _add_named_object(
+        doc,
         "PartDesign::Component",
-        _legal_object_name("Component", part_number),
+        label,
+        "Component",
     )
     if component is None or _type_id(component) != "PartDesign::Component":
         raise RuntimeError("VibeCAD did not create a PartDesign::Component")
     _classify_structure(doc, component)
     _set_label(component, label)
+    _stamp_metadata(component, part_number, source_path)
 
-    placeholder = doc.addObject(
+    placeholder = _add_named_object(
+        doc,
         "PartDesign::Body",
-        _legal_object_name("Body", part_number),
+        label,
+        "Body",
     )
     _classify_structure(doc, placeholder)
     if not _adopt(component, placeholder):

--- a/src/Mod/McMasterInsert/McMasterInsert.py
+++ b/src/Mod/McMasterInsert/McMasterInsert.py
@@ -53,6 +53,21 @@ def downloads_dir() -> Path:
     return Path.home() / "Downloads"
 
 
+def webview2_profile_root() -> Path:
+    """Persistent WebView2 data so McMaster login survives VibeCAD restarts."""
+    local_app_data = str(os.environ.get("LOCALAPPDATA", "") or "").strip()
+    if local_app_data:
+        root = Path(local_app_data) / "VibeCAD" / "McMasterBrowser"
+    else:
+        root = Path(App.getUserAppDataDir()) / "McMasterBrowser"
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def webview2_helper_path() -> Path:
+    return Path(__file__).resolve().parent / "McMasterCatalogWebView2.exe"
+
+
 def helper_app_path() -> Path:
     return Path(__file__).resolve().parent / "McMasterCatalog.app"
 
@@ -237,19 +252,29 @@ def _stamp_metadata(obj, part_number: str, source_path: Path) -> None:
             continue
 
 
-def _stamp_body(obj, part_number: str, source_path: Path) -> None:
-    _set_label(obj, part_number or source_path.stem)
+def _stamp_body(
+    obj,
+    part_number: str,
+    source_path: Path,
+    role: str = "Body",
+) -> None:
+    base_label = part_number or source_path.stem
+    _set_label(obj, f"{base_label} {role}".strip())
     _clear_description(obj)
 
 
 def _name_imported_tree(component, part_number: str, source_path: Path) -> None:
-    """Component: part number + catalog summary. Inner body: part number only."""
+    """Apply stable, unique labels to the imported component hierarchy."""
     _stamp_metadata(component, part_number, source_path)
+    body_index = 0
+    geometry_index = 0
     for child in list(getattr(component, "Group", []) or []):
         if _is_origin_object(child):
             continue
         if _type_id(child) == "PartDesign::Body":
-            _stamp_body(child, part_number, source_path)
+            body_index += 1
+            body_role = "Body" if body_index == 1 else f"Body {body_index}"
+            _stamp_body(child, part_number, source_path, body_role)
             owned = list(getattr(child, "Group", []) or [])
             tip = getattr(child, "Tip", None)
             if tip is not None and tip not in owned:
@@ -257,7 +282,11 @@ def _name_imported_tree(component, part_number: str, source_path: Path) -> None:
             for inner in owned:
                 if _is_origin_object(inner):
                     continue
-                _stamp_body(inner, part_number, source_path)
+                geometry_index += 1
+                role = "Geometry"
+                if geometry_index > 1:
+                    role = f"Geometry {geometry_index}"
+                _stamp_body(inner, part_number, source_path, role)
 
 
 _SKIP_TRANSFORM_TYPES = (
@@ -284,7 +313,13 @@ def _type_id(obj) -> str:
 
 def _is_origin_object(obj) -> bool:
     tid = _type_id(obj)
-    return tid in _SKIP_TRANSFORM_TYPES or "Origin" in tid
+    name = str(getattr(obj, "Name", "") or "")
+    return (
+        tid in _SKIP_TRANSFORM_TYPES
+        or "Origin" in tid
+        or bool(re.fullmatch(r"Origin\d*", name))
+        or name == "VibeCADTimeline"
+    )
 
 
 def _classify_structure(doc, obj) -> None:
@@ -434,13 +469,12 @@ def _promote_to_component(doc, created: list, part_number: str, source_path: Pat
     placeholder = _add_named_object(
         doc,
         "PartDesign::Body",
-        label,
+        f"{label} Body",
         "Body",
     )
     _classify_structure(doc, placeholder)
     if not _adopt(component, placeholder):
         raise RuntimeError("could not add Body to Component")
-    _stamp_body(placeholder, part_number, source_path)
 
     imported_bodies = [obj for obj in imported if _type_id(obj) == "PartDesign::Body"]
     imported_other = [obj for obj in imported if _type_id(obj) != "PartDesign::Body"]
@@ -449,7 +483,9 @@ def _promote_to_component(doc, created: list, part_number: str, source_path: Pat
 
     for obj in imported_bodies:
         if _adopt(component, obj):
-            _stamp_body(obj, part_number, source_path)
+            body_index = len(kept_bodies) + 1
+            role = "Body" if body_index == 1 else f"Body {body_index}"
+            _stamp_body(obj, part_number, source_path, role)
             kept_bodies.append(obj)
         elif _copy_into_body(placeholder, obj, part_number):
             leftovers.append(obj)
@@ -459,7 +495,9 @@ def _promote_to_component(doc, created: list, part_number: str, source_path: Pat
     if kept_bodies:
         leftovers.append(placeholder)
     else:
+        _stamp_body(placeholder, part_number, source_path)
         kept_bodies.append(placeholder)
+        geometry_index = 0
         for obj in imported_other:
             if _parent_of(obj) in imported_bodies:
                 leftovers.append(obj)
@@ -469,7 +507,9 @@ def _promote_to_component(doc, created: list, part_number: str, source_path: Pat
                     placeholder.Tip = obj
                 except Exception:
                     pass
-                _stamp_body(obj, part_number, source_path)
+                geometry_index += 1
+                role = "Geometry" if geometry_index == 1 else f"Geometry {geometry_index}"
+                _stamp_body(obj, part_number, source_path, role)
             elif _copy_into_body(placeholder, obj, part_number):
                 leftovers.append(obj)
 
@@ -735,73 +775,85 @@ def import_cad(path: Path, part_number: str) -> list[str]:
     if doc is None:
         doc = App.newDocument("McMaster")
     before = set(doc.Objects)
-    imported = False
+    owns_transaction = not bool(getattr(doc, "HasPendingTransaction", False))
+    if owns_transaction:
+        doc.openTransaction("Insert McMaster-Carr Component")
     try:
-        import ImportGui
-
+        imported = False
         try:
-            ImportGui.insert(
-                name=str(path),
-                docName=doc.Name,
-                merge=False,
-                useLinkGroup=True,
-                importSolidBodies=True,
-            )
-        except TypeError:
-            ImportGui.insert(str(path), doc.Name)
-        imported = True
-    except Exception:
-        pass
-    if not imported:
-        import Part
+            import ImportGui
 
-        Part.insert(str(path), doc.Name)
-    created = [obj for obj in doc.Objects if obj not in before]
-    if not created:
-        raise RuntimeError(f"Import produced no objects from {path.name}")
-    try:
-        component = _promote_to_component(doc, created, part_number, path)
-        _name_imported_tree(component, part_number, path)
-        doc.recompute()
-        _name_imported_tree(component, part_number, path)
-        try:
-            import FreeCADGui as Gui
-            from PySide import QtCore
-
-            Gui.updateGui()
-            doc_name = doc.Name
-            obj_name = component.Name
-            path_str = str(path)
-            pn = part_number
-
-            def _relabel() -> None:
-                live_doc = App.getDocument(doc_name)
-                if live_doc is None:
-                    return
-                live = live_doc.getObject(obj_name)
-                if live is None:
-                    return
-                _name_imported_tree(live, pn, Path(path_str))
-                App.Console.PrintMessage(
-                    f"McMaster: renamed {live.Name} -> {live.Label!r}\n"
+            try:
+                ImportGui.insert(
+                    name=str(path),
+                    docName=doc.Name,
+                    merge=False,
+                    useLinkGroup=True,
+                    importSolidBodies=True,
                 )
-
-            QtCore.QTimer.singleShot(0, _relabel)
-            QtCore.QTimer.singleShot(250, _relabel)
+            except TypeError:
+                ImportGui.insert(str(path), doc.Name)
+            imported = True
         except Exception:
             pass
-        return [component.Name]
-    except Exception as exc:
-        App.Console.PrintWarning(
-            f"McMaster: could not wrap as a component ({exc}); imported objects were left as-is\n"
-        )
-        for obj in created:
-            if not _is_origin_object(obj):
-                _stamp_metadata(obj, part_number, path)
-        doc.recompute()
-        return [obj.Name for obj in created if not _is_origin_object(obj)] or [
-            obj.Name for obj in created
-        ]
+        if not imported:
+            import Part
+
+            Part.insert(str(path), doc.Name)
+        created = [obj for obj in doc.Objects if obj not in before]
+        if not created:
+            raise RuntimeError(f"Import produced no objects from {path.name}")
+        try:
+            component = _promote_to_component(doc, created, part_number, path)
+            _name_imported_tree(component, part_number, path)
+            doc.recompute()
+            _name_imported_tree(component, part_number, path)
+            try:
+                import FreeCADGui as Gui
+                from PySide import QtCore
+
+                Gui.updateGui()
+                doc_name = doc.Name
+                obj_name = component.Name
+                path_str = str(path)
+                pn = part_number
+
+                def _relabel() -> None:
+                    live_doc = App.getDocument(doc_name)
+                    if live_doc is None:
+                        return
+                    live = live_doc.getObject(obj_name)
+                    if live is None:
+                        return
+                    _name_imported_tree(live, pn, Path(path_str))
+                    App.Console.PrintMessage(
+                        f"McMaster: renamed {live.Name} -> {live.Label!r}\n"
+                    )
+
+                QtCore.QTimer.singleShot(0, _relabel)
+                QtCore.QTimer.singleShot(250, _relabel)
+            except Exception:
+                pass
+            result = [component.Name]
+        except Exception as exc:
+            App.Console.PrintWarning(
+                f"McMaster: could not wrap as a component ({exc}); "
+                "imported objects were left as-is\n"
+            )
+            for obj in created:
+                if not _is_origin_object(obj):
+                    _stamp_metadata(obj, part_number, path)
+            doc.recompute()
+            result = [obj.Name for obj in created if not _is_origin_object(obj)] or [
+                obj.Name for obj in created
+            ]
+        if owns_transaction:
+            doc.commitTransaction()
+        return result
+    except Exception:
+        if owns_transaction:
+            doc.abortTransaction()
+        raise
 
 
 def _is_cad_file(path: Path) -> bool:
@@ -881,6 +933,44 @@ def open_external_catalog() -> bool:
         return _open_system_url(CATALOG_URL)
     except Exception as exc:
         App.Console.PrintError(f"McMaster-Carr: could not open {CATALOG_URL}: {exc}\n")
+        return False
+
+
+def show_webview2_catalog_window() -> bool:
+    """Launch the Windows catalog helper backed by Edge WebView2."""
+    if os.name != "nt":
+        return False
+    helper = webview2_helper_path()
+    if not helper.is_file():
+        return False
+    try:
+        import FreeCADGui as Gui
+
+        process = subprocess.Popen(
+            [
+                str(helper),
+                "--inbox",
+                str(inbox_dir()),
+                "--profile",
+                str(webview2_profile_root()),
+                "--url",
+                CATALOG_URL,
+                "--parent-pid",
+                str(os.getpid()),
+            ],
+            cwd=str(helper.parent),
+            close_fds=True,
+        )
+        Gui.McMasterCatalogProcess = process
+        App.Console.PrintMessage(
+            "McMaster catalog opened with Edge WebView2; "
+            f"profile={webview2_profile_root()}\n"
+        )
+        return True
+    except OSError as exc:
+        App.Console.PrintWarning(
+            f"McMaster-Carr: WebView2 helper could not start ({exc})\n"
+        )
         return False
 
 
@@ -991,6 +1081,17 @@ def show_catalog_window() -> bool:
 
 def open_catalog() -> str:
     """Open the best available catalog backend and return its mode."""
+    try:
+        if show_webview2_catalog_window():
+            return "embedded"
+    except Exception as exc:
+        try:
+            App.Console.PrintWarning(
+                f"McMaster-Carr: WebView2 unavailable ({exc}); "
+                "trying another browser\n"
+            )
+        except Exception:
+            pass
     try:
         if _webkit_dylib() is not None and show_catalog_window():
             return "embedded"

--- a/src/Mod/McMasterInsert/McMasterInsert.py
+++ b/src/Mod/McMasterInsert/McMasterInsert.py
@@ -1,0 +1,879 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Browse the McMaster-Carr catalog and import downloaded CAD into VibeCAD.
+
+Opens McMaster's live website in a catalog window (same idea as Fusion 360 /
+SolidWorks). When you download 3-D STEP from a product page, the file is
+imported into the active document. No McMaster API key and no part number
+required up front.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+import time
+import zipfile
+from pathlib import Path
+
+import FreeCAD as App
+
+CAD_SUFFIXES = (
+    ".step",
+    ".stp",
+    ".stpz",
+    ".iges",
+    ".igs",
+    ".sat",
+    ".sab",
+    ".x_t",
+    ".x_b",
+    ".sldprt",
+    ".zip",
+)
+PART_NUMBER_RE = re.compile(r"^[0-9]{2,6}[A-Za-z][0-9A-Za-z]{1,8}$")
+FILENAME_PN_RE = re.compile(r"([0-9]{2,6}[A-Za-z][0-9A-Za-z]{1,8})")
+CATALOG_URL = "https://www.mcmaster.com/"
+
+
+def cache_root() -> Path:
+    path = Path(App.getUserAppDataDir()) / "McMasterCache"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def inbox_dir() -> Path:
+    path = cache_root() / "inbox"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def downloads_dir() -> Path:
+    return Path.home() / "Downloads"
+
+
+def helper_app_path() -> Path:
+    return Path(__file__).resolve().parent / "McMasterCatalog.app"
+
+
+def helper_path() -> Path:
+    bundled = helper_app_path() / "Contents" / "MacOS" / "McMasterCatalog"
+    if bundled.is_file():
+        return bundled
+    return Path(__file__).resolve().parent / "McMasterCatalog"
+
+
+def normalize_part_number(raw: str) -> str:
+    token = (raw or "").strip()
+    if "mcmaster.com" in token.lower():
+        token = token.split("?", 1)[0].rstrip("/")
+        token = token.rsplit("/", 1)[-1]
+    token = token.strip().upper().replace(" ", "")
+    return token.strip("/")
+
+
+def product_url(part_number: str) -> str:
+    return f"https://www.mcmaster.com/{part_number}"
+
+
+def part_number_from_filename(name: str) -> str:
+    match = FILENAME_PN_RE.search(Path(name).stem.upper().replace(" ", ""))
+    if match and PART_NUMBER_RE.match(match.group(1)):
+        return match.group(1)
+    return ""
+
+
+def cached_cad(part_number: str) -> Path | None:
+    folder = cache_root() / part_number
+    if not folder.is_dir():
+        return None
+    for path in sorted(folder.iterdir(), key=lambda p: p.stat().st_mtime, reverse=True):
+        if path.is_file() and path.suffix.lower() in CAD_SUFFIXES and path.suffix.lower() != ".zip":
+            return path
+    return None
+
+
+def unpack_if_zip(path: Path, part_number: str) -> Path:
+    if path.suffix.lower() != ".zip":
+        return path
+    dest = cache_root() / part_number
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path) as archive:
+        archive.extractall(dest)
+    for candidate in dest.rglob("*"):
+        if (
+            candidate.is_file()
+            and candidate.suffix.lower() in CAD_SUFFIXES
+            and candidate.suffix.lower() != ".zip"
+        ):
+            return candidate
+    raise RuntimeError(f"ZIP {path.name} did not contain a CAD file")
+
+
+def store_in_cache(source: Path, part_number: str) -> Path:
+    unpacked = unpack_if_zip(source, part_number or "UNNUMBERED")
+    key = part_number or part_number_from_filename(unpacked.name) or "UNNUMBERED"
+    dest_dir = cache_root() / key
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / unpacked.name
+    if unpacked.resolve() != dest.resolve():
+        shutil.copy2(unpacked, dest)
+    return dest
+
+
+def catalog_description(part_number: str, source_path: Path) -> str:
+    """Catalog title from the McMaster STEP filename, e.g. 'Black-Oxide Alloy Steel Socket Head Screw'."""
+    stem = re.sub(r"[_\s]+", " ", source_path.stem).strip()
+    title = stem
+    if part_number:
+        prefix = re.compile(re.escape(part_number) + r"[\s\-]*", re.IGNORECASE)
+        title = prefix.sub("", stem, count=1).strip(" -")
+    title = re.sub(r"\s+", " ", title).strip()
+    if not title or (part_number and title.upper() == part_number.upper()):
+        return "McMaster-Carr catalog part"
+    return title
+
+
+def _stamp_metadata(obj, part_number: str, source_path: Path) -> None:
+    label = part_number or source_path.stem
+    description = catalog_description(part_number, source_path)
+    try:
+        obj.Label = label
+    except Exception:
+        pass
+    try:
+        obj.Label2 = description
+    except Exception:
+        pass
+    group = "McMaster"
+    specs = (
+        ("Vendor", "App::PropertyString", "McMaster-Carr"),
+        ("PartNumber", "App::PropertyString", part_number),
+        ("Description", "App::PropertyString", description),
+        ("SourceURL", "App::PropertyString", product_url(part_number) if part_number else CATALOG_URL),
+        ("SourceFile", "App::PropertyString", str(source_path)),
+    )
+    for name, ptype, value in specs:
+        try:
+            if not hasattr(obj, name):
+                adder = getattr(obj, "addProperty", None)
+                if callable(adder):
+                    adder(ptype, name, group, "")
+            setattr(obj, name, value)
+        except Exception:
+            continue
+
+
+_SKIP_TRANSFORM_TYPES = (
+    "App::Origin",
+    "App::Line",
+    "App::Plane",
+    "App::OriginFeature",
+)
+
+
+def _shape_volume(obj) -> float:
+    try:
+        shape = getattr(obj, "Shape", None)
+        if shape is None or shape.isNull():
+            return 0.0
+        return abs(float(shape.Volume))
+    except Exception:
+        return 0.0
+
+
+def _type_id(obj) -> str:
+    return str(getattr(obj, "TypeId", "") or "")
+
+
+def _is_origin_object(obj) -> bool:
+    tid = _type_id(obj)
+    return tid in _SKIP_TRANSFORM_TYPES or "Origin" in tid
+
+
+def _classify_structure(doc, obj) -> None:
+    classify = getattr(doc, "classifyProvisionalTimelineInternalObject", None)
+    if callable(classify):
+        classify(obj)
+
+
+def _active_component():
+    try:
+        import FreeCADGui as Gui
+
+        view = Gui.activeView()
+        if view is None:
+            return None
+        for key in ("part", "pdcomponent"):
+            candidate = view.getActiveObject(key)
+            if _type_id(candidate) in ("PartDesign::Component", "App::Part"):
+                return candidate
+    except Exception:
+        return None
+    return None
+
+
+def _import_roots(created: list) -> list:
+    created_set = set(created)
+    roots = []
+    for obj in created:
+        if obj is None or _is_origin_object(obj):
+            continue
+        parent = None
+        try:
+            parent = obj.getParentGeoFeatureGroup()
+        except Exception:
+            parent = None
+        if parent is not None and parent in created_set:
+            continue
+        roots.append(obj)
+    return roots
+
+
+def _ensure_body(doc, obj):
+    tid = _type_id(obj)
+    if tid == "PartDesign::Body":
+        return obj
+    if tid == "PartDesign::Component":
+        return obj
+    try:
+        parent = obj.getParentGeoFeatureGroup()
+        if parent is not None and _type_id(parent) == "PartDesign::Body":
+            return parent
+    except Exception:
+        pass
+    body = doc.addObject("PartDesign::Body", "Body")
+    _classify_structure(doc, body)
+    try:
+        body.Label = "Body"
+    except Exception:
+        pass
+    try:
+        body.addObject(obj)
+    except Exception:
+        pass
+    try:
+        if getattr(obj, "Shape", None) is not None:
+            body.Tip = obj
+    except Exception:
+        pass
+    return body
+
+
+def _promote_to_component(doc, created: list, part_number: str, source_path: Path):
+    roots = _import_roots(created)
+    existing = [obj for obj in roots if _type_id(obj) == "PartDesign::Component"]
+    if len(existing) == 1 and len(roots) == 1:
+        return existing[0]
+
+    component = doc.addObject("PartDesign::Component", "Component")
+    if component is None or _type_id(component) != "PartDesign::Component":
+        raise RuntimeError("VibeCAD did not create a PartDesign::Component")
+    _classify_structure(doc, component)
+    try:
+        component.Label = part_number or source_path.stem
+    except Exception:
+        pass
+
+    parent = _active_component()
+    if parent is not None and parent is not component:
+        try:
+            parent.addObject(component)
+        except Exception:
+            pass
+
+    bodies = []
+    for root in roots:
+        if root is component or _is_origin_object(root):
+            continue
+        if _type_id(root) == "PartDesign::Component":
+            for child in list(getattr(root, "Group", []) or []):
+                if _type_id(child) == "PartDesign::Body":
+                    bodies.append(child)
+            continue
+        bodies.append(_ensure_body(doc, root))
+
+    unique_bodies = []
+    seen = set()
+    for body in bodies:
+        if body is None or id(body) in seen:
+            continue
+        seen.add(id(body))
+        unique_bodies.append(body)
+        try:
+            if body.getParentGeoFeatureGroup() is not component:
+                component.addObject(body)
+        except Exception:
+            pass
+        if len(unique_bodies) == 1:
+            try:
+                body.Label = "Body"
+            except Exception:
+                pass
+
+    try:
+        import FreeCADGui as Gui
+
+        view = Gui.activeView()
+        if view is not None:
+            view.setActiveObject("part", component)
+    except Exception:
+        pass
+    return component
+
+
+def _transform_target(objects: list):
+    usable = [
+        obj
+        for obj in objects
+        if obj is not None and not _is_origin_object(obj)
+    ]
+    if not usable:
+        return None
+    for type_id in (
+        "PartDesign::Component",
+        "App::Part",
+        "App::DocumentObjectGroup",
+        "PartDesign::Body",
+    ):
+        for obj in usable:
+            if _type_id(obj) == type_id:
+                return obj
+    placed = [obj for obj in usable if hasattr(obj, "Placement")]
+    if not placed:
+        return usable[0]
+    return max(placed, key=_shape_volume)
+
+
+def _show_placement_dialog(obj) -> None:
+    """Fallback XYZ / rotation panel when VibeCAD has no transform command."""
+    from PySide import QtCore, QtWidgets
+    import FreeCADGui as Gui
+
+    original = App.Placement(obj.Placement)
+
+    class PlacementPanel(QtWidgets.QDialog):
+        def __init__(self, parent=None):
+            flags = (
+                QtCore.Qt.Tool
+                | QtCore.Qt.WindowTitleHint
+                | QtCore.Qt.WindowCloseButtonHint
+            )
+            super().__init__(parent, flags)
+            self.setObjectName("McMasterPlacementPanel")
+            self.setWindowTitle(f"Position {obj.Label}")
+            self.setAttribute(QtCore.Qt.WA_MacAlwaysShowToolWindow, True)
+            form = QtWidgets.QFormLayout(self)
+            self._spins = {}
+            base = original.Base
+            yaw, pitch, roll = original.Rotation.getYawPitchRoll()
+            for key, value, suffix in (
+                ("X", base.x, " mm"),
+                ("Y", base.y, " mm"),
+                ("Z", base.z, " mm"),
+                ("Yaw", yaw, " °"),
+                ("Pitch", pitch, " °"),
+                ("Roll", roll, " °"),
+            ):
+                spin = QtWidgets.QDoubleSpinBox()
+                spin.setRange(-1e6, 1e6)
+                spin.setDecimals(3)
+                spin.setSingleStep(1.0 if suffix == " mm" else 15.0)
+                spin.setSuffix(suffix)
+                spin.setValue(value)
+                spin.valueChanged.connect(self._apply)
+                self._spins[key] = spin
+                form.addRow(key, spin)
+            rotate_row = QtWidgets.QHBoxLayout()
+            for axis, angle in (("X", 90), ("Y", 90), ("Z", 90)):
+                button = QtWidgets.QPushButton(f"Rotate {axis} 90°")
+                button.clicked.connect(lambda _=False, a=axis: self._nudge_rotate(a))
+                rotate_row.addWidget(button)
+            form.addRow(rotate_row)
+            buttons = QtWidgets.QDialogButtonBox(
+                QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Reset
+            )
+            buttons.accepted.connect(self.accept)
+            buttons.button(QtWidgets.QDialogButtonBox.Reset).clicked.connect(self._reset)
+            form.addRow(buttons)
+
+        def _placement(self) -> "App.Placement":
+            return App.Placement(
+                App.Vector(
+                    self._spins["X"].value(),
+                    self._spins["Y"].value(),
+                    self._spins["Z"].value(),
+                ),
+                App.Rotation(
+                    self._spins["Yaw"].value(),
+                    self._spins["Pitch"].value(),
+                    self._spins["Roll"].value(),
+                ),
+            )
+
+        def _apply(self, *_args) -> None:
+            try:
+                obj.Placement = self._placement()
+                obj.Document.recompute()
+            except Exception:
+                pass
+
+        def _nudge_rotate(self, axis: str) -> None:
+            current = obj.Placement
+            rotation = App.Rotation(
+                App.Vector(
+                    1 if axis == "X" else 0,
+                    1 if axis == "Y" else 0,
+                    1 if axis == "Z" else 0,
+                ),
+                90,
+            )
+            obj.Placement = App.Placement(current.Base, rotation * current.Rotation)
+            yaw, pitch, roll = obj.Placement.Rotation.getYawPitchRoll()
+            self._spins["Yaw"].blockSignals(True)
+            self._spins["Pitch"].blockSignals(True)
+            self._spins["Roll"].blockSignals(True)
+            self._spins["Yaw"].setValue(yaw)
+            self._spins["Pitch"].setValue(pitch)
+            self._spins["Roll"].setValue(roll)
+            self._spins["Yaw"].blockSignals(False)
+            self._spins["Pitch"].blockSignals(False)
+            self._spins["Roll"].blockSignals(False)
+            try:
+                obj.Document.recompute()
+            except Exception:
+                pass
+
+        def _reset(self) -> None:
+            obj.Placement = App.Placement(original)
+            base = original.Base
+            yaw, pitch, roll = original.Rotation.getYawPitchRoll()
+            values = {
+                "X": base.x,
+                "Y": base.y,
+                "Z": base.z,
+                "Yaw": yaw,
+                "Pitch": pitch,
+                "Roll": roll,
+            }
+            for key, value in values.items():
+                self._spins[key].blockSignals(True)
+                self._spins[key].setValue(value)
+                self._spins[key].blockSignals(False)
+            try:
+                obj.Document.recompute()
+            except Exception:
+                pass
+
+    panel = PlacementPanel(Gui.getMainWindow())
+    panel.show()
+    panel.raise_()
+    Gui.McMasterPlacementPanel = panel
+
+
+def open_position_dialog(object_names: list[str]) -> None:
+    """Select the imported body and open VibeCAD's transform / placement UI."""
+    from PySide import QtCore
+    import FreeCADGui as Gui
+
+    names = list(object_names)
+
+    def _launch() -> None:
+        doc = App.ActiveDocument
+        if doc is None:
+            return
+        objects = [doc.getObject(name) for name in names]
+        target = _transform_target(objects)
+        if target is None or not hasattr(target, "Placement"):
+            return
+        try:
+            existing = getattr(Gui, "McMasterPlacementPanel", None)
+            if existing is not None:
+                existing.close()
+                Gui.McMasterPlacementPanel = None
+        except Exception:
+            pass
+        try:
+            if Gui.Control.activeDialog():
+                Gui.Control.closeDialog()
+        except Exception:
+            pass
+        try:
+            Gui.Selection.clearSelection()
+            Gui.Selection.addSelection(doc.Name, target.Name)
+        except Exception:
+            return
+        try:
+            Gui.SendMsgToActiveView("ViewFit")
+        except Exception:
+            pass
+        try:
+            Gui.updateGui()
+        except Exception:
+            pass
+        available = set()
+        try:
+            available = set(Gui.listCommands())
+        except Exception:
+            pass
+        for command in ("Std_TransformManip", "Std_Transform", "Std_Placement"):
+            if available and command not in available:
+                continue
+            try:
+                Gui.runCommand(command, 0)
+                App.Console.PrintMessage(
+                    f"McMaster: position {target.Label} — drag the triad or use the transform panel\n"
+                )
+                return
+            except Exception:
+                continue
+        try:
+            Gui.activeDocument().setEdit(target.Name, 1)
+            App.Console.PrintMessage(
+                f"McMaster: position {target.Label} — transform handles are active\n"
+            )
+            return
+        except Exception:
+            pass
+        _show_placement_dialog(target)
+
+    QtCore.QTimer.singleShot(500, _launch)
+
+
+def import_cad(path: Path, part_number: str) -> list[str]:
+    doc = App.ActiveDocument
+    if doc is None:
+        doc = App.newDocument("McMaster")
+    before = set(doc.Objects)
+    imported = False
+    try:
+        import ImportGui
+
+        try:
+            ImportGui.insert(
+                name=str(path),
+                docName=doc.Name,
+                merge=False,
+                useLinkGroup=True,
+                importSolidBodies=True,
+            )
+        except TypeError:
+            ImportGui.insert(str(path), doc.Name)
+        imported = True
+    except Exception:
+        pass
+    if not imported:
+        import Part
+
+        Part.insert(str(path), doc.Name)
+    created = [obj for obj in doc.Objects if obj not in before]
+    if not created:
+        raise RuntimeError(f"Import produced no objects from {path.name}")
+    try:
+        component = _promote_to_component(doc, created, part_number, path)
+        _stamp_metadata(component, part_number, path)
+        doc.recompute()
+        return [component.Name]
+    except Exception as exc:
+        App.Console.PrintWarning(
+            f"McMaster: could not wrap as a component ({exc}); imported objects were left as-is\n"
+        )
+        for obj in created:
+            if not _is_origin_object(obj):
+                _stamp_metadata(obj, part_number, path)
+        doc.recompute()
+        return [obj.Name for obj in created if not _is_origin_object(obj)] or [
+            obj.Name for obj in created
+        ]
+
+
+def _is_cad_file(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    name = path.name.lower()
+    if name.endswith(".download") or name.endswith(".crdownload") or name.endswith(".part"):
+        return False
+    return path.suffix.lower() in CAD_SUFFIXES
+
+
+def _looks_like_mcmaster_download(path: Path) -> bool:
+    if not _is_cad_file(path):
+        return False
+    return bool(part_number_from_filename(path.name)) or path.parent == inbox_dir()
+
+
+def catalog_helper_running() -> bool:
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", str(helper_path())],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        return bool(result.stdout.strip())
+    except Exception:
+        return False
+
+
+_webkit_lib = None
+
+
+def _webkit_dylib():
+    global _webkit_lib
+    if _webkit_lib is not None:
+        return _webkit_lib
+    path = Path(__file__).resolve().parent / "libMcMasterWebKit.dylib"
+    if not path.is_file():
+        return None
+    import ctypes
+
+    lib = ctypes.CDLL(str(path))
+    lib.McMasterWebKit_Attach.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    lib.McMasterWebKit_Attach.restype = ctypes.c_int
+    lib.McMasterWebKit_Status.argtypes = []
+    lib.McMasterWebKit_Status.restype = ctypes.c_char_p
+    _webkit_lib = lib
+    return lib
+
+
+def close_catalog_panel() -> None:
+    try:
+        import FreeCADGui as Gui
+    except Exception:
+        return
+    panel = getattr(Gui, "McMasterCatalogPanel", None)
+    if panel is None:
+        return
+    try:
+        panel.close()
+        panel.deleteLater()
+    except Exception:
+        pass
+    Gui.McMasterCatalogPanel = None
+
+
+def attach_webkit(widget, out_dir: Path) -> bool:
+    lib = _webkit_dylib()
+    if lib is None:
+        return False
+    from PySide import QtCore
+
+    widget.setAttribute(QtCore.Qt.WA_NativeWindow, True)
+    handle = int(widget.winId())
+    if handle == 0:
+        return False
+    return lib.McMasterWebKit_Attach(handle, str(out_dir).encode("utf-8")) == 0
+
+
+def show_catalog_window() -> bool:
+    """Fusion-style catalog: a tool window owned by VibeCAD (works in fullscreen)."""
+    from PySide import QtCore, QtWidgets
+    import FreeCADGui as Gui
+
+    existing = getattr(Gui, "McMasterCatalogPanel", None)
+    if existing is not None:
+        try:
+            existing.close()
+            existing.deleteLater()
+        except Exception:
+            pass
+        Gui.McMasterCatalogPanel = None
+
+    mw = Gui.getMainWindow()
+    flags = (
+        QtCore.Qt.Tool
+        | QtCore.Qt.WindowTitleHint
+        | QtCore.Qt.WindowCloseButtonHint
+        | QtCore.Qt.WindowMinMaxButtonsHint
+    )
+
+    class CatalogPanel(QtWidgets.QDialog):
+        def __init__(self, parent=None):
+            super().__init__(parent, flags)
+            self.setObjectName("McMasterCatalogPanel")
+            self.setWindowTitle("Insert McMaster-Carr Component")
+            self.resize(1000, 720)
+            self.setAttribute(QtCore.Qt.WA_MacAlwaysShowToolWindow, True)
+            self._attached = False
+
+            self.host = QtWidgets.QWidget(self)
+            self.host.setMinimumSize(640, 480)
+            self.host.setAttribute(QtCore.Qt.WA_NativeWindow, True)
+            self.status = QtWidgets.QLabel("Loading McMaster-Carr…")
+            layout = QtWidgets.QVBoxLayout(self)
+            layout.setContentsMargins(0, 0, 8, 8)
+            layout.addWidget(self.host, 1)
+            layout.addWidget(self.status)
+            self._status_timer = QtCore.QTimer(self)
+            self._status_timer.setInterval(800)
+            self._status_timer.timeout.connect(self._poll_webkit)
+            QtCore.QTimer.singleShot(0, self._attach)
+            QtCore.QTimer.singleShot(300, self._attach)
+            QtCore.QTimer.singleShot(800, self._attach)
+
+        def showEvent(self, event) -> None:
+            super().showEvent(event)
+            QtCore.QTimer.singleShot(0, self._attach)
+
+        def _attach(self) -> None:
+            if self._attached:
+                return
+            if self.host.width() < 64 or self.host.height() < 64:
+                QtCore.QTimer.singleShot(120, self._attach)
+                return
+            if attach_webkit(self.host, inbox_dir()):
+                self._attached = True
+                self.status.setText("Connecting to McMaster-Carr…")
+                self._status_timer.start()
+                App.Console.PrintMessage("McMaster catalog attached inside VibeCAD\n")
+            else:
+                self.status.setText(
+                    "Catalog view is not ready yet. If it stays blank, click Catalog again."
+                )
+
+        def _poll_webkit(self) -> None:
+            lib = _webkit_dylib()
+            if lib is None:
+                return
+            raw = lib.McMasterWebKit_Status()
+            if not raw:
+                return
+            text = raw.decode("utf-8", "replace") if isinstance(raw, bytes) else str(raw)
+            if "download finished" in text.lower():
+                self.status.setText("Imported. Closing catalog…")
+                QtCore.QTimer.singleShot(400, close_catalog_panel)
+            elif text.startswith("ok"):
+                self.status.setText("Download 3-D STEP to import into this document.")
+            elif text.startswith("error") or "fail" in text.lower():
+                self.status.setText(f"McMaster load problem: {text}")
+            elif text.startswith("loading"):
+                self.status.setText("Loading McMaster-Carr…")
+
+    panel = CatalogPanel(mw)
+    panel.show()
+    panel.raise_()
+    panel.activateWindow()
+    Gui.McMasterCatalogPanel = panel
+    return True
+
+
+def _ensure_import_watcher() -> None:
+    from PySide import QtCore
+    import FreeCADGui as Gui
+
+    existing = getattr(Gui, "McMasterImportWatcher", None)
+    if existing is not None:
+        return
+
+    class Watcher(QtCore.QObject):
+        def __init__(self, parent=None):
+            super().__init__(parent)
+            self._seen: set[str] = set()
+            self._started = time.time()
+            for folder in (inbox_dir(), downloads_dir()):
+                if not folder.is_dir():
+                    continue
+                for path in folder.iterdir():
+                    if _is_cad_file(path):
+                        self._seen.add(self._key(path))
+            self._timer = QtCore.QTimer(self)
+            self._timer.setInterval(800)
+            self._timer.timeout.connect(self._poll)
+            self._timer.start()
+
+        def _key(self, path: Path) -> str:
+            try:
+                st = path.stat()
+            except OSError:
+                return str(path)
+            return f"{path.resolve()}::{st.st_mtime_ns}::{st.st_size}"
+
+        def _poll(self) -> None:
+            for folder in (inbox_dir(), downloads_dir()):
+                if not folder.is_dir():
+                    continue
+                for path in folder.iterdir():
+                    key = self._key(path)
+                    if key in self._seen:
+                        continue
+                    if not _looks_like_mcmaster_download(path):
+                        continue
+                    try:
+                        if path.stat().st_mtime < self._started - 1:
+                            self._seen.add(key)
+                            continue
+                    except OSError:
+                        continue
+                    self._seen.add(key)
+                    self._import_path(path)
+
+        def _import_path(self, path: Path) -> None:
+            pn = part_number_from_filename(path.name)
+            try:
+                cached = store_in_cache(path, pn)
+                names = import_cad(cached, pn or cached.stem)
+                App.Console.PrintMessage(
+                    f"McMaster: inserted {pn or cached.stem} as {', '.join(names)}\n"
+                )
+                try:
+                    Gui.SendMsgToActiveView("ViewFit")
+                except Exception:
+                    pass
+                close_catalog_panel()
+                open_position_dialog(names)
+            except Exception as exc:
+                App.Console.PrintError(f"McMaster insert: {exc}\n")
+
+    mw = Gui.getMainWindow()
+    Gui.McMasterImportWatcher = Watcher(mw)
+
+
+def run() -> None:
+    if not App.GuiUp:
+        raise RuntimeError("McMaster catalog requires the VibeCAD GUI")
+    _ensure_import_watcher()
+    if show_catalog_window():
+        App.Console.PrintMessage(
+            "McMaster-Carr catalog overlay opened. "
+            "Download 3-D STEP — it imports automatically (no Save dialog).\n"
+        )
+        return
+    App.Console.PrintError("McMaster-Carr: could not open https://www.mcmaster.com/\n")
+
+
+def import_file() -> None:
+    """Pick a CAD file and import it without opening the catalog."""
+    if not App.GuiUp:
+        raise RuntimeError("Import requires the VibeCAD GUI")
+    from PySide import QtWidgets
+    import FreeCADGui as Gui
+
+    path, _ = QtWidgets.QFileDialog.getOpenFileName(
+        Gui.getMainWindow(),
+        "McMaster CAD file",
+        str(downloads_dir()),
+        "CAD (*.step *.stp *.iges *.igs *.sat *.sldprt *.zip);;All files (*)",
+    )
+    if not path:
+        return
+    source = Path(path)
+    pn = part_number_from_filename(source.name)
+    cached = store_in_cache(source, pn)
+    names = import_cad(cached, pn or cached.stem)
+    App.Console.PrintMessage(
+        f"McMaster: inserted {pn or cached.stem} as {', '.join(names)}\n"
+    )
+    try:
+        Gui.SendMsgToActiveView("ViewFit")
+    except Exception:
+        pass
+    open_position_dialog(names)
+
+
+def open_cache() -> None:
+    from PySide import QtCore, QtGui
+
+    QtGui.QDesktopServices.openUrl(
+        QtCore.QUrl.fromLocalFile(str(cache_root()))
+    )

--- a/src/Mod/McMasterInsert/McMasterInsert.py
+++ b/src/Mod/McMasterInsert/McMasterInsert.py
@@ -122,26 +122,46 @@ def store_in_cache(source: Path, part_number: str) -> Path:
     return dest
 
 
+_CAD_VARIANT_PREFIX = re.compile(
+    r"^(NO THREADS|NO-THREADS|NOTHREADS|SIMPLIFIED)\s+",
+    re.IGNORECASE,
+)
+
+
 def catalog_description(part_number: str, source_path: Path) -> str:
-    """Catalog title from the McMaster STEP filename, e.g. 'Black-Oxide Alloy Steel Socket Head Screw'."""
+    """McMaster catalog summary from the STEP filename, without CAD-variant prefixes."""
     stem = re.sub(r"[_\s]+", " ", source_path.stem).strip()
     title = stem
     if part_number:
         prefix = re.compile(re.escape(part_number) + r"[\s\-]*", re.IGNORECASE)
         title = prefix.sub("", stem, count=1).strip(" -")
+    title = _CAD_VARIANT_PREFIX.sub("", title).strip()
     title = re.sub(r"\s+", " ", title).strip()
     if not title or (part_number and title.upper() == part_number.upper()):
         return "McMaster-Carr catalog part"
     return title
 
 
-def _stamp_metadata(obj, part_number: str, source_path: Path) -> None:
-    label = part_number or source_path.stem
-    description = catalog_description(part_number, source_path)
+def _set_label(obj, label: str) -> None:
     try:
         obj.Label = label
     except Exception:
         pass
+
+
+def _clear_description(obj) -> None:
+    for attr in ("Label2", "Description"):
+        try:
+            if hasattr(obj, attr):
+                setattr(obj, attr, "")
+        except Exception:
+            pass
+
+
+def _stamp_metadata(obj, part_number: str, source_path: Path) -> None:
+    label = part_number or source_path.stem
+    description = catalog_description(part_number, source_path)
+    _set_label(obj, label)
     try:
         obj.Label2 = description
     except Exception:
@@ -163,6 +183,29 @@ def _stamp_metadata(obj, part_number: str, source_path: Path) -> None:
             setattr(obj, name, value)
         except Exception:
             continue
+
+
+def _stamp_body(obj, part_number: str, source_path: Path) -> None:
+    _set_label(obj, part_number or source_path.stem)
+    _clear_description(obj)
+
+
+def _name_imported_tree(component, part_number: str, source_path: Path) -> None:
+    """Component: part number + catalog summary. Inner body: part number only."""
+    _stamp_metadata(component, part_number, source_path)
+    for child in list(getattr(component, "Group", []) or []):
+        if _is_origin_object(child):
+            continue
+        if _type_id(child) == "PartDesign::Body":
+            _stamp_body(child, part_number, source_path)
+            owned = list(getattr(child, "Group", []) or [])
+            tip = getattr(child, "Tip", None)
+            if tip is not None and tip not in owned:
+                owned.append(tip)
+            for inner in owned:
+                if _is_origin_object(inner):
+                    continue
+                _stamp_body(inner, part_number, source_path)
 
 
 _SKIP_TRANSFORM_TYPES = (
@@ -246,10 +289,6 @@ def _ensure_body(doc, obj):
     body = doc.addObject("PartDesign::Body", "Body")
     _classify_structure(doc, body)
     try:
-        body.Label = "Body"
-    except Exception:
-        pass
-    try:
         body.addObject(obj)
     except Exception:
         pass
@@ -306,11 +345,6 @@ def _promote_to_component(doc, created: list, part_number: str, source_path: Pat
                 component.addObject(body)
         except Exception:
             pass
-        if len(unique_bodies) == 1:
-            try:
-                body.Label = "Body"
-            except Exception:
-                pass
 
     try:
         import FreeCADGui as Gui
@@ -572,7 +606,7 @@ def import_cad(path: Path, part_number: str) -> list[str]:
         raise RuntimeError(f"Import produced no objects from {path.name}")
     try:
         component = _promote_to_component(doc, created, part_number, path)
-        _stamp_metadata(component, part_number, path)
+        _name_imported_tree(component, part_number, path)
         doc.recompute()
         return [component.Name]
     except Exception as exc:

--- a/src/Mod/McMasterInsert/McMasterInsert.py
+++ b/src/Mod/McMasterInsert/McMasterInsert.py
@@ -142,11 +142,26 @@ def catalog_description(part_number: str, source_path: Path) -> str:
     return title
 
 
+def _legal_object_name(prefix: str, part_number: str) -> str:
+    raw = re.sub(r"[^0-9A-Za-z_]", "_", part_number or "Part")
+    if not raw or not raw[0].isalpha():
+        raw = f"{prefix}_{raw}"
+    return raw[:50]
+
+
 def _set_label(obj, label: str) -> None:
+    wanted = str(label or "").strip()
+    if obj is None or not wanted:
+        return
     try:
-        obj.Label = label
-    except Exception:
-        pass
+        obj.Label = wanted
+    except Exception as exc:
+        App.Console.PrintWarning(f"McMaster: could not set Label on {obj.Name}: {exc}\n")
+        return
+    if str(getattr(obj, "Label", "") or "") != wanted:
+        App.Console.PrintWarning(
+            f"McMaster: {obj.Name} Label is {obj.Label!r}, wanted {wanted!r}\n"
+        )
 
 
 def _clear_description(obj) -> None:
@@ -300,52 +315,100 @@ def _ensure_body(doc, obj):
     return body
 
 
-def _promote_to_component(doc, created: list, part_number: str, source_path: Path):
-    roots = _import_roots(created)
-    existing = [obj for obj in roots if _type_id(obj) == "PartDesign::Component"]
-    if len(existing) == 1 and len(roots) == 1:
-        return existing[0]
-
-    component = doc.addObject("PartDesign::Component", "Component")
-    if component is None or _type_id(component) != "PartDesign::Component":
-        raise RuntimeError("VibeCAD did not create a PartDesign::Component")
-    _classify_structure(doc, component)
-    try:
-        component.Label = part_number or source_path.stem
-    except Exception:
-        pass
-
-    parent = _active_component()
-    if parent is not None and parent is not component:
-        try:
-            parent.addObject(component)
-        except Exception:
-            pass
-
+def _imported_bodies(doc, created: list) -> list:
     bodies = []
-    for root in roots:
-        if root is component or _is_origin_object(root):
-            continue
-        if _type_id(root) == "PartDesign::Component":
-            for child in list(getattr(root, "Group", []) or []):
-                if _type_id(child) == "PartDesign::Body":
-                    bodies.append(child)
-            continue
-        bodies.append(_ensure_body(doc, root))
-
-    unique_bodies = []
     seen = set()
-    for body in bodies:
+    for obj in created:
+        if obj is None or _is_origin_object(obj):
+            continue
+        body = None
+        tid = _type_id(obj)
+        if tid == "PartDesign::Body":
+            body = obj
+        elif tid == "PartDesign::Component":
+            continue
+        else:
+            try:
+                parent = obj.getParentGeoFeatureGroup()
+            except Exception:
+                parent = None
+            if parent is not None and _type_id(parent) == "PartDesign::Body":
+                body = parent
+            else:
+                body = _ensure_body(doc, obj)
         if body is None or id(body) in seen:
             continue
         seen.add(id(body))
-        unique_bodies.append(body)
+        bodies.append(body)
+    return bodies
+
+
+def _component_only_holds(component, bodies: list) -> bool:
+    owned = [
+        child
+        for child in list(getattr(component, "Group", []) or [])
+        if not _is_origin_object(child)
+    ]
+    if not owned:
+        return True
+    imported = set(bodies)
+    return all(child in imported for child in owned)
+
+
+def _promote_to_component(doc, created: list, part_number: str, source_path: Path):
+    label = part_number or source_path.stem
+    created_components = [
+        obj for obj in created if _type_id(obj) == "PartDesign::Component"
+    ]
+    bodies = _imported_bodies(doc, created)
+
+    if len(created_components) == 1 and not bodies:
+        component = created_components[0]
+        _set_label(component, label)
+        return component
+
+    parents = []
+    for body in bodies:
+        try:
+            parent = body.getParentGeoFeatureGroup()
+        except Exception:
+            parent = None
+        if parent is not None and _type_id(parent) in (
+            "PartDesign::Component",
+            "App::Part",
+        ):
+            parents.append(parent)
+    unique_parents = []
+    seen = set()
+    for parent in parents:
+        if id(parent) in seen:
+            continue
+        seen.add(id(parent))
+        unique_parents.append(parent)
+
+    component = None
+    if len(unique_parents) == 1 and _component_only_holds(unique_parents[0], bodies):
+        component = unique_parents[0]
+    elif len(created_components) == 1:
+        component = created_components[0]
+
+    if component is None:
+        component = doc.addObject(
+            "PartDesign::Component",
+            _legal_object_name("Component", part_number),
+        )
+        if component is None or _type_id(component) != "PartDesign::Component":
+            raise RuntimeError("VibeCAD did not create a PartDesign::Component")
+        _classify_structure(doc, component)
+
+    for body in bodies:
         try:
             if body.getParentGeoFeatureGroup() is not component:
                 component.addObject(body)
         except Exception:
             pass
 
+    _set_label(component, label)
     try:
         import FreeCADGui as Gui
 
@@ -354,6 +417,9 @@ def _promote_to_component(doc, created: list, part_number: str, source_path: Pat
             view.setActiveObject("part", component)
     except Exception:
         pass
+    App.Console.PrintMessage(
+        f"McMaster: component {component.Name} Label={component.Label!r}\n"
+    )
     return component
 
 
@@ -608,6 +674,33 @@ def import_cad(path: Path, part_number: str) -> list[str]:
         component = _promote_to_component(doc, created, part_number, path)
         _name_imported_tree(component, part_number, path)
         doc.recompute()
+        _name_imported_tree(component, part_number, path)
+        try:
+            import FreeCADGui as Gui
+            from PySide import QtCore
+
+            Gui.updateGui()
+            doc_name = doc.Name
+            obj_name = component.Name
+            path_str = str(path)
+            pn = part_number
+
+            def _relabel() -> None:
+                live_doc = App.getDocument(doc_name)
+                if live_doc is None:
+                    return
+                live = live_doc.getObject(obj_name)
+                if live is None:
+                    return
+                _name_imported_tree(live, pn, Path(path_str))
+                App.Console.PrintMessage(
+                    f"McMaster: renamed {live.Name} -> {live.Label!r}\n"
+                )
+
+            QtCore.QTimer.singleShot(0, _relabel)
+            QtCore.QTimer.singleShot(250, _relabel)
+        except Exception:
+            pass
         return [component.Name]
     except Exception as exc:
         App.Console.PrintWarning(

--- a/src/Mod/McMasterInsert/McMasterWebKit.swift
+++ b/src/Mod/McMasterInsert/McMasterWebKit.swift
@@ -1,0 +1,238 @@
+import AppKit
+import WebKit
+
+/// Embed WKWebView in a Qt NSView. No extra NSWindow collectionBehavior.
+
+final class Host: NSObject, WKNavigationDelegate, WKDownloadDelegate, WKUIDelegate {
+    let webView: WKWebView
+    let outDir: URL
+    let cadExtensions: Set<String> = [
+        "step", "stp", "stpz", "iges", "igs", "sat", "sab", "x_t", "x_b", "sldprt", "zip",
+    ]
+
+    init(parent: NSView, outDir: URL) {
+        self.outDir = outDir
+        parent.wantsLayer = true
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = WKWebsiteDataStore.default()
+        config.defaultWebpagePreferences.allowsContentJavaScript = true
+        config.preferences.javaScriptCanOpenWindowsAutomatically = true
+        let webView = WKWebView(frame: parent.bounds, configuration: config)
+        webView.autoresizingMask = [.width, .height]
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        self.webView = webView
+        super.init()
+        webView.navigationDelegate = self
+        webView.uiDelegate = self
+        parent.addSubview(webView)
+        NSLayoutConstraint.activate([
+            webView.topAnchor.constraint(equalTo: parent.topAnchor),
+            webView.bottomAnchor.constraint(equalTo: parent.bottomAnchor),
+            webView.leadingAnchor.constraint(equalTo: parent.leadingAnchor),
+            webView.trailingAnchor.constraint(equalTo: parent.trailingAnchor),
+        ])
+        log("attach bounds=\(parent.bounds) window=\(String(describing: parent.window))")
+        DispatchQueue.main.async { [weak self] in
+            self?.loadCatalog()
+        }
+    }
+
+    func loadCatalog() {
+        let url = URL(string: "https://www.mcmaster.com/")!
+        let request = URLRequest(url: url, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 45)
+        log("load \(url.absoluteString) webView.bounds=\(webView.bounds)")
+        webView.load(request)
+        setStatus("loading")
+    }
+
+    func isCAD(_ response: URLResponse) -> Bool {
+        let name = response.suggestedFilename?.lowercased() ?? ""
+        let ext = (name as NSString).pathExtension
+        if cadExtensions.contains(ext) { return true }
+        if let url = response.url, cadExtensions.contains(url.pathExtension.lowercased()) {
+            return true
+        }
+        return false
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        if let url = navigationAction.request.url,
+           cadExtensions.contains(url.pathExtension.lowercased()),
+           #available(macOS 11.3, *)
+        {
+            decisionHandler(.download)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
+        if isCAD(navigationResponse.response), #available(macOS 11.3, *) {
+            decisionHandler(.download)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    @available(macOS 11.3, *)
+    func webView(
+        _ webView: WKWebView,
+        navigationAction: WKNavigationAction,
+        didBecome download: WKDownload
+    ) {
+        download.delegate = self
+    }
+
+    @available(macOS 11.3, *)
+    func webView(
+        _ webView: WKWebView,
+        navigationResponse: WKNavigationResponse,
+        didBecome download: WKDownload
+    ) {
+        download.delegate = self
+    }
+
+    @available(macOS 11.3, *)
+    func download(
+        _ download: WKDownload,
+        decideDestinationUsing response: URLResponse,
+        suggestedFilename: String,
+        completionHandler: @escaping (URL?) -> Void
+    ) {
+        let safe = suggestedFilename.replacingOccurrences(of: "/", with: "_")
+        let dest = outDir.appendingPathComponent(safe)
+        try? FileManager.default.removeItem(at: dest)
+        log("download \(safe)")
+        completionHandler(dest)
+    }
+
+    @available(macOS 11.3, *)
+    func downloadDidFinish(_ download: WKDownload) {
+        log("download finished")
+    }
+
+    @available(macOS 11.3, *)
+    func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {
+        log("download failed \(error)")
+    }
+
+    func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+        setStatus("loading")
+        log("didStart \(webView.url?.absoluteString ?? "")")
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        setStatus("ok \(webView.url?.host ?? "")")
+        log("didFinish \(webView.url?.absoluteString ?? "")")
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        handleFail(error)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        handleFail(error)
+    }
+
+    func handleFail(_ error: Error) {
+        let nsError = error as NSError
+        if nsError.domain == NSURLErrorDomain && nsError.code == NSURLErrorCancelled {
+            return
+        }
+        setStatus("error \(nsError.localizedDescription)")
+        log("load fail \(error)")
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        if let url = navigationAction.request.url {
+            webView.load(URLRequest(url: url))
+        }
+        return nil
+    }
+}
+
+private var hosts: [ObjectIdentifier: Host] = [:]
+private var lastStatus = "idle"
+private let statusRaw: UnsafeMutablePointer<CChar> = {
+    let pointer = UnsafeMutablePointer<CChar>.allocate(capacity: 1024)
+    pointer.initialize(repeating: 0, count: 1024)
+    return pointer
+}()
+
+private func log(_ message: String) {
+    NSLog("McMasterWebKit \(message)")
+    lastStatus = message
+    let dir = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask).first?
+        .appendingPathComponent("Logs", isDirectory: true)
+    guard let dir else { return }
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let file = dir.appendingPathComponent("McMasterWebKit.log")
+    let line = "\(Date()) \(message)\n"
+    guard let data = line.data(using: .utf8) else { return }
+    if FileManager.default.fileExists(atPath: file.path),
+       let handle = try? FileHandle(forWritingTo: file)
+    {
+        handle.seekToEndOfFile()
+        handle.write(data)
+        try? handle.close()
+    } else {
+        try? data.write(to: file)
+    }
+}
+
+private func setStatus(_ value: String) {
+    lastStatus = value
+    let chars = Array(value.utf8CString.prefix(1023))
+    for i in 0..<1024 {
+        statusRaw[i] = i < chars.count ? chars[i] : 0
+    }
+}
+
+@_cdecl("McMasterWebKit_Attach")
+public func McMasterWebKit_Attach(
+    _ nsviewPtr: UnsafeMutableRawPointer?,
+    _ outDirC: UnsafePointer<CChar>?
+) -> Int32 {
+    guard let nsviewPtr, let outDirC else {
+        log("attach missing pointer")
+        return 1
+    }
+    let view = Unmanaged<NSView>.fromOpaque(nsviewPtr).takeUnretainedValue()
+    let outDir = URL(fileURLWithPath: String(cString: outDirC), isDirectory: true)
+    try? FileManager.default.createDirectory(at: outDir, withIntermediateDirectories: true)
+    let work = {
+        if hosts[ObjectIdentifier(view)] != nil {
+            hosts[ObjectIdentifier(view)]?.loadCatalog()
+            return
+        }
+        hosts[ObjectIdentifier(view)] = Host(parent: view, outDir: outDir)
+    }
+    if Thread.isMainThread {
+        work()
+    } else {
+        DispatchQueue.main.sync(execute: work)
+    }
+    return 0
+}
+
+@_cdecl("McMasterWebKit_Status")
+public func McMasterWebKit_Status() -> UnsafePointer<CChar>? {
+    UnsafePointer(statusRaw)
+}

--- a/src/Mod/McMasterInsert/README.md
+++ b/src/Mod/McMasterInsert/README.md
@@ -31,6 +31,13 @@ disk.
 `McMasterCatalog.swift` is the older out-of-process helper. It cannot join a
 macOS fullscreen Space, so the in-process WebKit attach is preferred.
 
+## Windows and Linux catalog
+
+Catalog opens the live McMaster-Carr site in the system browser when the macOS
+WebKit helper is unavailable. Download 3-D STEP to the standard Downloads
+folder and VibeCAD imports it automatically. If the browser saves somewhere
+else, use **Import** to select the downloaded CAD file.
+
 ## Cache
 
 Downloaded CAD is stored under the user app-data directory:

--- a/src/Mod/McMasterInsert/README.md
+++ b/src/Mod/McMasterInsert/README.md
@@ -31,12 +31,19 @@ disk.
 `McMasterCatalog.swift` is the older out-of-process helper. It cannot join a
 macOS fullscreen Space, so the in-process WebKit attach is preferred.
 
-## Windows and Linux catalog
+## Windows catalog
 
-Catalog opens the live McMaster-Carr site in the system browser when the macOS
-WebKit helper is unavailable. Download 3-D STEP to the standard Downloads
-folder and VibeCAD imports it automatically. If the browser saves somewhere
-else, use **Import** to select the downloaded CAD file.
+Catalog opens the live site in a VibeCAD window backed by the installed
+Microsoft Edge WebView2 Runtime. Downloaded CAD goes directly to VibeCAD's
+watched McMaster inbox and imports automatically. The WebView2 profile is kept
+under `%LOCALAPPDATA%\VibeCAD\McMasterBrowser`, preserving McMaster cookies and
+the login session across VibeCAD restarts and upgrades.
+
+## Linux catalog
+
+Catalog opens the live site in the system browser. Download 3-D STEP to the
+standard Downloads folder and VibeCAD imports it automatically. If the browser
+saves somewhere else, use **Import** to select the downloaded CAD file.
 
 ## Cache
 

--- a/src/Mod/McMasterInsert/README.md
+++ b/src/Mod/McMasterInsert/README.md
@@ -1,0 +1,46 @@
+# McMaster-Carr insert
+
+Python workbench that opens the live McMaster-Carr catalog inside VibeCAD and
+imports 3-D STEP as a `PartDesign::Component`.
+
+## Use
+
+- Ribbon tab **McMaster**: **Catalog** and **Import**
+- Menu **McMaster-Carr → Open Cache Folder** for local copies
+
+Download **3-D STEP** from a product page. The catalog overlay intercepts the
+file (no Save dialog on macOS), imports it, names the component with the part
+number, and puts the catalog title on **Description**. A transform manipulator
+opens so the component can be placed immediately. The overlay closes after one
+part.
+
+## macOS catalog overlay
+
+The Fusion-style overlay uses an in-process WKWebView (`McMasterWebKit.swift`)
+attached to a Qt tool window. Build the helper library with:
+
+```
+swiftc -emit-library -o libMcMasterWebKit.dylib \
+  -framework AppKit -framework WebKit McMasterWebKit.swift
+```
+
+Place `libMcMasterWebKit.dylib` next to the Python files. Without it, Catalog
+still opens the overlay host; Import remains available for a STEP already on
+disk.
+
+`McMasterCatalog.swift` is the older out-of-process helper. It cannot join a
+macOS fullscreen Space, so the in-process WebKit attach is preferred.
+
+## Cache
+
+Downloaded CAD is stored under the user app-data directory:
+
+`McMasterCache/<part-number>/…STEP`
+
+## Tests
+
+```
+python3 -m unittest src/Mod/McMasterInsert/tests/test_catalog.py src/Mod/McMasterInsert/tests/test_ribbon.py
+```
+
+`test_catalog.py` needs FreeCAD on `PYTHONPATH` (or `freecadcmd`). `test_ribbon.py` is pure Python.

--- a/src/Mod/McMasterInsert/icons/cache.svg
+++ b/src/Mod/McMasterInsert/icons/cache.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Open McMaster CAD cache">
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="#1B7A3D"/>
+  <path d="M16 24 h12 l4 5 h16 v19 H16 Z" fill="none" stroke="#ffffff" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M16 33 h32" fill="none" stroke="#D7F0E0" stroke-width="3"/>
+</svg>

--- a/src/Mod/McMasterInsert/icons/catalog.svg
+++ b/src/Mod/McMasterInsert/icons/catalog.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Insert McMaster-Carr Component">
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="#1B7A3D"/>
+  <path d="M32 16 L48 25 L32 34 L16 25 Z" fill="#ffffff"/>
+  <path d="M16 25 L32 34 L32 50 L16 41 Z" fill="#D7F0E0"/>
+  <path d="M32 34 L48 25 L48 41 L32 50 Z" fill="#A8D5B8"/>
+</svg>

--- a/src/Mod/McMasterInsert/icons/import.svg
+++ b/src/Mod/McMasterInsert/icons/import.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="Import McMaster CAD file">
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="#1B7A3D"/>
+  <path d="M32 14 v22" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round"/>
+  <path d="M22 28 l10 12 l10 -12" fill="none" stroke="#ffffff" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M18 46 h28" fill="none" stroke="#D7F0E0" stroke-width="4" stroke-linecap="round"/>
+</svg>

--- a/src/Mod/McMasterInsert/icons/mcmaster-workbench.svg
+++ b/src/Mod/McMasterInsert/icons/mcmaster-workbench.svg
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 64 64" role="img" aria-label="McMaster-Carr">
+  <rect x="6" y="6" width="52" height="52" rx="12" fill="#1B7A3D"/>
+  <path d="M32 16 L48 25 L32 34 L16 25 Z" fill="#ffffff"/>
+  <path d="M16 25 L32 34 L32 50 L16 41 Z" fill="#D7F0E0"/>
+  <path d="M32 34 L48 25 L48 41 L32 50 Z" fill="#A8D5B8"/>
+</svg>

--- a/src/Mod/McMasterInsert/package.xml
+++ b/src/Mod/McMasterInsert/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<package format="1" xmlns="https://wiki.freecad.org/Package_Metadata">
+  <name>McMasterInsert</name>
+  <description>McMaster-Carr catalog workbench for VibeCAD. Browse mcmaster.com and import 3-D STEP as a component.</description>
+  <version>1.2.0</version>
+  <date>2026-08-20</date>
+  <maintainer email="bludwick@users.noreply.github.com">bludwick</maintainer>
+  <license file="README.md">LGPL-2.1-or-later</license>
+  <url type="repository" branch="main">https://github.com/10-X-eng/vibecad</url>
+  <content>
+    <workbench>
+      <classname>McMasterWorkbench</classname>
+      <subdirectory>./</subdirectory>
+      <icon>icons/mcmaster-workbench.svg</icon>
+    </workbench>
+  </content>
+</package>

--- a/src/Mod/McMasterInsert/tests/__init__.py
+++ b/src/Mod/McMasterInsert/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later

--- a/src/Mod/McMasterInsert/tests/test_catalog.py
+++ b/src/Mod/McMasterInsert/tests/test_catalog.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import sys
 import unittest
 from pathlib import Path
+from types import ModuleType
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -13,14 +15,13 @@ if str(ROOT) not in sys.path:
 
 try:
     import McMasterInsert as mmc
-except ImportError as exc:  # pragma: no cover - needs FreeCAD on PYTHONPATH
-    mmc = None
-    _IMPORT_ERROR = exc
-else:
-    _IMPORT_ERROR = None
+except ImportError as exc:
+    if exc.name != "FreeCAD":
+        raise
+    with mock.patch.dict(sys.modules, {"FreeCAD": ModuleType("FreeCAD")}):
+        import McMasterInsert as mmc
 
 
-@unittest.skipIf(mmc is None, f"FreeCAD not importable: {_IMPORT_ERROR}")
 class TestCatalogNames(unittest.TestCase):
     def test_part_number_from_mcmaster_step_filename(self):
         self.assertEqual(
@@ -85,6 +86,47 @@ class TestCatalogNames(unittest.TestCase):
             TypeId = "App::Origin"
 
         self.assertTrue(mmc._is_origin_object(Origin()))
+
+
+class TestCatalogLaunch(unittest.TestCase):
+    def test_without_webkit_opens_catalog_in_system_browser(self):
+        with (
+            mock.patch.object(mmc, "_webkit_dylib", return_value=None),
+            mock.patch.object(mmc, "show_catalog_window") as embedded,
+            mock.patch.object(mmc, "open_external_catalog", return_value=True) as external,
+        ):
+            self.assertEqual(mmc.open_catalog(), "external")
+
+        embedded.assert_not_called()
+        external.assert_called_once_with()
+
+    def test_available_webkit_keeps_embedded_catalog(self):
+        with (
+            mock.patch.object(mmc, "_webkit_dylib", return_value=object()),
+            mock.patch.object(mmc, "show_catalog_window", return_value=True) as embedded,
+            mock.patch.object(mmc, "open_external_catalog") as external,
+        ):
+            self.assertEqual(mmc.open_catalog(), "embedded")
+
+        embedded.assert_called_once_with()
+        external.assert_not_called()
+
+    def test_broken_webkit_falls_back_to_system_browser(self):
+        with (
+            mock.patch.object(mmc, "_webkit_dylib", side_effect=OSError("bad library")),
+            mock.patch.object(mmc, "show_catalog_window") as embedded,
+            mock.patch.object(mmc, "open_external_catalog", return_value=True) as external,
+        ):
+            self.assertEqual(mmc.open_catalog(), "external")
+
+        embedded.assert_not_called()
+        external.assert_called_once_with()
+
+    def test_external_catalog_opens_live_mcmaster_url(self):
+        with mock.patch.object(mmc, "_open_system_url", return_value=True) as open_url:
+            self.assertTrue(mmc.open_external_catalog())
+
+        open_url.assert_called_once_with(mmc.CATALOG_URL)
 
 
 if __name__ == "__main__":

--- a/src/Mod/McMasterInsert/tests/test_catalog.py
+++ b/src/Mod/McMasterInsert/tests/test_catalog.py
@@ -80,6 +80,12 @@ class TestCatalogNames(unittest.TestCase):
             "Black-Oxide Alloy Steel Socket Head Screw",
         )
         self.assertEqual(obj.Label2, obj.Description)
+        self.assertFalse(str(obj.Label).startswith("Component_"))
+
+    def test_legal_internal_name_is_not_component_prefix(self):
+        name = mmc._legal_object_name("Component", "90031A551")
+        self.assertEqual(name, "_90031A551")
+        self.assertFalse(name.startswith("Component_"))
 
     def test_origin_objects_are_not_transform_targets(self):
         class Origin:

--- a/src/Mod/McMasterInsert/tests/test_catalog.py
+++ b/src/Mod/McMasterInsert/tests/test_catalog.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 from types import ModuleType
@@ -47,7 +48,7 @@ class TestCatalogNames(unittest.TestCase):
             "Black-Oxide Alloy Steel Socket Head Screw",
         )
 
-    def test_inner_body_is_part_number_with_no_description(self):
+    def test_inner_body_has_unique_part_number_label_with_no_description(self):
         class Dummy:
             pass
 
@@ -59,7 +60,7 @@ class TestCatalogNames(unittest.TestCase):
             "91251A051",
             Path("91251A051_Black-Oxide Alloy Steel Socket Head Screw.STEP"),
         )
-        self.assertEqual(body.Label, "91251A051")
+        self.assertEqual(body.Label, "91251A051 Body")
         self.assertEqual(body.Label2, "")
         self.assertEqual(body.Description, "")
 
@@ -93,10 +94,213 @@ class TestCatalogNames(unittest.TestCase):
 
         self.assertTrue(mmc._is_origin_object(Origin()))
 
+    def test_generated_origin_and_timeline_objects_are_internal(self):
+        class Internal:
+            TypeId = "App::FeaturePython"
+
+            def __init__(self, name):
+                self.Name = name
+
+        self.assertTrue(mmc._is_origin_object(Internal("Origin001")))
+        self.assertTrue(mmc._is_origin_object(Internal("VibeCADTimeline")))
+
+    def test_timeline_classified_component_remains_a_transform_target(self):
+        class Component:
+            Name = "Component_95462A029"
+            TypeId = "PartDesign::Component"
+            VibeCADTimelineRole = "internal"
+
+        component = Component()
+
+        self.assertIs(mmc._transform_target([component]), component)
+
+    def test_component_tree_labels_are_unique_across_bodies_and_geometry(self):
+        class Object:
+            def __init__(self, name, type_id, group=None):
+                self.Name = name
+                self.TypeId = type_id
+                self.Group = list(group or [])
+                self.Label = name
+                self.Label2 = ""
+                self.Description = ""
+
+        geometry_1 = Object("Feature1", "PartDesign::Feature")
+        geometry_2 = Object("Feature2", "PartDesign::Feature")
+        body_1 = Object("Body1", "PartDesign::Body", [geometry_1])
+        body_2 = Object("Body2", "PartDesign::Body", [geometry_2])
+        component = Object(
+            "Component", "PartDesign::Component", [body_1, body_2]
+        )
+
+        mmc._name_imported_tree(
+            component,
+            "91251A051",
+            Path("91251A051_Black-Oxide Alloy Steel Socket Head Screw.STEP"),
+        )
+
+        self.assertEqual(component.Label, "91251A051")
+        self.assertEqual(body_1.Label, "91251A051 Body")
+        self.assertEqual(body_2.Label, "91251A051 Body 2")
+        self.assertEqual(geometry_1.Label, "91251A051 Geometry")
+        self.assertEqual(geometry_2.Label, "91251A051 Geometry 2")
+
+
+class TestCatalogImport(unittest.TestCase):
+    def test_promoted_solid_never_uses_its_parent_body_label(self):
+        class Object:
+            def __init__(self, name, type_id):
+                self.Name = name
+                self.TypeId = type_id
+                self.Group = []
+                self.Label = name
+                self._parent = None
+
+            def getParentGeoFeatureGroup(self):
+                return self._parent
+
+            def addObject(self, child):
+                child._parent = self
+                self.Group.append(child)
+
+        class Document:
+            def __init__(self):
+                self.created = []
+
+            def addObject(self, type_id, name):
+                obj = Object(name, type_id)
+                self.created.append(obj)
+                return obj
+
+            def removeObject(self, name):
+                self.created = [obj for obj in self.created if obj.Name != name]
+
+        imported = Object("ImportedSolid", "Part::Feature")
+        stamped = []
+        named = []
+
+        def stamp(obj, _part_number, _source_path, role="Body"):
+            stamped.append((obj, role))
+
+        def add_named(doc, type_id, visible_name, fallback_prefix):
+            named.append((type_id, visible_name))
+            return doc.addObject(type_id, fallback_prefix)
+
+        with (
+            mock.patch.object(mmc, "_stamp_body", side_effect=stamp),
+            mock.patch.object(mmc, "_add_named_object", side_effect=add_named),
+        ):
+            mmc._promote_to_component(
+                Document(),
+                [imported],
+                "95462A029",
+                Path("95462A029_Zinc-Plated Medium-Strength Steel Hex Nut.STEP"),
+            )
+
+        imported_roles = [role for obj, role in stamped if obj is imported]
+        self.assertEqual(imported_roles, ["Geometry"])
+        self.assertEqual(
+            named,
+            [
+                ("PartDesign::Component", "95462A029"),
+                ("PartDesign::Body", "95462A029 Body"),
+            ],
+        )
+
+    def test_import_owns_transaction_through_component_promotion(self):
+        events = []
+
+        class Imported:
+            Name = "ImportedSolid"
+            TypeId = "Part::Feature"
+
+        class Component:
+            Name = "McMasterComponent"
+
+        class Document:
+            Name = "TestDocument"
+            HasPendingTransaction = False
+
+            def __init__(self):
+                self.Objects = []
+
+            def openTransaction(self, label):
+                events.append(("open", label))
+                self.HasPendingTransaction = True
+
+            def commitTransaction(self):
+                events.append(("commit", None))
+                self.HasPendingTransaction = False
+
+            def abortTransaction(self):
+                events.append(("abort", None))
+                self.HasPendingTransaction = False
+
+            def recompute(self):
+                events.append(("recompute", None))
+
+        document = Document()
+        imported = Imported()
+        component = Component()
+        import_gui = ModuleType("ImportGui")
+
+        def insert(**_kwargs):
+            events.append(("insert", document.HasPendingTransaction))
+            document.Objects.append(imported)
+
+        def promote(doc, created, _part_number, _path):
+            events.append(("promote", doc.HasPendingTransaction))
+            self.assertEqual(created, [imported])
+            return component
+
+        import_gui.insert = insert
+        with (
+            mock.patch.object(mmc.App, "ActiveDocument", document, create=True),
+            mock.patch.dict(sys.modules, {"ImportGui": import_gui}),
+            mock.patch.object(mmc, "_promote_to_component", side_effect=promote),
+            mock.patch.object(mmc, "_name_imported_tree"),
+        ):
+            self.assertEqual(
+                mmc.import_cad(Path("95462A029.STEP"), "95462A029"),
+                ["McMasterComponent"],
+            )
+
+        self.assertEqual(events[0], ("open", "Insert McMaster-Carr Component"))
+        self.assertIn(("insert", True), events)
+        self.assertIn(("promote", True), events)
+        self.assertEqual(events[-1], ("commit", None))
+        self.assertNotIn(("abort", None), events)
+
 
 class TestCatalogLaunch(unittest.TestCase):
+    def test_webview2_profile_is_persistent_under_vibecad_user_data(self):
+        with tempfile.TemporaryDirectory() as temp_dir:
+            with mock.patch.dict(mmc.os.environ, {"LOCALAPPDATA": temp_dir}):
+                root = mmc.webview2_profile_root()
+
+            self.assertEqual(root, Path(temp_dir) / "VibeCAD" / "McMasterBrowser")
+            self.assertTrue(root.is_dir())
+
+    def test_webview2_is_the_preferred_catalog_backend(self):
+        with (
+            mock.patch.object(
+                mmc, "show_webview2_catalog_window", return_value=True
+            ) as webview2,
+            mock.patch.object(mmc, "_webkit_dylib") as webkit,
+            mock.patch.object(mmc, "show_catalog_window") as native_catalog,
+            mock.patch.object(mmc, "open_external_catalog") as external,
+        ):
+            self.assertEqual(mmc.open_catalog(), "embedded")
+
+        webview2.assert_called_once_with()
+        webkit.assert_not_called()
+        native_catalog.assert_not_called()
+        external.assert_not_called()
+
     def test_without_webkit_opens_catalog_in_system_browser(self):
         with (
+            mock.patch.object(
+                mmc, "show_webview2_catalog_window", return_value=False
+            ),
             mock.patch.object(mmc, "_webkit_dylib", return_value=None),
             mock.patch.object(mmc, "show_catalog_window") as embedded,
             mock.patch.object(mmc, "open_external_catalog", return_value=True) as external,
@@ -108,6 +312,9 @@ class TestCatalogLaunch(unittest.TestCase):
 
     def test_available_webkit_keeps_embedded_catalog(self):
         with (
+            mock.patch.object(
+                mmc, "show_webview2_catalog_window", return_value=False
+            ),
             mock.patch.object(mmc, "_webkit_dylib", return_value=object()),
             mock.patch.object(mmc, "show_catalog_window", return_value=True) as embedded,
             mock.patch.object(mmc, "open_external_catalog") as external,
@@ -119,6 +326,9 @@ class TestCatalogLaunch(unittest.TestCase):
 
     def test_broken_webkit_falls_back_to_system_browser(self):
         with (
+            mock.patch.object(
+                mmc, "show_webview2_catalog_window", return_value=False
+            ),
             mock.patch.object(mmc, "_webkit_dylib", side_effect=OSError("bad library")),
             mock.patch.object(mmc, "show_catalog_window") as embedded,
             mock.patch.object(mmc, "open_external_catalog", return_value=True) as external,
@@ -133,6 +343,23 @@ class TestCatalogLaunch(unittest.TestCase):
             self.assertTrue(mmc.open_external_catalog())
 
         open_url.assert_called_once_with(mmc.CATALOG_URL)
+
+    def test_windows_build_defines_and_installs_webview2_helper(self):
+        cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+        source = ROOT / "McMasterCatalogWebView2.cpp"
+        bundle = (
+            ROOT.parents[2] / "package/rattler-build/windows/create_bundle.sh"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("if(WIN32 AND BUILD_GUI)", cmake)
+        self.assertIn("McMasterCatalogWebView2", cmake)
+        self.assertIn("WebView2LoaderStatic.lib", cmake)
+        self.assertIn("INSTALL(TARGETS McMasterCatalogWebView2", cmake)
+        self.assertIn('McMasterCatalogWebView2.exe" --smoke-test', bundle)
+        webview_source = source.read_text(encoding="utf-8")
+        self.assertIn('L".download"', webview_source)
+        self.assertIn("std::filesystem::rename", webview_source)
+        self.assertTrue(source.is_file())
 
 
 if __name__ == "__main__":

--- a/src/Mod/McMasterInsert/tests/test_catalog.py
+++ b/src/Mod/McMasterInsert/tests/test_catalog.py
@@ -37,14 +37,30 @@ class TestCatalogNames(unittest.TestCase):
             "Black-Oxide Alloy Steel Socket Head Screw",
         )
 
-    def test_catalog_description_keeps_no_threads_variant(self):
+    def test_catalog_description_strips_cad_variant_prefix(self):
         path = Path(
             "91290A115_NO THREADS_Black-Oxide Alloy Steel Socket Head Screw.STEP"
         )
         self.assertEqual(
             mmc.catalog_description("91290A115", path),
-            "NO THREADS Black-Oxide Alloy Steel Socket Head Screw",
+            "Black-Oxide Alloy Steel Socket Head Screw",
         )
+
+    def test_inner_body_is_part_number_with_no_description(self):
+        class Dummy:
+            pass
+
+        body = Dummy()
+        body.Label2 = "should be cleared"
+        body.Description = "should be cleared"
+        mmc._stamp_body(
+            body,
+            "91251A051",
+            Path("91251A051_Black-Oxide Alloy Steel Socket Head Screw.STEP"),
+        )
+        self.assertEqual(body.Label, "91251A051")
+        self.assertEqual(body.Label2, "")
+        self.assertEqual(body.Description, "")
 
     def test_component_label_is_part_number_not_mmc_prefix(self):
         class Dummy:

--- a/src/Mod/McMasterInsert/tests/test_catalog.py
+++ b/src/Mod/McMasterInsert/tests/test_catalog.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Catalog filename parsing and imported-component naming."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+try:
+    import McMasterInsert as mmc
+except ImportError as exc:  # pragma: no cover - needs FreeCAD on PYTHONPATH
+    mmc = None
+    _IMPORT_ERROR = exc
+else:
+    _IMPORT_ERROR = None
+
+
+@unittest.skipIf(mmc is None, f"FreeCAD not importable: {_IMPORT_ERROR}")
+class TestCatalogNames(unittest.TestCase):
+    def test_part_number_from_mcmaster_step_filename(self):
+        self.assertEqual(
+            mmc.part_number_from_filename(
+                "91251A051_Black-Oxide Alloy Steel Socket Head Screw.STEP"
+            ),
+            "91251A051",
+        )
+
+    def test_catalog_description_strips_part_number(self):
+        path = Path("91251A051_Black-Oxide Alloy Steel Socket Head Screw.STEP")
+        self.assertEqual(
+            mmc.catalog_description("91251A051", path),
+            "Black-Oxide Alloy Steel Socket Head Screw",
+        )
+
+    def test_catalog_description_keeps_no_threads_variant(self):
+        path = Path(
+            "91290A115_NO THREADS_Black-Oxide Alloy Steel Socket Head Screw.STEP"
+        )
+        self.assertEqual(
+            mmc.catalog_description("91290A115", path),
+            "NO THREADS Black-Oxide Alloy Steel Socket Head Screw",
+        )
+
+    def test_component_label_is_part_number_not_mmc_prefix(self):
+        class Dummy:
+            pass
+
+        obj = Dummy()
+        mmc._stamp_metadata(
+            obj,
+            "91251A051",
+            Path("91251A051_Black-Oxide Alloy Steel Socket Head Screw.STEP"),
+        )
+        self.assertEqual(obj.Label, "91251A051")
+        self.assertFalse(str(obj.Label).startswith("MMC-"))
+        self.assertEqual(
+            obj.Description,
+            "Black-Oxide Alloy Steel Socket Head Screw",
+        )
+        self.assertEqual(obj.Label2, obj.Description)
+
+    def test_origin_objects_are_not_transform_targets(self):
+        class Origin:
+            TypeId = "App::Origin"
+
+        self.assertTrue(mmc._is_origin_object(Origin()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/Mod/McMasterInsert/tests/test_ribbon.py
+++ b/src/Mod/McMasterInsert/tests/test_ribbon.py
@@ -3,9 +3,12 @@
 
 from __future__ import annotations
 
+import os
 import sys
 import unittest
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest import mock
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
@@ -16,6 +19,55 @@ import Commands  # noqa: E402
 
 
 class TestMcMasterRibbon(unittest.TestCase):
+    def test_workbench_registers_when_initgui_has_no_file_global(self):
+        registered = []
+
+        class DummyWorkbench:
+            pass
+
+        freecad = ModuleType("FreeCAD")
+        freecad.getResourceDir = lambda: "C:/VibeCAD/"
+        freecad.Console = SimpleNamespace(
+            PrintMessage=lambda _message: None,
+            PrintError=lambda _message: None,
+            PrintWarning=lambda _message: None,
+        )
+        gui = ModuleType("FreeCADGui")
+        gui.addWorkbench = registered.append
+        qtcore = SimpleNamespace(
+            QTimer=SimpleNamespace(singleShot=lambda _delay, _callback: None)
+        )
+        pyside = ModuleType("PySide")
+        pyside.QtCore = qtcore
+        install_ui = ModuleType("InstallUI")
+        install_ui.install_with_retry = lambda: None
+        namespace = {
+            "__builtins__": __builtins__,
+            "Workbench": DummyWorkbench,
+            "Log": lambda _message: None,
+            "Msg": lambda _message: None,
+        }
+
+        with mock.patch.dict(
+            sys.modules,
+            {
+                "FreeCAD": freecad,
+                "FreeCADGui": gui,
+                "PySide": pyside,
+                "InstallUI": install_ui,
+            },
+        ):
+            source = (ROOT / "InitGui.py").read_text(encoding="utf-8")
+            exec(compile(source, str(ROOT / "InitGui.py"), "exec"), namespace)
+
+        self.assertEqual(len(registered), 1)
+        self.assertEqual(
+            os.path.normpath(registered[0].Icon),
+            os.path.normpath(
+                "C:/VibeCAD/Mod/McMasterInsert/icons/mcmaster-workbench.svg"
+            ),
+        )
+
     def test_ribbon_buttons_are_catalog_and_import(self):
         labels = tuple(label for label, _command, _icon in InstallUI.BUTTONS)
         self.assertEqual(labels, ("Catalog", "Import"))

--- a/src/Mod/McMasterInsert/tests/test_ribbon.py
+++ b/src/Mod/McMasterInsert/tests/test_ribbon.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Ribbon surface: Catalog and Import only; Cache stays on the menu."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import InstallUI  # noqa: E402
+import Commands  # noqa: E402
+
+
+class TestMcMasterRibbon(unittest.TestCase):
+    def test_ribbon_buttons_are_catalog_and_import(self):
+        labels = tuple(label for label, _command, _icon in InstallUI.BUTTONS)
+        self.assertEqual(labels, ("Catalog", "Import"))
+        self.assertNotIn("Cache", labels)
+
+    def test_ribbon_does_not_run_open_cache(self):
+        commands = tuple(command for _label, command, _icon in InstallUI.BUTTONS)
+        self.assertNotIn("McMaster_OpenCache", commands)
+
+    def test_cache_remains_a_registered_menu_command(self):
+        self.assertIn("McMaster_OpenCache", Commands.COMMANDS)
+        self.assertIn("McMaster_BrowseCatalog", Commands.COMMANDS)
+        self.assertIn("McMaster_ImportFile", Commands.COMMANDS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC4",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 6,
+  "build_version": 7,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
Adds a native McMaster-Carr catalog workflow so VibeCAD can browse the live site, download 3-D CAD, import it as a component, and place it immediately.

## User-visible outcome

- Adds a **McMaster** ribbon tab with **Catalog** and **Import**.
- Windows opens the catalog in a VibeCAD-branded Edge WebView2 window with Back, Forward, Reload, and Open in Browser controls.
- Windows keeps McMaster cookies/login under `%LOCALAPPDATA%\VibeCAD\McMasterBrowser` across VibeCAD upgrades.
- Completed CAD downloads move atomically from a `.download` staging file into VibeCAD's watched inbox, preventing partial-file imports.
- macOS keeps its WKWebView path; Linux keeps the existing system-browser path.
- Imported STEP is created inside a caller-owned transaction so VibeCAD timeline classification succeeds.
- Generated Origin/timeline objects are excluded from naming and transform selection without excluding the inserted Component/Body.

## Naming

- Component visible name is the McMaster part number (`95462A029`), not `Component_95462A029`.
- Component Description/Label2 is the catalog summary.
- Body and geometry labels are unique and stable (`95462A029 Body`, `95462A029 Geometry`).
- Inner objects do not inherit the component description.

## Release identity

Bumps VibeCAD `26.3.1-RC4` from build 6 to build 7 so the merged feature can be published as a new immutable preview release.

## Test-driven validation

Red tests were added first for generated Origin/timeline handling, caller-owned transactions, duplicate Body/geometry labels, Windows WebView2 packaging, complete-download staging, and keeping timeline-classified components positionable. Each failed before its implementation and passed afterward.

Exact successful checks:

```text
package/rattler-build/windows/VibeCAD-26.3.1-RC4-build6-Windows-x86_64/bin/python.exe -m unittest discover -s src/Mod/McMasterInsert/tests -p 'test_*.py' -v
# Ran 23 tests: OK

package/rattler-build/windows/VibeCAD-26.3.1-RC4-build6-Windows-x86_64/bin/python.exe -m unittest src.Tools.tests.test_sync_version -v
# Ran 44 tests: OK

cmake --build C:\Users\robit\vibecad\build\webview2-check --target McMasterCatalogWebView2 --parallel 4
# Built and linked McMasterCatalogWebView2.exe

McMasterCatalogWebView2.exe --smoke-test
# exit 0

bash -n package/rattler-build/windows/create_bundle.sh
git diff --check
# passed
```

A real downloaded `95462A029` STEP was also imported with packaged FreeCADCmd. It produced `_95462A029` / `95462A029`, `95462A029 Body`, and `95462A029 Geometry`; the component remained the transform target and no transaction remained pending.

The full Windows Rattler + bundle + NSIS installer path completed successfully for the WebView2/import fix, including bundle runtime checks and installer SHA-256 verification. The final contributor naming commit was then integrated and exercised through the focused tests and real STEP import above.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing macOS behavior remains available.
- [x] Linux behavior and packaging are unchanged.
- [x] No dependency was removed and no existing Qt version was changed.
- [x] No breaking change is included.

## Risk and non-goals

The Windows embedded browser requires the Microsoft Edge WebView2 Runtime. The helper detects a missing runtime and offers the official installer page. This PR does not replace the Linux system-browser workflow or add a McMaster API integration.