### PR TITLE
Bump VibeCAD to RC5 build 0

### DIFF
--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -16,7 +16,7 @@
 
 Name:           vibecad
 Epoch:          1
-Version:        26.3.1~RC4
+Version:        26.3.1~RC5
 Release:        1%{?dist}
 
 Summary:        A general purpose 3D CAD modeler

--- a/package/rattler-build/pixi.toml
+++ b/package/rattler-build/pixi.toml
@@ -8,7 +8,7 @@ preview = ["pixi-build"]
 
 [package]
 name = "vibecad"
-version = "26.3.1RC4"
+version = "26.3.1RC5"
 homepage = "https://freecad.org"
 repository = "https://github.com/FreeCAD/FreeCAD"
 description = "VibeCAD"

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "26.3.1RC4"
+  version: "26.3.1RC5"
 
 package:
   name: vibecad
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 7
+  number: 0
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -4,8 +4,8 @@
   "version_minor": 3,
   "version_patch": 1,
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
-  "version_suffix": "RC4",
+  "version_suffix": "RC5",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 7,
+  "build_version": 0,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
﻿## Outcome
Advance the canonical VibeCAD preview identity from `26.3.1-RC4 build 7` to `26.3.1-RC5 build 0` after all current feature and fix PRs have merged.

## Changes
- Set `version.json` to RC5/build 0.
- Synchronize the Rattler/Conda and Fedora package versions with the canonical version file.

## Risk
Low. This is release metadata only; no runtime, API, preference, schema, signing, packaging-flow, or CI-gate behavior changes.

## Test plan and results
TDD does not apply because this is a metadata-only release identity change with no executable behavior.

- `py -3.11 src/Tools/sync_version.py --check` -> **passed; all files in sync**
- `py -3.11 -m unittest src.Tools.tests.test_sync_version src.Tools.tests.test_release_artifact_name src.Tools.tests.test_windows_installer_version src.Tools.tests.test_generate_update_manifest src.Tools.tests.test_release_workflow src.Tools.tests.test_vibecad_update -v` -> **110 passed, 1 skipped** (optional local `python-tuf` dependency unavailable; protected CI installs and requires it)
- Canonical resolution -> `26.3.1-RC5`, build `0`, tag `v26.3.1-RC5-build0`, title `VibeCAD 26.3.1-RC5 (Build 0)`
- Confirmed the release and Git tag do not already exist.
- `git diff --check` -> **passed**

## Compatibility checklist
- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults and runtime behavior are unchanged.
- [x] No deprecations.
- [x] No breaking changes.
