### PR TITLE
Fix Linux AppImage McMaster packaging validation

### DIFF
--- a/package/rattler-build/linux/create_bundle.sh
+++ b/package/rattler-build/linux/create_bundle.sh
@@ -145,12 +145,12 @@ EOF
         exit 1
     fi
     if ! env -u PYTHONHOME -u PYTHONPATH -u LD_LIBRARY_PATH \
-        /usr/bin/python3 \
-        "${conda_env}/Mod/McMasterInsert/McMasterCatalogWebKit.py" \
-        --smoke-test; then
-        echo "VibeCAD McMaster WebKit helper smoke test failed; the Linux bundle cannot provide the embedded catalog."
+        /usr/bin/python3 -m py_compile \
+        "${conda_env}/Mod/McMasterInsert/McMasterCatalogWebKit.py"; then
+        echo "VibeCAD McMaster WebKit helper is not valid Python."
         exit 1
     fi
+    rm -rf -- "${conda_env}/Mod/McMasterInsert/__pycache__"
 
     # Finalize AppDir here so the packaging phases only ever read it.
     chmod a+x ./AppDir/AppRun

--- a/src/Mod/McMasterInsert/tests/test_catalog.py
+++ b/src/Mod/McMasterInsert/tests/test_catalog.py
@@ -606,7 +606,7 @@ class TestCatalogLaunch(unittest.TestCase):
 
         self.assertIn("McMasterCatalogWebKit.py", cmake)
         self.assertIn("McMasterCatalogWebKit.py", bundle)
-        self.assertIn("--smoke-test", bundle)
+        self.assertIn("-m py_compile", bundle)
         self.assertTrue(source.is_file())
 
 


### PR DESCRIPTION
## Outcome

Restores Linux AppImage production after the McMaster embedded-browser work. Packaging now validates that the bundled WebKit helper is valid system-Python code without requiring optional host WebKitGTK libraries on the GitHub runner. Runtime capability probing and external-browser fallback remain unchanged.

The previous release job failed because the packaging step treated missing Gtk/WebKitGTK on the build host as fatal even though those libraries are intentionally optional at runtime.

## TDD

Red before implementation:

- python3 src/Mod/McMasterInsert/tests/test_catalog.py TestCatalogLaunch.test_linux_build_packages_webkit_helper
  - failed because the bundle did not use Python compile validation

Green after implementation:

- python3 src/Mod/McMasterInsert/tests/test_catalog.py TestCatalogLaunch.test_linux_build_packages_webkit_helper
  - 1 passed
- python3 -m unittest src.Tools.tests.test_release_workflow
  - 3 passed
- bash -n package/rattler-build/linux/create_bundle.sh
  - passed
- git diff --check
  - passed

## Production validation

- pixi reinstall -e default
  - clean 8,672-target VibeCAD package rebuild completed
- CREATE_BUNDLE_PHASE=appdir pixi run -e package create_bundle
  - passed all provider, geometry-worker, dependency, command-line, and McMaster helper checks
- APPIMAGE_EXTRACT_AND_RUN=1 GH_UPDATE_TAG=v26.3.1-RC5-build0 CREATE_BUNDLE_PHASE=appimage pixi run -e package create_bundle
  - produced the 919 MB AppImage and zsync metadata
- sha256sum --check VibeCAD-26.3.1-RC5-build0-Linux-x86_64.AppImage-SHA256.txt
  - passed
- completed AppImage freecadcmd --safe-mode --version
  - VibeCAD 26.3.1-RC5 Build 0
- bundled McMasterCatalogWebKit.py --smoke-test on the Linux host
  - WebKitGTK browser helper is available

The Build 0 artifact was generated only for local validation and will not be published. A fresh build number will be committed before the next release is dispatched.

## Compatibility

- [x] Existing public functions/APIs remain present and compatible.
- [x] No preference keys, tool names, or schema fields changed.
- [x] Runtime embedded-browser detection and fallback behavior are unchanged.
- [x] No breaking changes.