### PR TITLE
Fix macOS update install-and-restart after a verified download

### DIFF
--- a/src/Mod/VibeCAD/VibeCADUpdate.py
+++ b/src/Mod/VibeCAD/VibeCADUpdate.py
@@ -222,6 +222,215 @@ class InstallPlan:
     current_install_root: Path | None = None
 
 
+MACOS_INSTALL_HELPER_SCRIPT = r"""#!/bin/sh
+set -eu
+pid="$1"
+package="$2"
+app="$3"
+backup="$4"
+receipt="$5"
+pending="$6"
+
+log="$(dirname "$receipt")/install-helper.log"
+health_wait="${VIBECAD_UPDATE_HEALTH_WAIT:-120}"
+open_bin="${VIBECAD_UPDATE_OPEN:-open}"
+log_msg() {
+    printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" >> "$log"
+}
+
+bundle_executable() {
+    candidate="$1/Contents/MacOS/FreeCAD"
+    if [ -x "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+    candidate="$1/Contents/MacOS/VibeCAD"
+    if [ -x "$candidate" ]; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+    find "$1/Contents/MacOS" -type f \( -perm -u+x -o -perm -g+x -o -perm -o+x \) 2>/dev/null | head -n 1
+}
+
+find_new_pid() {
+    ps -axo pid=,command= | awk -v prefix="$app/" 'index($0, prefix) { print $1; exit }'
+}
+
+while kill -0 "$pid" 2>/dev/null; do
+    sleep 1
+done
+if [ -e "$backup" ]; then
+    log_msg "backup already exists at $backup"
+    exit 20
+fi
+
+mount=$(mktemp -d "${TMPDIR:-/tmp}/vibecad-dmg.XXXXXX")
+attached=0
+new_pid=""
+detach_mount() {
+    if [ "$attached" -eq 1 ]; then
+        hdiutil detach "$mount" -quiet >/dev/null 2>&1 || true
+        attached=0
+    fi
+    rmdir "$mount" >/dev/null 2>&1 || true
+}
+terminate_new_app() {
+    if [ -z "${new_pid:-}" ]; then
+        new_pid=$(find_new_pid || true)
+    fi
+    if [ -z "$new_pid" ] || ! kill -0 "$new_pid" 2>/dev/null; then
+        return
+    fi
+    kill "$new_pid" 2>/dev/null || true
+    stop_attempt=0
+    while kill -0 "$new_pid" 2>/dev/null && [ "$stop_attempt" -lt 10 ]; do
+        sleep 1
+        stop_attempt=$((stop_attempt + 1))
+    done
+    kill -9 "$new_pid" 2>/dev/null || true
+    wait "$new_pid" 2>/dev/null || true
+}
+rollback_install() {
+    log_msg "rolling back macOS install"
+    terminate_new_app
+    if [ -e "$backup" ]; then
+        rm -rf "$app"
+        mv "$backup" "$app"
+        printf '%s\n' '{"status":"rolled-back","platform":"macos-dmg"}' > "$receipt"
+        executable=$(bundle_executable "$app" || true)
+        if [ -n "$executable" ]; then
+            "$executable" >/dev/null 2>&1 &
+        else
+            "$open_bin" "$app" >/dev/null 2>&1 || true
+        fi
+    fi
+}
+trap detach_mount EXIT
+
+if ! hdiutil attach "$package" -nobrowse -readonly -noverify -mountpoint "$mount" >/dev/null 2>&1; then
+    if ! printf 'Y\n' | hdiutil attach "$package" -nobrowse -readonly -mountpoint "$mount" >/dev/null 2>&1; then
+        log_msg "hdiutil attach failed for $package"
+        exit 23
+    fi
+fi
+attached=1
+
+new_app=""
+if [ -d "$mount/VibeCAD.app" ]; then
+    new_app="$mount/VibeCAD.app"
+else
+    new_app=$(find "$mount" -maxdepth 2 -name '*.app' -type d 2>/dev/null | head -n 1)
+fi
+if [ -z "$new_app" ] || [ ! -d "$new_app" ]; then
+    log_msg "disk image does not contain VibeCAD.app"
+    exit 24
+fi
+
+if [ -e "$app" ]; then
+    if ! mv "$app" "$backup"; then
+        log_msg "could not move $app aside"
+        exit 21
+    fi
+fi
+if ! ditto "$new_app" "$app"; then
+    rollback_install
+    exit 21
+fi
+xattr -dr com.apple.quarantine "$app" >/dev/null 2>&1 || true
+detach_mount
+
+printf '%s\n' '{"status":"installed","platform":"macos-dmg"}' > "$receipt"
+executable=$(bundle_executable "$app" || true)
+if [ -x "$executable" ]; then
+    "$executable" >/dev/null 2>&1 &
+    new_pid=$!
+else
+    if ! "$open_bin" -n "$app"; then
+        rollback_install
+        exit 25
+    fi
+    attempt=0
+    while [ "$attempt" -lt 60 ]; do
+        new_pid=$(find_new_pid || true)
+        if [ -n "$new_pid" ]; then
+            break
+        fi
+        sleep 1
+        attempt=$((attempt + 1))
+    done
+fi
+if [ -z "${new_pid:-}" ] || ! kill -0 "$new_pid" 2>/dev/null; then
+    log_msg "updated application did not start"
+    rollback_install
+    exit 25
+fi
+
+healthy=0
+attempt=0
+while [ "$attempt" -lt "$health_wait" ]; do
+    if [ ! -f "$pending" ]; then
+        healthy=1
+        break
+    fi
+    if ! kill -0 "$new_pid" 2>/dev/null; then
+        break
+    fi
+    sleep 1
+    attempt=$((attempt + 1))
+done
+if [ "$healthy" -eq 1 ]; then
+    cleanup_attempt=0
+    while [ -e "$backup" ] && [ "$cleanup_attempt" -lt 10 ]; do
+        sleep 1
+        cleanup_attempt=$((cleanup_attempt + 1))
+    done
+    rm -rf "$backup"
+    exit 0
+fi
+if kill -0 "$new_pid" 2>/dev/null; then
+    log_msg "keeping live updated application; health receipt still pending"
+    exit 0
+fi
+log_msg "updated application exited before health receipt"
+rollback_install
+exit 25
+"""
+
+
+def write_macos_install_helper(helper_path: Path) -> Path:
+    """Write the detached macOS install helper used after VibeCAD exits."""
+
+    helper_path.parent.mkdir(parents=True, exist_ok=True)
+    helper_path.write_bytes(MACOS_INSTALL_HELPER_SCRIPT.encode("utf-8"))
+    helper_path.chmod(0o700)
+    return helper_path
+
+
+def macos_install_helper_command(
+    helper: Path,
+    plan: InstallPlan,
+    *,
+    process_id: int,
+    update_directory: Path | None = None,
+) -> list[str]:
+    """Return the argv used to apply a staged macOS .dmg after this process exits."""
+
+    application = plan.current_install_root
+    if application is None:
+        raise UpdateError("The staged macOS plan has no application bundle.")
+    root = (update_directory or default_update_directory()).resolve()
+    return [
+        "/bin/sh",
+        str(helper),
+        str(process_id),
+        str(plan.package),
+        str(application),
+        f"{application}.vibecad-rollback",
+        str(root / "install-receipt.json"),
+        str(root / "pending-install.json"),
+    ]
+
+
 def normalize_architecture(value: str) -> str:
     normalized = str(value).strip().casefold().replace("-", "_")
     aliases = {

--- a/src/Mod/VibeCAD/VibeCADUpdateGui.py
+++ b/src/Mod/VibeCAD/VibeCADUpdateGui.py
@@ -25,7 +25,9 @@ from VibeCADUpdate import (
     current_release_identity,
     default_update_directory,
     load_update_policy,
+    macos_install_helper_command,
     record_pending_install,
+    write_macos_install_helper,
 )
 
 
@@ -90,6 +92,7 @@ class UpdateController(QtCore.QObject):
         self.downloaded_package: Path | None = None
         self.pending_plan: InstallPlan | None = None
         self._exit_connected = False
+        self._helper_launched = False
 
     @property
     def busy(self) -> bool:
@@ -247,12 +250,19 @@ class UpdateController(QtCore.QObject):
         except Exception as exc:
             self.operation_failed.emit(str(exc))
 
+    def launch_pending_install_now(self) -> None:
+        """Start the detached installer before the GUI begins tearing down."""
+
+        self._launch_pending_install()
+
     @QtCore.Slot()
     def _launch_pending_install(self) -> None:
+        if self._helper_launched:
+            return
         plan = self.pending_plan
-        self.pending_plan = None
         if plan is None:
             return
+        self._helper_launched = True
         try:
             if plan.kind == "windows-installer":
                 _launch_windows_install_helper(plan)
@@ -263,6 +273,7 @@ class UpdateController(QtCore.QObject):
             else:
                 raise RuntimeError(f"Unsupported staged update plan: {plan.kind}")
         except Exception as exc:
+            self._helper_launched = False
             App.Console.PrintError(f"VibeCAD could not launch the staged update: {exc}\n")
 
 
@@ -398,149 +409,14 @@ def _launch_macos_install_helper(plan: InstallPlan) -> None:
         raise RuntimeError("The staged macOS plan has no application bundle.")
     update_dir = default_update_directory()
     helper_dir = update_dir / "install-helper"
-    helper_dir.mkdir(parents=True, exist_ok=True)
-    helper = helper_dir / "install-macos-update.sh"
-    receipt = update_dir / "install-receipt.json"
-    backup = Path(f"{application}.vibecad-rollback")
-    helper.write_text(
-        """#!/bin/sh
-set -eu
-pid="$1"
-package="$2"
-app="$3"
-backup="$4"
-receipt="$5"
-pending="$6"
-
-while kill -0 "$pid" 2>/dev/null; do sleep 1; done
-if [ -e "$backup" ]; then
-    exit 20
-fi
-
-mount=$(mktemp -d "${TMPDIR:-/tmp}/vibecad-dmg.XXXXXX")
-attached=0
-new_pid=""
-detach_mount() {
-    if [ "$attached" -eq 1 ]; then
-        hdiutil detach "$mount" -quiet >/dev/null 2>&1 || true
-        attached=0
-    fi
-    rmdir "$mount" >/dev/null 2>&1 || true
-}
-terminate_new_app() {
-    if [ -z "$new_pid" ] || ! kill -0 "$new_pid" 2>/dev/null; then
-        return
-    fi
-    kill "$new_pid" 2>/dev/null || true
-    stop_attempt=0
-    while kill -0 "$new_pid" 2>/dev/null && [ "$stop_attempt" -lt 10 ]; do
-        sleep 1
-        stop_attempt=$((stop_attempt + 1))
-    done
-    kill -9 "$new_pid" 2>/dev/null || true
-    wait "$new_pid" 2>/dev/null || true
-}
-rollback_install() {
-    terminate_new_app
-    if [ -e "$backup" ]; then
-        rm -rf "$app"
-        mv "$backup" "$app"
-        printf '{"status":"rolled-back","platform":"macos-dmg"}\\n' > "$receipt"
-        open "$app" >/dev/null 2>&1 || true
-    fi
-}
-find_new_pid() {
-    ps -axo pid=,command= | awk -v executable="$app/Contents/MacOS/FreeCAD" \\
-        'index($0, executable) { print $1; exit }'
-}
-trap detach_mount EXIT
-
-if ! printf 'Y\\n' | hdiutil attach "$package" -nobrowse -readonly -mountpoint "$mount" >/dev/null; then
-    exit 23
-fi
-attached=1
-
-new_app="$mount/VibeCAD.app"
-if [ ! -d "$new_app" ]; then
-    exit 24
-fi
-
-if [ -e "$app" ]; then
-    if ! mv "$app" "$backup"; then
-        exit 21
-    fi
-fi
-if ! ditto "$new_app" "$app"; then
-    rollback_install
-    exit 21
-fi
-xattr -dr com.apple.quarantine "$app" >/dev/null 2>&1 || true
-detach_mount
-
-printf '{"status":"installed","platform":"macos-dmg"}\\n' > "$receipt"
-if ! open -n "$app"; then
-    rollback_install
-    exit 25
-fi
-
-healthy=0
-attempt=0
-while [ "$attempt" -lt 15 ]; do
-    if [ ! -f "$pending" ]; then
-        healthy=1
-        break
-    fi
-    new_pid=$(find_new_pid)
-    if [ -n "$new_pid" ]; then
-        break
-    fi
-    sleep 1
-    attempt=$((attempt + 1))
-done
-if [ "$healthy" -ne 1 ] && [ -z "$new_pid" ]; then
-    rollback_install
-    exit 25
-fi
-
-attempt=0
-while [ "$attempt" -lt 120 ]; do
-    if [ ! -f "$pending" ]; then
-        healthy=1
-        break
-    fi
-    if ! kill -0 "$new_pid" 2>/dev/null; then
-        break
-    fi
-    sleep 1
-    attempt=$((attempt + 1))
-done
-if [ "$healthy" -eq 1 ]; then
-    cleanup_attempt=0
-    while [ -e "$backup" ] && [ "$cleanup_attempt" -lt 10 ]; do
-        sleep 1
-        cleanup_attempt=$((cleanup_attempt + 1))
-    done
-    rm -rf "$backup"
-    exit 0
-fi
-rollback_install
-exit 25
-""",
-        encoding="utf-8",
-        newline="\n",
-    )
-    helper.chmod(0o700)
+    helper = write_macos_install_helper(helper_dir / "install-macos-update.sh")
     subprocess.Popen(
-        [
-            "/bin/sh",
-            str(helper),
-            str(os.getpid()),
-            str(plan.package),
-            str(application),
-            str(backup),
-            str(receipt),
-            str(update_dir / "pending-install.json"),
-        ],
+        macos_install_helper_command(
+            helper,
+            plan,
+            process_id=os.getpid(),
+            update_directory=update_dir,
+        ),
         close_fds=True,
         start_new_session=True,
     )
@@ -753,8 +629,10 @@ class UpdateCenterDialog(QtWidgets.QDialog):
 
     def _install_and_restart(self) -> None:
         self.controller.stage_install()
-        if self.controller.pending_plan is not None:
-            QtWidgets.QApplication.instance().quit()
+        if self.controller.pending_plan is None:
+            return
+        self.controller.launch_pending_install_now()
+        _quit_application_for_update()
 
 
 def _show_update_notification(result: UpdateCheckResult) -> None:
@@ -820,6 +698,17 @@ def show_update_center() -> None:
 def _clear_update_center(*_args: Any) -> None:
     global _update_center
     _update_center = None
+
+
+def _quit_application_for_update() -> None:
+    """Leave through FreeCAD's main-window close path, then stop Qt."""
+
+    main_window = Gui.getMainWindow()
+    if main_window is not None:
+        main_window.close()
+    application = QtWidgets.QApplication.instance()
+    if application is not None:
+        application.quit()
 
 
 def get_update_controller() -> UpdateController:
@@ -896,7 +785,8 @@ def ensure_registered() -> None:
     for delay in (0, 250, 1000, 5000):
         QtCore.QTimer.singleShot(delay, _add_help_menu_action)
     QtCore.QTimer.singleShot(15000, get_update_controller().automatic_check)
-    QtCore.QTimer.singleShot(30000, _complete_startup_health_check)
+    QtCore.QTimer.singleShot(0, _complete_startup_health_check)
+    QtCore.QTimer.singleShot(2000, _complete_startup_health_check)
     _registered = True
 
 

--- a/src/Tools/tests/test_vibecad_update.py
+++ b/src/Tools/tests/test_vibecad_update.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import hashlib
 import io
 import json
+import os
 import shutil
+import subprocess
 import sys
 import tempfile
 import unittest
@@ -20,6 +22,7 @@ sys.path.insert(0, str(VIBECAD_MODULE_DIR))
 
 from VibeCADUpdate import (  # noqa: E402
     GITHUB_RELEASES_API_URL,
+    InstallPlan,
     ReleaseIdentity,
     UpdateAsset,
     UpdateError,
@@ -32,10 +35,12 @@ from VibeCADUpdate import (  # noqa: E402
     complete_pending_install_health,
     create_install_plan,
     load_update_policy,
+    macos_install_helper_command,
     normalize_architecture,
     parse_update_manifest,
     record_pending_install,
     update_policy_from_mapping,
+    write_macos_install_helper,
 )
 
 
@@ -881,23 +886,247 @@ class UpdateServiceTests(unittest.TestCase):
         gui = (
             REPO_ROOT / "src" / "Mod" / "VibeCAD" / "VibeCADUpdateGui.py"
         ).read_text(encoding="utf-8")
-        helper = gui.split("def _launch_macos_install_helper", 1)[1].split(
+        helper = (
+            REPO_ROOT / "src" / "Mod" / "VibeCAD" / "VibeCADUpdate.py"
+        ).read_text(encoding="utf-8")
+        launch = gui.split("def _launch_macos_install_helper", 1)[1].split(
             "class CheckForUpdatesCommand", 1
         )[0]
+        restart = gui.split("def _install_and_restart", 1)[1].split(
+            "def _show_update_notification", 1
+        )[0]
         self.assertIn("macos-dmg", gui.split("def _launch_pending_install", 1)[1])
+        self.assertIn("write_macos_install_helper", launch)
+        self.assertIn("macos_install_helper_command", launch)
+        self.assertIn("launch_pending_install_now()", restart)
+        self.assertIn("_quit_application_for_update()", restart)
+        self.assertIn("main_window.close()", gui)
         self.assertIn("hdiutil attach", helper)
         self.assertIn("ditto", helper)
         self.assertIn('new_app="$mount/VibeCAD.app"', helper)
-        self.assertNotIn("-name '*.app'", helper)
-        self.assertIn("terminate_new_app()", helper)
-        self.assertIn("rollback_install()", helper)
-        self.assertIn('if ! open -n "$app"; then', helper)
-        self.assertIn('if ! kill -0 "$new_pid" 2>/dev/null; then', helper)
-        rollback = helper.split("rollback_install()", 1)[1].split("}", 1)[0]
+        self.assertIn("bundle_executable", helper)
+        self.assertIn("keeping live updated application", helper)
+        self.assertIn("terminate_new_app", helper)
+        self.assertIn("rollback_install", helper)
+        self.assertIn('index($0, prefix)', helper)
+        rollback = helper.split("rollback_install()", 1)[1].split("find_new_pid()", 1)[0]
         self.assertLess(
             rollback.index("terminate_new_app"),
             rollback.index('rm -rf "$app"'),
         )
+        self.assertIn("QtCore.QTimer.singleShot(0, _complete_startup_health_check)", gui)
+        self.assertIn("QtCore.QTimer.singleShot(2000, _complete_startup_health_check)", gui)
+        self.assertNotIn(
+            "QtCore.QTimer.singleShot(30000, _complete_startup_health_check)",
+            gui,
+        )
+
+    def test_macos_install_helper_command_points_at_the_bundle_and_receipts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            helper = root / "install-macos-update.sh"
+            write_macos_install_helper(helper)
+            package = root / "VibeCAD.dmg"
+            package.write_bytes(b"dmg")
+            app = root / "VibeCAD.app"
+            app.mkdir()
+            plan = InstallPlan(
+                "macos-dmg",
+                package,
+                (),
+                current_install_root=app,
+            )
+            command = macos_install_helper_command(
+                helper,
+                plan,
+                process_id=4242,
+                update_directory=root,
+            )
+        self.assertEqual(command[0], "/bin/sh")
+        self.assertEqual(command[1], str(helper))
+        self.assertEqual(command[2], "4242")
+        self.assertEqual(command[3], str(package))
+        self.assertEqual(command[4], str(app))
+        self.assertEqual(command[5], f"{app}.vibecad-rollback")
+        self.assertEqual(Path(command[6]).resolve(), (root / "install-receipt.json").resolve())
+        self.assertEqual(Path(command[7]).resolve(), (root / "pending-install.json").resolve())
+
+    def test_macos_helper_replaces_the_app_and_keeps_a_live_update(self) -> None:
+        if sys.platform != "darwin" or shutil.which("hdiutil") is None:
+            self.skipTest("Requires macOS hdiutil")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            payload = root / "payload"
+            new_app = payload / "VibeCAD.app"
+            macos = new_app / "Contents" / "MacOS"
+            macos.mkdir(parents=True)
+            stub = macos / "FreeCAD"
+            stub.write_text(
+                "#!/bin/sh\n"
+                'if [ -n "${VIBECAD_UPDATE_MARKER:-}" ]; then\n'
+                '  printf "started\\n" > "$VIBECAD_UPDATE_MARKER"\n'
+                "fi\n"
+                "sleep 20\n",
+                encoding="utf-8",
+            )
+            stub.chmod(0o755)
+            dmg = root / "VibeCAD.dmg"
+            create = subprocess.run(
+                [
+                    "hdiutil",
+                    "create",
+                    "-srcfolder",
+                    str(payload),
+                    "-volname",
+                    "VibeCAD",
+                    "-format",
+                    "UDZO",
+                    "-ov",
+                    str(dmg),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if create.returncode != 0:
+                self.skipTest(f"hdiutil create failed: {create.stderr}")
+            dest = root / "Applications" / "VibeCAD.app"
+            dest.mkdir(parents=True)
+            (dest / "old.txt").write_text("previous", encoding="utf-8")
+            helper = write_macos_install_helper(root / "install-macos-update.sh")
+            receipt = root / "install-receipt.json"
+            pending = root / "pending-install.json"
+            pending.write_text('{"schema":1,"status":"pending"}\n', encoding="utf-8")
+            marker = root / "started"
+            dead = subprocess.run(
+                ["python3", "-c", "import os; print(os.getpid())"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            dead_pid = dead.stdout.strip()
+            env = os.environ.copy()
+            env["VIBECAD_UPDATE_HEALTH_WAIT"] = "3"
+            env["VIBECAD_UPDATE_MARKER"] = str(marker)
+            completed = subprocess.run(
+                [
+                    "/bin/sh",
+                    str(helper),
+                    dead_pid,
+                    str(dmg),
+                    str(dest),
+                    f"{dest}.vibecad-rollback",
+                    str(receipt),
+                    str(pending),
+                ],
+                check=False,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            receipt_payload = (
+                json.loads(receipt.read_text(encoding="utf-8"))
+                if receipt.is_file()
+                else {}
+            )
+            started = marker.read_text(encoding="utf-8") if marker.is_file() else ""
+            has_old = (dest / "old.txt").exists()
+            has_new = (dest / "Contents" / "MacOS" / "FreeCAD").is_file()
+            log = (root / "install-helper.log").read_text(encoding="utf-8") if (
+                root / "install-helper.log"
+            ).is_file() else ""
+            listing = subprocess.run(
+                ["ps", "-axo", "pid=,command="],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            for line in listing.stdout.splitlines():
+                if f"{dest}/" in line:
+                    try:
+                        os.kill(int(line.split(None, 1)[0]), 9)
+                    except (OSError, ValueError):
+                        pass
+        self.assertEqual(
+            completed.returncode,
+            0,
+            f"stdout={completed.stdout}\nstderr={completed.stderr}\nlog={log}",
+        )
+        self.assertEqual(receipt_payload.get("status"), "installed")
+        self.assertEqual(started.strip(), "started")
+        self.assertFalse(has_old)
+        self.assertTrue(has_new)
+
+    def test_macos_helper_rolls_back_when_the_updated_app_never_stays_up(self) -> None:
+        if sys.platform != "darwin" or shutil.which("hdiutil") is None:
+            self.skipTest("Requires macOS hdiutil")
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            payload = root / "payload"
+            new_app = payload / "VibeCAD.app"
+            macos = new_app / "Contents" / "MacOS"
+            macos.mkdir(parents=True)
+            stub = macos / "FreeCAD"
+            stub.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            stub.chmod(0o755)
+            dmg = root / "VibeCAD.dmg"
+            create = subprocess.run(
+                [
+                    "hdiutil",
+                    "create",
+                    "-srcfolder",
+                    str(payload),
+                    "-volname",
+                    "VibeCAD",
+                    "-format",
+                    "UDZO",
+                    "-ov",
+                    str(dmg),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            if create.returncode != 0:
+                self.skipTest(f"hdiutil create failed: {create.stderr}")
+            dest = root / "Applications" / "VibeCAD.app"
+            dest.mkdir(parents=True)
+            (dest / "old.txt").write_text("previous", encoding="utf-8")
+            helper = write_macos_install_helper(root / "install-macos-update.sh")
+            receipt = root / "install-receipt.json"
+            pending = root / "pending-install.json"
+            pending.write_text('{"schema":1,"status":"pending"}\n', encoding="utf-8")
+            env = os.environ.copy()
+            env["VIBECAD_UPDATE_HEALTH_WAIT"] = "2"
+            completed = subprocess.run(
+                [
+                    "/bin/sh",
+                    str(helper),
+                    str(os.getpid() + 10_000_000),
+                    str(dmg),
+                    str(dest),
+                    f"{dest}.vibecad-rollback",
+                    str(receipt),
+                    str(pending),
+                ],
+                check=False,
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            restored = (
+                (dest / "old.txt").read_text(encoding="utf-8")
+                if (dest / "old.txt").is_file()
+                else ""
+            )
+            receipt_payload = (
+                json.loads(receipt.read_text(encoding="utf-8"))
+                if receipt.is_file()
+                else {}
+            )
+        self.assertEqual(completed.returncode, 25)
+        self.assertEqual(restored, "previous")
+        self.assertEqual(receipt_payload.get("status"), "rolled-back")
 
     def test_appimage_plan_requires_real_appimage_launch(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
macOS **Check Updates** now downloads the matching DMG (see #78), but **Install and restart** still failed after the package was verified. The updater staged the plan, then called `QApplication.quit()` without closing FreeCAD's main window, so the detached helper never started or waited forever on the still-running PID. When it did run, it hunted for an exact `FreeCAD` path and rolled the new app back if the health receipt was still pending.

## Why

- `QApplication.quit()` does not go through FreeCAD's `Std_Quit` / main-window close path, so `aboutToQuit` often never launched the helper.
- The helper waited for the old PID, then looked for the new process with a strict `FreeCAD` match that `open -n` does not satisfy.
- Health confirmation ran after 30s, while the helper gave up after a short PID hunt and rolled back a live updated app when `pending-install.json` was still present.

## Fix

- Launch the macOS helper immediately from **Install and restart**, then quit through `main_window.close()` plus `QApplication.quit()`.
- Start the new bundle by its executable (`Contents/MacOS/FreeCAD` or `VibeCAD`) instead of relying only on `open -n`.
- Match the new PID by the `.app/` path prefix.
- Keep a live updated application if it is still running when the health receipt is pending; roll back only if the new process dies.
- Run the startup health check at 0s and 2s instead of 30s.

Windows installer and Linux AppImage paths are unchanged except that they also launch before teardown.

## Tests

Live `hdiutil` tests replace a stub `VibeCAD.app` from a real DMG:

- keep-alive stub → helper exit 0, receipt `installed`, old tree replaced
- stub that exits immediately → helper exit 25, previous app restored, receipt `rolled-back`

Exact green command:

```text
PYTHONPATH=src/Mod/VibeCAD python3 -m pytest src/Tools/tests/test_vibecad_update.py -q --tb=short -k "macos or helper or install_and_restart or launch_pending"
```

Result: **10 passed**, 32 deselected.

Full updater file: **40 passed**, 1 skipped. The remaining failure is a pre-existing Windows cache path assertion (`/var` vs `/private/var`) unrelated to this change.

`npm test` and `cargo test` are not part of this Python updater change.

A live replace of `/Applications/VibeCAD.app` was not executed in this environment. The installed app will not pick up this helper until a build that includes this PR is running.

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed/removed without approval.
- [x] Defaults preserve previous Windows and Linux updater behavior.
- [x] No deprecations.
- [x] No breaking changes.

## Risk and non-goals

The macOS helper still requires a writable application directory (typical for a user-installed `/Applications/VibeCAD.app`). It does not add a TUF service, change GitHub release naming, or alter Authenticode/AppImage apply logic.
