### PR TITLE
Allow Fillet and Chamfer to start before picking an edge or face

### DIFF
--- a/src/Mod/PartDesign/Gui/Command.cpp
+++ b/src/Mod/PartDesign/Gui/Command.cpp
@@ -3201,6 +3201,40 @@ DesignDressupSelection selectedDesignDressup(DesignDressupSelectionKind selectio
     return result;
 }
 
+bool selectionHasDressupSubelements()
+{
+    for (auto& selected : Gui::Selection().getSelectionEx()) {
+        if (!selected.getSubNames().empty()) {
+            return true;
+        }
+    }
+    return false;
+}
+
+PartDesign::Body* pendingDressupBody()
+{
+    auto* body = PartDesignGui::getBodyForCommandState();
+    if (!body || !usableSolidTip(body)
+        || !PartDesign::designBodyStateBefore(body, nullptr)) {
+        return nullptr;
+    }
+    return body;
+}
+
+DesignDressupSelection pendingFilletOrChamferSelection()
+{
+    DesignDressupSelection result;
+    auto* body = pendingDressupBody();
+    if (!body || !body->getDocument()) {
+        return result;
+    }
+    result.document = body->getDocument();
+    result.bodies.push_back(body);
+    result.elementGroups.emplace_back();
+    result.valid = true;
+    return result;
+}
+
 template<typename Operation>
 void startDesignDressupOperation(
     Gui::Command& command,
@@ -3210,7 +3244,11 @@ void startDesignDressupOperation(
     DesignDressupSelectionKind selectionKind
 )
 {
-    const auto selected = selectedDesignDressup(selectionKind);
+    auto selected = selectedDesignDressup(selectionKind);
+    if (!selected.valid && selectionKind == DesignDressupSelectionKind::EdgesOrFaces
+        && !selectionHasDressupSubelements()) {
+        selected = pendingFilletOrChamferSelection();
+    }
     if (!selected.valid) {
         QMessageBox::warning(
             Gui::getMainWindow(),
@@ -3220,9 +3258,8 @@ void startDesignDressupOperation(
             selectionKind != DesignDressupSelectionKind::EdgesOrFaces
                 ? QObject::tr("Select one or more supported faces. Selections may "
                               "belong to multiple Bodies in this Design.")
-                : QObject::tr("Select one or more dressable edges or faces. "
-                              "Selections may belong to multiple Bodies in this "
-                              "Design.")
+                : QObject::tr("Select one or more dressable edges or faces, or start "
+                              "the tool and pick them on a solid Body.")
         );
         return;
     }
@@ -3271,7 +3308,17 @@ void startDesignDressupOperation(
 
 bool designDressupOperationActive(DesignDressupSelectionKind selectionKind)
 {
-    return PartDesignGui::canStartModelingCommand() && selectedDesignDressup(selectionKind).valid;
+    if (!PartDesignGui::canStartModelingCommand()) {
+        return false;
+    }
+    if (selectedDesignDressup(selectionKind).valid) {
+        return true;
+    }
+    if (selectionKind != DesignDressupSelectionKind::EdgesOrFaces
+        || selectionHasDressupSubelements()) {
+        return false;
+    }
+    return pendingDressupBody() != nullptr;
 }
 
 }  // namespace
@@ -3466,7 +3513,9 @@ CmdPartDesignFillet::CmdPartDesignFillet()
     sAppModule = "PartDesign";
     sGroup = QT_TR_NOOP("PartDesign");
     sMenuText = QT_TR_NOOP("Fillet");
-    sToolTipText = QT_TR_NOOP("Applies a fillet to the selected edges or faces");
+    sToolTipText = QT_TR_NOOP(
+        "Applies a fillet to selected edges or faces, or starts picking them on a solid Body"
+    );
     sWhatsThis = "PartDesign_Fillet";
     sStatusTip = sToolTipText;
     sPixmap = "PartDesign_Fillet";
@@ -3500,7 +3549,9 @@ CmdPartDesignChamfer::CmdPartDesignChamfer()
     sAppModule = "PartDesign";
     sGroup = QT_TR_NOOP("PartDesign");
     sMenuText = QT_TR_NOOP("Chamfer");
-    sToolTipText = QT_TR_NOOP("Applies a chamfer to the selected edges or faces");
+    sToolTipText = QT_TR_NOOP(
+        "Applies a chamfer to selected edges or faces, or starts picking them on a solid Body"
+    );
     sWhatsThis = "PartDesign_Chamfer";
     sStatusTip = sToolTipText;
     sPixmap = "PartDesign_Chamfer";

--- a/src/Mod/PartDesign/PartDesignTests/TestConsolidatedPartTools.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestConsolidatedPartTools.py
@@ -1059,8 +1059,6 @@ class TestConsolidatedPartTools(unittest.TestCase):
     def test_body_native_finish_tools_require_explicit_geometry(self):
         self._box("FinishSelectionSource")
         for command_name in (
-            "PartDesign_Fillet",
-            "PartDesign_Chamfer",
             "PartDesign_Draft",
             "PartDesign_Thickness",
         ):
@@ -1074,6 +1072,25 @@ class TestConsolidatedPartTools(unittest.TestCase):
             self._process_events()
 
             self.assertFalse(Gui.Control.activeDialog(), command_name)
+            self.assertEqual(
+                tuple(obj.Name for obj in self.document.Objects),
+                original_names,
+                command_name,
+            )
+            self.assertEqual(tuple(self.body.Group), original_group, command_name)
+            self.assertEqual(self.body.Tip, original_tip, command_name)
+
+        for command_name in ("PartDesign_Fillet", "PartDesign_Chamfer"):
+            Gui.Selection.clearSelection()
+            original_names = tuple(obj.Name for obj in self.document.Objects)
+            original_group = tuple(self.body.Group)
+            original_tip = self.body.Tip
+
+            self.assertTrue(Gui.isCommandActive(command_name), command_name)
+            Gui.runCommand(command_name, 0)
+            self._process_events()
+            self.assertTrue(Gui.Control.activeDialog(), command_name)
+            self._cancel_task_dialog()
             self.assertEqual(
                 tuple(obj.Name for obj in self.document.Objects),
                 original_names,

--- a/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
@@ -2161,15 +2161,24 @@ class TestNativeRibbonTools(unittest.TestCase):
 
     def test_finish_tools_require_real_subelements_and_lock_during_tasks(self):
         body, _base = self._new_body("FinishStateBody", solid=True)
+        pending_commands = ("PartDesign_Fillet", "PartDesign_Chamfer")
         finish_commands = tuple(case[0] for case in FINISH_COMMANDS)
 
         Gui.Selection.clearSelection()
-        for command_name in finish_commands:
-            self.assertFalse(Gui.isCommandActive(command_name), command_name)
+        self._process_events()
+        for command_name in pending_commands:
+            self.assertTrue(
+                Gui.isCommandActive(command_name),
+                f"{command_name} must start from an active solid Body",
+            )
+        self.assertFalse(Gui.isCommandActive("PartDesign_Thickness"))
+        self.assertFalse(Gui.isCommandActive("PartDesign_Draft"))
 
         self._activate_body(body)
-        for command_name in finish_commands:
-            self.assertFalse(Gui.isCommandActive(command_name), command_name)
+        for command_name in pending_commands:
+            self.assertTrue(Gui.isCommandActive(command_name), command_name)
+        self.assertFalse(Gui.isCommandActive("PartDesign_Thickness"))
+        self.assertFalse(Gui.isCommandActive("PartDesign_Draft"))
 
         self._activate_body(body, "Vertex1")
         for command_name in finish_commands:
@@ -2194,20 +2203,75 @@ class TestNativeRibbonTools(unittest.TestCase):
         self._cancel_task("unrelated additive primitive")
         self._assert_snapshot(body, expected, "unrelated additive primitive")
 
-    def test_chamfer_without_an_edge_is_a_strict_no_op(self):
+    def test_chamfer_without_an_edge_opens_pending_selection_and_cancel_is_exact(self):
         body, _base = self._new_body("ChamferNoEdgeBody", solid=True)
         self._activate_body(body)
         expected = self._snapshot(body)
 
-        self.assertFalse(Gui.isCommandActive("PartDesign_Chamfer"))
+        self.assertTrue(Gui.isCommandActive("PartDesign_Chamfer"))
         actions = Gui.Command.get("PartDesign_Chamfer").getAction()
         self.assertTrue(actions)
-        self.assertFalse(actions[0].isEnabled())
-        actions[0].trigger()
+        self.assertTrue(actions[0].isEnabled())
+        Gui.runCommand("PartDesign_Chamfer", 0)
         self._process_events(50)
 
-        self.assertFalse(Gui.Control.activeDialog())
+        self.assertTrue(Gui.Control.activeDialog())
+        operation = self.document.ActiveObject
+        self.assertEqual(operation.TypeId, "PartDesign::DesignChamfer")
+        self.assertEqual(list(operation.TargetElements), [])
+        self._cancel_task("PartDesign_Chamfer without an edge")
         self._assert_snapshot(body, expected, "PartDesign_Chamfer without an edge")
+
+    def test_fillet_and_chamfer_accept_picks_after_starting_empty(self):
+        for command_name, feature_type, subelement in (
+            ("PartDesign_Fillet", "PartDesign::DesignFillet", "Edge1"),
+            ("PartDesign_Chamfer", "PartDesign::DesignChamfer", "Edge1"),
+        ):
+            with self.subTest(command=command_name):
+                body, source = self._new_body(
+                    f"Pending{feature_type.rsplit('::', 1)[-1]}Body",
+                    solid=True,
+                )
+                self._activate_body(body)
+                self.assertTrue(Gui.isCommandActive(command_name), command_name)
+
+                Gui.runCommand(command_name, 0)
+                self._process_events(80)
+                self.assertTrue(Gui.Control.activeDialog(), command_name)
+                operation = self.document.ActiveObject
+                self.assertEqual(operation.TypeId, feature_type, command_name)
+                self.assertEqual(list(operation.InputStates), [source], command_name)
+                self.assertEqual(list(operation.TargetElements), [], command_name)
+
+                Gui.Selection.addSelection(body, subelement)
+                self._process_events(200)
+                self.assertEqual(
+                    list(operation.TargetElements),
+                    [subelement],
+                    command_name,
+                )
+                self._accept_task(command_name)
+                committed = self.document.getObject(operation.Name)
+                self.assertIsNotNone(committed, command_name)
+                self.assertEqual(committed.TypeId, feature_type, command_name)
+                self.assertEqual(list(committed.TargetElements), [subelement], command_name)
+                self.assertTrue(committed.isValid(), committed.getStatusString())
+                self.assertGreater(committed.Shape.Volume, 0.0, command_name)
+
+    def test_fillet_stays_off_without_a_solid_body(self):
+        empty_body, _feature = self._new_body("EmptyFilletBody", solid=False)
+        Gui.activeView().setActiveObject("pdbody", empty_body)
+        Gui.Selection.clearSelection()
+        self._process_events()
+        self.assertFalse(Gui.isCommandActive("PartDesign_Fillet"))
+        self.assertFalse(Gui.isCommandActive("PartDesign_Chamfer"))
+
+        wire_body, _wire = self._wire_body("WireFilletBody")
+        Gui.activeView().setActiveObject("pdbody", wire_body)
+        Gui.Selection.clearSelection()
+        self._process_events()
+        self.assertFalse(Gui.isCommandActive("PartDesign_Fillet"))
+        self.assertFalse(Gui.isCommandActive("PartDesign_Chamfer"))
 
     def test_new_sketch_on_body_face_uses_tip_and_cancel_is_exact(self):
         preferences = App.ParamGet(

--- a/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
@@ -2216,7 +2216,9 @@ class TestNativeRibbonTools(unittest.TestCase):
         self._process_events(50)
 
         self.assertTrue(Gui.Control.activeDialog())
-        operation = self.document.ActiveObject
+        editing = Gui.activeDocument().getInEdit()
+        self.assertIsNotNone(editing)
+        operation = editing.Object
         self.assertEqual(operation.TypeId, "PartDesign::DesignChamfer")
         self.assertEqual(list(operation.TargetElements), [])
         self._cancel_task("PartDesign_Chamfer without an edge")
@@ -2238,9 +2240,27 @@ class TestNativeRibbonTools(unittest.TestCase):
                 Gui.runCommand(command_name, 0)
                 self._process_events(80)
                 self.assertTrue(Gui.Control.activeDialog(), command_name)
-                operation = self.document.ActiveObject
+                editing = Gui.activeDocument().getInEdit()
+                self.assertIsNotNone(editing, command_name)
+                operation = editing.Object
                 self.assertEqual(operation.TypeId, feature_type, command_name)
-                self.assertEqual(list(operation.InputStates), [source], command_name)
+                self.assertEqual(len(operation.InputStates), 1, command_name)
+                input_state = operation.InputStates[0]
+                self.assertEqual(
+                    input_state.TypeId,
+                    "PartDesign::DesignBodyState",
+                    command_name,
+                )
+                self.assertEqual(
+                    str(input_state.BodyId),
+                    str(body.VibeCADBodyId),
+                    command_name,
+                )
+                self.assertAlmostEqual(
+                    input_state.Shape.Volume,
+                    source.Shape.Volume,
+                    msg=command_name,
+                )
                 self.assertEqual(list(operation.TargetElements), [], command_name)
 
                 Gui.Selection.addSelection(body, subelement)
@@ -2256,7 +2276,9 @@ class TestNativeRibbonTools(unittest.TestCase):
                 self.assertEqual(committed.TypeId, feature_type, command_name)
                 self.assertEqual(list(committed.TargetElements), [subelement], command_name)
                 self.assertTrue(committed.isValid(), committed.getStatusString())
-                self.assertGreater(committed.Shape.Volume, 0.0, command_name)
+                self.assertEqual(len(committed.OutputShapes), 1, command_name)
+                self.assertGreater(committed.OutputShapes[0].Volume, 0.0, command_name)
+                self.assertGreater(body.Shape.Volume, 0.0, command_name)
 
     def test_fillet_stays_off_without_a_solid_body(self):
         empty_body, _feature = self._new_body("EmptyFilletBody", solid=False)

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_ribbon_transaction_guards.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_ribbon_transaction_guards.py
@@ -330,6 +330,33 @@ def test_every_transaction_owning_implementation_calls_its_boundary_guard() -> N
         ), command
 
 
+def test_fillet_and_chamfer_can_start_from_an_active_solid_body() -> None:
+    source = (_REPOSITORY / _PARTDESIGN_COMMAND).read_text(encoding="utf-8")
+    fillet = _cpp_command_section(source, "PartDesign_Fillet")
+    chamfer = _cpp_command_section(source, "PartDesign_Chamfer")
+    draft = _cpp_command_section(source, "PartDesign_Draft")
+    thickness = _cpp_command_section(source, "PartDesign_Thickness")
+    active = _function_section(
+        source, "bool designDressupOperationActive(DesignDressupSelectionKind selectionKind)"
+    )
+    start = _function_section(
+        source, "void startDesignDressupOperation("
+    )
+
+    assert "designDressupOperationActive" in fillet
+    assert "designDressupOperationActive" in chamfer
+    assert "pendingDressupBody" in active
+    assert "pendingFilletOrChamferSelection" in start
+    assert "selectionHasDressupSubelements" in active
+    assert "DesignDressupSelectionKind::EdgesOrFaces" in active
+    assert "pendingFilletOrChamferSelection" in start
+    assert "DesignDressupSelectionKind::EdgesOrFaces" in start
+    assert "pendingDressupBody" not in draft
+    assert "pendingDressupBody" not in thickness
+    assert "or start " in start
+    assert "the tool and pick them on a solid Body" in start
+
+
 def test_inspection_tasks_close_only_their_exact_locked_transactions() -> None:
     measure = (_REPOSITORY / "src/Mod/Measure/Gui/TaskMeasure.cpp").read_text(
         encoding="utf-8"


### PR DESCRIPTION
Fillet and Chamfer can now be started from an active solid Body before picking an edge or face. The task opens in pick mode; selecting edges or faces fills the operation. Cancel still restores the document exactly.

## What stays the same

- Pre-selected dressable edges and faces still start the tool with those references.
- Vertex and other non-dressable picks still reject Fillet and Chamfer.
- Draft and Thickness still require supported faces first.
- Empty, wire, or missing Bodies keep Fillet and Chamfer disabled.
- Another open task still locks the commands.

## TDD and validation

The original contributor change added failing coverage before its production implementation for enablement, pending start and cancel, pending start and pick and accept, and non-solid Bodies.

Validated after updating the branch to current main:

- cmake --build build/release --target PartDesignGui -j16
  - passed
- FreeCAD --run-test PartDesignTests.TestNativeRibbonTools.TestNativeRibbonTools.test_chamfer_without_an_edge_opens_pending_selection_and_cancel_is_exact under Xvfb
  - passed
- FreeCAD --run-test PartDesignTests.TestNativeRibbonTools.TestNativeRibbonTools.test_fillet_and_chamfer_accept_picks_after_starting_empty under Xvfb
  - passed for both Fillet and Chamfer
- FreeCAD --run-test PartDesignTests.TestNativeRibbonTools.TestNativeRibbonTools.test_fillet_stays_off_without_a_solid_body under Xvfb
  - passed
- FreeCAD --run-test PartDesignTests.TestNativeRibbonTools.TestNativeRibbonTools.test_finish_tools_require_real_subelements_and_lock_during_tasks under Xvfb
  - passed
- FreeCAD --run-test PartDesignTests.TestConsolidatedPartTools.TestConsolidatedPartTools.test_body_native_finish_tools_require_explicit_geometry under Xvfb
  - passed
- python3 -m pytest src/Mod/VibeCAD/vibecad_tests/test_native_ribbon_transaction_guards.py -q
  - 4 passed

The updated assertions use the current durable Design contract: the task operation comes from the active edit session, inputs are immutable DesignBodyState objects, and committed results are OutputShapes published through the stable Body.

## Compatibility

- [x] Existing public functions and APIs remain present.
- [x] Existing pre-selection behavior remains compatible.
- [x] Draft and Thickness behavior is unchanged.
- [x] No preference, schema, or wire-format changes.
- [x] No breaking changes.