### PR TITLE
Bump VibeCAD to RC5 build 1

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 0
+  number: 1
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC5",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 0,
+  "build_version": 1,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Outcome

Advances the canonical VibeCAD release identity from RC5 Build 0 to RC5 Build 1 after the Linux AppImage repair and fillet/chamfer integration merged.

This is the required release gate that prevents reusing the immutable Build 0 tag, artifact names, update identity, or package build number.

## Changes

- version.json build_version: 0 to 1
- package/rattler-build/recipe.yaml build.number: 0 to 1, generated by the canonical sync tool

Resolved release identity:

- Tag: v26.3.1-RC5-build1
- Artifact base: VibeCAD-26.3.1-RC5-build1

## Validation

Metadata consistency red check after changing the canonical file:

- python3 src/Tools/sync_version.py --check
  - correctly reported package/rattler-build/recipe.yaml out of sync

Metadata update and green checks:

- python3 src/Tools/sync_version.py --update
  - updated only package/rattler-build/recipe.yaml
- python3 src/Tools/sync_version.py --check
  - all version targets synchronized
- python3 -m unittest src.Tools.tests.test_sync_version src.Tools.tests.test_release_artifact_name src.Tools.tests.test_release_workflow
  - 59 passed
- python3 src/Tools/resolve_release_artifact_name.py . --component release-tag
  - v26.3.1-RC5-build1
- python3 src/Tools/resolve_release_artifact_name.py .
  - VibeCAD-26.3.1-RC5-build1
- git diff --check
  - passed

This is a metadata-only release increment; no runtime behavior is changed.

## Compatibility

- [x] Existing public functions and APIs remain unchanged.
- [x] No preference keys, tool names, schemas, or defaults changed.
- [x] The existing RC5 version is retained and only its re-release build identity advances.
- [x] No breaking changes.