### PR TITLE
Make Section View work like SolidWorks and Fusion 360

### DIFF
--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2575,7 +2575,7 @@ VibeCADCmdSectionView::VibeCADCmdSectionView()
 {
     sGroup = "Standard-View";
     sMenuText = QT_TR_NOOP("Section View");
-    sToolTipText = QT_TR_NOOP("Cuts the model with a draggable section plane");
+    sToolTipText = QT_TR_NOOP("Cuts the model with a Front, Top, or Right section plane");
     sStatusTip = sToolTipText;
     sWhatsThis = "VibeCAD_SectionView";
     sPixmap = "Std_ToggleClipPlane";

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -26,6 +26,7 @@ set(VibeCAD_Scripts
     VibeCADFastenerAssembly.py
     VibeCADGrid.py
     VibeCADSectionView.py
+    VibeCADSectionViewGui.py
     VibeCADGrokAuth.py
     VibeCADGeometry.py
     VibeCADGeometryFallback.py

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -1,14 +1,15 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""Fusion-style 3D section view for VibeCAD.
+"""SolidWorks/Fusion-style 3D section view for VibeCAD.
 
-Toggles a clipping plane in the active 3D view so the model can be cut and
-inspected. The clip uses a manipulator so the plane can be dragged. The
-default plane is XY through the visible bounding-box center.
+Cuts the active 3D view with a Front (XY), Top (XZ), or Right (YZ) plane
+through the model. Offset slides the plane along its normal; Flip keeps the
+opposite half. The clip is a plain Inventor clipping plane, not the Coin
+manipulator, and does not change model geometry.
 
 The native ``VibeCAD_SectionView`` command owns the View-ribbon action. This
-module only inspects and toggles the active Inventor view's clipping plane;
-when no 3D view is open it reports inactive and does not create a clip.
+module inspects and applies the active Inventor view's clipping plane; when no
+3D view is open it reports inactive and does not create a clip.
 
 The module imports safely outside FreeCAD (guarded imports) so tooling such
 as linters and test collectors can load it.
@@ -16,12 +17,81 @@ as linters and test collectors can load it.
 
 from __future__ import annotations
 
-from typing import Any
+from dataclasses import dataclass, replace
+from typing import Any, Iterable
 
 try:
     import FreeCAD as App
 except ImportError:  # pragma: no cover - only outside FreeCAD (tooling/tests)
     App = None  # type: ignore[assignment]
+
+
+SECTION_PLANES = ("front", "top", "right")
+_PLANE_NORMALS = {
+    "front": (0.0, 0.0, 1.0),
+    "top": (0.0, 1.0, 0.0),
+    "right": (1.0, 0.0, 0.0),
+}
+_OVERLAY_NAME = "VibeCADSectionPlaneOverlay"
+
+
+@dataclass(frozen=True)
+class SectionViewSettings:
+    plane: str = "front"
+    offset: float = 0.0
+    flipped: bool = False
+    show_plane: bool = True
+
+    def __post_init__(self) -> None:
+        plane = str(self.plane).strip().casefold()
+        if plane not in _PLANE_NORMALS:
+            raise ValueError("Section plane must be front, top, or right.")
+        object.__setattr__(self, "plane", plane)
+        object.__setattr__(self, "offset", float(self.offset))
+        object.__setattr__(self, "flipped", bool(self.flipped))
+        object.__setattr__(self, "show_plane", bool(self.show_plane))
+
+
+@dataclass(frozen=True)
+class ModelBounds:
+    xmin: float
+    xmax: float
+    ymin: float
+    ymax: float
+    zmin: float
+    zmax: float
+
+    @property
+    def center(self) -> tuple[float, float, float]:
+        return (
+            (self.xmin + self.xmax) / 2.0,
+            (self.ymin + self.ymax) / 2.0,
+            (self.zmin + self.zmax) / 2.0,
+        )
+
+    def axis_half_extent(self, plane: str) -> float:
+        name = str(plane).strip().casefold()
+        if name == "front":
+            return abs(self.zmax - self.zmin) / 2.0
+        if name == "top":
+            return abs(self.ymax - self.ymin) / 2.0
+        if name == "right":
+            return abs(self.xmax - self.xmin) / 2.0
+        raise ValueError("Section plane must be front, top, or right.")
+
+
+_settings = SectionViewSettings()
+_overlay_node: Any | None = None
+
+
+def reset_section_view_settings() -> SectionViewSettings:
+    global _settings
+    _settings = SectionViewSettings()
+    return _settings
+
+
+def current_section_view_settings() -> SectionViewSettings:
+    return _settings
 
 
 def _object_bound_box(obj: Any) -> Any | None:
@@ -53,8 +123,8 @@ def _object_bound_box(obj: Any) -> Any | None:
     return None
 
 
-def bounds_center(objects: Any) -> tuple[float, float, float] | None:
-    """Return the combined BoundBox center of ``objects``, or None if empty."""
+def model_bounds(objects: Any) -> ModelBounds | None:
+    """Return the combined BoundBox of ``objects``, or None if empty."""
 
     xmin = ymin = zmin = float("inf")
     xmax = ymax = zmax = float("-inf")
@@ -72,7 +142,98 @@ def bounds_center(objects: Any) -> tuple[float, float, float] | None:
         zmax = max(zmax, float(box.ZMax))
     if not found:
         return None
-    return ((xmin + xmax) / 2.0, (ymin + ymax) / 2.0, (zmin + zmax) / 2.0)
+    return ModelBounds(xmin, xmax, ymin, ymax, zmin, zmax)
+
+
+def bounds_center(objects: Any) -> tuple[float, float, float] | None:
+    """Return the combined BoundBox center of ``objects``, or None if empty."""
+
+    bounds = model_bounds(objects)
+    if bounds is None:
+        return None
+    return bounds.center
+
+
+def section_plane_normal(plane: str, flipped: bool = False) -> tuple[float, float, float]:
+    name = str(plane).strip().casefold()
+    normal = _PLANE_NORMALS.get(name)
+    if normal is None:
+        raise ValueError("Section plane must be front, top, or right.")
+    if flipped:
+        return (-normal[0], -normal[1], -normal[2])
+    return normal
+
+
+def section_offset_range(bounds: ModelBounds, plane: str) -> tuple[float, float]:
+    half = float(bounds.axis_half_extent(plane))
+    return (-half, half)
+
+
+def clip_plane_from_settings(
+    settings: SectionViewSettings,
+    center: tuple[float, float, float],
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+    """Return (origin, clip-normal) for the SolidWorks/Fusion section plane."""
+
+    normal = section_plane_normal(settings.plane, settings.flipped)
+    origin = (
+        center[0] + normal[0] * settings.offset,
+        center[1] + normal[1] * settings.offset,
+        center[2] + normal[2] * settings.offset,
+    )
+    return origin, normal
+
+
+def _cross(
+    left: tuple[float, float, float],
+    right: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    return (
+        left[1] * right[2] - left[2] * right[1],
+        left[2] * right[0] - left[0] * right[2],
+        left[0] * right[1] - left[1] * right[0],
+    )
+
+
+def _unit(vector: tuple[float, float, float]) -> tuple[float, float, float]:
+    length = (vector[0] ** 2 + vector[1] ** 2 + vector[2] ** 2) ** 0.5
+    if length == 0.0:
+        raise ValueError("A section-plane axis is degenerate.")
+    return (vector[0] / length, vector[1] / length, vector[2] / length)
+
+
+def section_plane_axes(
+    normal: tuple[float, float, float],
+) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
+    direction = _unit(normal)
+    helper = (0.0, 0.0, 1.0) if abs(direction[2]) < 0.9 else (0.0, 1.0, 0.0)
+    u_axis = _unit(_cross(direction, helper))
+    v_axis = _unit(_cross(direction, u_axis))
+    return u_axis, v_axis
+
+
+def section_plane_corners(
+    origin: tuple[float, float, float],
+    normal: tuple[float, float, float],
+    half_width: float,
+    half_height: float,
+) -> tuple[
+    tuple[float, float, float],
+    tuple[float, float, float],
+    tuple[float, float, float],
+    tuple[float, float, float],
+]:
+    u_axis, v_axis = section_plane_axes(normal)
+    corners = []
+    for u_sign, v_sign in ((-1.0, -1.0), (1.0, -1.0), (1.0, 1.0), (-1.0, 1.0)):
+        corners.append(
+            (
+                origin[0] + u_axis[0] * u_sign * half_width + v_axis[0] * v_sign * half_height,
+                origin[1] + u_axis[1] * u_sign * half_width + v_axis[1] * v_sign * half_height,
+                origin[2] + u_axis[2] * u_sign * half_width + v_axis[2] * v_sign * half_height,
+            )
+        )
+    return (corners[0], corners[1], corners[2], corners[3])
 
 
 def _active_document() -> Any | None:
@@ -110,17 +271,25 @@ def _active_3d_view(gui: Any | None = None) -> Any | None:
     return view
 
 
-def section_view_placement(document: Any | None = None) -> Any:
-    """XY plane through the document bounds center, or the origin if empty."""
+def _document_objects(document: Any | None) -> Iterable[Any]:
+    target = document if document is not None else _active_document()
+    return getattr(target, "Objects", ()) if target is not None else ()
+
+
+def section_view_placement(
+    document: Any | None = None,
+    settings: SectionViewSettings | None = None,
+) -> Any:
+    """Front/Top/Right plane through the document bounds center, or the origin."""
 
     if App is None:
         raise RuntimeError("FreeCAD is unavailable.")
-    target = document if document is not None else _active_document()
-    objects = getattr(target, "Objects", ()) if target is not None else ()
-    center = bounds_center(objects)
-    if center is None:
-        return App.Placement()
-    return App.Placement(App.Vector(*center), App.Rotation())
+    active = settings if settings is not None else _settings
+    bounds = model_bounds(_document_objects(document))
+    center = bounds.center if bounds is not None else (0.0, 0.0, 0.0)
+    origin, normal = clip_plane_from_settings(active, center)
+    rotation = App.Rotation(App.Vector(0.0, 0.0, -1.0), App.Vector(*normal))
+    return App.Placement(App.Vector(*origin), rotation)
 
 
 def is_section_view_active(view: Any | None = None) -> bool:
@@ -136,14 +305,204 @@ def is_section_view_active(view: Any | None = None) -> bool:
         return False
 
 
+def _top_level_nodes(scene: Any) -> tuple[Any, ...]:
+    children = getattr(scene, "getChildren", None)
+    if not callable(children):
+        return ()
+    try:
+        return tuple(children() or ())
+    except Exception:
+        return ()
+
+
+def _update_clip_plane(view: Any, placement: Any) -> bool:
+    get_scene = getattr(view, "getSceneGraph", None)
+    if not callable(get_scene) or App is None:
+        return False
+    try:
+        from pivy import coin
+    except ImportError:
+        return False
+    try:
+        scene = get_scene()
+    except Exception:
+        return False
+    if scene is None:
+        return False
+    try:
+        origin = (
+            float(placement.Base.x),
+            float(placement.Base.y),
+            float(placement.Base.z),
+        )
+        direction = placement.Rotation.multVec(App.Vector(0.0, 0.0, -1.0))
+        normal = (float(direction.x), float(direction.y), float(direction.z))
+    except Exception:
+        return False
+    for node in _top_level_nodes(scene):
+        if type(node).__name__ == "SoClipPlane":
+            node.plane.setValue(
+                coin.SbPlane(coin.SbVec3f(*normal), coin.SbVec3f(*origin))
+            )
+            return True
+    return False
+
+
+def _overlay_size(
+    bounds: ModelBounds | None,
+    normal: tuple[float, float, float],
+) -> tuple[float, float]:
+    if bounds is None:
+        return (50.0, 50.0)
+    u_axis, v_axis = section_plane_axes(normal)
+    extents = (
+        (bounds.xmax - bounds.xmin, 1.0, 0.0, 0.0),
+        (bounds.ymax - bounds.ymin, 0.0, 1.0, 0.0),
+        (bounds.zmax - bounds.zmin, 0.0, 0.0, 1.0),
+    )
+    half_width = 0.0
+    half_height = 0.0
+    for length, x_dir, y_dir, z_dir in extents:
+        half = abs(length) / 2.0
+        half_width = max(
+            half_width, abs(u_axis[0] * x_dir + u_axis[1] * y_dir + u_axis[2] * z_dir) * half
+        )
+        half_height = max(
+            half_height,
+            abs(v_axis[0] * x_dir + v_axis[1] * y_dir + v_axis[2] * z_dir) * half,
+        )
+    pad = 1.05
+    return (max(half_width, 1.0) * pad, max(half_height, 1.0) * pad)
+
+
+def _remove_overlay(view: Any) -> None:
+    global _overlay_node
+    if _overlay_node is None:
+        return
+    get_scene = getattr(view, "getSceneGraph", None)
+    if callable(get_scene):
+        try:
+            scene = get_scene()
+        except Exception:
+            scene = None
+        if scene is not None:
+            try:
+                index = scene.findChild(_overlay_node)
+            except Exception:
+                index = -1
+            if index >= 0:
+                scene.removeChild(_overlay_node)
+    _overlay_node = None
+
+
+def _sync_overlay(
+    view: Any,
+    document: Any | None,
+    settings: SectionViewSettings,
+) -> None:
+    global _overlay_node
+    _remove_overlay(view)
+    if not settings.show_plane:
+        return
+    get_scene = getattr(view, "getSceneGraph", None)
+    if not callable(get_scene):
+        return
+    try:
+        from pivy import coin
+    except ImportError:
+        return
+    try:
+        scene = get_scene()
+    except Exception:
+        return
+    if scene is None:
+        return
+    bounds = model_bounds(_document_objects(document))
+    center = bounds.center if bounds is not None else (0.0, 0.0, 0.0)
+    origin, normal = clip_plane_from_settings(settings, center)
+    half_width, half_height = _overlay_size(bounds, normal)
+    corners = section_plane_corners(origin, normal, half_width, half_height)
+    separator = coin.SoSeparator()
+    separator.setName(_OVERLAY_NAME)
+    light = coin.SoLightModel()
+    light.model = coin.SoLightModel.BASE_COLOR
+    material = coin.SoMaterial()
+    material.diffuseColor.setValue(0.15, 0.62, 0.78)
+    material.transparency.setValue(0.72)
+    material.emissiveColor.setValue(0.08, 0.35, 0.45)
+    coords = coin.SoCoordinate3()
+    for index, corner in enumerate(corners):
+        coords.point.set1Value(index, coin.SbVec3f(*corner))
+    faces = coin.SoIndexedFaceSet()
+    for index, value in enumerate((0, 1, 2, 3, -1)):
+        faces.coordIndex.set1Value(index, value)
+    style = coin.SoDrawStyle()
+    style.style = coin.SoDrawStyle.LINES
+    style.lineWidth = 2
+    line_material = coin.SoMaterial()
+    line_material.diffuseColor.setValue(0.05, 0.42, 0.58)
+    lines = coin.SoIndexedLineSet()
+    for index, value in enumerate((0, 1, 2, 3, 0, -1)):
+        lines.coordIndex.set1Value(index, value)
+    separator.addChild(light)
+    separator.addChild(material)
+    separator.addChild(coords)
+    separator.addChild(faces)
+    separator.addChild(style)
+    separator.addChild(line_material)
+    separator.addChild(lines)
+    try:
+        scene.insertChild(separator, 0)
+    except Exception:
+        return
+    _overlay_node = separator
+
+
+def _apply_clip(
+    view: Any,
+    document: Any | None,
+    settings: SectionViewSettings,
+) -> None:
+    placement = section_view_placement(document, settings)
+    if is_section_view_active(view):
+        if not _update_clip_plane(view, placement):
+            view.toggleClippingPlane(toggle=0)
+            view.toggleClippingPlane(toggle=1, noManip=True, pla=placement)
+    else:
+        view.toggleClippingPlane(toggle=1, noManip=True, pla=placement)
+    _sync_overlay(view, document, settings)
+
+
+def _close_ui() -> None:
+    try:
+        import VibeCADSectionViewGui as gui
+    except Exception:
+        return
+    closer = getattr(gui, "close_section_view_dialog", None)
+    if callable(closer):
+        closer()
+
+
+def _show_ui() -> None:
+    try:
+        import VibeCADSectionViewGui as gui
+    except Exception:
+        return
+    shower = getattr(gui, "show_section_view_dialog", None)
+    if callable(shower):
+        shower()
+
+
 def set_section_view(
     visible: bool,
     *,
     view: Any | None = None,
     document: Any | None = None,
+    show_ui: bool = False,
 ) -> dict[str, bool]:
     """Enable or disable the active 3D section clip."""
 
+    global _settings
     if type(visible) is not bool:
         raise TypeError("visible must be a boolean")
     active = view if view is not None else _active_3d_view()
@@ -151,33 +510,80 @@ def set_section_view(
         raise RuntimeError("Section view requires an active 3D view.")
     current = is_section_view_active(active)
     if current == visible:
+        if visible and show_ui:
+            _show_ui()
+        if not visible:
+            _remove_overlay(active)
+            _close_ui()
         return {"section_view": current}
     toggle = getattr(active, "toggleClippingPlane", None)
     if not callable(toggle):
         raise RuntimeError("The active 3D view cannot toggle a section plane.")
     if visible:
-        placement = section_view_placement(document)
-        toggle(toggle=1, noManip=False, pla=placement)
+        _apply_clip(active, document, _settings)
+        if show_ui:
+            _show_ui()
     else:
+        _remove_overlay(active)
         toggle(toggle=0)
+        _close_ui()
     observed = is_section_view_active(active)
     if observed != visible:
         raise RuntimeError("The active 3D view did not reach the requested section state.")
     return {"section_view": observed}
 
 
+def configure_section_view(
+    *,
+    plane: str | None = None,
+    offset: float | None = None,
+    flipped: bool | None = None,
+    show_plane: bool | None = None,
+    view: Any | None = None,
+    document: Any | None = None,
+) -> dict[str, object]:
+    """Update the live Front/Top/Right section without changing geometry."""
+
+    global _settings
+    updates: dict[str, object] = {}
+    if plane is not None:
+        updates["plane"] = plane
+    if offset is not None:
+        updates["offset"] = offset
+    if flipped is not None:
+        updates["flipped"] = flipped
+    if show_plane is not None:
+        updates["show_plane"] = show_plane
+    _settings = replace(_settings, **updates) if updates else _settings
+    active = view if view is not None else _active_3d_view()
+    if active is not None and is_section_view_active(active):
+        _apply_clip(active, document, _settings)
+    return {
+        "plane": _settings.plane,
+        "offset": _settings.offset,
+        "flipped": _settings.flipped,
+        "show_plane": _settings.show_plane,
+        "section_view": is_section_view_active(active) if active is not None else False,
+    }
+
+
 def toggle_section_view(
     *,
     view: Any | None = None,
     document: Any | None = None,
+    show_ui: bool = True,
 ) -> dict[str, bool]:
     """Toggle the active 3D section clip and return the resulting state."""
 
     active = view if view is not None else _active_3d_view()
     if active is None:
         raise RuntimeError("Section view requires an active 3D view.")
+    if is_section_view_active(active):
+        return set_section_view(False, view=active, document=document)
+    reset_section_view_settings()
     return set_section_view(
-        not is_section_view_active(active),
+        True,
         view=active,
         document=document,
+        show_ui=show_ui,
     )

--- a/src/Mod/VibeCAD/VibeCADSectionViewGui.py
+++ b/src/Mod/VibeCAD/VibeCADSectionViewGui.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""SolidWorks/Fusion-style Section View dialog for the 3D viewport."""
+
+from __future__ import annotations
+
+from typing import Any
+
+try:
+    import FreeCADGui as Gui
+    from PySide import QtCore, QtWidgets
+except ImportError:  # pragma: no cover - only outside FreeCAD (tooling/tests)
+    Gui = None  # type: ignore[assignment]
+    QtCore = None  # type: ignore[assignment]
+    QtWidgets = None  # type: ignore[assignment]
+
+import VibeCADSectionView as section
+
+
+_dialog: "SectionViewDialog | None" = None
+_PLANE_LABELS = (
+    ("front", "Front (XY)"),
+    ("top", "Top (XZ)"),
+    ("right", "Right (YZ)"),
+)
+
+
+class SectionViewDialog(QtWidgets.QDialog):
+    """Non-modal Front/Top/Right section controls, live-previewed in the 3D view."""
+
+    def __init__(self, parent: Any | None = None) -> None:
+        super().__init__(parent)
+        self.setObjectName("VibeCADSectionViewDialog")
+        self.setWindowTitle("Section View")
+        self.setModal(False)
+        self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
+        self._updating = False
+
+        layout = QtWidgets.QVBoxLayout(self)
+        plane_group = QtWidgets.QGroupBox("Section plane", self)
+        plane_layout = QtWidgets.QVBoxLayout(plane_group)
+        self._plane_buttons: dict[str, QtWidgets.QRadioButton] = {}
+        for name, label in _PLANE_LABELS:
+            button = QtWidgets.QRadioButton(label, plane_group)
+            object_name = {
+                "front": "planeFront",
+                "top": "planeTop",
+                "right": "planeRight",
+            }[name]
+            button.setObjectName(object_name)
+            button.toggled.connect(self._plane_changed)
+            plane_layout.addWidget(button)
+            self._plane_buttons[name] = button
+        layout.addWidget(plane_group)
+
+        offset_row = QtWidgets.QHBoxLayout()
+        offset_label = QtWidgets.QLabel("Offset", self)
+        self.offset_spin = QtWidgets.QDoubleSpinBox(self)
+        self.offset_spin.setObjectName("sectionOffset")
+        self.offset_spin.setDecimals(3)
+        self.offset_spin.setSingleStep(1.0)
+        self.offset_spin.setRange(-1_000_000.0, 1_000_000.0)
+        self.offset_spin.setSuffix(" mm")
+        self.offset_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal, self)
+        self.offset_slider.setObjectName("sectionOffsetSlider")
+        self.offset_slider.setRange(-1000, 1000)
+        offset_row.addWidget(offset_label)
+        offset_row.addWidget(self.offset_spin)
+        layout.addLayout(offset_row)
+        layout.addWidget(self.offset_slider)
+
+        self.flip_button = QtWidgets.QPushButton("Flip", self)
+        self.flip_button.setObjectName("sectionFlip")
+        self.flip_button.setCheckable(True)
+        layout.addWidget(self.flip_button)
+
+        self.show_plane = QtWidgets.QCheckBox("Show section plane", self)
+        self.show_plane.setObjectName("sectionShowPlane")
+        self.show_plane.setChecked(True)
+        layout.addWidget(self.show_plane)
+
+        buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
+            self,
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self.offset_spin.valueChanged.connect(self._offset_spin_changed)
+        self.offset_slider.valueChanged.connect(self._offset_slider_changed)
+        self.flip_button.toggled.connect(self._flip_changed)
+        self.show_plane.toggled.connect(self._show_plane_changed)
+        self.destroyed.connect(_clear_dialog)
+        self._load_from_settings()
+
+    def _load_from_settings(self) -> None:
+        settings = section.current_section_view_settings()
+        self._updating = True
+        self._plane_buttons[settings.plane].setChecked(True)
+        self._sync_offset_limits()
+        self.offset_spin.setValue(settings.offset)
+        self._set_slider_from_offset(settings.offset)
+        self.flip_button.setChecked(settings.flipped)
+        self.show_plane.setChecked(settings.show_plane)
+        self._updating = False
+
+    def _sync_offset_limits(self) -> None:
+        try:
+            import FreeCAD as App
+        except ImportError:
+            return
+        document = getattr(App, "ActiveDocument", None)
+        objects = getattr(document, "Objects", ()) if document is not None else ()
+        bounds = section.model_bounds(objects)
+        if bounds is None:
+            return
+        low, high = section.section_offset_range(
+            bounds, section.current_section_view_settings().plane
+        )
+        if high <= low:
+            high = low + 1.0
+        self.offset_spin.setRange(low, high)
+        self.offset_slider.setRange(-1000, 1000)
+        self._offset_low = low
+        self._offset_high = high
+
+    @property
+    def _offset_low(self) -> float:
+        return float(self.offset_spin.minimum())
+
+    @_offset_low.setter
+    def _offset_low(self, value: float) -> None:
+        self.offset_spin.setMinimum(value)
+
+    @property
+    def _offset_high(self) -> float:
+        return float(self.offset_spin.maximum())
+
+    @_offset_high.setter
+    def _offset_high(self, value: float) -> None:
+        self.offset_spin.setMaximum(value)
+
+    def _slider_to_offset(self, value: int) -> float:
+        low = float(self.offset_spin.minimum())
+        high = float(self.offset_spin.maximum())
+        span = high - low
+        if span == 0.0:
+            return 0.0
+        return low + (float(value) + 1000.0) * span / 2000.0
+
+    def _set_slider_from_offset(self, offset: float) -> None:
+        low = float(self.offset_spin.minimum())
+        high = float(self.offset_spin.maximum())
+        span = high - low
+        if span == 0.0:
+            self.offset_slider.setValue(0)
+            return
+        ratio = (float(offset) - low) / span
+        self.offset_slider.setValue(int(round(ratio * 2000.0 - 1000.0)))
+
+    def _plane_changed(self, checked: bool) -> None:
+        if self._updating or not checked:
+            return
+        plane = next(
+            name for name, button in self._plane_buttons.items() if button.isChecked()
+        )
+        self._updating = True
+        section.configure_section_view(plane=plane, offset=0.0)
+        self._sync_offset_limits()
+        self.offset_spin.setValue(0.0)
+        self._set_slider_from_offset(0.0)
+        self._updating = False
+
+    def _offset_spin_changed(self, value: float) -> None:
+        if self._updating:
+            return
+        self._updating = True
+        self._set_slider_from_offset(value)
+        section.configure_section_view(offset=float(value))
+        self._updating = False
+
+    def _offset_slider_changed(self, value: int) -> None:
+        if self._updating:
+            return
+        offset = self._slider_to_offset(value)
+        self._updating = True
+        self.offset_spin.setValue(offset)
+        section.configure_section_view(offset=float(offset))
+        self._updating = False
+
+    def _flip_changed(self, checked: bool) -> None:
+        if self._updating:
+            return
+        section.configure_section_view(flipped=bool(checked))
+
+    def _show_plane_changed(self, checked: bool) -> None:
+        if self._updating:
+            return
+        section.configure_section_view(show_plane=bool(checked))
+
+    def accept(self) -> None:
+        """Keep the section cut and close the editor, like SolidWorks OK."""
+
+        super().accept()
+
+    def reject(self) -> None:
+        """Cancel the section cut, like SolidWorks/Fusion dismissing without keeping it."""
+
+        global _dialog
+        _dialog = None
+        view = None
+        try:
+            if Gui is not None and Gui.ActiveDocument is not None:
+                view = Gui.ActiveDocument.ActiveView
+        except Exception:
+            view = None
+        if view is not None and section.is_section_view_active(view):
+            section.set_section_view(False, view=view, show_ui=False)
+        super().reject()
+
+
+def _clear_dialog(*_args: Any) -> None:
+    global _dialog
+    _dialog = None
+
+
+def _main_window() -> Any | None:
+    if Gui is None:
+        return None
+    getter = getattr(Gui, "getMainWindow", None)
+    if not callable(getter):
+        return None
+    try:
+        return getter()
+    except Exception:
+        return None
+
+
+def show_section_view_dialog() -> SectionViewDialog | None:
+    """Show the Front/Top/Right section editor without stealing a modeling task."""
+
+    global _dialog
+    if QtWidgets is None:
+        return None
+    if _dialog is not None:
+        try:
+            _dialog._load_from_settings()
+            _dialog.show()
+            _dialog.raise_()
+            _dialog.activateWindow()
+            return _dialog
+        except RuntimeError:
+            _dialog = None
+    dialog = SectionViewDialog(_main_window())
+    _dialog = dialog
+    dialog.show()
+    return dialog
+
+
+def close_section_view_dialog() -> None:
+    global _dialog
+    dialog = _dialog
+    _dialog = None
+    if dialog is None:
+        return
+    try:
+        dialog.hide()
+        dialog.deleteLater()
+    except RuntimeError:
+        return
+
+
+def sync_section_view_dialog(visible: bool) -> None:
+    if visible:
+        show_section_view_dialog()
+        return
+    close_section_view_dialog()

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -7,6 +7,10 @@ import unittest
 import FreeCAD as App
 import FreeCADGui as Gui
 from PySide import QtCore, QtGui
+try:
+    from PySide import QtWidgets
+except ImportError:  # pragma: no cover - PySide1 compatibility
+    QtWidgets = QtGui
 from pivy import coin
 
 import VibeCADSectionView
@@ -34,6 +38,12 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
             view = Gui.ActiveDocument.ActiveView
         except Exception:
             view = None
+        try:
+            import VibeCADSectionViewGui
+
+            VibeCADSectionViewGui.close_section_view_dialog()
+        except Exception:
+            pass
         if view is not None and VibeCADSectionView.is_section_view_active(view):
             VibeCADSectionView.set_section_view(False, view=view, document=self.document)
         self._process_events()
@@ -68,10 +78,24 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         return actions[0]
 
     @staticmethod
-    def _scene_has_clip_plane(view):
+    def _scene_clip_nodes(view):
         scene = view.getSceneGraph()
         children = tuple(scene.getChildren()) if scene is not None else ()
-        return any(isinstance(node, coin.SoClipPlane) for node in children)
+        return tuple(
+            node
+            for node in children
+            if type(node).__name__ in {"SoClipPlane", "SoClipPlaneManip"}
+        )
+
+    @staticmethod
+    def _section_dialog():
+        application = QtGui.QApplication.instance()
+        if application is None:
+            return None
+        for widget in application.topLevelWidgets():
+            if widget.objectName() == "VibeCADSectionViewDialog":
+                return widget
+        return None
 
     def test_native_command_toggles_clip_plane_action_and_scene(self):
         command_name = "VibeCAD_SectionView"
@@ -90,7 +114,26 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         self.assertTrue(Gui.isCommandActive(command_name))
         Gui.Command.get(command_name).getAction()[0]
         self.assertTrue(view.hasClippingPlane())
-        self.assertTrue(self._scene_has_clip_plane(view) or view.hasClippingPlane())
+        clip_nodes = self._scene_clip_nodes(view)
+        self.assertTrue(clip_nodes or view.hasClippingPlane())
+        self.assertFalse(
+            any(type(node).__name__ == "SoClipPlaneManip" for node in clip_nodes),
+            "Section View must not use the Coin clip manipulator.",
+        )
+        dialog = self._section_dialog()
+        self.assertIsNotNone(dialog)
+        self.assertTrue(dialog.isVisible())
+        self.assertIsNotNone(dialog.findChild(QtWidgets.QRadioButton, "planeFront"))
+        self.assertIsNotNone(dialog.findChild(QtWidgets.QRadioButton, "planeTop"))
+        self.assertIsNotNone(dialog.findChild(QtWidgets.QRadioButton, "planeRight"))
+        self.assertIsNotNone(dialog.findChild(QtWidgets.QDoubleSpinBox, "sectionOffset"))
+        self.assertIsNotNone(dialog.findChild(QtWidgets.QPushButton, "sectionFlip"))
+
+        top = dialog.findChild(QtWidgets.QRadioButton, "planeTop")
+        top.setChecked(True)
+        self._process_events()
+        self.assertEqual(VibeCADSectionView.current_section_view_settings().plane, "top")
+        self.assertTrue(view.hasClippingPlane())
 
         Gui.runCommand(command_name, 0)
         self.assertTrue(
@@ -101,3 +144,7 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         )
         self.assertTrue(Gui.isCommandActive(command_name))
         self.assertFalse(view.hasClippingPlane())
+        self.assertTrue(
+            self._wait_until(lambda: self._section_dialog() is None),
+            "Section View did not close its editor dialog.",
+        )

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -11,8 +11,6 @@ try:
     from PySide import QtWidgets
 except ImportError:  # pragma: no cover - PySide1 compatibility
     QtWidgets = QtGui
-from pivy import coin
-
 import VibeCADSectionView
 
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
@@ -37,10 +37,13 @@ class _Object:
 class _View:
     def __init__(self, clipped=False):
         self.clipped = clipped
-        self.calls: list[tuple] = []
+        self.calls: list[dict] = []
 
     def hasClippingPlane(self) -> bool:
         return self.clipped
+
+    def getSceneGraph(self):
+        return None
 
     def toggleClippingPlane(self, **kwargs):
         self.calls.append(kwargs)
@@ -51,6 +54,13 @@ class _View:
             self.clipped = True
         else:
             self.clipped = not self.clipped
+
+
+@pytest.fixture(autouse=True)
+def _reset_section_settings() -> None:
+    section.reset_section_view_settings()
+    yield
+    section.reset_section_view_settings()
 
 
 def test_bounds_center_combines_valid_shape_boxes() -> None:
@@ -81,21 +91,98 @@ def test_toggle_requires_an_active_3d_view() -> None:
         section.toggle_section_view(view=None)
 
 
-def test_set_section_view_toggles_clip_with_manipulator(monkeypatch) -> None:
+def test_principal_planes_match_solidworks_and_fusion() -> None:
+    assert section.section_plane_normal("front") == (0.0, 0.0, 1.0)
+    assert section.section_plane_normal("top") == (0.0, 1.0, 0.0)
+    assert section.section_plane_normal("right") == (1.0, 0.0, 0.0)
+    assert section.section_plane_normal("front", flipped=True) == (0.0, 0.0, -1.0)
+    assert section.section_plane_normal("top", flipped=True) == (0.0, -1.0, 0.0)
+    assert section.section_plane_normal("right", flipped=True) == (-1.0, 0.0, 0.0)
+    with pytest.raises(ValueError, match="front, top, or right"):
+        section.section_plane_normal("camera")
+
+
+def test_clip_plane_origin_offsets_along_the_section_normal() -> None:
+    center = (10.0, 4.0, 2.0)
+    settings = section.SectionViewSettings(plane="front", offset=5.0)
+    origin, normal = section.clip_plane_from_settings(settings, center)
+    assert normal == (0.0, 0.0, 1.0)
+    assert origin == (10.0, 4.0, 7.0)
+
+    flipped = section.SectionViewSettings(plane="right", offset=3.0, flipped=True)
+    origin, normal = section.clip_plane_from_settings(flipped, center)
+    assert normal == (-1.0, 0.0, 0.0)
+    assert origin == (7.0, 4.0, 2.0)
+
+
+def test_offset_range_follows_the_selected_axis_extent() -> None:
+    bounds = section.model_bounds(
+        (_Object(_Box(0.0, 20.0, -4.0, 4.0, -10.0, 10.0)),)
+    )
+    assert bounds is not None
+    assert section.section_offset_range(bounds, "front") == (-10.0, 10.0)
+    assert section.section_offset_range(bounds, "top") == (-4.0, 4.0)
+    assert section.section_offset_range(bounds, "right") == (-10.0, 10.0)
+
+
+def test_section_plane_corners_are_centered_and_coplanar() -> None:
+    origin = (1.0, 2.0, 3.0)
+    normal = (0.0, 0.0, 1.0)
+    corners = section.section_plane_corners(origin, normal, 4.0, 5.0)
+    assert len(corners) == 4
+    cx = sum(corner[0] for corner in corners) / 4.0
+    cy = sum(corner[1] for corner in corners) / 4.0
+    cz = sum(corner[2] for corner in corners) / 4.0
+    assert (cx, cy, cz) == pytest.approx(origin)
+    for corner in corners:
+        assert corner[2] == pytest.approx(3.0)
+
+
+def test_set_section_view_uses_a_clean_clip_without_a_coin_manipulator(
+    monkeypatch,
+) -> None:
     view = _View(clipped=False)
     placement = object()
-    monkeypatch.setattr(section, "section_view_placement", lambda document=None: placement)
+    monkeypatch.setattr(
+        section,
+        "section_view_placement",
+        lambda document=None, settings=None: placement,
+    )
 
     assert section.set_section_view(True, view=view) == {"section_view": True}
-    assert view.calls == [{"toggle": 1, "noManip": False, "pla": placement}]
+    assert view.calls == [{"toggle": 1, "noManip": True, "pla": placement}]
     assert section.is_section_view_active(view) is True
 
     assert section.set_section_view(True, view=view) == {"section_view": True}
-    assert view.calls == [{"toggle": 1, "noManip": False, "pla": placement}]
+    assert view.calls == [{"toggle": 1, "noManip": True, "pla": placement}]
 
-    assert section.toggle_section_view(view=view) == {"section_view": False}
+    assert section.toggle_section_view(view=view, show_ui=False) == {
+        "section_view": False
+    }
     assert view.calls[-1] == {"toggle": 0}
     assert section.is_section_view_active(view) is False
+
+
+def test_configure_section_view_reapplies_a_live_cut(monkeypatch) -> None:
+    view = _View(clipped=False)
+    seen: list[object] = []
+
+    def fake_placement(document=None, settings=None):
+        seen.append(settings)
+        return object()
+
+    monkeypatch.setattr(section, "section_view_placement", fake_placement)
+    section.set_section_view(True, view=view)
+    section.configure_section_view(plane="top", offset=8.0, flipped=True, view=view)
+
+    assert view.clipped is True
+    assert view.calls[-2] == {"toggle": 0}
+    assert view.calls[-1]["toggle"] == 1
+    assert view.calls[-1]["noManip"] is True
+    assert seen[-1].plane == "top"
+    assert seen[-1].offset == 8.0
+    assert seen[-1].flipped is True
+    assert section.current_section_view_settings().plane == "top"
 
 
 def test_visible_argument_must_be_a_boolean() -> None:
@@ -119,3 +206,25 @@ def test_native_command_is_registered_next_to_grid() -> None:
     grid = command_view.index("new VibeCADCmdToggleGrid()")
     section_cmd = command_view.index("new VibeCADCmdSectionView()")
     assert grid < section_cmd
+    assert "Front, Top, or Right section plane" in command_view
+    assert "draggable section plane" not in command_view
+
+
+def test_section_view_dialog_matches_solidworks_and_fusion_controls() -> None:
+    gui = (
+        REPO / "src/Mod/VibeCAD/VibeCADSectionViewGui.py"
+    ).read_text(encoding="utf-8")
+    helper = (
+        REPO / "src/Mod/VibeCAD/VibeCADSectionView.py"
+    ).read_text(encoding="utf-8")
+    assert "class SectionViewDialog" in gui
+    assert 'setObjectName("VibeCADSectionViewDialog")' in gui
+    assert "Front (XY)" in gui
+    assert "Top (XZ)" in gui
+    assert "Right (YZ)" in gui
+    assert "Flip" in gui
+    assert "Offset" in gui
+    assert "noManip=True" in helper or "noManip=True" in gui
+    assert "SoClipPlaneManip" not in helper
+    assert "show_section_view_dialog" in gui
+    assert "close_section_view_dialog" in gui


### PR DESCRIPTION
The Model ribbon **Section View** control was a one-click Coin clip-plane manipulator. That is not how SolidWorks or Fusion 360 section a model: it showed a huge dragger, had no Front/Top/Right plane, no offset, and no flip, and it did not look like a CAD section.

## Why

`VibeCAD_SectionView` called `toggleClippingPlane(..., noManip=False)`, which inserts Coin's `SoClipPlaneManip`. That widget is an Inventor trackball over a giant plane. SolidWorks Section View and Fusion Section Analysis instead:

- start a cut on a principal plane (Front/XY, Top/XZ, Right/YZ)
- let you offset along the plane normal
- flip which half is kept
- preview live without changing geometry
- dismiss with OK to keep the cut, or Cancel to turn it off

## Fix

- Cut with a plain clipping plane (`noManip=True`), not the Coin manipulator.
- Open a non-modal **Section View** editor: Front (XY) / Top (XZ) / Right (YZ), Offset, Flip, and Show section plane.
- Offset 0 is the model-bounds center; changing plane resets offset to center, matching those products.
- OK keeps the cut and closes the editor; Cancel/X turns the cut off; the ribbon button still toggles it.
- Draw a translucent section-plane overlay instead of a dragger.
- Geometry is unchanged (viewport presentation only).

Windows/Linux clip behavior for this command follows the same Front/Top/Right editor. TechDraw drawing section views are unchanged.

## Tests

Red tests were added first for principal-plane normals, offset along the normal, flip, a clean `noManip=True` clip, live reconfigure, and the dialog controls.

Exact green command:

```text
PYTHONPATH=src/Mod/VibeCAD python3 -m pytest src/Mod/VibeCAD/vibecad_tests/test_section_view.py -q
```

Result: **14 passed**.

Live GUI test (VibeCAD 3.11, `TestVibeCADSectionViewCommand`): enables a clip with no `SoClipPlaneManip`, shows Front/Top/Right + Offset + Flip, switching to Top updates the live cut, toggling the ribbon command off removes the clip and closes the dialog. **1 passed**.

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible (`set_section_view`, `toggle_section_view`, `is_section_view_active`).
- [x] No preference keys, tool names, or schema fields renamed/removed without approval.
- [x] Ribbon placement is unchanged (Fit All, Isometric, Grid, Section View).
- [x] No deprecations.
- [x] No breaking changes.

## Risk and non-goals

This is still a viewport clip, not a boolean feature and not a saved Fusion Analysis folder item. Cut faces are not hatched the way Fusion/SolidWorks cap section faces; the overlay marks the plane. A rebuild is required for the C++ tooltip; the Python editor is what changes the behavior.
