### PR TITLE
Add integrated PrusaSlicer, Bambu Studio, and OrcaSlicer handoff

### DIFF
--- a/src/Gui/VibeCADRibbon.cpp
+++ b/src/Gui/VibeCADRibbon.cpp
@@ -77,7 +77,7 @@ struct DomainDefinition
     const char* surface;
 };
 
-constexpr std::array<DomainDefinition, 8> domains = {{
+constexpr std::array<DomainDefinition, 9> domains = {{
     {"Model", "PartDesignWorkbench", "model"},
     {"Assemble", "AssemblyWorkbench", "assemble"},
     {"Mesh", "MeshWorkbench", "mesh"},
@@ -86,6 +86,7 @@ constexpr std::array<DomainDefinition, 8> domains = {{
     {"Drawing", "TechDrawWorkbench", "drawing"},
     {"Parameters", "SpreadsheetWorkbench", "parameters"},
     {"Aero", "VibeCADAeroWorkbench", "aero"},
+    {"3D Print", "VibeCADPrintWorkbench", "print"},
 }};
 
 constexpr auto chromePreferencesPath = "User parameter:BaseApp/Preferences/VibeCAD/Chrome";

--- a/src/Mod/CMakeLists.txt
+++ b/src/Mod/CMakeLists.txt
@@ -167,6 +167,7 @@ endif(BUILD_TECHDRAW)
 
 add_subdirectory(VibeCAD)
 add_subdirectory(VibeCADAero)
+add_subdirectory(VibeCADPrint)
 add_subdirectory(McMasterInsert)
 
 #add_subdirectory(TemplatePyMod)

--- a/src/Mod/VibeCAD/vibecad_tests/qt_ribbon_theme_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/qt_ribbon_theme_integration.py
@@ -1339,6 +1339,7 @@ def _run():
             "Drawing",
             "Parameters",
             "Aero",
+            "3D Print",
         ]
         actual_tabs = [tabs.tabText(index) for index in range(tabs.count())]
         assert actual_tabs == expected_tabs, {
@@ -1625,6 +1626,7 @@ def _run():
                 "TechDrawWorkbench": "drawing",
                 "SpreadsheetWorkbench": "parameters",
                 "VibeCADAeroWorkbench": "aero",
+                "VibeCADPrintWorkbench": "print",
             }[workbench]
             _assert_ribbon_surface(
                 ribbon_controller,
@@ -1671,7 +1673,31 @@ def _run():
             assert page_overflow.isVisible() == bool(hidden_page_groups)
             if page_overflow.isVisible():
                 _assert_visible_inside(page_overflow, page)
-            if workbench == "VibeCADAeroWorkbench":
+            if workbench == "VibeCADPrintWorkbench":
+                print_group_labels = _page_group_labels(page)
+                assert print_group_labels == [
+                    "VIEW",
+                    "SEND",
+                    "SETUP",
+                    "INSPECT",
+                ], print_group_labels
+                send_group = main_window.findChild(
+                    QtWidgets.QFrame, "VibeCADRibbonGroup_Send"
+                )
+                setup_group = main_window.findChild(
+                    QtWidgets.QFrame, "VibeCADRibbonGroup_Setup"
+                )
+                assert send_group is not None
+                assert setup_group is not None
+                assert _group_commands(send_group) == {
+                    "VibeCADPrint_OpenInPrusaSlicer",
+                    "VibeCADPrint_Save3MF",
+                }
+                assert _group_commands(setup_group) == {
+                    "VibeCADPrint_Setup",
+                }
+                del print_group_labels, send_group, setup_group
+            elif workbench == "VibeCADAeroWorkbench":
                 aero_group_labels = _page_group_labels(page)
                 assert aero_group_labels == [
                     "VIEW",

--- a/src/Mod/VibeCADPrint/BambuStudio.py
+++ b/src/Mod/VibeCADPrint/BambuStudio.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import json
 import ntpath
 import os
@@ -14,6 +14,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 from typing import Any, Callable, Iterable, Mapping, Sequence
 from uuid import uuid4
 import xml.etree.ElementTree as ET
@@ -64,14 +65,40 @@ class _ProfileRecord:
 @dataclass(frozen=True)
 class _ProfileStore:
     records: tuple[_ProfileRecord, ...]
+    _by_type: Mapping[str, tuple[_ProfileRecord, ...]] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+    _by_type_name: Mapping[tuple[str, str], tuple[_ProfileRecord, ...]] = field(
+        init=False,
+        repr=False,
+        compare=False,
+    )
+
+    def __post_init__(self) -> None:
+        by_type: dict[str, list[_ProfileRecord]] = {}
+        by_type_name: dict[tuple[str, str], list[_ProfileRecord]] = {}
+        for record in self.records:
+            by_type.setdefault(record.profile_type, []).append(record)
+            by_type_name.setdefault((record.profile_type, record.name), []).append(
+                record
+            )
+        object.__setattr__(
+            self,
+            "_by_type",
+            {key: tuple(values) for key, values in by_type.items()},
+        )
+        object.__setattr__(
+            self,
+            "_by_type_name",
+            {key: tuple(values) for key, values in by_type_name.items()},
+        )
 
     def records_for(self, profile_type: str, name: str = "") -> tuple[_ProfileRecord, ...]:
-        return tuple(
-            record
-            for record in self.records
-            if record.profile_type == profile_type
-            and (not name or record.name == name)
-        )
+        if name:
+            return self._by_type_name.get((profile_type, name), ())
+        return self._by_type.get(profile_type, ())
 
 
 def _truthy(value: Any) -> bool:
@@ -170,6 +197,7 @@ def _resolve_record(
     record: _ProfileRecord,
     *,
     stack: tuple[tuple[str, str, str], ...] = (),
+    cache: dict[tuple[str, str, str, str, bool], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     key = (record.profile_type, record.vendor, record.name)
     if key in stack:
@@ -177,6 +205,12 @@ def _resolve_record(
         raise VibeCADPrint.SlicerQueryError(
             f"Bambu Studio profile inheritance contains a cycle: {chain}."
         )
+    if cache is None:
+        cache = {}
+    cache_key = (*key, str(record.path), record.is_user)
+    cached = cache.get(cache_key)
+    if cached is not None:
+        return dict(cached)
     resolved: dict[str, Any] = {}
     for relation in ("inherits", "include"):
         for name in _references(record.data.get(relation)):
@@ -186,10 +220,18 @@ def _resolve_record(
                 name,
                 vendor=record.vendor,
             )
-            resolved.update(_resolve_record(store, parent, stack=(*stack, key)))
+            resolved.update(
+                _resolve_record(
+                    store,
+                    parent,
+                    stack=(*stack, key),
+                    cache=cache,
+                )
+            )
     resolved.update(record.data)
     resolved.pop("inherits", None)
     resolved.pop("include", None)
+    cache[cache_key] = dict(resolved)
     return resolved
 
 
@@ -216,8 +258,9 @@ def _instantiated_profiles(
             current = selected.get(record.name)
             if current is None or (record.is_user and not current.is_user):
                 selected[record.name] = record
+    cache: dict[tuple[str, str, str, str, bool], dict[str, Any]] = {}
     return tuple(
-        (record, _resolve_record(store, record))
+        (record, _resolve_record(store, record, cache=cache))
         for _name, record in sorted(selected.items(), key=lambda item: item[0].casefold())
     )
 
@@ -253,12 +296,11 @@ def _bed_info(profile: Mapping[str, Any]) -> VibeCADPrint.BedInfo:
     )
 
 
-def query_printer_profiles(
-    installation: VibeCADPrint.SlicerInstallation,
+def _printer_profiles_from_instantiated(
+    profiles: tuple[tuple[_ProfileRecord, dict[str, Any]], ...],
 ) -> tuple[VibeCADPrint.PrinterProfile, ...]:
-    store = _load_profile_store(installation)
     printers: list[VibeCADPrint.PrinterProfile] = []
-    for record, profile in _instantiated_profiles(store, "machine"):
+    for record, profile in profiles:
         diameters = profile.get("nozzle_diameter", ())
         extruders = (
             len(diameters)
@@ -283,6 +325,15 @@ def query_printer_profiles(
     return tuple(printers)
 
 
+def query_printer_profiles(
+    installation: VibeCADPrint.SlicerInstallation,
+) -> tuple[VibeCADPrint.PrinterProfile, ...]:
+    store = _load_profile_store(installation)
+    return _printer_profiles_from_instantiated(
+        _instantiated_profiles(store, "machine")
+    )
+
+
 def _is_compatible(profile: Mapping[str, Any], printer_name: str) -> bool:
     compatible = profile.get("compatible_printers", ())
     if not isinstance(compatible, Sequence) or isinstance(compatible, (str, bytes)):
@@ -290,11 +341,12 @@ def _is_compatible(profile: Mapping[str, Any], printer_name: str) -> bool:
     return printer_name in {str(value) for value in compatible}
 
 
-def query_compatible_profiles(
-    installation: VibeCADPrint.SlicerInstallation,
+def _compatible_profile_catalog(
+    store: _ProfileStore,
     printer_name: str,
+    materials_data: tuple[tuple[_ProfileRecord, dict[str, Any]], ...],
+    processes_data: tuple[tuple[_ProfileRecord, dict[str, Any]], ...],
 ) -> VibeCADPrint.ProfileCatalog:
-    store = _load_profile_store(installation)
     printer = _select_record(store, "machine", printer_name)
     if not _truthy(printer.data.get("instantiation")):
         raise VibeCADPrint.SlicerQueryError(
@@ -302,7 +354,7 @@ def query_compatible_profiles(
         )
     materials = tuple(
         VibeCADPrint.MaterialProfile(name=record.name, is_user=record.is_user)
-        for record, profile in _instantiated_profiles(store, "filament")
+        for record, profile in materials_data
         if _is_compatible(profile, printer_name)
     )
     profiles = tuple(
@@ -311,12 +363,25 @@ def query_compatible_profiles(
             materials=materials,
             is_user=record.is_user,
         )
-        for record, profile in _instantiated_profiles(store, "process")
+        for record, profile in processes_data
         if _is_compatible(profile, printer_name)
     )
     return VibeCADPrint.ProfileCatalog(
         printer_profile=printer_name,
         print_profiles=profiles,
+    )
+
+
+def query_compatible_profiles(
+    installation: VibeCADPrint.SlicerInstallation,
+    printer_name: str,
+) -> VibeCADPrint.ProfileCatalog:
+    store = _load_profile_store(installation)
+    return _compatible_profile_catalog(
+        store,
+        printer_name,
+        _instantiated_profiles(store, "filament"),
+        _instantiated_profiles(store, "process"),
     )
 
 
@@ -522,13 +587,17 @@ def discover_bambu_installations(
         if gui is None or cli is None or gui in seen:
             continue
         try:
-            completed = runner(
-                [*cli, "--help"],
-                capture_output=True,
-                text=True,
-                timeout=15.0,
-                check=False,
-            )
+            with tempfile.TemporaryDirectory(
+                prefix="vibecad-slicer-probe-"
+            ) as working_directory:
+                completed = runner(
+                    [*cli, "--help"],
+                    capture_output=True,
+                    text=True,
+                    timeout=15.0,
+                    check=False,
+                    cwd=working_directory,
+                )
         except (OSError, subprocess.SubprocessError):
             continue
         output = "\n".join(
@@ -688,13 +757,18 @@ def prepare_bambu_project(
             profile_paths[1],
             profile_paths[2:],
         )
-        completed = runner(
-            list(command),
-            capture_output=True,
-            text=True,
-            timeout=timeout,
-            check=False,
-        )
+        with tempfile.TemporaryDirectory(
+            prefix=".vibecad-slicer-",
+            dir=target.parent,
+        ) as working_directory:
+            completed = runner(
+                list(command),
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                check=False,
+                cwd=working_directory,
+            )
         if completed.returncode != 0 or not partial.is_file():
             details = " ".join(
                 value.strip()
@@ -756,22 +830,94 @@ class BambuStudioBackend:
     display_name = "Bambu Studio"
     capabilities = BAMBU_CAPABILITIES
 
+    def __init__(self) -> None:
+        self._installation_cache: dict[
+            str, tuple[VibeCADPrint.SlicerInstallation, ...]
+        ] = {}
+        self._store_cache: dict[
+            VibeCADPrint.SlicerInstallation, _ProfileStore
+        ] = {}
+        self._resolved_cache: dict[
+            tuple[VibeCADPrint.SlicerInstallation, str],
+            tuple[tuple[_ProfileRecord, dict[str, Any]], ...],
+        ] = {}
+        self._printer_cache: dict[
+            VibeCADPrint.SlicerInstallation,
+            tuple[VibeCADPrint.PrinterProfile, ...],
+        ] = {}
+        self._catalog_cache: dict[
+            tuple[VibeCADPrint.SlicerInstallation, str],
+            VibeCADPrint.ProfileCatalog,
+        ] = {}
+
+    def invalidate_cache(self) -> None:
+        """Forget all slicer data so an explicit Refresh rereads disk and CLI state."""
+
+        self._installation_cache.clear()
+        self._store_cache.clear()
+        self._resolved_cache.clear()
+        self._printer_cache.clear()
+        self._catalog_cache.clear()
+
+    def _store(
+        self,
+        installation: VibeCADPrint.SlicerInstallation,
+    ) -> _ProfileStore:
+        value = self._store_cache.get(installation)
+        if value is None:
+            value = _load_profile_store(installation)
+            self._store_cache[installation] = value
+        return value
+
+    def _resolved(
+        self,
+        installation: VibeCADPrint.SlicerInstallation,
+        profile_type: str,
+    ) -> tuple[tuple[_ProfileRecord, dict[str, Any]], ...]:
+        key = (installation, profile_type)
+        value = self._resolved_cache.get(key)
+        if value is None:
+            value = _instantiated_profiles(self._store(installation), profile_type)
+            self._resolved_cache[key] = value
+        return value
+
     def discover(
         self, explicit_executable: str = ""
     ) -> tuple[VibeCADPrint.SlicerInstallation, ...]:
-        return discover_bambu_installations(explicit_executable)
+        key = str(explicit_executable or "").strip()
+        value = self._installation_cache.get(key)
+        if value is None:
+            value = discover_bambu_installations(key)
+            self._installation_cache[key] = value
+        return value
 
     def query_printers(
         self, installation: VibeCADPrint.SlicerInstallation
     ) -> tuple[VibeCADPrint.PrinterProfile, ...]:
-        return query_printer_profiles(installation)
+        value = self._printer_cache.get(installation)
+        if value is None:
+            value = _printer_profiles_from_instantiated(
+                self._resolved(installation, "machine")
+            )
+            self._printer_cache[installation] = value
+        return value
 
     def query_profiles(
         self,
         installation: VibeCADPrint.SlicerInstallation,
         printer_profile: str,
     ) -> VibeCADPrint.ProfileCatalog:
-        return query_compatible_profiles(installation, printer_profile)
+        key = (installation, printer_profile)
+        value = self._catalog_cache.get(key)
+        if value is None:
+            value = _compatible_profile_catalog(
+                self._store(installation),
+                printer_profile,
+                self._resolved(installation, "filament"),
+                self._resolved(installation, "process"),
+            )
+            self._catalog_cache[key] = value
+        return value
 
     def prepare_project(
         self,

--- a/src/Mod/VibeCADPrint/BambuStudio.py
+++ b/src/Mod/VibeCADPrint/BambuStudio.py
@@ -40,6 +40,9 @@ _BAMBU_VERSION_RE = re.compile(
 _POINT_RE = re.compile(r"^\s*(-?(?:\d+(?:\.\d*)?|\.\d+))x"
                        r"(-?(?:\d+(?:\.\d*)?|\.\d+))\s*$")
 _PROFILE_TYPES = {"machine", "process", "filament"}
+_PLAIN_VERSION_RE = re.compile(
+    r"(?<!\d)(\d+)\.(\d+)(?:\.(\d+))?(?:\.(\d+))?"
+)
 
 
 @dataclass(frozen=True)
@@ -99,6 +102,121 @@ class _ProfileStore:
         if name:
             return self._by_type_name.get((profile_type, name), ())
         return self._by_type.get(profile_type, ())
+
+
+def _normalized_version(value: str) -> str:
+    match = _PLAIN_VERSION_RE.search(str(value or ""))
+    if match is None:
+        return ""
+    parts = [str(int(part or 0)) for part in match.groups()]
+    return ".".join(parts[:3] + ([parts[3]] if match.group(4) else []))
+
+
+def _windows_file_version(executable: str) -> str:
+    try:
+        import ctypes
+        from ctypes import wintypes
+
+        class VS_FIXEDFILEINFO(ctypes.Structure):
+            _fields_ = [
+                ("dwSignature", wintypes.DWORD),
+                ("dwStrucVersion", wintypes.DWORD),
+                ("dwFileVersionMS", wintypes.DWORD),
+                ("dwFileVersionLS", wintypes.DWORD),
+                ("dwProductVersionMS", wintypes.DWORD),
+                ("dwProductVersionLS", wintypes.DWORD),
+                ("dwFileFlagsMask", wintypes.DWORD),
+                ("dwFileFlags", wintypes.DWORD),
+                ("dwFileOS", wintypes.DWORD),
+                ("dwFileType", wintypes.DWORD),
+                ("dwFileSubtype", wintypes.DWORD),
+                ("dwFileDateMS", wintypes.DWORD),
+                ("dwFileDateLS", wintypes.DWORD),
+            ]
+
+        api = ctypes.windll.version
+        ignored = wintypes.DWORD()
+        size = api.GetFileVersionInfoSizeW(str(executable), ctypes.byref(ignored))
+        if not size:
+            return ""
+        buffer = ctypes.create_string_buffer(size)
+        if not api.GetFileVersionInfoW(str(executable), 0, size, buffer):
+            return ""
+        pointer = ctypes.c_void_p()
+        length = wintypes.UINT()
+        if not api.VerQueryValueW(
+            buffer,
+            "\\",
+            ctypes.byref(pointer),
+            ctypes.byref(length),
+        ):
+            return ""
+        info = ctypes.cast(pointer, ctypes.POINTER(VS_FIXEDFILEINFO)).contents
+        if info.dwSignature != 0xFEEF04BD:
+            return ""
+        return ".".join(
+            str(part)
+            for part in (
+                info.dwFileVersionMS >> 16,
+                info.dwFileVersionMS & 0xFFFF,
+                info.dwFileVersionLS >> 16,
+                info.dwFileVersionLS & 0xFFFF,
+            )
+        )
+    except (AttributeError, ImportError, OSError, TypeError, ValueError):
+        return ""
+
+
+def _windows_registry_versions(product_name: str) -> tuple[str, ...]:
+    try:
+        import winreg
+    except ImportError:
+        return ()
+
+    expected = str(product_name or "").strip().casefold()
+    if not expected:
+        return ()
+    versions: list[str] = []
+    uninstall = r"Software\Microsoft\Windows\CurrentVersion\Uninstall"
+    for root in (winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE):
+        for view in (winreg.KEY_WOW64_64KEY, winreg.KEY_WOW64_32KEY):
+            try:
+                key = winreg.OpenKey(root, uninstall, 0, winreg.KEY_READ | view)
+            except OSError:
+                continue
+            with key:
+                for index in range(winreg.QueryInfoKey(key)[0]):
+                    try:
+                        name = winreg.EnumKey(key, index)
+                        with winreg.OpenKey(key, name) as product:
+                            display_name = str(
+                                winreg.QueryValueEx(product, "DisplayName")[0]
+                            ).strip()
+                            if display_name.casefold() != expected:
+                                continue
+                            versions.append(
+                                str(
+                                    winreg.QueryValueEx(product, "DisplayVersion")[0]
+                                ).strip()
+                            )
+                    except OSError:
+                        continue
+    return tuple(versions)
+
+
+def windows_installed_version(executable: str, product_name: str) -> str:
+    """Read a Windows GUI slicer's version without relying on console output."""
+
+    candidates = (
+        _windows_file_version(executable),
+        *_windows_registry_versions(product_name),
+    )
+    normalized = tuple(
+        value
+        for value in (_normalized_version(candidate) for candidate in candidates)
+        if VibeCADPrint.version_key(value) != (0, 0, 0)
+    )
+    return max(normalized, key=VibeCADPrint.version_key, default="")
 
 
 def _truthy(value: Any) -> bool:
@@ -570,6 +688,7 @@ def discover_bambu_installations(
     environ: Mapping[str, str] | None = None,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     which: Callable[[str], str | None] = shutil.which,
+    windows_version_reader: Callable[[str, str], str] = windows_installed_version,
 ) -> tuple[VibeCADPrint.SlicerInstallation, ...]:
     """Discover current native and Flatpak Bambu Studio installations."""
 
@@ -604,10 +723,19 @@ def discover_bambu_installations(
             str(value or "") for value in (completed.stdout, completed.stderr)
         )
         match = _BAMBU_VERSION_RE.search(output)
-        if match is None:
+        if match is not None:
+            pieces = [str(int(value or 0)) for value in match.groups()]
+            version = ".".join(
+                pieces[:3] + ([pieces[3]] if match.group(4) else [])
+            )
+        elif platform == "win32" and completed.returncode == 0:
+            version = _normalized_version(
+                windows_version_reader(gui[0], candidate.display_name)
+            )
+        else:
+            version = ""
+        if not version:
             continue
-        pieces = [str(int(value or 0)) for value in match.groups()]
-        version = ".".join(pieces[:3] + ([pieces[3]] if match.group(4) else []))
         resource_dir = candidate.resource_dir or _flatpak_resource_dir(
             candidate.source,
             runner=runner,
@@ -814,13 +942,15 @@ def launch_bambu_studio(
     handoff_file: str | os.PathLike[str],
     *,
     popen: Callable[..., subprocess.Popen[Any]] = subprocess.Popen,
+    platform: str | None = None,
 ) -> VibeCADPrint.LaunchResult:
-    command = (*installation.gui_command, str(Path(handoff_file)))
-    try:
-        process = popen(list(command), close_fds=(os.name != "nt"))
-    except OSError as exc:
-        raise VibeCADPrint.SlicerError(f"Could not start Bambu Studio: {exc}") from exc
-    return VibeCADPrint.LaunchResult(command=command, process_id=process.pid)
+    return VibeCADPrint.launch_slicer_gui(
+        installation,
+        handoff_file,
+        slicer_name="Bambu Studio",
+        popen=popen,
+        platform=platform,
+    )
 
 
 class BambuStudioBackend:

--- a/src/Mod/VibeCADPrint/BambuStudio.py
+++ b/src/Mod/VibeCADPrint/BambuStudio.py
@@ -1,0 +1,796 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Bambu Studio discovery, exact profile resolution, project prep, and launch."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+import json
+import ntpath
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+from typing import Any, Callable, Iterable, Mapping, Sequence
+from uuid import uuid4
+import xml.etree.ElementTree as ET
+import zipfile
+
+import VibeCADPrint
+
+
+BAMBU_APP_ID = "com.bambulab.BambuStudio"
+TESTED_BAMBU_VERSION = (2, 8, 2)
+BAMBU_CAPABILITIES = (
+    "gui_handoff",
+    "profile_store",
+    "project_export",
+    "auto_arrange",
+    "ensure_on_bed",
+)
+
+_BAMBU_VERSION_RE = re.compile(
+    r"BambuStudio[- ]0*(\d+)\.0*(\d+)\.0*(\d+)(?:\.0*(\d+))?",
+    re.IGNORECASE,
+)
+_POINT_RE = re.compile(r"^\s*(-?(?:\d+(?:\.\d*)?|\.\d+))x"
+                       r"(-?(?:\d+(?:\.\d*)?|\.\d+))\s*$")
+_PROFILE_TYPES = {"machine", "process", "filament"}
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    gui_command: tuple[str, ...]
+    cli_command: tuple[str, ...]
+    source: str
+    display_name: str = "Bambu Studio"
+    config_dir: str = ""
+    resource_dir: str = ""
+
+
+@dataclass(frozen=True)
+class _ProfileRecord:
+    profile_type: str
+    name: str
+    vendor: str
+    path: Path
+    data: Mapping[str, Any]
+    is_user: bool
+
+
+@dataclass(frozen=True)
+class _ProfileStore:
+    records: tuple[_ProfileRecord, ...]
+
+    def records_for(self, profile_type: str, name: str = "") -> tuple[_ProfileRecord, ...]:
+        return tuple(
+            record
+            for record in self.records
+            if record.profile_type == profile_type
+            and (not name or record.name == name)
+        )
+
+
+def _truthy(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    return str(value or "").strip().lower() in {"1", "true", "yes"}
+
+
+def _references(value: Any) -> tuple[str, ...]:
+    if isinstance(value, str):
+        return (value,) if value else ()
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        return tuple(str(item) for item in value if str(item or "").strip())
+    return ()
+
+
+def _profile_roots(installation: VibeCADPrint.SlicerInstallation) -> tuple[tuple[Path, bool], ...]:
+    roots: list[tuple[Path, bool]] = []
+    if installation.resource_dir:
+        resource = Path(installation.resource_dir)
+        if resource.is_dir():
+            roots.append((resource, False))
+    if installation.config_dir:
+        config = Path(installation.config_dir)
+        if config.is_dir():
+            roots.append((config, True))
+    return tuple(roots)
+
+
+def _load_profile_store(installation: VibeCADPrint.SlicerInstallation) -> _ProfileStore:
+    records: list[_ProfileRecord] = []
+    for root, is_user in _profile_roots(installation):
+        for path in sorted(root.rglob("*.json")):
+            try:
+                value = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if not isinstance(value, Mapping):
+                continue
+            try:
+                relative = path.relative_to(root)
+            except ValueError:
+                relative = Path(path.name)
+            profile_type = str(value.get("type", "") or "").strip()
+            if profile_type not in _PROFILE_TYPES:
+                profile_type = next(
+                    (
+                        part
+                        for part in reversed(relative.parts[:-1])
+                        if part in _PROFILE_TYPES
+                    ),
+                    "",
+                )
+            name = str(value.get("name", "") or "").strip()
+            if profile_type not in _PROFILE_TYPES or not name:
+                continue
+            vendor = relative.parts[0] if len(relative.parts) > 2 else "user"
+            records.append(
+                _ProfileRecord(
+                    profile_type=profile_type,
+                    name=name,
+                    vendor=vendor,
+                    path=path,
+                    data=value,
+                    is_user=is_user,
+                )
+            )
+    if not records:
+        raise VibeCADPrint.SlicerQueryError(
+            "Bambu Studio's machine, process, and filament profile store was not found."
+        )
+    return _ProfileStore(tuple(records))
+
+
+def _select_record(
+    store: _ProfileStore,
+    profile_type: str,
+    name: str,
+    *,
+    vendor: str = "",
+) -> _ProfileRecord:
+    candidates = store.records_for(profile_type, name)
+    if vendor:
+        matching_vendor = tuple(record for record in candidates if record.vendor == vendor)
+        if matching_vendor:
+            candidates = matching_vendor
+    if not candidates:
+        raise VibeCADPrint.SlicerQueryError(
+            f"Bambu Studio profile '{name}' ({profile_type}) is not available."
+        )
+    return max(candidates, key=lambda record: (record.is_user, str(record.path)))
+
+
+def _resolve_record(
+    store: _ProfileStore,
+    record: _ProfileRecord,
+    *,
+    stack: tuple[tuple[str, str, str], ...] = (),
+) -> dict[str, Any]:
+    key = (record.profile_type, record.vendor, record.name)
+    if key in stack:
+        chain = " -> ".join(item[2] for item in (*stack, key))
+        raise VibeCADPrint.SlicerQueryError(
+            f"Bambu Studio profile inheritance contains a cycle: {chain}."
+        )
+    resolved: dict[str, Any] = {}
+    for relation in ("inherits", "include"):
+        for name in _references(record.data.get(relation)):
+            parent = _select_record(
+                store,
+                record.profile_type,
+                name,
+                vendor=record.vendor,
+            )
+            resolved.update(_resolve_record(store, parent, stack=(*stack, key)))
+    resolved.update(record.data)
+    resolved.pop("inherits", None)
+    resolved.pop("include", None)
+    return resolved
+
+
+def resolved_profile(
+    installation: VibeCADPrint.SlicerInstallation,
+    profile_type: str,
+    name: str,
+) -> dict[str, Any]:
+    """Return the engine profile with inheritance/includes fully materialized."""
+
+    if profile_type not in _PROFILE_TYPES:
+        raise ValueError(f"Unsupported Bambu Studio profile type: {profile_type}")
+    store = _load_profile_store(installation)
+    return _resolve_record(store, _select_record(store, profile_type, name))
+
+
+def _instantiated_profiles(
+    store: _ProfileStore,
+    profile_type: str,
+) -> tuple[tuple[_ProfileRecord, dict[str, Any]], ...]:
+    selected: dict[str, _ProfileRecord] = {}
+    for record in store.records_for(profile_type):
+        if _truthy(record.data.get("instantiation")):
+            current = selected.get(record.name)
+            if current is None or (record.is_user and not current.is_user):
+                selected[record.name] = record
+    return tuple(
+        (record, _resolve_record(store, record))
+        for _name, record in sorted(selected.items(), key=lambda item: item[0].casefold())
+    )
+
+
+def _float(value: Any) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _bed_info(profile: Mapping[str, Any]) -> VibeCADPrint.BedInfo:
+    points: list[tuple[float, float]] = []
+    raw_points = profile.get("printable_area", ())
+    if isinstance(raw_points, Sequence) and not isinstance(raw_points, (str, bytes)):
+        for raw in raw_points:
+            match = _POINT_RE.match(str(raw or ""))
+            if match:
+                points.append((_float(match.group(1)), _float(match.group(2))))
+    if not points:
+        return VibeCADPrint.BedInfo(
+            kind="Polygon",
+            max_print_height=_float(profile.get("printable_height")),
+        )
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    return VibeCADPrint.BedInfo(
+        kind="Polygon",
+        width=max(xs) - min(xs),
+        height=max(ys) - min(ys),
+        origin=(min(xs), min(ys)),
+        max_print_height=_float(profile.get("printable_height")),
+    )
+
+
+def query_printer_profiles(
+    installation: VibeCADPrint.SlicerInstallation,
+) -> tuple[VibeCADPrint.PrinterProfile, ...]:
+    store = _load_profile_store(installation)
+    printers: list[VibeCADPrint.PrinterProfile] = []
+    for record, profile in _instantiated_profiles(store, "machine"):
+        diameters = profile.get("nozzle_diameter", ())
+        extruders = (
+            len(diameters)
+            if isinstance(diameters, Sequence)
+            and not isinstance(diameters, (str, bytes))
+            else 1
+        )
+        printers.append(
+            VibeCADPrint.PrinterProfile(
+                name=record.name,
+                model_id=str(profile.get("printer_model", "") or ""),
+                model_name=str(profile.get("printer_model", "") or record.name),
+                variant_name=str(profile.get("printer_variant", "") or ""),
+                vendor_id=record.vendor,
+                vendor_name=record.vendor,
+                technology="FFF",
+                extruders=max(1, extruders),
+                bed=_bed_info(profile),
+                is_user=record.is_user,
+            )
+        )
+    return tuple(printers)
+
+
+def _is_compatible(profile: Mapping[str, Any], printer_name: str) -> bool:
+    compatible = profile.get("compatible_printers", ())
+    if not isinstance(compatible, Sequence) or isinstance(compatible, (str, bytes)):
+        return False
+    return printer_name in {str(value) for value in compatible}
+
+
+def query_compatible_profiles(
+    installation: VibeCADPrint.SlicerInstallation,
+    printer_name: str,
+) -> VibeCADPrint.ProfileCatalog:
+    store = _load_profile_store(installation)
+    printer = _select_record(store, "machine", printer_name)
+    if not _truthy(printer.data.get("instantiation")):
+        raise VibeCADPrint.SlicerQueryError(
+            f"Bambu Studio printer profile '{printer_name}' is not selectable."
+        )
+    materials = tuple(
+        VibeCADPrint.MaterialProfile(name=record.name, is_user=record.is_user)
+        for record, profile in _instantiated_profiles(store, "filament")
+        if _is_compatible(profile, printer_name)
+    )
+    profiles = tuple(
+        VibeCADPrint.PrintProfile(
+            name=record.name,
+            materials=materials,
+            is_user=record.is_user,
+        )
+        for record, profile in _instantiated_profiles(store, "process")
+        if _is_compatible(profile, printer_name)
+    )
+    return VibeCADPrint.ProfileCatalog(
+        printer_profile=printer_name,
+        print_profiles=profiles,
+    )
+
+
+def _default_config_dir(
+    platform: str,
+    environ: Mapping[str, str],
+    *,
+    flatpak: bool = False,
+) -> str:
+    home = environ.get("HOME", "")
+    if flatpak:
+        return (
+            str(Path(home) / ".var/app" / BAMBU_APP_ID / "config/BambuStudio")
+            if home
+            else ""
+        )
+    if platform == "win32":
+        base = environ.get("APPDATA", "")
+        return ntpath.join(base, "BambuStudio") if base else ""
+    if platform == "darwin":
+        return (
+            str(Path(home) / "Library/Application Support/BambuStudio")
+            if home
+            else ""
+        )
+    base = environ.get("XDG_CONFIG_HOME", "")
+    return str(Path(base or (Path(home) / ".config")) / "BambuStudio") if base or home else ""
+
+
+def _native_resource_dir(executable: str, platform: str) -> str:
+    path = Path(executable)
+    candidates: list[Path]
+    if platform == "darwin":
+        candidates = [path.parent.parent / "Resources/profiles"]
+    elif platform == "win32":
+        candidates = [path.parent / "resources/profiles", path.parent / "profiles"]
+    else:
+        candidates = [
+            path.parent.parent / "share/BambuStudio/profiles",
+            path.parent / "resources/profiles",
+        ]
+    return str(next((candidate for candidate in candidates if candidate.is_dir()), ""))
+
+
+def _candidate_specs(
+    explicit_executable: str,
+    *,
+    platform: str,
+    environ: Mapping[str, str],
+) -> tuple[_Candidate, ...]:
+    values: list[_Candidate] = []
+    explicit = str(explicit_executable or "").strip()
+    if explicit:
+        if platform == "darwin" and explicit.endswith(".app"):
+            explicit = str(Path(explicit) / "Contents/MacOS/BambuStudio")
+        values.append(
+            _Candidate(
+                (explicit,),
+                (explicit,),
+                "explicit",
+                config_dir=_default_config_dir(platform, environ),
+            )
+        )
+    if platform == "win32":
+        roots = [
+            environ.get("ProgramFiles", r"C:\Program Files"),
+            environ.get("LOCALAPPDATA", ""),
+        ]
+        for root in (value for value in roots if value):
+            executable = ntpath.join(root, "Bambu Studio", "bambu-studio.exe")
+            values.append(
+                _Candidate(
+                    (executable,),
+                    (executable,),
+                    "standard",
+                    config_dir=_default_config_dir(platform, environ),
+                )
+            )
+        values.append(
+            _Candidate(
+                ("bambu-studio.exe",),
+                ("bambu-studio.exe",),
+                "path",
+                config_dir=_default_config_dir(platform, environ),
+            )
+        )
+    elif platform == "darwin":
+        executable = "/Applications/BambuStudio.app/Contents/MacOS/BambuStudio"
+        values.extend(
+            (
+                _Candidate(
+                    (executable,),
+                    (executable,),
+                    "standard",
+                    config_dir=_default_config_dir(platform, environ),
+                ),
+                _Candidate(
+                    ("bambu-studio",),
+                    ("bambu-studio",),
+                    "path",
+                    config_dir=_default_config_dir(platform, environ),
+                ),
+            )
+        )
+    else:
+        values.extend(
+            (
+                _Candidate(
+                    ("bambu-studio",),
+                    ("bambu-studio",),
+                    "path",
+                    config_dir=_default_config_dir(platform, environ),
+                ),
+                _Candidate(
+                    ("flatpak", "--user", "run", BAMBU_APP_ID),
+                    (
+                        "flatpak",
+                        "--user",
+                        "run",
+                        "--command=/app/bin/bambu-studio",
+                        BAMBU_APP_ID,
+                    ),
+                    "flatpak-user",
+                    "Bambu Studio (Flatpak)",
+                    _default_config_dir(platform, environ, flatpak=True),
+                ),
+                _Candidate(
+                    ("flatpak", "--system", "run", BAMBU_APP_ID),
+                    (
+                        "flatpak",
+                        "--system",
+                        "run",
+                        "--command=/app/bin/bambu-studio",
+                        BAMBU_APP_ID,
+                    ),
+                    "flatpak-system",
+                    "Bambu Studio (Flatpak)",
+                    _default_config_dir(platform, environ, flatpak=True),
+                ),
+            )
+        )
+    return tuple(values)
+
+
+def _resolve_command(
+    command: tuple[str, ...], which: Callable[[str], str | None]
+) -> tuple[str, ...] | None:
+    if not command:
+        return None
+    program = command[0]
+    if os.path.isabs(program) or (len(program) > 2 and program[1:3] == ":\\"):
+        return command if Path(program).is_file() else None
+    resolved = which(program)
+    return (resolved, *command[1:]) if resolved else None
+
+
+def _flatpak_resource_dir(
+    source: str,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> str:
+    if not source.startswith("flatpak-"):
+        return ""
+    scope = source.removeprefix("flatpak-")
+    try:
+        completed = runner(
+            ["flatpak", "info", f"--{scope}", "--show-location", BAMBU_APP_ID],
+            capture_output=True,
+            text=True,
+            timeout=10.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    location = Path(str(completed.stdout or "").strip())
+    root = location / "files/share/BambuStudio/profiles"
+    return str(root) if root.is_dir() else ""
+
+
+def discover_bambu_installations(
+    explicit_executable: str = "",
+    *,
+    platform: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    which: Callable[[str], str | None] = shutil.which,
+) -> tuple[VibeCADPrint.SlicerInstallation, ...]:
+    """Discover current native and Flatpak Bambu Studio installations."""
+
+    platform = platform or sys.platform
+    env = dict(os.environ if environ is None else environ)
+    installations: list[VibeCADPrint.SlicerInstallation] = []
+    seen: set[tuple[str, ...]] = set()
+    for candidate in _candidate_specs(
+        explicit_executable,
+        platform=platform,
+        environ=env,
+    ):
+        gui = _resolve_command(candidate.gui_command, which)
+        cli = _resolve_command(candidate.cli_command, which)
+        if gui is None or cli is None or gui in seen:
+            continue
+        try:
+            completed = runner(
+                [*cli, "--help"],
+                capture_output=True,
+                text=True,
+                timeout=15.0,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        output = "\n".join(
+            str(value or "") for value in (completed.stdout, completed.stderr)
+        )
+        match = _BAMBU_VERSION_RE.search(output)
+        if match is None:
+            continue
+        pieces = [str(int(value or 0)) for value in match.groups()]
+        version = ".".join(pieces[:3] + ([pieces[3]] if match.group(4) else []))
+        resource_dir = candidate.resource_dir or _flatpak_resource_dir(
+            candidate.source,
+            runner=runner,
+        )
+        if not resource_dir:
+            resource_dir = _native_resource_dir(gui[0], platform)
+        seen.add(gui)
+        installations.append(
+            VibeCADPrint.SlicerInstallation(
+                backend_id="bambustudio",
+                version=version,
+                gui_command=tuple(gui),
+                cli_command=tuple(cli),
+                source=candidate.source,
+                display_name=f"{candidate.display_name} {version}",
+                config_dir=candidate.config_dir,
+                capabilities=BAMBU_CAPABILITIES,
+                resource_dir=resource_dir,
+                tested_version=TESTED_BAMBU_VERSION,
+            )
+        )
+    return tuple(installations)
+
+
+def build_prepare_project_command(
+    installation: VibeCADPrint.SlicerInstallation,
+    source_file: str | os.PathLike[str],
+    output_file: str | os.PathLike[str],
+    setup: VibeCADPrint.PrintSetup,
+    machine_profile: str | os.PathLike[str],
+    process_profile: str | os.PathLike[str],
+    material_profiles: Iterable[str | os.PathLike[str]],
+) -> tuple[str, ...]:
+    """Build Bambu Studio's shell-free, exact-profile project export command."""
+
+    command = [*installation.cli_command, "--debug", "2"]
+    command.extend(("--arrange", "1" if setup.auto_arrange else "0"))
+    if setup.ensure_on_bed:
+        command.append("--ensure-on-bed")
+    command.extend(
+        (
+            "--load-settings",
+            f"{Path(machine_profile)};{Path(process_profile)}",
+            "--load-filaments",
+            ";".join(str(Path(path)) for path in material_profiles),
+            "--export-3mf",
+            str(Path(output_file)),
+            str(Path(source_file)),
+        )
+    )
+    return tuple(command)
+
+
+def _source_object_names(path: Path) -> tuple[str, ...]:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            root = ET.fromstring(archive.read("3D/3dmodel.model"))
+    except (ET.ParseError, OSError, KeyError, zipfile.BadZipFile) as exc:
+        raise VibeCADPrint.SlicerError(
+            "Could not prepare the Bambu Studio project because the source 3MF "
+            "does not contain a valid object model."
+        ) from exc
+    objects = root.findall("./{*}resources/{*}object")
+    if not objects:
+        raise VibeCADPrint.SlicerError(
+            "Could not prepare the Bambu Studio project because the source 3MF "
+            "does not contain printable objects."
+        )
+    return tuple(str(obj.attrib.get("name", "") or "") for obj in objects)
+
+
+def _prepared_object_names(path: Path) -> tuple[str, ...]:
+    try:
+        with zipfile.ZipFile(path) as archive:
+            root = ET.fromstring(archive.read("Metadata/model_settings.config"))
+            json.loads(archive.read("Metadata/project_settings.config"))
+    except (
+        ET.ParseError,
+        OSError,
+        KeyError,
+        TypeError,
+        ValueError,
+        json.JSONDecodeError,
+        zipfile.BadZipFile,
+    ) as exc:
+        raise VibeCADPrint.SlicerError(
+            "Bambu Studio produced an invalid project 3MF without project metadata."
+        ) from exc
+    return tuple(
+        str(metadata.attrib.get("value", "") or "")
+        for metadata in root.findall('./{*}object/{*}metadata[@key="name"]')
+    )
+
+
+def prepare_bambu_project(
+    installation: VibeCADPrint.SlicerInstallation,
+    source_file: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    setup: VibeCADPrint.PrintSetup,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    timeout: float = 120.0,
+) -> Path:
+    """Atomically prepare a full-profile, named, multi-object Bambu 3MF."""
+
+    source = Path(source_file)
+    target = Path(destination)
+    source_names = _source_object_names(source)
+    backend = BambuStudioBackend()
+    printers = backend.query_printers(installation)
+    printer = next((item for item in printers if item.name == setup.printer_profile), None)
+    if printer is None:
+        raise VibeCADPrint.SlicerError(
+            f"Bambu Studio printer profile '{setup.printer_profile}' is not available."
+        )
+    catalog = backend.query_profiles(installation, printer.name)
+    errors = VibeCADPrint.validate_setup(setup, printer, catalog)
+    if errors:
+        raise VibeCADPrint.SlicerError("\n".join(errors))
+    resolved = (
+        ("machine", setup.printer_profile),
+        ("process", setup.print_profile),
+        *[("filament", name) for name in setup.material_profiles],
+    )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    token = uuid4().hex
+    profile_paths: list[Path] = []
+    partial = target.with_name(f"{target.stem}.{token}.partial.3mf")
+    try:
+        for index, (profile_type, name) in enumerate(resolved):
+            path = target.parent / f".{target.stem}.{token}.{index}.profile.json"
+            path.write_text(
+                json.dumps(
+                    resolved_profile(installation, profile_type, name),
+                    ensure_ascii=False,
+                    indent=2,
+                ),
+                encoding="utf-8",
+            )
+            profile_paths.append(path)
+        command = build_prepare_project_command(
+            installation,
+            source,
+            partial,
+            setup,
+            profile_paths[0],
+            profile_paths[1],
+            profile_paths[2:],
+        )
+        completed = runner(
+            list(command),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        if completed.returncode != 0 or not partial.is_file():
+            details = " ".join(
+                value.strip()
+                for value in (completed.stdout or "", completed.stderr or "")
+                if value.strip()
+            )
+            suffix = f" {details}" if details else ""
+            raise VibeCADPrint.SlicerError(
+                "Bambu Studio could not prepare the 3MF project "
+                f"(status {completed.returncode}).{suffix}"
+            )
+        prepared_names = _prepared_object_names(partial)
+        if len(prepared_names) != len(source_names):
+            raise VibeCADPrint.SlicerError(
+                "Bambu Studio changed the project object count from "
+                f"{len(source_names)} to {len(prepared_names)}; the original 3MF "
+                "was preserved."
+            )
+        if all(source_names) and Counter(prepared_names) != Counter(source_names):
+            raise VibeCADPrint.SlicerError(
+                "Bambu Studio changed the project object names; the original 3MF "
+                "was preserved."
+            )
+        os.replace(partial, target)
+    except VibeCADPrint.SlicerError:
+        raise
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise VibeCADPrint.SlicerError(
+            f"Could not prepare the Bambu Studio project: {exc}"
+        ) from exc
+    finally:
+        for path in (partial, *profile_paths):
+            if path.exists():
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+    return target
+
+
+def launch_bambu_studio(
+    installation: VibeCADPrint.SlicerInstallation,
+    handoff_file: str | os.PathLike[str],
+    *,
+    popen: Callable[..., subprocess.Popen[Any]] = subprocess.Popen,
+) -> VibeCADPrint.LaunchResult:
+    command = (*installation.gui_command, str(Path(handoff_file)))
+    try:
+        process = popen(list(command), close_fds=(os.name != "nt"))
+    except OSError as exc:
+        raise VibeCADPrint.SlicerError(f"Could not start Bambu Studio: {exc}") from exc
+    return VibeCADPrint.LaunchResult(command=command, process_id=process.pid)
+
+
+class BambuStudioBackend:
+    """Backend adapter consumed by the shared VibeCAD print workflow."""
+
+    backend_id = "bambustudio"
+    display_name = "Bambu Studio"
+    capabilities = BAMBU_CAPABILITIES
+
+    def discover(
+        self, explicit_executable: str = ""
+    ) -> tuple[VibeCADPrint.SlicerInstallation, ...]:
+        return discover_bambu_installations(explicit_executable)
+
+    def query_printers(
+        self, installation: VibeCADPrint.SlicerInstallation
+    ) -> tuple[VibeCADPrint.PrinterProfile, ...]:
+        return query_printer_profiles(installation)
+
+    def query_profiles(
+        self,
+        installation: VibeCADPrint.SlicerInstallation,
+        printer_profile: str,
+    ) -> VibeCADPrint.ProfileCatalog:
+        return query_compatible_profiles(installation, printer_profile)
+
+    def prepare_project(
+        self,
+        installation: VibeCADPrint.SlicerInstallation,
+        source_file: str | os.PathLike[str],
+        destination: str | os.PathLike[str],
+        setup: VibeCADPrint.PrintSetup,
+    ) -> Path:
+        return prepare_bambu_project(
+            installation,
+            source_file,
+            destination,
+            setup,
+        )
+
+    def launch(
+        self,
+        installation: VibeCADPrint.SlicerInstallation,
+        handoff_file: str | os.PathLike[str],
+        _setup: VibeCADPrint.PrintSetup | None,
+    ) -> VibeCADPrint.LaunchResult:
+        return launch_bambu_studio(installation, handoff_file)

--- a/src/Mod/VibeCADPrint/BambuStudio.py
+++ b/src/Mod/VibeCADPrint/BambuStudio.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 import json
 import ntpath
 import os
@@ -31,6 +31,7 @@ BAMBU_CAPABILITIES = (
     "project_export",
     "auto_arrange",
     "ensure_on_bed",
+    "object_filament_assignment",
 )
 
 _BAMBU_VERSION_RE = re.compile(
@@ -518,7 +519,7 @@ def _default_config_dir(
         )
     if platform == "win32":
         base = environ.get("APPDATA", "")
-        return ntpath.join(base, "BambuStudio") if base else ""
+        return _platform_path(platform, base, "BambuStudio") if base else ""
     if platform == "darwin":
         return (
             str(Path(home) / "Library/Application Support/BambuStudio")
@@ -542,6 +543,16 @@ def _native_resource_dir(executable: str, platform: str) -> str:
             path.parent / "resources/profiles",
         ]
     return str(next((candidate for candidate in candidates if candidate.is_dir()), ""))
+
+
+def _platform_path(platform: str, root: str, *parts: str) -> str:
+    """Join real Windows roots while keeping injected POSIX test roots usable."""
+
+    if platform == "win32" and (
+        bool(ntpath.splitdrive(root)[0]) or str(root).startswith(("\\\\", "//"))
+    ):
+        return ntpath.join(root, *parts)
+    return str(Path(root).joinpath(*parts))
 
 
 def _candidate_specs(
@@ -569,7 +580,12 @@ def _candidate_specs(
             environ.get("LOCALAPPDATA", ""),
         ]
         for root in (value for value in roots if value):
-            executable = ntpath.join(root, "Bambu Studio", "bambu-studio.exe")
+            executable = _platform_path(
+                platform,
+                root,
+                "Bambu Studio",
+                "bambu-studio.exe",
+            )
             values.append(
                 _Candidate(
                     (executable,),
@@ -768,25 +784,83 @@ def build_prepare_project_command(
     machine_profile: str | os.PathLike[str],
     process_profile: str | os.PathLike[str],
     material_profiles: Iterable[str | os.PathLike[str]],
+    *,
+    model_files: Iterable[str | os.PathLike[str]] = (),
 ) -> tuple[str, ...]:
     """Build Bambu Studio's shell-free, exact-profile project export command."""
 
+    material_paths = tuple(material_profiles)
+    model_paths = tuple(Path(path) for path in model_files)
+    if model_paths and not setup.object_filament_ids:
+        raise VibeCADPrint.SlicerError(
+            "Choose a filament for each object before preparing a multi-filament "
+            "project."
+        )
+    if model_paths and len(model_paths) != len(setup.object_filament_ids):
+        raise VibeCADPrint.SlicerError(
+            "Bambu Studio requires one separate model file and filament choice for "
+            "each object."
+        )
     command = [*installation.cli_command, "--debug", "2"]
     command.extend(("--arrange", "1" if setup.auto_arrange else "0"))
     if setup.ensure_on_bed:
         command.append("--ensure-on-bed")
+    if model_paths:
+        command.extend(
+            (
+                "--load-filament-ids",
+                ",".join(str(value) for value in setup.object_filament_ids),
+            )
+        )
     command.extend(
         (
             "--load-settings",
             f"{Path(machine_profile)};{Path(process_profile)}",
             "--load-filaments",
-            ";".join(str(Path(path)) for path in material_profiles),
+            ";".join(str(Path(path)) for path in material_paths),
             "--export-3mf",
             str(Path(output_file)),
-            str(Path(source_file)),
         )
     )
+    command.extend(str(path) for path in model_paths or (Path(source_file),))
     return tuple(command)
+
+
+def _project_setup(
+    setup: VibeCADPrint.PrintSetup,
+    *,
+    object_count: int,
+) -> VibeCADPrint.PrintSetup:
+    """Return a dense project-filament setup with one explicit ID per object."""
+
+    material_count = len(setup.material_profiles)
+    raw_ids = tuple(setup.object_filament_ids)
+    if material_count == 1 and not raw_ids:
+        raw_ids = (1,) * object_count
+    if len(raw_ids) != object_count:
+        raise VibeCADPrint.SlicerError(
+            "Choose a filament for each object before preparing the slicer project."
+        )
+    if any(
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 1
+        or value > material_count
+        for value in raw_ids
+    ):
+        raise VibeCADPrint.SlicerError(
+            "Choose a valid filament for each object before preparing the slicer "
+            "project."
+        )
+    used_ids = tuple(sorted(set(raw_ids)))
+    remap = {source_id: index for index, source_id in enumerate(used_ids, start=1)}
+    return replace(
+        setup,
+        material_profiles=tuple(
+            setup.material_profiles[source_id - 1] for source_id in used_ids
+        ),
+        object_filament_ids=tuple(remap[value] for value in raw_ids),
+    )
 
 
 def _source_object_names(path: Path) -> tuple[str, ...]:
@@ -830,21 +904,180 @@ def _prepared_object_names(path: Path) -> tuple[str, ...]:
     )
 
 
+def _metadata_tag(element: ET.Element) -> str:
+    namespace = (
+        element.tag.partition("}")[0] + "}" if element.tag.startswith("{") else ""
+    )
+    return f"{namespace}metadata"
+
+
+def _set_metadata(element: ET.Element, key: str, value: str) -> None:
+    metadata = next(
+        (
+            item
+            for item in element.findall("./{*}metadata")
+            if item.attrib.get("key") == key
+        ),
+        None,
+    )
+    if metadata is None:
+        metadata = ET.SubElement(element, _metadata_tag(element), {"key": key})
+    metadata.set("value", value)
+
+
+def _normalize_project_metadata(
+    path: Path,
+    *,
+    source_names: Sequence[str],
+    setup: VibeCADPrint.PrintSetup,
+    filament_keys: set[str],
+) -> None:
+    """Repair Bambu-format CLI metadata without changing selected profiles."""
+
+    try:
+        with zipfile.ZipFile(path) as archive:
+            model = ET.fromstring(archive.read("Metadata/model_settings.config"))
+            settings = json.loads(archive.read("Metadata/project_settings.config"))
+    except (
+        ET.ParseError,
+        OSError,
+        KeyError,
+        TypeError,
+        ValueError,
+        json.JSONDecodeError,
+        zipfile.BadZipFile,
+    ) as exc:
+        raise VibeCADPrint.SlicerError(
+            "Bambu Studio produced an invalid project 3MF without editable project "
+            "metadata."
+        ) from exc
+    if not isinstance(settings, dict):
+        raise VibeCADPrint.SlicerError(
+            "Bambu Studio produced invalid project profile metadata."
+        )
+
+    objects = model.findall("./{*}object")
+    object_ids = tuple(setup.object_filament_ids)
+    if len(objects) != len(source_names) or (
+        object_ids and len(object_ids) != len(source_names)
+    ):
+        raise VibeCADPrint.SlicerError(
+            "Bambu Studio changed the project object count while assigning "
+            "filaments."
+        )
+    for index, (obj, name) in enumerate(zip(objects, source_names)):
+        _set_metadata(obj, "name", str(name))
+        if object_ids:
+            _set_metadata(obj, "extruder", str(object_ids[index]))
+        for part in obj.findall("./{*}part"):
+            _set_metadata(part, "name", str(name))
+
+    material_count = len(setup.material_profiles)
+    for key in filament_keys | {"filament_colour", "filament_map"}:
+        values = settings.get(key)
+        if material_count > 1 and isinstance(values, list) and len(values) == 1:
+            settings[key] = values * material_count
+
+    filament_settings = settings.get("filament_settings_id")
+    if not isinstance(filament_settings, list) or len(filament_settings) != material_count:
+        raise VibeCADPrint.SlicerError(
+            "Bambu Studio produced incomplete filament profile metadata."
+        )
+
+    nozzle_diameters = settings.get("nozzle_diameter")
+    nozzle_count = len(nozzle_diameters) if isinstance(nozzle_diameters, list) else 0
+    nozzle_types = settings.get("nozzle_volume_type")
+    if (
+        nozzle_count > 1
+        and isinstance(nozzle_types, list)
+        and 0 < len(nozzle_types) < nozzle_count
+    ):
+        defaults = settings.get("default_nozzle_volume_type")
+        if isinstance(defaults, list) and len(defaults) == nozzle_count:
+            settings["nozzle_volume_type"] = list(defaults)
+        elif len(nozzle_types) == 1:
+            settings["nozzle_volume_type"] = nozzle_types * nozzle_count
+        else:
+            raise VibeCADPrint.SlicerError(
+                "Bambu Studio produced incomplete nozzle metadata."
+            )
+
+    replacements = {
+        "Metadata/model_settings.config": ET.tostring(
+            model,
+            encoding="utf-8",
+            xml_declaration=True,
+        ),
+        "Metadata/project_settings.config": json.dumps(
+            settings,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        ).encode("utf-8"),
+    }
+    rewritten = path.with_name(f".{path.name}.{uuid4().hex}.rewrite")
+    try:
+        with (
+            zipfile.ZipFile(path) as source_archive,
+            zipfile.ZipFile(rewritten, "w") as rewritten_archive,
+        ):
+            rewritten_archive.comment = source_archive.comment
+            for item in source_archive.infolist():
+                replacement = replacements.get(item.filename)
+                if replacement is not None:
+                    rewritten_archive.writestr(item, replacement)
+                    continue
+                with (
+                    source_archive.open(item) as source_entry,
+                    rewritten_archive.open(
+                        item,
+                        mode="w",
+                        force_zip64=True,
+                    ) as rewritten_entry,
+                ):
+                    shutil.copyfileobj(source_entry, rewritten_entry)
+        os.replace(rewritten, path)
+    except (OSError, ValueError, zipfile.BadZipFile) as exc:
+        raise VibeCADPrint.SlicerError(
+            f"Could not finalize the Bambu Studio project metadata: {exc}"
+        ) from exc
+    finally:
+        if rewritten.exists():
+            try:
+                rewritten.unlink()
+            except OSError:
+                pass
+
+
 def prepare_bambu_project(
     installation: VibeCADPrint.SlicerInstallation,
     source_file: str | os.PathLike[str],
     destination: str | os.PathLike[str],
     setup: VibeCADPrint.PrintSetup,
     *,
+    model_files: Iterable[str | os.PathLike[str]] = (),
+    source_names: Iterable[str] = (),
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     timeout: float = 120.0,
+    backend: BambuStudioBackend | None = None,
 ) -> Path:
     """Atomically prepare a full-profile, named, multi-object Bambu 3MF."""
 
     source = Path(source_file)
     target = Path(destination)
-    source_names = _source_object_names(source)
-    backend = BambuStudioBackend()
+    exact_source_names = tuple(str(name) for name in source_names)
+    if not exact_source_names:
+        exact_source_names = _source_object_names(source)
+    model_paths = tuple(Path(path) for path in model_files)
+    if model_paths and len(model_paths) != len(exact_source_names):
+        raise VibeCADPrint.SlicerError(
+            "Bambu Studio requires one separate model file for each source object."
+        )
+    project_setup = (
+        _project_setup(setup, object_count=len(exact_source_names))
+        if model_paths
+        else setup
+    )
+    backend = backend or BambuStudioBackend()
     printers = backend.query_printers(installation)
     printer = next((item for item in printers if item.name == setup.printer_profile), None)
     if printer is None:
@@ -858,18 +1091,32 @@ def prepare_bambu_project(
     resolved = (
         ("machine", setup.printer_profile),
         ("process", setup.print_profile),
-        *[("filament", name) for name in setup.material_profiles],
+        *[("filament", name) for name in project_setup.material_profiles],
     )
     target.parent.mkdir(parents=True, exist_ok=True)
     token = uuid4().hex
     profile_paths: list[Path] = []
+    resolved_profiles: list[dict[str, Any]] = []
     partial = target.with_name(f"{target.stem}.{token}.partial.3mf")
     try:
         for index, (profile_type, name) in enumerate(resolved):
+            profile = next(
+                (
+                    value
+                    for record, value in backend._resolved(installation, profile_type)
+                    if record.name == name
+                ),
+                None,
+            )
+            if profile is None:
+                raise VibeCADPrint.SlicerError(
+                    f"Bambu Studio profile '{name}' ({profile_type}) is not available."
+                )
+            resolved_profiles.append(dict(profile))
             path = target.parent / f".{target.stem}.{token}.{index}.profile.json"
             path.write_text(
                 json.dumps(
-                    resolved_profile(installation, profile_type, name),
+                    profile,
                     ensure_ascii=False,
                     indent=2,
                 ),
@@ -880,10 +1127,11 @@ def prepare_bambu_project(
             installation,
             source,
             partial,
-            setup,
+            project_setup,
             profile_paths[0],
             profile_paths[1],
             profile_paths[2:],
+            model_files=model_paths,
         )
         with tempfile.TemporaryDirectory(
             prefix=".vibecad-slicer-",
@@ -908,14 +1156,27 @@ def prepare_bambu_project(
                 "Bambu Studio could not prepare the 3MF project "
                 f"(status {completed.returncode}).{suffix}"
             )
+        _normalize_project_metadata(
+            partial,
+            source_names=exact_source_names,
+            setup=project_setup,
+            filament_keys={
+                key
+                for profile in resolved_profiles[2:]
+                for key in profile
+                if key.startswith("filament_")
+            },
+        )
         prepared_names = _prepared_object_names(partial)
-        if len(prepared_names) != len(source_names):
+        if len(prepared_names) != len(exact_source_names):
             raise VibeCADPrint.SlicerError(
                 "Bambu Studio changed the project object count from "
-                f"{len(source_names)} to {len(prepared_names)}; the original 3MF "
+                f"{len(exact_source_names)} to {len(prepared_names)}; the original 3MF "
                 "was preserved."
             )
-        if all(source_names) and Counter(prepared_names) != Counter(source_names):
+        if all(exact_source_names) and Counter(prepared_names) != Counter(
+            exact_source_names
+        ):
             raise VibeCADPrint.SlicerError(
                 "Bambu Studio changed the project object names; the original 3MF "
                 "was preserved."
@@ -1055,12 +1316,18 @@ class BambuStudioBackend:
         source_file: str | os.PathLike[str],
         destination: str | os.PathLike[str],
         setup: VibeCADPrint.PrintSetup,
+        *,
+        model_files: Iterable[str | os.PathLike[str]] = (),
+        source_names: Iterable[str] = (),
     ) -> Path:
         return prepare_bambu_project(
             installation,
             source_file,
             destination,
             setup,
+            model_files=model_files,
+            source_names=source_names,
+            backend=self,
         )
 
     def launch(

--- a/src/Mod/VibeCADPrint/CMakeLists.txt
+++ b/src/Mod/VibeCADPrint/CMakeLists.txt
@@ -3,6 +3,7 @@
 SET(VibeCADPrint_SRCS
     Init.py
     InitGui.py
+    BambuStudio.py
     Commands.py
     PrintCommandLoader.py
     PrintIcons.py
@@ -22,12 +23,15 @@ SET(VibeCADPrint_Tests
     tests/__init__.py
     tests/conftest.py
     tests/qt_dialog_layout.py
+    tests/qt_bambu_setup_integration.py
+    tests/qt_backend_switch_integration.py
     tests/qt_panel_integration.py
     tests/qt_panel_persistence_integration.py
     tests/qt_progress_integration.py
     tests/qt_selection_integration.py
     tests/qt_workbench_panel_integration.py
     tests/test_backend.py
+    tests/test_bambu_backend.py
     tests/test_commands.py
     tests/test_export.py
     tests/test_preferences.py

--- a/src/Mod/VibeCADPrint/CMakeLists.txt
+++ b/src/Mod/VibeCADPrint/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(VibeCADPrint_SRCS
     Init.py
     InitGui.py
     BambuStudio.py
+    OrcaSlicer.py
     Commands.py
     PrintCommandLoader.py
     PrintIcons.py
@@ -32,6 +33,7 @@ SET(VibeCADPrint_Tests
     tests/qt_workbench_panel_integration.py
     tests/test_backend.py
     tests/test_bambu_backend.py
+    tests/test_orca_backend.py
     tests/test_commands.py
     tests/test_export.py
     tests/test_preferences.py

--- a/src/Mod/VibeCADPrint/CMakeLists.txt
+++ b/src/Mod/VibeCADPrint/CMakeLists.txt
@@ -24,6 +24,7 @@ SET(VibeCADPrint_Tests
     tests/qt_dialog_layout.py
     tests/qt_panel_integration.py
     tests/qt_panel_persistence_integration.py
+    tests/qt_progress_integration.py
     tests/qt_selection_integration.py
     tests/qt_workbench_panel_integration.py
     tests/test_backend.py

--- a/src/Mod/VibeCADPrint/CMakeLists.txt
+++ b/src/Mod/VibeCADPrint/CMakeLists.txt
@@ -6,6 +6,7 @@ SET(VibeCADPrint_SRCS
     Commands.py
     PrintCommandLoader.py
     PrintIcons.py
+    PrintPanel.py
     PrintPreferences.py
     PrintSetupDialog.py
     VibeCADPrint.py
@@ -21,6 +22,8 @@ SET(VibeCADPrint_Tests
     tests/__init__.py
     tests/conftest.py
     tests/qt_dialog_layout.py
+    tests/qt_panel_integration.py
+    tests/qt_workbench_panel_integration.py
     tests/test_backend.py
     tests/test_export.py
     tests/test_preferences.py

--- a/src/Mod/VibeCADPrint/CMakeLists.txt
+++ b/src/Mod/VibeCADPrint/CMakeLists.txt
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+SET(VibeCADPrint_SRCS
+    Init.py
+    InitGui.py
+    Commands.py
+    PrintCommandLoader.py
+    PrintIcons.py
+    PrintPreferences.py
+    PrintSetupDialog.py
+    VibeCADPrint.py
+)
+
+SET(VibeCADPrint_Icons
+    icons/vibecad-print-open.svg
+    icons/vibecad-print-save.svg
+    icons/vibecad-print-setup.svg
+)
+
+SET(VibeCADPrint_Tests
+    tests/__init__.py
+    tests/conftest.py
+    tests/qt_dialog_layout.py
+    tests/test_backend.py
+    tests/test_export.py
+    tests/test_preferences.py
+    tests/test_workbench.py
+)
+
+SET(VibeCADPrint_All
+    ${VibeCADPrint_SRCS}
+    ${VibeCADPrint_Icons}
+    ${VibeCADPrint_Tests}
+)
+
+SOURCE_GROUP("" FILES ${VibeCADPrint_SRCS})
+
+ADD_CUSTOM_TARGET(VibeCADPrint ALL SOURCES ${VibeCADPrint_All})
+
+fc_copy_sources(VibeCADPrint "${CMAKE_BINARY_DIR}/Mod/VibeCADPrint" ${VibeCADPrint_All})
+
+INSTALL(FILES ${VibeCADPrint_SRCS} DESTINATION Mod/VibeCADPrint)
+INSTALL(FILES ${VibeCADPrint_Icons} DESTINATION Mod/VibeCADPrint/icons)
+
+if(BUILD_TEST)
+    INSTALL(FILES ${VibeCADPrint_Tests} DESTINATION Mod/VibeCADPrint/tests)
+endif()

--- a/src/Mod/VibeCADPrint/CMakeLists.txt
+++ b/src/Mod/VibeCADPrint/CMakeLists.txt
@@ -23,6 +23,8 @@ SET(VibeCADPrint_Tests
     tests/conftest.py
     tests/qt_dialog_layout.py
     tests/qt_panel_integration.py
+    tests/qt_panel_persistence_integration.py
+    tests/qt_selection_integration.py
     tests/qt_workbench_panel_integration.py
     tests/test_backend.py
     tests/test_commands.py

--- a/src/Mod/VibeCADPrint/CMakeLists.txt
+++ b/src/Mod/VibeCADPrint/CMakeLists.txt
@@ -25,6 +25,7 @@ SET(VibeCADPrint_Tests
     tests/qt_panel_integration.py
     tests/qt_workbench_panel_integration.py
     tests/test_backend.py
+    tests/test_commands.py
     tests/test_export.py
     tests/test_preferences.py
     tests/test_workbench.py

--- a/src/Mod/VibeCADPrint/Commands.py
+++ b/src/Mod/VibeCADPrint/Commands.py
@@ -34,6 +34,32 @@ def _main_window() -> Any:
     return FreeCADGui.getMainWindow()
 
 
+def _whole_object_for_selection(entry: Any) -> Any | None:
+    """Resolve a picked body subelement to the complete printable body."""
+
+    obj = getattr(entry, "Object", None)
+    if obj is None or not tuple(getattr(entry, "SubElementNames", ()) or ()):
+        return obj
+    parent_getter = getattr(obj, "getParentGeoFeatureGroup", None)
+    if not callable(parent_getter):
+        return obj
+    try:
+        parent = parent_getter()
+    except Exception:
+        return obj
+    if parent is None:
+        return obj
+    type_id = str(getattr(parent, "TypeId", ""))
+    is_derived_from = getattr(parent, "isDerivedFrom", None)
+    try:
+        is_body = type_id == "PartDesign::Body" or (
+            callable(is_derived_from) and is_derived_from("PartDesign::Body")
+        )
+    except Exception:
+        is_body = type_id == "PartDesign::Body"
+    return parent if is_body else obj
+
+
 def _warning(title: str, message: str) -> None:
     _console(message, "warning")
     from PySide import QtWidgets
@@ -57,7 +83,14 @@ def _active_selection() -> tuple[Any, tuple[Any, ...]]:
     import FreeCADGui
 
     document = FreeCAD.ActiveDocument
-    selected = tuple(FreeCADGui.Selection.getSelection() or ())
+    selected = tuple(
+        obj
+        for obj in (
+            _whole_object_for_selection(entry)
+            for entry in (FreeCADGui.Selection.getSelectionEx() or ())
+        )
+        if obj is not None
+    )
     objects = VibeCADPrint.collect_printable_objects(
         selected,
         active_document=document,
@@ -219,6 +252,19 @@ def open_selected_in_prusaslicer(
     try:
         destination, managed = _handoff_destination(document, objects)
         VibeCADPrint.export_selection_3mf(objects, destination)
+        if installation.tested and setup is not None:
+            import PrintSetupDialog
+
+            PrintSetupDialog.run_with_progress(
+                _main_window(),
+                "Arranging objects and preparing the PrusaSlicer project…",
+                lambda: backend.prepare_project(
+                    installation,
+                    destination,
+                    destination,
+                    setup,
+                ),
+            )
         result = backend.launch(installation, destination, setup)
         if managed:
             VibeCADPrint.prune_managed_handoffs(

--- a/src/Mod/VibeCADPrint/Commands.py
+++ b/src/Mod/VibeCADPrint/Commands.py
@@ -176,6 +176,32 @@ def _managed_cache_directory() -> Path:
     return Path(str(FreeCAD.getUserCachePath())) / "VibeCAD" / "3DPrint" / "handoff"
 
 
+def _handoff_destination(
+    document: Any,
+    objects: tuple[Any, ...],
+) -> tuple[Path, bool]:
+    storage = PrintPreferences.load_handoff_storage()
+    label = str(getattr(document, "Label", "") or "Untitled")
+    names = tuple(str(getattr(obj, "Name", "")) for obj in objects)
+    if storage.mode == "folder":
+        return (
+            VibeCADPrint.persistent_handoff_path(
+                storage.directory,
+                document_label=label,
+                object_names=names,
+            ),
+            False,
+        )
+    return (
+        VibeCADPrint.managed_handoff_path(
+            _managed_cache_directory(),
+            document_label=label,
+            object_names=names,
+        ),
+        True,
+    )
+
+
 def _open_selected_in_prusaslicer() -> None:
     try:
         document, objects = _active_selection()
@@ -188,19 +214,16 @@ def _open_selected_in_prusaslicer() -> None:
     if resolved is None:
         return
     installation, setup = resolved
-    destination = VibeCADPrint.managed_handoff_path(
-        _managed_cache_directory(),
-        document_label=str(getattr(document, "Label", "") or "Untitled"),
-        object_names=tuple(str(getattr(obj, "Name", "")) for obj in objects),
-    )
     try:
+        destination, managed = _handoff_destination(document, objects)
         VibeCADPrint.export_selection_3mf(objects, destination)
         result = backend.launch(installation, destination, setup)
-        VibeCADPrint.prune_managed_handoffs(
-            destination.parent,
-            keep=VibeCADPrint.DEFAULT_HANDOFF_LIMIT,
-        )
-    except VibeCADPrint.SlicerError as exc:
+        if managed:
+            VibeCADPrint.prune_managed_handoffs(
+                destination.parent,
+                keep=VibeCADPrint.DEFAULT_HANDOFF_LIMIT,
+            )
+    except (OSError, VibeCADPrint.SlicerError) as exc:
         _warning("Open in PrusaSlicer", str(exc))
         return
     profile = (
@@ -210,7 +233,7 @@ def _open_selected_in_prusaslicer() -> None:
     )
     _status(
         f"Opened {len(objects)} selected object(s) in {installation.display_name} "
-        f"using {profile}. Process {result.process_id or 'started'}."
+        f"using {profile}. 3MF: {destination}. Process {result.process_id or 'started'}."
     )
 
 
@@ -291,13 +314,9 @@ class _PrintSetupCommand:
         return True
 
     def Activated(self) -> None:
-        import PrintSetupDialog
+        import PrintPanel
 
-        PrintSetupDialog.choose_print_setup(
-            parent=_main_window(),
-            backend=VibeCADPrint.PrusaSlicerBackend(),
-            open_after_save=False,
-        )
+        PrintPanel.show_panel()
 
 
 def register_commands(gui: Any | None = None) -> None:

--- a/src/Mod/VibeCADPrint/Commands.py
+++ b/src/Mod/VibeCADPrint/Commands.py
@@ -98,6 +98,19 @@ def _active_selection() -> tuple[Any, tuple[Any, ...]]:
     return document, objects
 
 
+def _resolved_selection(
+    selection: tuple[Any, tuple[Any, ...]] | None,
+) -> tuple[Any, tuple[Any, ...]]:
+    if selection is None:
+        return _active_selection()
+    document, selected = selection
+    objects = VibeCADPrint.collect_printable_objects(
+        selected,
+        active_document=document,
+    )
+    return document, objects
+
+
 def _selection_available() -> bool:
     try:
         import FreeCAD
@@ -235,11 +248,12 @@ def open_selected_in_prusaslicer(
     *,
     installation: VibeCADPrint.SlicerInstallation | None = None,
     setup: VibeCADPrint.PrintSetup | None = None,
+    selection: tuple[Any, tuple[Any, ...]] | None = None,
 ) -> bool:
     """Export and open the selection, optionally using panel-validated choices."""
 
     try:
-        document, objects = _active_selection()
+        document, objects = _resolved_selection(selection)
     except VibeCADPrint.PrintSelectionError as exc:
         _warning("Open in PrusaSlicer", str(exc))
         return False
@@ -290,9 +304,12 @@ def _open_selected_in_prusaslicer() -> None:
     open_selected_in_prusaslicer()
 
 
-def _save_selected_3mf() -> None:
+def _save_selected_3mf(
+    *,
+    selection: tuple[Any, tuple[Any, ...]] | None = None,
+) -> None:
     try:
-        document, objects = _active_selection()
+        document, objects = _resolved_selection(selection)
     except VibeCADPrint.PrintSelectionError as exc:
         _warning("Save 3MF", str(exc))
         return

--- a/src/Mod/VibeCADPrint/Commands.py
+++ b/src/Mod/VibeCADPrint/Commands.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import tempfile
 from typing import Any
 
 import PrintIcons
@@ -319,16 +320,46 @@ def _open_resolved_in_slicer(
         if installation.tested and setup is not None:
             import PrintSetupDialog
 
-            PrintSetupDialog.run_with_progress(
-                _main_window(),
-                f"Arranging objects and preparing the {slicer_name} project…",
-                lambda: backend.prepare_project(
-                    installation,
-                    destination,
-                    destination,
-                    setup,
-                ),
+            progress_label = (
+                f"Arranging objects and preparing the {slicer_name} project…"
             )
+            if "object_filament_assignment" in tuple(
+                getattr(backend, "capabilities", ()) or ()
+            ):
+                with tempfile.TemporaryDirectory(
+                    prefix=".vibecad-models-",
+                    dir=destination.parent,
+                ) as model_directory:
+                    model_files = VibeCADPrint.export_objects_stl(
+                        objects,
+                        model_directory,
+                    )
+                    PrintSetupDialog.run_with_progress(
+                        _main_window(),
+                        progress_label,
+                        lambda: backend.prepare_project(
+                            installation,
+                            destination,
+                            destination,
+                            setup,
+                            model_files=model_files,
+                            source_names=tuple(
+                                VibeCADPrint.printable_object_name(obj)
+                                for obj in objects
+                            ),
+                        ),
+                    )
+            else:
+                PrintSetupDialog.run_with_progress(
+                    _main_window(),
+                    progress_label,
+                    lambda: backend.prepare_project(
+                        installation,
+                        destination,
+                        destination,
+                        setup,
+                    ),
+                )
         result = backend.launch(installation, destination, setup)
         if managed:
             VibeCADPrint.prune_managed_handoffs(

--- a/src/Mod/VibeCADPrint/Commands.py
+++ b/src/Mod/VibeCADPrint/Commands.py
@@ -1,0 +1,314 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""GUI commands for explicit 3MF export and PrusaSlicer handoff."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import PrintIcons
+import PrintPreferences
+import VibeCADPrint
+
+
+_WARNED_OLD_INSTALLATIONS: set[tuple[tuple[str, ...], str]] = set()
+
+
+def _console(message: str, kind: str = "message") -> None:
+    try:
+        import FreeCAD
+
+        writer = {
+            "error": FreeCAD.Console.PrintError,
+            "warning": FreeCAD.Console.PrintWarning,
+        }.get(kind, FreeCAD.Console.PrintMessage)
+        writer(message.rstrip() + "\n")
+    except Exception:
+        print(message)
+
+
+def _main_window() -> Any:
+    import FreeCADGui
+
+    return FreeCADGui.getMainWindow()
+
+
+def _warning(title: str, message: str) -> None:
+    _console(message, "warning")
+    from PySide import QtWidgets
+
+    QtWidgets.QMessageBox.warning(_main_window(), title, message)
+
+
+def _status(message: str) -> None:
+    _console(message)
+    try:
+        window = _main_window()
+        bar = window.statusBar() if window is not None else None
+        if bar is not None:
+            bar.showMessage(message, 8000)
+    except Exception:
+        pass
+
+
+def _active_selection() -> tuple[Any, tuple[Any, ...]]:
+    import FreeCAD
+    import FreeCADGui
+
+    document = FreeCAD.ActiveDocument
+    selected = tuple(FreeCADGui.Selection.getSelection() or ())
+    objects = VibeCADPrint.collect_printable_objects(
+        selected,
+        active_document=document,
+    )
+    return document, objects
+
+
+def _selection_available() -> bool:
+    try:
+        import FreeCAD
+        import FreeCADGui
+
+        return FreeCAD.ActiveDocument is not None and bool(
+            FreeCADGui.Selection.getSelection()
+        )
+    except Exception:
+        return False
+
+
+def _validated_saved_setup(
+    installation: VibeCADPrint.SlicerInstallation,
+    backend: VibeCADPrint.PrusaSlicerBackend,
+    parent: Any,
+) -> tuple[VibeCADPrint.PrintSetup | None, str]:
+    setup = PrintPreferences.load_confirmed_setup()
+    if setup is None:
+        return (
+            None,
+            "Choose and confirm the exact printer, print, and material profiles.",
+        )
+    import PrintSetupDialog
+
+    try:
+        printers = PrintSetupDialog.run_with_progress(
+            parent,
+            "Checking installed printer profiles...",
+            lambda: backend.query_printers(installation),
+        )
+        printer = next(
+            (value for value in printers if value.name == setup.printer_profile), None
+        )
+        if printer is None:
+            return (
+                None,
+                f"Printer profile '{setup.printer_profile}' is no longer installed.",
+            )
+        catalog = PrintSetupDialog.run_with_progress(
+            parent,
+            "Checking compatible print and material profiles...",
+            lambda: backend.query_profiles(installation, printer.name),
+        )
+    except Exception as exc:
+        return None, f"Could not refresh installed PrusaSlicer profiles: {exc}"
+    errors = VibeCADPrint.validate_setup(setup, printer, catalog)
+    return (setup, "") if not errors else (None, "\n".join(errors))
+
+
+def _confirm_old_installation(
+    installation: VibeCADPrint.SlicerInstallation, parent: Any
+) -> bool:
+    key = (installation.gui_command, installation.version)
+    if key in _WARNED_OLD_INSTALLATIONS:
+        return True
+    from PySide import QtWidgets
+
+    result = QtWidgets.QMessageBox.question(
+        parent,
+        "Older PrusaSlicer",
+        f"PrusaSlicer {installation.version} is older than the tested 2.9.6 "
+        "integration baseline.\n\nVibeCAD will open the selected 3MF without "
+        "passing printer, print, or material profiles. Continue?",
+        QtWidgets.QMessageBox.Yes | QtWidgets.QMessageBox.No,
+        QtWidgets.QMessageBox.No,
+    )
+    if result == QtWidgets.QMessageBox.Yes:
+        _WARNED_OLD_INSTALLATIONS.add(key)
+        return True
+    return False
+
+
+def _resolve_handoff_configuration(
+    backend: VibeCADPrint.PrusaSlicerBackend,
+    parent: Any,
+) -> tuple[VibeCADPrint.SlicerInstallation, VibeCADPrint.PrintSetup | None] | None:
+    import PrintSetupDialog
+
+    override = PrintPreferences.executable_override()
+    installations = backend.discover(override)
+    installation = VibeCADPrint.preferred_installation(installations)
+    if installation is not None and not installation.tested:
+        if _confirm_old_installation(installation, parent):
+            return installation, None
+        return None
+
+    reason = ""
+    if installation is not None:
+        setup, reason = _validated_saved_setup(installation, backend, parent)
+        if setup is not None:
+            return installation, setup
+
+    choice = PrintSetupDialog.choose_print_setup(
+        parent=parent,
+        backend=backend,
+        open_after_save=True,
+        initial_installation=installation,
+        initial_message=reason,
+    )
+    if not choice.accepted or choice.installation is None:
+        return None
+    return choice.installation, choice.setup
+
+
+def _managed_cache_directory() -> Path:
+    import FreeCAD
+
+    return Path(str(FreeCAD.getUserCachePath())) / "VibeCAD" / "3DPrint" / "handoff"
+
+
+def _open_selected_in_prusaslicer() -> None:
+    try:
+        document, objects = _active_selection()
+    except VibeCADPrint.PrintSelectionError as exc:
+        _warning("Open in PrusaSlicer", str(exc))
+        return
+    parent = _main_window()
+    backend = VibeCADPrint.PrusaSlicerBackend()
+    resolved = _resolve_handoff_configuration(backend, parent)
+    if resolved is None:
+        return
+    installation, setup = resolved
+    destination = VibeCADPrint.managed_handoff_path(
+        _managed_cache_directory(),
+        document_label=str(getattr(document, "Label", "") or "Untitled"),
+        object_names=tuple(str(getattr(obj, "Name", "")) for obj in objects),
+    )
+    try:
+        VibeCADPrint.export_selection_3mf(objects, destination)
+        result = backend.launch(installation, destination, setup)
+        VibeCADPrint.prune_managed_handoffs(
+            destination.parent,
+            keep=VibeCADPrint.DEFAULT_HANDOFF_LIMIT,
+        )
+    except VibeCADPrint.SlicerError as exc:
+        _warning("Open in PrusaSlicer", str(exc))
+        return
+    profile = (
+        setup.printer_profile
+        if setup is not None
+        else "profiles selected in PrusaSlicer"
+    )
+    _status(
+        f"Opened {len(objects)} selected object(s) in {installation.display_name} "
+        f"using {profile}. Process {result.process_id or 'started'}."
+    )
+
+
+def _save_selected_3mf() -> None:
+    try:
+        document, objects = _active_selection()
+    except VibeCADPrint.PrintSelectionError as exc:
+        _warning("Save 3MF", str(exc))
+        return
+    from PySide import QtWidgets
+
+    label = str(getattr(document, "Label", "") or "Selection")
+    initial = str(Path.home() / f"{label}.3mf")
+    selected, _filter = QtWidgets.QFileDialog.getSaveFileName(
+        _main_window(),
+        "Save selected objects as 3MF",
+        initial,
+        "3MF files (*.3mf);;All files (*)",
+    )
+    if not selected:
+        return
+    destination = Path(selected)
+    if destination.suffix.lower() != ".3mf":
+        destination = destination.with_suffix(".3mf")
+    try:
+        VibeCADPrint.export_selection_3mf(objects, destination)
+    except VibeCADPrint.SlicerError as exc:
+        _warning("Save 3MF", str(exc))
+        return
+    _status(f"Saved {len(objects)} selected object(s) to {destination}.")
+
+
+class _OpenInPrusaSlicerCommand:
+    def GetResources(self) -> dict[str, str]:
+        return {
+            "Pixmap": PrintIcons.icon_path("open"),
+            "MenuText": "Open in PrusaSlicer",
+            "ToolTip": (
+                "Export the explicitly selected printable objects as 3MF and open "
+                "them with the confirmed PrusaSlicer setup"
+            ),
+        }
+
+    def IsActive(self) -> bool:
+        return _selection_available()
+
+    def Activated(self) -> None:
+        _open_selected_in_prusaslicer()
+
+
+class _Save3MFCommand:
+    def GetResources(self) -> dict[str, str]:
+        return {
+            "Pixmap": PrintIcons.icon_path("save"),
+            "MenuText": "Save 3MF",
+            "ToolTip": "Save the explicitly selected printable objects as one 3MF",
+        }
+
+    def IsActive(self) -> bool:
+        return _selection_available()
+
+    def Activated(self) -> None:
+        _save_selected_3mf()
+
+
+class _PrintSetupCommand:
+    def GetResources(self) -> dict[str, str]:
+        return {
+            "Pixmap": PrintIcons.icon_path("setup"),
+            "MenuText": "Print Setup",
+            "ToolTip": (
+                "Locate PrusaSlicer and explicitly confirm printer, print, material, "
+                "auto-arrange, and ensure-on-bed choices"
+            ),
+        }
+
+    def IsActive(self) -> bool:
+        return True
+
+    def Activated(self) -> None:
+        import PrintSetupDialog
+
+        PrintSetupDialog.choose_print_setup(
+            parent=_main_window(),
+            backend=VibeCADPrint.PrusaSlicerBackend(),
+            open_after_save=False,
+        )
+
+
+def register_commands(gui: Any | None = None) -> None:
+    if gui is None:
+        import FreeCADGui as gui  # type: ignore[no-redef]
+    commands = {
+        "VibeCADPrint_OpenInPrusaSlicer": _OpenInPrusaSlicerCommand(),
+        "VibeCADPrint_Save3MF": _Save3MFCommand(),
+        "VibeCADPrint_Setup": _PrintSetupCommand(),
+    }
+    existing = {str(command) for command in getattr(gui, "listCommands", lambda: [])()}
+    for name, command in commands.items():
+        if name not in existing:
+            gui.addCommand(name, command)

--- a/src/Mod/VibeCADPrint/Commands.py
+++ b/src/Mod/VibeCADPrint/Commands.py
@@ -395,7 +395,7 @@ class _OpenInPrusaSlicerCommand:
             "MenuText": "Print",
             "ToolTip": (
                 "Export the explicitly selected printable objects as 3MF and open "
-                "them with the confirmed PrusaSlicer setup"
+                "them with the confirmed external slicer setup"
             ),
         }
 

--- a/src/Mod/VibeCADPrint/Commands.py
+++ b/src/Mod/VibeCADPrint/Commands.py
@@ -263,6 +263,56 @@ def open_selected_in_prusaslicer(
         if resolved is None:
             return False
         installation, setup = resolved
+    return _open_resolved_in_slicer(
+        backend=backend,
+        installation=installation,
+        setup=setup,
+        document=document,
+        objects=objects,
+    )
+
+
+def open_selected_in_slicer(
+    *,
+    backend: Any,
+    installation: VibeCADPrint.SlicerInstallation,
+    setup: VibeCADPrint.PrintSetup | None,
+    selection: tuple[Any, tuple[Any, ...]] | None = None,
+) -> bool:
+    """Export, prepare, and launch using an already validated slicer backend."""
+
+    slicer_name = str(
+        getattr(backend, "display_name", "")
+        or getattr(installation, "display_name", "")
+        or "slicer"
+    )
+    try:
+        document, objects = _resolved_selection(selection)
+    except VibeCADPrint.PrintSelectionError as exc:
+        _warning(f"Open in {slicer_name}", str(exc))
+        return False
+    return _open_resolved_in_slicer(
+        backend=backend,
+        installation=installation,
+        setup=setup,
+        document=document,
+        objects=objects,
+    )
+
+
+def _open_resolved_in_slicer(
+    *,
+    backend: Any,
+    installation: VibeCADPrint.SlicerInstallation,
+    setup: VibeCADPrint.PrintSetup | None,
+    document: Any,
+    objects: tuple[Any, ...],
+) -> bool:
+    slicer_name = str(
+        getattr(backend, "display_name", "")
+        or getattr(installation, "display_name", "")
+        or "slicer"
+    )
     try:
         destination, managed = _handoff_destination(document, objects)
         VibeCADPrint.export_selection_3mf(objects, destination)
@@ -271,7 +321,7 @@ def open_selected_in_prusaslicer(
 
             PrintSetupDialog.run_with_progress(
                 _main_window(),
-                "Arranging objects and preparing the PrusaSlicer project…",
+                f"Arranging objects and preparing the {slicer_name} project…",
                 lambda: backend.prepare_project(
                     installation,
                     destination,
@@ -286,12 +336,12 @@ def open_selected_in_prusaslicer(
                 keep=VibeCADPrint.DEFAULT_HANDOFF_LIMIT,
             )
     except (OSError, VibeCADPrint.SlicerError) as exc:
-        _warning("Open in PrusaSlicer", str(exc))
+        _warning(f"Open in {slicer_name}", str(exc))
         return False
     profile = (
         setup.printer_profile
         if setup is not None
-        else "profiles selected in PrusaSlicer"
+        else f"profiles selected in {slicer_name}"
     )
     _status(
         f"Opened {len(objects)} selected object(s) in {installation.display_name} "

--- a/src/Mod/VibeCADPrint/Commands.py
+++ b/src/Mod/VibeCADPrint/Commands.py
@@ -142,32 +142,28 @@ def _resolve_handoff_configuration(
     backend: VibeCADPrint.PrusaSlicerBackend,
     parent: Any,
 ) -> tuple[VibeCADPrint.SlicerInstallation, VibeCADPrint.PrintSetup | None] | None:
-    import PrintSetupDialog
-
     override = PrintPreferences.executable_override()
     installations = backend.discover(override)
     installation = VibeCADPrint.preferred_installation(installations)
+    if installation is None:
+        _warning(
+            "Print Setup Required",
+            "PrusaSlicer is not configured. Click Setup before printing.",
+        )
+        return None
     if installation is not None and not installation.tested:
         if _confirm_old_installation(installation, parent):
             return installation, None
         return None
 
-    reason = ""
-    if installation is not None:
-        setup, reason = _validated_saved_setup(installation, backend, parent)
-        if setup is not None:
-            return installation, setup
-
-    choice = PrintSetupDialog.choose_print_setup(
-        parent=parent,
-        backend=backend,
-        open_after_save=True,
-        initial_installation=installation,
-        initial_message=reason,
+    setup, reason = _validated_saved_setup(installation, backend, parent)
+    if setup is not None:
+        return installation, setup
+    _warning(
+        "Print Setup Required",
+        reason + "\n\nClick Setup to review the exact installed profiles.",
     )
-    if not choice.accepted or choice.installation is None:
-        return None
-    return choice.installation, choice.setup
+    return None
 
 
 def _managed_cache_directory() -> Path:
@@ -202,18 +198,24 @@ def _handoff_destination(
     )
 
 
-def _open_selected_in_prusaslicer() -> None:
+def open_selected_in_prusaslicer(
+    *,
+    installation: VibeCADPrint.SlicerInstallation | None = None,
+    setup: VibeCADPrint.PrintSetup | None = None,
+) -> bool:
+    """Export and open the selection, optionally using panel-validated choices."""
+
     try:
         document, objects = _active_selection()
     except VibeCADPrint.PrintSelectionError as exc:
         _warning("Open in PrusaSlicer", str(exc))
-        return
-    parent = _main_window()
+        return False
     backend = VibeCADPrint.PrusaSlicerBackend()
-    resolved = _resolve_handoff_configuration(backend, parent)
-    if resolved is None:
-        return
-    installation, setup = resolved
+    if installation is None:
+        resolved = _resolve_handoff_configuration(backend, _main_window())
+        if resolved is None:
+            return False
+        installation, setup = resolved
     try:
         destination, managed = _handoff_destination(document, objects)
         VibeCADPrint.export_selection_3mf(objects, destination)
@@ -225,7 +227,7 @@ def _open_selected_in_prusaslicer() -> None:
             )
     except (OSError, VibeCADPrint.SlicerError) as exc:
         _warning("Open in PrusaSlicer", str(exc))
-        return
+        return False
     profile = (
         setup.printer_profile
         if setup is not None
@@ -235,6 +237,11 @@ def _open_selected_in_prusaslicer() -> None:
         f"Opened {len(objects)} selected object(s) in {installation.display_name} "
         f"using {profile}. 3MF: {destination}. Process {result.process_id or 'started'}."
     )
+    return True
+
+
+def _open_selected_in_prusaslicer() -> None:
+    open_selected_in_prusaslicer()
 
 
 def _save_selected_3mf() -> None:
@@ -246,7 +253,9 @@ def _save_selected_3mf() -> None:
     from PySide import QtWidgets
 
     label = str(getattr(document, "Label", "") or "Selection")
-    initial = str(Path.home() / f"{label}.3mf")
+    storage = PrintPreferences.load_handoff_storage()
+    initial_root = Path(storage.directory) if storage.mode == "folder" else Path.home()
+    initial = str(initial_root / f"{label}.3mf")
     selected, _filter = QtWidgets.QFileDialog.getSaveFileName(
         _main_window(),
         "Save selected objects as 3MF",
@@ -260,7 +269,7 @@ def _save_selected_3mf() -> None:
         destination = destination.with_suffix(".3mf")
     try:
         VibeCADPrint.export_selection_3mf(objects, destination)
-    except VibeCADPrint.SlicerError as exc:
+    except (OSError, VibeCADPrint.SlicerError) as exc:
         _warning("Save 3MF", str(exc))
         return
     _status(f"Saved {len(objects)} selected object(s) to {destination}.")
@@ -270,7 +279,7 @@ class _OpenInPrusaSlicerCommand:
     def GetResources(self) -> dict[str, str]:
         return {
             "Pixmap": PrintIcons.icon_path("open"),
-            "MenuText": "Open in PrusaSlicer",
+            "MenuText": "Print",
             "ToolTip": (
                 "Export the explicitly selected printable objects as 3MF and open "
                 "them with the confirmed PrusaSlicer setup"
@@ -281,7 +290,11 @@ class _OpenInPrusaSlicerCommand:
         return _selection_available()
 
     def Activated(self) -> None:
-        _open_selected_in_prusaslicer()
+        import PrintPanel
+
+        panel = PrintPanel.show_panel(refresh=False)
+        if panel is not None:
+            panel.print_selected()
 
 
 class _Save3MFCommand:
@@ -316,7 +329,7 @@ class _PrintSetupCommand:
     def Activated(self) -> None:
         import PrintPanel
 
-        PrintPanel.show_panel()
+        PrintPanel.open_setup_dialog(parent=_main_window())
 
 
 def register_commands(gui: Any | None = None) -> None:

--- a/src/Mod/VibeCADPrint/Init.py
+++ b/src/Mod/VibeCADPrint/Init.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Application bootstrap for the VibeCAD 3D Print module."""

--- a/src/Mod/VibeCADPrint/InitGui.py
+++ b/src/Mod/VibeCADPrint/InitGui.py
@@ -4,10 +4,10 @@
 
 
 class VibeCADPrintWorkbench(Workbench):
-    """PrusaSlicer profile selection and explicit 3MF handoff."""
+    """External slicer profile selection and explicit 3MF handoff."""
 
     MenuText = "3D Print"
-    ToolTip = "Prepare selected CAD objects and open them in PrusaSlicer"
+    ToolTip = "Prepare selected CAD objects and open them in an external slicer"
 
     def __init__(self):
         self.__class__.Icon = (

--- a/src/Mod/VibeCADPrint/InitGui.py
+++ b/src/Mod/VibeCADPrint/InitGui.py
@@ -16,8 +16,10 @@ class VibeCADPrintWorkbench(Workbench):
 
     def Initialize(self):
         import PrintCommandLoader
+        import PrintPanel
 
         PrintCommandLoader.ensure_commands_registered()
+        PrintPanel.ensure_panel_registered()
         send_commands = [
             "VibeCADPrint_OpenInPrusaSlicer",
             "VibeCADPrint_Save3MF",
@@ -29,9 +31,15 @@ class VibeCADPrintWorkbench(Workbench):
         Log("Loading VibeCAD 3D Print workbench... done\n")
 
     def Activated(self):
+        import PrintPanel
+
         Msg("VibeCADPrintWorkbench::Activated()\n")
+        PrintPanel.show_panel()
 
     def Deactivated(self):
+        import PrintPanel
+
+        PrintPanel.hide_panel()
         Msg("VibeCADPrintWorkbench::Deactivated()\n")
 
     def GetClassName(self):

--- a/src/Mod/VibeCADPrint/InitGui.py
+++ b/src/Mod/VibeCADPrint/InitGui.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""GUI bootstrap for VibeCAD's additive 3D Print workbench."""
+
+
+class VibeCADPrintWorkbench(Workbench):
+    """PrusaSlicer profile selection and explicit 3MF handoff."""
+
+    MenuText = "3D Print"
+    ToolTip = "Prepare selected CAD objects and open them in PrusaSlicer"
+
+    def __init__(self):
+        self.__class__.Icon = (
+            FreeCAD.getHomePath() + "Mod/VibeCADPrint/icons/vibecad-print-open.svg"
+        )
+
+    def Initialize(self):
+        import PrintCommandLoader
+
+        PrintCommandLoader.ensure_commands_registered()
+        send_commands = [
+            "VibeCADPrint_OpenInPrusaSlicer",
+            "VibeCADPrint_Save3MF",
+        ]
+        setup_commands = ["VibeCADPrint_Setup"]
+        self.appendToolbar("Send", send_commands)
+        self.appendToolbar("Setup", setup_commands)
+        self.appendMenu("3D Print", send_commands + setup_commands)
+        Log("Loading VibeCAD 3D Print workbench... done\n")
+
+    def Activated(self):
+        Msg("VibeCADPrintWorkbench::Activated()\n")
+
+    def Deactivated(self):
+        Msg("VibeCADPrintWorkbench::Deactivated()\n")
+
+    def GetClassName(self):
+        return "Gui::PythonWorkbench"
+
+
+import PrintSetupDialog
+
+Gui.addPreferencePage(PrintSetupDialog.VibeCADPrintPreferencesPage, "VibeCAD")
+Gui.addWorkbench(VibeCADPrintWorkbench())

--- a/src/Mod/VibeCADPrint/OrcaSlicer.py
+++ b/src/Mod/VibeCADPrint/OrcaSlicer.py
@@ -102,14 +102,20 @@ def _candidate_specs(
             )
         )
     if platform == "win32":
-        standard = (
-            (environ.get("ProgramFiles", r"C:\Program Files"), "OrcaSlicer.exe"),
-            (environ.get("LOCALAPPDATA", ""), r"Programs\OrcaSlicer\OrcaSlicer.exe"),
-        )
-        for root, suffix in standard:
-            if not root:
-                continue
-            executable = ntpath.join(root, "OrcaSlicer", suffix) if "\\" not in suffix else ntpath.join(root, suffix)
+        standard: list[str] = []
+        program_files = environ.get("ProgramFiles", r"C:\Program Files")
+        if program_files:
+            standard.extend(
+                ntpath.join(program_files, "OrcaSlicer", name)
+                for name in ("OrcaSlicer.exe", "orca-slicer.exe")
+            )
+        local_app_data = environ.get("LOCALAPPDATA", "")
+        if local_app_data:
+            standard.extend(
+                ntpath.join(local_app_data, "Programs", "OrcaSlicer", name)
+                for name in ("OrcaSlicer.exe", "orca-slicer.exe")
+            )
+        for executable in standard:
             values.append(
                 _Candidate(
                     (executable,),
@@ -217,6 +223,9 @@ def discover_orca_installations(
     environ: Mapping[str, str] | None = None,
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     which: Callable[[str], str | None] = shutil.which,
+    windows_version_reader: Callable[
+        [str, str], str
+    ] = BambuStudio.windows_installed_version,
 ) -> tuple[VibeCADPrint.SlicerInstallation, ...]:
     """Discover current native and Flatpak OrcaSlicer installations."""
 
@@ -251,10 +260,19 @@ def discover_orca_installations(
             str(value or "") for value in (completed.stdout, completed.stderr)
         )
         match = _ORCA_VERSION_RE.search(output)
-        if match is None:
+        if match is not None:
+            pieces = [str(int(value or 0)) for value in match.groups()]
+            version = ".".join(
+                pieces[:3] + ([pieces[3]] if match.group(4) else [])
+            )
+        elif platform == "win32" and completed.returncode == 0:
+            version = BambuStudio._normalized_version(
+                windows_version_reader(gui[0], candidate.display_name)
+            )
+        else:
+            version = ""
+        if not version:
             continue
-        pieces = [str(int(value or 0)) for value in match.groups()]
-        version = ".".join(pieces[:3] + ([pieces[3]] if match.group(4) else []))
         resource_dir = candidate.resource_dir or _flatpak_resource_dir(
             candidate.source,
             runner=runner,
@@ -350,13 +368,15 @@ def launch_orca_slicer(
     handoff_file: str | os.PathLike[str],
     *,
     popen: Callable[..., subprocess.Popen[Any]] = subprocess.Popen,
+    platform: str | None = None,
 ) -> VibeCADPrint.LaunchResult:
-    command = (*installation.gui_command, str(Path(handoff_file)))
-    try:
-        process = popen(list(command), close_fds=(os.name != "nt"))
-    except OSError as exc:
-        raise VibeCADPrint.SlicerError(f"Could not start OrcaSlicer: {exc}") from exc
-    return VibeCADPrint.LaunchResult(command=command, process_id=process.pid)
+    return VibeCADPrint.launch_slicer_gui(
+        installation,
+        handoff_file,
+        slicer_name="OrcaSlicer",
+        popen=popen,
+        platform=platform,
+    )
 
 
 class OrcaSlicerBackend(BambuStudio.BambuStudioBackend):

--- a/src/Mod/VibeCADPrint/OrcaSlicer.py
+++ b/src/Mod/VibeCADPrint/OrcaSlicer.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import ntpath
 import os
 from pathlib import Path
 import re
@@ -53,7 +52,7 @@ def _default_config_dir(
         )
     if platform == "win32":
         base = environ.get("APPDATA", "")
-        return ntpath.join(base, "OrcaSlicer") if base else ""
+        return BambuStudio._platform_path(platform, base, "OrcaSlicer") if base else ""
     if platform == "darwin":
         return (
             str(Path(home) / "Library/Application Support/OrcaSlicer")
@@ -106,13 +105,24 @@ def _candidate_specs(
         program_files = environ.get("ProgramFiles", r"C:\Program Files")
         if program_files:
             standard.extend(
-                ntpath.join(program_files, "OrcaSlicer", name)
+                BambuStudio._platform_path(
+                    platform,
+                    program_files,
+                    "OrcaSlicer",
+                    name,
+                )
                 for name in ("OrcaSlicer.exe", "orca-slicer.exe")
             )
         local_app_data = environ.get("LOCALAPPDATA", "")
         if local_app_data:
             standard.extend(
-                ntpath.join(local_app_data, "Programs", "OrcaSlicer", name)
+                BambuStudio._platform_path(
+                    platform,
+                    local_app_data,
+                    "Programs",
+                    "OrcaSlicer",
+                    name,
+                )
                 for name in ("OrcaSlicer.exe", "orca-slicer.exe")
             )
         for executable in standard:
@@ -329,6 +339,8 @@ def build_prepare_project_command(
     machine_profile: str | os.PathLike[str],
     process_profile: str | os.PathLike[str],
     material_profiles: Iterable[str | os.PathLike[str]],
+    *,
+    model_files: Iterable[str | os.PathLike[str]] = (),
 ) -> tuple[str, ...]:
     return BambuStudio.build_prepare_project_command(
         installation,
@@ -338,6 +350,7 @@ def build_prepare_project_command(
         machine_profile,
         process_profile,
         material_profiles,
+        model_files=model_files,
     )
 
 
@@ -347,8 +360,11 @@ def prepare_orca_project(
     destination: str | os.PathLike[str],
     setup: VibeCADPrint.PrintSetup,
     *,
+    model_files: Iterable[str | os.PathLike[str]] = (),
+    source_names: Iterable[str] = (),
     runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
     timeout: float = 120.0,
+    backend: BambuStudio.BambuStudioBackend | None = None,
 ) -> Path:
     try:
         return BambuStudio.prepare_bambu_project(
@@ -356,8 +372,11 @@ def prepare_orca_project(
             source_file,
             destination,
             setup,
+            model_files=model_files,
+            source_names=source_names,
             runner=runner,
             timeout=timeout,
+            backend=backend,
         )
     except VibeCADPrint.SlicerError as exc:
         raise _orca_error(exc) from exc
@@ -420,12 +439,18 @@ class OrcaSlicerBackend(BambuStudio.BambuStudioBackend):
         source_file: str | os.PathLike[str],
         destination: str | os.PathLike[str],
         setup: VibeCADPrint.PrintSetup,
+        *,
+        model_files: Iterable[str | os.PathLike[str]] = (),
+        source_names: Iterable[str] = (),
     ) -> Path:
         return prepare_orca_project(
             installation,
             source_file,
             destination,
             setup,
+            model_files=model_files,
+            source_names=source_names,
+            backend=self,
         )
 
     def launch(

--- a/src/Mod/VibeCADPrint/OrcaSlicer.py
+++ b/src/Mod/VibeCADPrint/OrcaSlicer.py
@@ -1,0 +1,417 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""OrcaSlicer discovery and exact-profile project handoff."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import ntpath
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Callable, Iterable, Mapping
+
+import BambuStudio
+import VibeCADPrint
+
+
+ORCA_APP_ID = "com.orcaslicer.OrcaSlicer"
+TESTED_ORCA_VERSION = (2, 4, 2)
+ORCA_CAPABILITIES = BambuStudio.BAMBU_CAPABILITIES
+_ORCA_VERSION_RE = re.compile(
+    r"OrcaSlicer[- ]0*(\d+)\.0*(\d+)\.0*(\d+)(?:\.0*(\d+))?",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class _Candidate:
+    gui_command: tuple[str, ...]
+    cli_command: tuple[str, ...]
+    source: str
+    display_name: str = "OrcaSlicer"
+    config_dir: str = ""
+    resource_dir: str = ""
+
+
+def _default_config_dir(
+    platform: str,
+    environ: Mapping[str, str],
+    *,
+    flatpak: bool = False,
+) -> str:
+    home = environ.get("HOME", "")
+    if flatpak:
+        return (
+            str(Path(home) / ".var/app" / ORCA_APP_ID / "config/OrcaSlicer")
+            if home
+            else ""
+        )
+    if platform == "win32":
+        base = environ.get("APPDATA", "")
+        return ntpath.join(base, "OrcaSlicer") if base else ""
+    if platform == "darwin":
+        return (
+            str(Path(home) / "Library/Application Support/OrcaSlicer")
+            if home
+            else ""
+        )
+    base = environ.get("XDG_CONFIG_HOME", "")
+    return (
+        str(Path(base or (Path(home) / ".config")) / "OrcaSlicer")
+        if base or home
+        else ""
+    )
+
+
+def _native_resource_dir(executable: str, platform: str) -> str:
+    path = Path(executable)
+    if platform == "darwin":
+        candidates = [path.parent.parent / "Resources/profiles"]
+    elif platform == "win32":
+        candidates = [path.parent / "resources/profiles", path.parent / "profiles"]
+    else:
+        candidates = [
+            path.parent.parent / "share/OrcaSlicer/profiles",
+            path.parent / "resources/profiles",
+        ]
+    return str(next((candidate for candidate in candidates if candidate.is_dir()), ""))
+
+
+def _candidate_specs(
+    explicit_executable: str,
+    *,
+    platform: str,
+    environ: Mapping[str, str],
+) -> tuple[_Candidate, ...]:
+    values: list[_Candidate] = []
+    explicit = str(explicit_executable or "").strip()
+    if explicit:
+        if platform == "darwin" and explicit.endswith(".app"):
+            explicit = str(Path(explicit) / "Contents/MacOS/OrcaSlicer")
+        values.append(
+            _Candidate(
+                (explicit,),
+                (explicit,),
+                "explicit",
+                config_dir=_default_config_dir(platform, environ),
+            )
+        )
+    if platform == "win32":
+        standard = (
+            (environ.get("ProgramFiles", r"C:\Program Files"), "OrcaSlicer.exe"),
+            (environ.get("LOCALAPPDATA", ""), r"Programs\OrcaSlicer\OrcaSlicer.exe"),
+        )
+        for root, suffix in standard:
+            if not root:
+                continue
+            executable = ntpath.join(root, "OrcaSlicer", suffix) if "\\" not in suffix else ntpath.join(root, suffix)
+            values.append(
+                _Candidate(
+                    (executable,),
+                    (executable,),
+                    "standard",
+                    config_dir=_default_config_dir(platform, environ),
+                )
+            )
+        for executable in ("OrcaSlicer.exe", "orca-slicer.exe"):
+            values.append(
+                _Candidate(
+                    (executable,),
+                    (executable,),
+                    "path",
+                    config_dir=_default_config_dir(platform, environ),
+                )
+            )
+    elif platform == "darwin":
+        executable = "/Applications/OrcaSlicer.app/Contents/MacOS/OrcaSlicer"
+        values.extend(
+            (
+                _Candidate(
+                    (executable,),
+                    (executable,),
+                    "standard",
+                    config_dir=_default_config_dir(platform, environ),
+                ),
+                _Candidate(
+                    ("orca-slicer",),
+                    ("orca-slicer",),
+                    "path",
+                    config_dir=_default_config_dir(platform, environ),
+                ),
+            )
+        )
+    else:
+        values.extend(
+            (
+                _Candidate(
+                    ("orca-slicer",),
+                    ("orca-slicer",),
+                    "path",
+                    config_dir=_default_config_dir(platform, environ),
+                ),
+                _Candidate(
+                    ("flatpak", "--user", "run", ORCA_APP_ID),
+                    (
+                        "flatpak",
+                        "--user",
+                        "run",
+                        "--command=/app/bin/orca-slicer",
+                        ORCA_APP_ID,
+                    ),
+                    "flatpak-user",
+                    "OrcaSlicer (Flatpak)",
+                    _default_config_dir(platform, environ, flatpak=True),
+                ),
+                _Candidate(
+                    ("flatpak", "--system", "run", ORCA_APP_ID),
+                    (
+                        "flatpak",
+                        "--system",
+                        "run",
+                        "--command=/app/bin/orca-slicer",
+                        ORCA_APP_ID,
+                    ),
+                    "flatpak-system",
+                    "OrcaSlicer (Flatpak)",
+                    _default_config_dir(platform, environ, flatpak=True),
+                ),
+            )
+        )
+    return tuple(values)
+
+
+def _flatpak_resource_dir(
+    source: str,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]],
+) -> str:
+    if not source.startswith("flatpak-"):
+        return ""
+    scope = source.removeprefix("flatpak-")
+    try:
+        completed = runner(
+            ["flatpak", "info", f"--{scope}", "--show-location", ORCA_APP_ID],
+            capture_output=True,
+            text=True,
+            timeout=10.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if completed.returncode != 0:
+        return ""
+    location = Path(str(completed.stdout or "").strip())
+    root = location / "files/share/OrcaSlicer/profiles"
+    return str(root) if root.is_dir() else ""
+
+
+def discover_orca_installations(
+    explicit_executable: str = "",
+    *,
+    platform: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    which: Callable[[str], str | None] = shutil.which,
+) -> tuple[VibeCADPrint.SlicerInstallation, ...]:
+    """Discover current native and Flatpak OrcaSlicer installations."""
+
+    platform = platform or sys.platform
+    env = dict(os.environ if environ is None else environ)
+    installations: list[VibeCADPrint.SlicerInstallation] = []
+    seen: set[tuple[str, ...]] = set()
+    for candidate in _candidate_specs(
+        explicit_executable,
+        platform=platform,
+        environ=env,
+    ):
+        gui = BambuStudio._resolve_command(candidate.gui_command, which)
+        cli = BambuStudio._resolve_command(candidate.cli_command, which)
+        if gui is None or cli is None or gui in seen:
+            continue
+        try:
+            with tempfile.TemporaryDirectory(
+                prefix="vibecad-slicer-probe-"
+            ) as working_directory:
+                completed = runner(
+                    [*cli, "--help"],
+                    capture_output=True,
+                    text=True,
+                    timeout=15.0,
+                    check=False,
+                    cwd=working_directory,
+                )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        output = "\n".join(
+            str(value or "") for value in (completed.stdout, completed.stderr)
+        )
+        match = _ORCA_VERSION_RE.search(output)
+        if match is None:
+            continue
+        pieces = [str(int(value or 0)) for value in match.groups()]
+        version = ".".join(pieces[:3] + ([pieces[3]] if match.group(4) else []))
+        resource_dir = candidate.resource_dir or _flatpak_resource_dir(
+            candidate.source,
+            runner=runner,
+        )
+        if not resource_dir:
+            resource_dir = _native_resource_dir(gui[0], platform)
+        seen.add(gui)
+        installations.append(
+            VibeCADPrint.SlicerInstallation(
+                backend_id="orcaslicer",
+                version=version,
+                gui_command=tuple(gui),
+                cli_command=tuple(cli),
+                source=candidate.source,
+                display_name=f"{candidate.display_name} {version}",
+                config_dir=candidate.config_dir,
+                capabilities=ORCA_CAPABILITIES,
+                resource_dir=resource_dir,
+                tested_version=TESTED_ORCA_VERSION,
+            )
+        )
+    return tuple(installations)
+
+
+def _orca_error(exc: VibeCADPrint.SlicerError) -> VibeCADPrint.SlicerError:
+    message = str(exc).replace("Bambu Studio", "OrcaSlicer")
+    return type(exc)(message)
+
+
+def query_printer_profiles(
+    installation: VibeCADPrint.SlicerInstallation,
+) -> tuple[VibeCADPrint.PrinterProfile, ...]:
+    try:
+        return BambuStudio.query_printer_profiles(installation)
+    except VibeCADPrint.SlicerError as exc:
+        raise _orca_error(exc) from exc
+
+
+def query_compatible_profiles(
+    installation: VibeCADPrint.SlicerInstallation,
+    printer_name: str,
+) -> VibeCADPrint.ProfileCatalog:
+    try:
+        return BambuStudio.query_compatible_profiles(installation, printer_name)
+    except VibeCADPrint.SlicerError as exc:
+        raise _orca_error(exc) from exc
+
+
+def build_prepare_project_command(
+    installation: VibeCADPrint.SlicerInstallation,
+    source_file: str | os.PathLike[str],
+    output_file: str | os.PathLike[str],
+    setup: VibeCADPrint.PrintSetup,
+    machine_profile: str | os.PathLike[str],
+    process_profile: str | os.PathLike[str],
+    material_profiles: Iterable[str | os.PathLike[str]],
+) -> tuple[str, ...]:
+    return BambuStudio.build_prepare_project_command(
+        installation,
+        source_file,
+        output_file,
+        setup,
+        machine_profile,
+        process_profile,
+        material_profiles,
+    )
+
+
+def prepare_orca_project(
+    installation: VibeCADPrint.SlicerInstallation,
+    source_file: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    setup: VibeCADPrint.PrintSetup,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    timeout: float = 120.0,
+) -> Path:
+    try:
+        return BambuStudio.prepare_bambu_project(
+            installation,
+            source_file,
+            destination,
+            setup,
+            runner=runner,
+            timeout=timeout,
+        )
+    except VibeCADPrint.SlicerError as exc:
+        raise _orca_error(exc) from exc
+
+
+def launch_orca_slicer(
+    installation: VibeCADPrint.SlicerInstallation,
+    handoff_file: str | os.PathLike[str],
+    *,
+    popen: Callable[..., subprocess.Popen[Any]] = subprocess.Popen,
+) -> VibeCADPrint.LaunchResult:
+    command = (*installation.gui_command, str(Path(handoff_file)))
+    try:
+        process = popen(list(command), close_fds=(os.name != "nt"))
+    except OSError as exc:
+        raise VibeCADPrint.SlicerError(f"Could not start OrcaSlicer: {exc}") from exc
+    return VibeCADPrint.LaunchResult(command=command, process_id=process.pid)
+
+
+class OrcaSlicerBackend(BambuStudio.BambuStudioBackend):
+    """Backend adapter consumed by the shared VibeCAD print workflow."""
+
+    backend_id = "orcaslicer"
+    display_name = "OrcaSlicer"
+    capabilities = ORCA_CAPABILITIES
+
+    def discover(
+        self, explicit_executable: str = ""
+    ) -> tuple[VibeCADPrint.SlicerInstallation, ...]:
+        key = str(explicit_executable or "").strip()
+        value = self._installation_cache.get(key)
+        if value is None:
+            value = discover_orca_installations(key)
+            self._installation_cache[key] = value
+        return value
+
+    def query_printers(
+        self, installation: VibeCADPrint.SlicerInstallation
+    ) -> tuple[VibeCADPrint.PrinterProfile, ...]:
+        try:
+            return super().query_printers(installation)
+        except VibeCADPrint.SlicerError as exc:
+            raise _orca_error(exc) from exc
+
+    def query_profiles(
+        self,
+        installation: VibeCADPrint.SlicerInstallation,
+        printer_profile: str,
+    ) -> VibeCADPrint.ProfileCatalog:
+        try:
+            return super().query_profiles(installation, printer_profile)
+        except VibeCADPrint.SlicerError as exc:
+            raise _orca_error(exc) from exc
+
+    def prepare_project(
+        self,
+        installation: VibeCADPrint.SlicerInstallation,
+        source_file: str | os.PathLike[str],
+        destination: str | os.PathLike[str],
+        setup: VibeCADPrint.PrintSetup,
+    ) -> Path:
+        return prepare_orca_project(
+            installation,
+            source_file,
+            destination,
+            setup,
+        )
+
+    def launch(
+        self,
+        installation: VibeCADPrint.SlicerInstallation,
+        handoff_file: str | os.PathLike[str],
+        _setup: VibeCADPrint.PrintSetup | None,
+    ) -> VibeCADPrint.LaunchResult:
+        return launch_orca_slicer(installation, handoff_file)

--- a/src/Mod/VibeCADPrint/PrintCommandLoader.py
+++ b/src/Mod/VibeCADPrint/PrintCommandLoader.py
@@ -44,6 +44,12 @@ def _load_command_module() -> Any:
     return module
 
 
+def command_module() -> Any:
+    """Return the exact VibeCAD print command module without name collisions."""
+
+    return _load_command_module()
+
+
 def ensure_commands_registered(gui: Any | None = None) -> None:
     if gui is None:
         import FreeCADGui as gui  # type: ignore[no-redef]

--- a/src/Mod/VibeCADPrint/PrintCommandLoader.py
+++ b/src/Mod/VibeCADPrint/PrintCommandLoader.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Register print commands from their exact file without module collisions."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from typing import Any
+
+
+COMMAND_IDS = (
+    "VibeCADPrint_OpenInPrusaSlicer",
+    "VibeCADPrint_Save3MF",
+    "VibeCADPrint_Setup",
+)
+_COMMAND_MODULE_NAME = "_vibecad_print_commands"
+
+
+def _registered_commands(gui: Any) -> set[str]:
+    reader = getattr(gui, "listCommands", None)
+    return {str(command) for command in reader()} if callable(reader) else set()
+
+
+def _load_command_module() -> Any:
+    source = Path(__file__).resolve().with_name("Commands.py")
+    existing = sys.modules.get(_COMMAND_MODULE_NAME)
+    if existing is not None:
+        existing_file = getattr(existing, "__file__", None)
+        if existing_file and Path(existing_file).resolve() == source:
+            return existing
+    spec = importlib.util.spec_from_file_location(_COMMAND_MODULE_NAME, source)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not load VibeCAD print commands from {source}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[_COMMAND_MODULE_NAME] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        if sys.modules.get(_COMMAND_MODULE_NAME) is module:
+            sys.modules.pop(_COMMAND_MODULE_NAME, None)
+        raise
+    return module
+
+
+def ensure_commands_registered(gui: Any | None = None) -> None:
+    if gui is None:
+        import FreeCADGui as gui  # type: ignore[no-redef]
+    registered = _registered_commands(gui)
+    if registered and set(COMMAND_IDS) <= registered:
+        return
+    module = _load_command_module()
+    module.register_commands(gui=gui)
+    reader = getattr(gui, "listCommands", None)
+    if callable(reader):
+        missing = set(COMMAND_IDS) - _registered_commands(gui)
+        if missing:
+            raise RuntimeError(
+                "VibeCAD print commands failed to register: "
+                + ", ".join(sorted(missing))
+            )

--- a/src/Mod/VibeCADPrint/PrintIcons.py
+++ b/src/Mod/VibeCADPrint/PrintIcons.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Repository-relative icons for the 3D Print workbench."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_ICONS = {
+    "open": "vibecad-print-open.svg",
+    "save": "vibecad-print-save.svg",
+    "setup": "vibecad-print-setup.svg",
+}
+
+
+def icon_path(name: str) -> str:
+    return str(Path(__file__).resolve().parent / "icons" / _ICONS[name])

--- a/src/Mod/VibeCADPrint/PrintPanel.py
+++ b/src/Mod/VibeCADPrint/PrintPanel.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""Persistent daily-use 3D Print panel backed by exact PrusaSlicer profiles."""
+"""Persistent daily-use 3D Print panel backed by exact slicer profiles."""
 
 from __future__ import annotations
 
@@ -40,6 +40,28 @@ def _active_print_selection() -> tuple[Any, tuple[Any, ...]]:
     return PrintCommandLoader.command_module()._active_selection()
 
 
+def _backend_for_id(backend_id: str) -> Any:
+    """Create a supported slicer adapter without loading unused integrations."""
+
+    if backend_id == "bambustudio":
+        import BambuStudio
+
+        return BambuStudio.BambuStudioBackend()
+    if backend_id == "prusaslicer":
+        return VibeCADPrint.PrusaSlicerBackend()
+    raise ValueError(f"Unsupported slicer backend: {backend_id}")
+
+
+def _backend_display_name(backend: Any) -> str:
+    value = str(getattr(backend, "display_name", "") or "").strip()
+    if value:
+        return value
+    return {
+        "bambustudio": "Bambu Studio",
+        "prusaslicer": "PrusaSlicer",
+    }.get(str(getattr(backend, "backend_id", "")), "PrusaSlicer")
+
+
 class _Bridge(QtCore.QObject):
     finished = QtCore.Signal(int, object, object)
 
@@ -72,12 +94,19 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self.setObjectName("VibeCADPrintPanelContents")
         self.setWindowTitle("3D Print")
         self.setMinimumWidth(280)
-        self.backend = VibeCADPrint.PrusaSlicerBackend()
+        self.backend_id = PrintPreferences.active_backend()
+        try:
+            self.backend = _backend_for_id(self.backend_id)
+        except ValueError:
+            self.backend_id = "prusaslicer"
+            self.backend = _backend_for_id(self.backend_id)
         self.installation: VibeCADPrint.SlicerInstallation | None = None
         self.printers: tuple[VibeCADPrint.PrinterProfile, ...] = ()
         self.catalog: VibeCADPrint.ProfileCatalog | None = None
         self.material_combos: list[Any] = []
-        self._remembered = PrintPreferences.load_confirmed_setup()
+        self._remembered = PrintPreferences.load_confirmed_setup(
+            backend_id=self.backend_id
+        )
         self._job = 0
         self._callback: Callable[[Any], None] | None = None
         self._futures: set[Future[Any]] = set()
@@ -95,19 +124,27 @@ class PrintPanelWidget(QtWidgets.QWidget):
         outer.setSpacing(8)
 
         header = QtWidgets.QHBoxLayout()
-        title = QtWidgets.QLabel("<b>Print with PrusaSlicer</b>", self)
-        header.addWidget(title, 1)
+        self.title_label = QtWidgets.QLabel("<b>3D Print</b>", self)
+        header.addWidget(self.title_label, 1)
         self.refresh_button = QtWidgets.QPushButton("Refresh", self)
-        self.refresh_button.setToolTip("Reload profiles installed by PrusaSlicer")
         self.refresh_button.clicked.connect(self.refresh)
         self.setup_button = QtWidgets.QPushButton("Setup…", self)
-        self.setup_button.setToolTip(
-            "Locate PrusaSlicer and configure profiles and 3MF storage"
-        )
         self.setup_button.clicked.connect(self._initial_setup)
         header.addWidget(self.refresh_button)
         header.addWidget(self.setup_button)
         outer.addLayout(header)
+
+        slicer_row = QtWidgets.QFormLayout()
+        slicer_row.setContentsMargins(0, 0, 0, 0)
+        self.slicer_combo = _compact_combo(QtWidgets.QComboBox(self))
+        self.slicer_combo.setObjectName("VibeCADPrintSlicerBackend")
+        self.slicer_combo.addItem("PrusaSlicer", "prusaslicer")
+        self.slicer_combo.addItem("Bambu Studio", "bambustudio")
+        selected_backend = self.slicer_combo.findData(self.backend_id)
+        self.slicer_combo.setCurrentIndex(max(0, selected_backend))
+        self.slicer_combo.currentIndexChanged.connect(self._slicer_changed)
+        slicer_row.addRow("Slicer", self.slicer_combo)
+        outer.addLayout(slicer_row)
 
         self.installation_label = _wrapped(QtWidgets.QLabel(self))
         self.installation_label.setObjectName("VibeCADPrintInstallationSummary")
@@ -224,6 +261,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self.installation_combo = QtWidgets.QComboBox(self)
         self.installation_combo.hide()
 
+        self._update_backend_ui()
         self._update_output_location()
         self._clear_profiles()
         self._attach_selection_observer()
@@ -234,18 +272,62 @@ class PrintPanelWidget(QtWidgets.QWidget):
         return QtCore.QSize(360, 640)
 
     def refresh(self) -> None:
-        self._remembered = PrintPreferences.load_confirmed_setup()
+        self._remembered = PrintPreferences.load_confirmed_setup(
+            backend_id=self.backend_id
+        )
         if self._remembered is not None:
             self.auto_arrange.setChecked(self._remembered.auto_arrange)
             self.ensure_on_bed.setChecked(self._remembered.ensure_on_bed)
         self._update_output_location()
-        override = PrintPreferences.executable_override()
+        override = PrintPreferences.executable_override(backend_id=self.backend_id)
         self._clear_profiles()
         self._start_job(
-            "Loading installed PrusaSlicer profiles…",
+            f"Loading installed {_backend_display_name(self.backend)} profiles…",
             lambda: self.backend.discover(override),
             self._installations_loaded,
         )
+
+    def _update_backend_ui(self) -> None:
+        display_name = _backend_display_name(self.backend)
+        self.refresh_button.setToolTip(
+            f"Reload profiles installed by {display_name}"
+        )
+        self.setup_button.setToolTip(
+            f"Locate {display_name} and configure profiles and 3MF storage"
+        )
+        self.print_button.setToolTip(
+            f"Export the selection and open it in {display_name} with these exact profiles"
+        )
+
+    def _slicer_changed(self, _index: int) -> None:
+        backend_id = str(self.slicer_combo.currentData() or "")
+        if not backend_id or backend_id == self.backend_id:
+            return
+        try:
+            backend = _backend_for_id(backend_id)
+        except ValueError as exc:
+            self.status.setText(str(exc))
+            return
+        PrintPreferences.set_active_backend(backend_id)
+        self.backend_id = backend_id
+        self.backend = backend
+        self.installation = None
+        self._remembered = PrintPreferences.load_confirmed_setup(
+            backend_id=self.backend_id
+        )
+        remembered = self._remembered
+        self.auto_arrange.blockSignals(True)
+        self.ensure_on_bed.blockSignals(True)
+        self.auto_arrange.setChecked(
+            remembered.auto_arrange if remembered is not None else True
+        )
+        self.ensure_on_bed.setChecked(
+            remembered.ensure_on_bed if remembered is not None else True
+        )
+        self.auto_arrange.blockSignals(False)
+        self.ensure_on_bed.blockSignals(False)
+        self._update_backend_ui()
+        self.refresh()
 
     def _update_output_location(self) -> None:
         storage = PrintPreferences.load_handoff_storage()
@@ -393,6 +475,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
 
     def _set_busy(self, busy: bool) -> None:
         self._busy = busy
+        self.slicer_combo.setEnabled(not busy)
         self.refresh_button.setEnabled(not busy)
         self.printer_combo.setEnabled(not busy)
         self.print_combo.setEnabled(not busy)
@@ -409,14 +492,21 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self.installation_combo.blockSignals(False)
         self.installation = preferred
         if preferred is None:
-            self.installation_label.setText("PrusaSlicer is not configured")
-            self.status.setText("Click Setup to locate PrusaSlicer and choose profiles.")
+            self.installation_label.setText(
+                f"{_backend_display_name(self.backend)} is not configured"
+            )
+            self.status.setText(
+                f"Click Setup to locate {_backend_display_name(self.backend)} and "
+                "choose profiles."
+            )
             self._update_actions()
             return
         self.installation_label.setText(preferred.display_name)
         if not preferred.tested:
+            baseline = ".".join(str(part) for part in preferred.tested_version)
             self.status.setText(
-                f"PrusaSlicer {preferred.version} is below the tested 2.9.6 baseline."
+                f"{_backend_display_name(self.backend)} {preferred.version} is below the "
+                f"tested {baseline} baseline."
             )
             self._update_actions()
             return
@@ -503,11 +593,15 @@ class PrintPanelWidget(QtWidgets.QWidget):
 
     def _profiles_loaded(self, value: Any) -> None:
         if not isinstance(value, VibeCADPrint.ProfileCatalog):
-            self.status.setText("PrusaSlicer returned an invalid profile catalog.")
+            self.status.setText(
+                f"{_backend_display_name(self.backend)} returned an invalid profile catalog."
+            )
             return
         printer = self._selected_printer()
         if printer is None or value.printer_profile != printer.name:
-            self.status.setText("PrusaSlicer returned profiles for another printer.")
+            self.status.setText(
+                f"{_backend_display_name(self.backend)} returned profiles for another printer."
+            )
             return
         self.catalog = value
         self.print_combo.blockSignals(True)
@@ -609,7 +703,10 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self.print_button.setEnabled(ready)
         self.export_button.setEnabled(self._print_selection_ready)
         if setup is not None:
-            PrintPreferences.save_confirmed_setup(setup)
+            PrintPreferences.save_confirmed_setup(
+                setup,
+                backend_id=self.backend_id,
+            )
             self._remembered = setup
             self.status.setText("Ready · selections saved automatically")
         elif not self._busy and self.status.text().startswith("Ready"):
@@ -620,7 +717,10 @@ class PrintPanelWidget(QtWidgets.QWidget):
         if setup is None:
             self.status.setText("Choose a printer, quality, and material.")
             return False
-        PrintPreferences.save_confirmed_setup(setup)
+        PrintPreferences.save_confirmed_setup(
+            setup,
+            backend_id=self.backend_id,
+        )
         self._remembered = setup
         self.status.setText("Ready · selections saved automatically")
         return True
@@ -638,7 +738,8 @@ class PrintPanelWidget(QtWidgets.QWidget):
         import PrintCommandLoader
 
         commands = PrintCommandLoader.command_module()
-        commands.open_selected_in_prusaslicer(
+        commands.open_selected_in_slicer(
+            backend=self.backend,
             installation=self.installation,
             setup=self._current_setup(),
             selection=selection,
@@ -712,7 +813,7 @@ def hide_panel() -> None:
 def open_setup_dialog(
     *,
     parent: Any | None = None,
-    backend: VibeCADPrint.PrusaSlicerBackend | None = None,
+    backend: Any | None = None,
 ) -> Any:
     """Open explicit slicer configuration and refresh the daily-use panel."""
 

--- a/src/Mod/VibeCADPrint/PrintPanel.py
+++ b/src/Mod/VibeCADPrint/PrintPanel.py
@@ -1,0 +1,568 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Persistent 3D Print workspace for exact PrusaSlicer handoff choices."""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from pathlib import Path
+from typing import Any, Callable
+
+from PySide import QtCore, QtWidgets
+
+import PrintPreferences
+import PrintSetupDialog
+import VibeCADPrint
+
+
+DOCK_NAME = "VibeCADPrintPanel"
+_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="vibecad-print-panel")
+
+
+def _wrapped(label: Any) -> Any:
+    label.setWordWrap(True)
+    policy = label.sizePolicy()
+    policy.setVerticalPolicy(QtWidgets.QSizePolicy.Minimum)
+    label.setSizePolicy(policy)
+    return label
+
+
+class _Bridge(QtCore.QObject):
+    finished = QtCore.Signal(int, object, object)
+
+
+class PrintPanelWidget(QtWidgets.QWidget):
+    """Non-modal profile, placement, and 3MF storage controls."""
+
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
+        self.setObjectName("VibeCADPrintPanelContents")
+        self.setWindowTitle("3D Print")
+        self.setMinimumWidth(320)
+        self.backend = VibeCADPrint.PrusaSlicerBackend()
+        self.installation: VibeCADPrint.SlicerInstallation | None = None
+        self.printers: tuple[VibeCADPrint.PrinterProfile, ...] = ()
+        self.catalog: VibeCADPrint.ProfileCatalog | None = None
+        self.material_combos: list[Any] = []
+        self._remembered = PrintPreferences.load_confirmed_setup()
+        self._job = 0
+        self._callback: Callable[[Any], None] | None = None
+        self._futures: set[Future[Any]] = set()
+        self._bridge = _Bridge(self)
+        self._bridge.finished.connect(self._job_finished)
+
+        outer = QtWidgets.QVBoxLayout(self)
+        outer.setContentsMargins(6, 6, 6, 6)
+        outer.setSpacing(6)
+
+        intro = _wrapped(
+            QtWidgets.QLabel(
+                "Choose exact installed profiles. VibeCAD never substitutes a "
+                "printer, print profile, or material.",
+                self,
+            )
+        )
+        outer.addWidget(intro)
+
+        scroll = QtWidgets.QScrollArea(self)
+        scroll.setObjectName("VibeCADPrintPanelScroll")
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QtWidgets.QFrame.NoFrame)
+        content = QtWidgets.QWidget(scroll)
+        content_layout = QtWidgets.QVBoxLayout(content)
+        content_layout.setContentsMargins(0, 0, 0, 0)
+        content_layout.setSpacing(6)
+
+        slicer_group = QtWidgets.QGroupBox("PrusaSlicer", content)
+        slicer_layout = QtWidgets.QVBoxLayout(slicer_group)
+        slicer_layout.addWidget(QtWidgets.QLabel("Detected installation", slicer_group))
+        self.installation_combo = QtWidgets.QComboBox(slicer_group)
+        self.installation_combo.setObjectName("VibeCADPrintInstallation")
+        self.installation_combo.currentIndexChanged.connect(
+            self._installation_changed
+        )
+        slicer_layout.addWidget(self.installation_combo)
+        slicer_buttons = QtWidgets.QHBoxLayout()
+        self.refresh_button = QtWidgets.QPushButton("Refresh profiles", slicer_group)
+        self.refresh_button.clicked.connect(self.refresh)
+        initial_setup = QtWidgets.QPushButton("Initial setup…", slicer_group)
+        initial_setup.clicked.connect(self._initial_setup)
+        slicer_buttons.addWidget(self.refresh_button)
+        slicer_buttons.addWidget(initial_setup)
+        slicer_layout.addLayout(slicer_buttons)
+        content_layout.addWidget(slicer_group)
+
+        profiles_group = QtWidgets.QGroupBox("Installed profiles", content)
+        profiles_layout = QtWidgets.QVBoxLayout(profiles_group)
+        profiles_layout.addWidget(QtWidgets.QLabel("Printer profile", profiles_group))
+        self.printer_combo = QtWidgets.QComboBox(profiles_group)
+        self.printer_combo.setObjectName("VibeCADPrintPrinterProfile")
+        self.printer_combo.currentIndexChanged.connect(self._printer_changed)
+        profiles_layout.addWidget(self.printer_combo)
+        self.bed_details = _wrapped(QtWidgets.QLabel(profiles_group))
+        self.bed_details.setObjectName("VibeCADPrintBuildVolume")
+        profiles_layout.addWidget(self.bed_details)
+        profiles_layout.addWidget(QtWidgets.QLabel("Print profile", profiles_group))
+        self.print_combo = QtWidgets.QComboBox(profiles_group)
+        self.print_combo.setObjectName("VibeCADPrintPrintProfile")
+        self.print_combo.currentIndexChanged.connect(self._print_changed)
+        profiles_layout.addWidget(self.print_combo)
+        profiles_layout.addWidget(QtWidgets.QLabel("Materials", profiles_group))
+        self.material_widget = QtWidgets.QWidget(profiles_group)
+        self.material_layout = QtWidgets.QFormLayout(self.material_widget)
+        self.material_layout.setContentsMargins(0, 0, 0, 0)
+        self.material_layout.setRowWrapPolicy(QtWidgets.QFormLayout.WrapLongRows)
+        profiles_layout.addWidget(self.material_widget)
+        content_layout.addWidget(profiles_group)
+
+        placement_group = QtWidgets.QGroupBox("Placement", content)
+        placement_layout = QtWidgets.QVBoxLayout(placement_group)
+        self.auto_arrange = QtWidgets.QCheckBox("Auto-arrange", placement_group)
+        self.ensure_on_bed = QtWidgets.QCheckBox("Ensure on bed", placement_group)
+        remembered = self._remembered
+        self.auto_arrange.setChecked(
+            remembered.auto_arrange if remembered is not None else True
+        )
+        self.ensure_on_bed.setChecked(
+            remembered.ensure_on_bed if remembered is not None else True
+        )
+        self.auto_arrange.toggled.connect(self._update_actions)
+        self.ensure_on_bed.toggled.connect(self._update_actions)
+        placement_layout.addWidget(self.auto_arrange)
+        placement_layout.addWidget(self.ensure_on_bed)
+        content_layout.addWidget(placement_group)
+
+        storage_group = QtWidgets.QGroupBox("3MF handoff location", content)
+        storage_layout = QtWidgets.QVBoxLayout(storage_group)
+        self.managed_storage = QtWidgets.QRadioButton(
+            "Managed VibeCAD cache", storage_group
+        )
+        self.folder_storage = QtWidgets.QRadioButton(
+            "Choose a folder", storage_group
+        )
+        storage_layout.addWidget(self.managed_storage)
+        storage_layout.addWidget(self.folder_storage)
+        folder_row = QtWidgets.QHBoxLayout()
+        self.folder_edit = QtWidgets.QLineEdit(storage_group)
+        self.folder_edit.setObjectName("VibeCADPrintHandoffDirectory")
+        self.folder_edit.setPlaceholderText("Folder for persistent 3MF files")
+        browse = QtWidgets.QPushButton("Browse…", storage_group)
+        browse.clicked.connect(self._browse_folder)
+        folder_row.addWidget(self.folder_edit, 1)
+        folder_row.addWidget(browse)
+        storage_layout.addLayout(folder_row)
+        storage_note = _wrapped(
+            QtWidgets.QLabel(
+                "Managed files are automatically limited to recent handoffs. "
+                "Files in your chosen folder are never pruned by VibeCAD.",
+                storage_group,
+            )
+        )
+        storage_layout.addWidget(storage_note)
+        storage = PrintPreferences.load_handoff_storage()
+        self.folder_edit.setText(storage.directory)
+        self.folder_edit.textChanged.connect(self._update_actions)
+        self.managed_storage.setChecked(storage.mode == "managed")
+        self.folder_storage.setChecked(storage.mode == "folder")
+        self.managed_storage.toggled.connect(self._storage_changed)
+        self.folder_storage.toggled.connect(self._storage_changed)
+        content_layout.addWidget(storage_group)
+        content_layout.addStretch(1)
+        scroll.setWidget(content)
+        outer.addWidget(scroll, 1)
+
+        self.status = _wrapped(QtWidgets.QLabel(self))
+        self.status.setObjectName("VibeCADPrintPanelStatus")
+        self.status.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+        outer.addWidget(self.status)
+
+        setup_actions = QtWidgets.QHBoxLayout()
+        self.apply_button = QtWidgets.QPushButton("Apply setup", self)
+        self.apply_button.clicked.connect(self._save)
+        self.open_button = QtWidgets.QPushButton("Open selected", self)
+        self.open_button.clicked.connect(self._open_selected)
+        setup_actions.addWidget(self.apply_button)
+        setup_actions.addWidget(self.open_button)
+        outer.addLayout(setup_actions)
+        save_3mf = QtWidgets.QPushButton("Save selected 3MF…", self)
+        save_3mf.clicked.connect(self._save_selected)
+        outer.addWidget(save_3mf)
+
+        self._clear_profiles()
+        self._storage_changed()
+        self._update_actions()
+
+    def sizeHint(self):
+        return QtCore.QSize(390, 720)
+
+    def refresh(self) -> None:
+        self._remembered = PrintPreferences.load_confirmed_setup()
+        override = PrintPreferences.executable_override()
+        self._clear_profiles()
+        self._start_job(
+            "Detecting PrusaSlicer and reading installed profiles…",
+            lambda: self.backend.discover(override),
+            self._installations_loaded,
+        )
+
+    def _start_job(
+        self,
+        message: str,
+        operation: Callable[[], Any],
+        callback: Callable[[Any], None],
+    ) -> None:
+        self._job += 1
+        job = self._job
+        self._callback = callback
+        self._set_busy(True)
+        self.status.setText(message)
+        future = _EXECUTOR.submit(operation)
+        self._futures.add(future)
+
+        def complete(value: Future[Any]) -> None:
+            self._futures.discard(value)
+            try:
+                result, error = value.result(), None
+            except Exception as exc:
+                result, error = None, exc
+            try:
+                self._bridge.finished.emit(job, result, error)
+            except RuntimeError:
+                pass
+
+        future.add_done_callback(complete)
+
+    def _job_finished(self, job: int, result: Any, error: Any) -> None:
+        if job != self._job:
+            return
+        callback = self._callback
+        self._callback = None
+        self._set_busy(False)
+        if error is not None:
+            self.status.setText(str(error))
+            self._update_actions()
+            return
+        if callback is not None:
+            callback(result)
+
+    def _set_busy(self, busy: bool) -> None:
+        self.refresh_button.setEnabled(not busy)
+        self.installation_combo.setEnabled(not busy)
+        self.printer_combo.setEnabled(not busy)
+        self.print_combo.setEnabled(not busy)
+        if busy:
+            self.apply_button.setEnabled(False)
+
+    def _installations_loaded(self, values: Any) -> None:
+        installations = tuple(values or ())
+        preferred = VibeCADPrint.preferred_installation(installations)
+        self.installation_combo.blockSignals(True)
+        self.installation_combo.clear()
+        for installation in installations:
+            self.installation_combo.addItem(installation.display_name, installation)
+        if preferred is not None:
+            for index, installation in enumerate(installations):
+                if installation.gui_command == preferred.gui_command:
+                    self.installation_combo.setCurrentIndex(index)
+                    break
+        self.installation_combo.blockSignals(False)
+        if preferred is None:
+            self.installation = None
+            self.status.setText(
+                "PrusaSlicer was not found. Use Initial setup to locate or install it."
+            )
+            self._update_actions()
+            return
+        self._installation_changed(self.installation_combo.currentIndex())
+
+    def _selected_installation(self) -> VibeCADPrint.SlicerInstallation | None:
+        value = self.installation_combo.currentData()
+        return value if isinstance(value, VibeCADPrint.SlicerInstallation) else None
+
+    def _installation_changed(self, _index: int) -> None:
+        self.installation = self._selected_installation()
+        self._clear_profiles()
+        if self.installation is None:
+            self.status.setText("Choose a PrusaSlicer installation.")
+            return
+        if not self.installation.tested:
+            self.status.setText(
+                f"PrusaSlicer {self.installation.version} is below the tested 2.9.6 "
+                "profile-integration baseline."
+            )
+            return
+        self._start_job(
+            "Reading exact installed printer profiles…",
+            lambda: self.backend.query_printers(self.installation),
+            self._printers_loaded,
+        )
+
+    def _clear_profiles(self) -> None:
+        self.printers = ()
+        self.catalog = None
+        self.printer_combo.blockSignals(True)
+        self.printer_combo.clear()
+        self.printer_combo.addItem("Choose a printer profile…", None)
+        self.printer_combo.blockSignals(False)
+        self.print_combo.blockSignals(True)
+        self.print_combo.clear()
+        self.print_combo.addItem("Choose a print profile…", None)
+        self.print_combo.blockSignals(False)
+        self.bed_details.setText("No printer selected.")
+        self._clear_materials()
+
+    def _printers_loaded(self, values: Any) -> None:
+        self.printers = tuple(values or ())
+        self.printer_combo.blockSignals(True)
+        self.printer_combo.clear()
+        self.printer_combo.addItem("Choose a printer profile…", None)
+        selected = 0
+        for index, printer in enumerate(self.printers, start=1):
+            self.printer_combo.addItem(
+                printer.name + (" — user" if printer.is_user else ""), printer
+            )
+            if self._remembered and printer.name == self._remembered.printer_profile:
+                selected = index
+        self.printer_combo.setCurrentIndex(selected)
+        self.printer_combo.blockSignals(False)
+        if selected:
+            self._printer_changed(selected)
+        else:
+            self.status.setText("Choose the exact installed printer profile.")
+            self._update_actions()
+
+    def _selected_printer(self) -> VibeCADPrint.PrinterProfile | None:
+        value = self.printer_combo.currentData()
+        return value if isinstance(value, VibeCADPrint.PrinterProfile) else None
+
+    def _printer_changed(self, _index: int) -> None:
+        printer = self._selected_printer()
+        self.catalog = None
+        self.print_combo.blockSignals(True)
+        self.print_combo.clear()
+        self.print_combo.addItem("Choose a print profile…", None)
+        self.print_combo.blockSignals(False)
+        self._clear_materials()
+        if printer is None:
+            self.bed_details.setText("No printer selected.")
+            self.status.setText("Choose the exact installed printer profile.")
+            self._update_actions()
+            return
+        bed = printer.bed
+        self.bed_details.setText(
+            f"{bed.width:g} × {bed.height:g} × {bed.max_print_height:g} mm; "
+            f"{printer.extruders} extruder(s)"
+        )
+        if self.installation is None:
+            return
+        self._start_job(
+            f"Reading profiles compatible with {printer.name}…",
+            lambda: self.backend.query_profiles(self.installation, printer.name),
+            self._profiles_loaded,
+        )
+
+    def _profiles_loaded(self, value: Any) -> None:
+        if not isinstance(value, VibeCADPrint.ProfileCatalog):
+            self.status.setText("PrusaSlicer returned an invalid profile catalog.")
+            return
+        self.catalog = value
+        self.print_combo.blockSignals(True)
+        self.print_combo.clear()
+        self.print_combo.addItem("Choose a print profile…", None)
+        selected = 0
+        printer = self._selected_printer()
+        for index, profile in enumerate(value.print_profiles, start=1):
+            self.print_combo.addItem(
+                profile.name + (" — user" if profile.is_user else ""), profile
+            )
+            if (
+                self._remembered
+                and printer is not None
+                and self._remembered.printer_profile == printer.name
+                and profile.name == self._remembered.print_profile
+            ):
+                selected = index
+        self.print_combo.setCurrentIndex(selected)
+        self.print_combo.blockSignals(False)
+        if selected:
+            self._print_changed(selected)
+        else:
+            self.status.setText("Choose the exact compatible print profile.")
+            self._update_actions()
+
+    def _selected_print(self) -> VibeCADPrint.PrintProfile | None:
+        value = self.print_combo.currentData()
+        return value if isinstance(value, VibeCADPrint.PrintProfile) else None
+
+    def _clear_materials(self) -> None:
+        self.material_combos.clear()
+        while self.material_layout.count():
+            item = self.material_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def _print_changed(self, _index: int) -> None:
+        self._clear_materials()
+        printer = self._selected_printer()
+        profile = self._selected_print()
+        if printer is None or profile is None:
+            self._update_actions()
+            return
+        for extruder in range(printer.extruders):
+            combo = QtWidgets.QComboBox(self.material_widget)
+            combo.addItem("Choose a material profile…", None)
+            for material in profile.materials:
+                combo.addItem(
+                    material.name + (" — user" if material.is_user else ""),
+                    material.name,
+                )
+            if (
+                self._remembered
+                and self._remembered.printer_profile == printer.name
+                and self._remembered.print_profile == profile.name
+                and extruder < len(self._remembered.material_profiles)
+            ):
+                index = combo.findData(self._remembered.material_profiles[extruder])
+                if index >= 0:
+                    combo.setCurrentIndex(index)
+            combo.currentIndexChanged.connect(self._update_actions)
+            self.material_layout.addRow(f"Extruder {extruder + 1}", combo)
+            self.material_combos.append(combo)
+        self.status.setText("Review the exact setup, then click Apply setup.")
+        self._update_actions()
+
+    def _current_setup(self) -> VibeCADPrint.PrintSetup | None:
+        printer = self._selected_printer()
+        profile = self._selected_print()
+        if printer is None or profile is None or self.catalog is None:
+            return None
+        materials = tuple(str(combo.currentData() or "") for combo in self.material_combos)
+        if len(materials) != printer.extruders or any(not value for value in materials):
+            return None
+        setup = VibeCADPrint.PrintSetup(
+            printer_profile=printer.name,
+            print_profile=profile.name,
+            material_profiles=materials,
+            auto_arrange=self.auto_arrange.isChecked(),
+            ensure_on_bed=self.ensure_on_bed.isChecked(),
+        )
+        return None if VibeCADPrint.validate_setup(setup, printer, self.catalog) else setup
+
+    def _current_storage(self) -> PrintPreferences.HandoffStorage | None:
+        directory = self.folder_edit.text().strip()
+        if self.folder_storage.isChecked():
+            if not directory:
+                return None
+            return PrintPreferences.HandoffStorage("folder", directory)
+        return PrintPreferences.HandoffStorage("managed", directory)
+
+    def _storage_changed(self, *_args) -> None:
+        folder = self.folder_storage.isChecked()
+        self.folder_edit.setEnabled(folder)
+        self._update_actions()
+
+    def _update_actions(self, *_args) -> None:
+        ready = self._current_setup() is not None and self._current_storage() is not None
+        self.apply_button.setEnabled(ready)
+        self.open_button.setEnabled(ready)
+
+    def _save(self) -> bool:
+        setup = self._current_setup()
+        storage = self._current_storage()
+        if setup is None:
+            self.status.setText(
+                "Choose a printer, print profile, and one material per extruder."
+            )
+            return False
+        if storage is None:
+            self.status.setText("Choose a folder or select Managed VibeCAD cache.")
+            return False
+        PrintPreferences.save_confirmed_setup(setup)
+        PrintPreferences.save_handoff_storage(storage)
+        self._remembered = setup
+        destination = (
+            storage.directory if storage.mode == "folder" else "the managed VibeCAD cache"
+        )
+        self.status.setText(f"Setup applied. New handoffs will be written to {destination}.")
+        return True
+
+    def _browse_folder(self) -> None:
+        start = self.folder_edit.text().strip() or str(Path.home())
+        selected = QtWidgets.QFileDialog.getExistingDirectory(
+            self,
+            "Choose a folder for 3MF handoffs",
+            start,
+        )
+        if selected:
+            self.folder_edit.setText(str(selected))
+            self.folder_storage.setChecked(True)
+
+    def _open_selected(self) -> None:
+        if not self._save():
+            return
+        import FreeCADGui
+
+        FreeCADGui.runCommand("VibeCADPrint_OpenInPrusaSlicer")
+
+    def _save_selected(self) -> None:
+        import FreeCADGui
+
+        FreeCADGui.runCommand("VibeCADPrint_Save3MF")
+
+    def _initial_setup(self) -> None:
+        choice = PrintSetupDialog.choose_print_setup(
+            parent=self,
+            backend=self.backend,
+            open_after_save=False,
+            initial_installation=self.installation,
+        )
+        if choice.accepted:
+            self.refresh()
+
+
+def _main_window() -> Any:
+    import FreeCADGui
+
+    return FreeCADGui.getMainWindow()
+
+
+def _find_dock() -> Any | None:
+    main = _main_window()
+    if main is None:
+        return None
+    return main.findChild(QtWidgets.QDockWidget, DOCK_NAME)
+
+
+def ensure_panel_registered() -> Any:
+    """Create the native dock once so View > Panels can also control it."""
+
+    dock = _find_dock()
+    if dock is not None:
+        return dock
+    main = _main_window()
+    if main is None:
+        raise RuntimeError("FreeCAD main window is unavailable.")
+    dock = QtWidgets.QDockWidget("3D Print", main)
+    dock.setObjectName(DOCK_NAME)
+    dock.setAllowedAreas(QtCore.Qt.LeftDockWidgetArea | QtCore.Qt.RightDockWidgetArea)
+    dock.setWidget(PrintPanelWidget(dock))
+    main.addDockWidget(QtCore.Qt.RightDockWidgetArea, dock)
+    dock.toggleViewAction().setVisible(True)
+    dock.hide()
+    return dock
+
+
+def show_panel() -> None:
+    dock = ensure_panel_registered()
+    dock.show()
+    dock.raise_()
+    widget = dock.widget()
+    if isinstance(widget, PrintPanelWidget):
+        widget.refresh()
+
+
+def hide_panel() -> None:
+    dock = _find_dock()
+    if dock is not None:
+        dock.hide()

--- a/src/Mod/VibeCADPrint/PrintPanel.py
+++ b/src/Mod/VibeCADPrint/PrintPanel.py
@@ -1,11 +1,10 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""Persistent 3D Print workspace for exact PrusaSlicer handoff choices."""
+"""Persistent daily-use 3D Print panel backed by exact PrusaSlicer profiles."""
 
 from __future__ import annotations
 
 from concurrent.futures import Future, ThreadPoolExecutor
-from pathlib import Path
 from typing import Any, Callable
 
 from PySide import QtCore, QtWidgets
@@ -27,18 +26,26 @@ def _wrapped(label: Any) -> Any:
     return label
 
 
+def _compact_combo(combo: Any) -> Any:
+    combo.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToMinimumContentsLengthWithIcon)
+    combo.setMinimumContentsLength(12)
+    combo.setMinimumWidth(0)
+    combo.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+    return combo
+
+
 class _Bridge(QtCore.QObject):
     finished = QtCore.Signal(int, object, object)
 
 
 class PrintPanelWidget(QtWidgets.QWidget):
-    """Non-modal profile, placement, and 3MF storage controls."""
+    """Remembered, non-modal controls for the normal print workflow."""
 
     def __init__(self, parent=None) -> None:
         super().__init__(parent)
         self.setObjectName("VibeCADPrintPanelContents")
         self.setWindowTitle("3D Print")
-        self.setMinimumWidth(320)
+        self.setMinimumWidth(280)
         self.backend = VibeCADPrint.PrusaSlicerBackend()
         self.installation: VibeCADPrint.SlicerInstallation | None = None
         self.printers: tuple[VibeCADPrint.PrinterProfile, ...] = ()
@@ -48,77 +55,81 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self._job = 0
         self._callback: Callable[[Any], None] | None = None
         self._futures: set[Future[Any]] = set()
+        self._busy = False
         self._bridge = _Bridge(self)
         self._bridge.finished.connect(self._job_finished)
 
         outer = QtWidgets.QVBoxLayout(self)
-        outer.setContentsMargins(6, 6, 6, 6)
-        outer.setSpacing(6)
+        outer.setContentsMargins(8, 8, 8, 8)
+        outer.setSpacing(8)
 
-        intro = _wrapped(
-            QtWidgets.QLabel(
-                "Choose exact installed profiles. VibeCAD never substitutes a "
-                "printer, print profile, or material.",
-                self,
-            )
+        header = QtWidgets.QHBoxLayout()
+        title = QtWidgets.QLabel("<b>Print with PrusaSlicer</b>", self)
+        header.addWidget(title, 1)
+        self.refresh_button = QtWidgets.QPushButton("Refresh", self)
+        self.refresh_button.setToolTip("Reload profiles installed by PrusaSlicer")
+        self.refresh_button.clicked.connect(self.refresh)
+        self.setup_button = QtWidgets.QPushButton("Setup…", self)
+        self.setup_button.setToolTip(
+            "Locate PrusaSlicer and configure profiles and 3MF storage"
         )
-        outer.addWidget(intro)
+        self.setup_button.clicked.connect(self._initial_setup)
+        header.addWidget(self.refresh_button)
+        header.addWidget(self.setup_button)
+        outer.addLayout(header)
+
+        self.installation_label = _wrapped(QtWidgets.QLabel(self))
+        self.installation_label.setObjectName("VibeCADPrintInstallationSummary")
+        outer.addWidget(self.installation_label)
 
         scroll = QtWidgets.QScrollArea(self)
         scroll.setObjectName("VibeCADPrintPanelScroll")
         scroll.setWidgetResizable(True)
         scroll.setFrameShape(QtWidgets.QFrame.NoFrame)
+        scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAlwaysOff)
         content = QtWidgets.QWidget(scroll)
+        content.setMinimumWidth(0)
         content_layout = QtWidgets.QVBoxLayout(content)
         content_layout.setContentsMargins(0, 0, 0, 0)
-        content_layout.setSpacing(6)
+        content_layout.setSpacing(8)
 
-        slicer_group = QtWidgets.QGroupBox("PrusaSlicer", content)
-        slicer_layout = QtWidgets.QVBoxLayout(slicer_group)
-        slicer_layout.addWidget(QtWidgets.QLabel("Detected installation", slicer_group))
-        self.installation_combo = QtWidgets.QComboBox(slicer_group)
-        self.installation_combo.setObjectName("VibeCADPrintInstallation")
-        self.installation_combo.currentIndexChanged.connect(
-            self._installation_changed
-        )
-        slicer_layout.addWidget(self.installation_combo)
-        slicer_buttons = QtWidgets.QHBoxLayout()
-        self.refresh_button = QtWidgets.QPushButton("Refresh profiles", slicer_group)
-        self.refresh_button.clicked.connect(self.refresh)
-        initial_setup = QtWidgets.QPushButton("Initial setup…", slicer_group)
-        initial_setup.clicked.connect(self._initial_setup)
-        slicer_buttons.addWidget(self.refresh_button)
-        slicer_buttons.addWidget(initial_setup)
-        slicer_layout.addLayout(slicer_buttons)
-        content_layout.addWidget(slicer_group)
+        content_layout.addWidget(QtWidgets.QLabel("<b>PRINT SETTINGS</b>", content))
+        profiles = QtWidgets.QFormLayout()
+        profiles.setContentsMargins(0, 0, 0, 0)
+        profiles.setSpacing(6)
+        profiles.setFieldGrowthPolicy(QtWidgets.QFormLayout.AllNonFixedFieldsGrow)
+        profiles.setRowWrapPolicy(QtWidgets.QFormLayout.WrapLongRows)
 
-        profiles_group = QtWidgets.QGroupBox("Installed profiles", content)
-        profiles_layout = QtWidgets.QVBoxLayout(profiles_group)
-        profiles_layout.addWidget(QtWidgets.QLabel("Printer profile", profiles_group))
-        self.printer_combo = QtWidgets.QComboBox(profiles_group)
+        self.printer_combo = _compact_combo(QtWidgets.QComboBox(content))
         self.printer_combo.setObjectName("VibeCADPrintPrinterProfile")
         self.printer_combo.currentIndexChanged.connect(self._printer_changed)
-        profiles_layout.addWidget(self.printer_combo)
-        self.bed_details = _wrapped(QtWidgets.QLabel(profiles_group))
+        profiles.addRow("Printer", self.printer_combo)
+
+        self.bed_details = _wrapped(QtWidgets.QLabel(content))
         self.bed_details.setObjectName("VibeCADPrintBuildVolume")
-        profiles_layout.addWidget(self.bed_details)
-        profiles_layout.addWidget(QtWidgets.QLabel("Print profile", profiles_group))
-        self.print_combo = QtWidgets.QComboBox(profiles_group)
+        profiles.addRow("", self.bed_details)
+
+        self.print_combo = _compact_combo(QtWidgets.QComboBox(content))
         self.print_combo.setObjectName("VibeCADPrintPrintProfile")
         self.print_combo.currentIndexChanged.connect(self._print_changed)
-        profiles_layout.addWidget(self.print_combo)
-        profiles_layout.addWidget(QtWidgets.QLabel("Materials", profiles_group))
-        self.material_widget = QtWidgets.QWidget(profiles_group)
+        profiles.addRow("Quality", self.print_combo)
+
+        self.material_widget = QtWidgets.QWidget(content)
         self.material_layout = QtWidgets.QFormLayout(self.material_widget)
         self.material_layout.setContentsMargins(0, 0, 0, 0)
+        self.material_layout.setSpacing(6)
+        self.material_layout.setFieldGrowthPolicy(
+            QtWidgets.QFormLayout.AllNonFixedFieldsGrow
+        )
         self.material_layout.setRowWrapPolicy(QtWidgets.QFormLayout.WrapLongRows)
-        profiles_layout.addWidget(self.material_widget)
-        content_layout.addWidget(profiles_group)
+        profiles.addRow("Material", self.material_widget)
+        content_layout.addLayout(profiles)
 
-        placement_group = QtWidgets.QGroupBox("Placement", content)
-        placement_layout = QtWidgets.QVBoxLayout(placement_group)
-        self.auto_arrange = QtWidgets.QCheckBox("Auto-arrange", placement_group)
-        self.ensure_on_bed = QtWidgets.QCheckBox("Ensure on bed", placement_group)
+        content_layout.addWidget(QtWidgets.QLabel("<b>PLACEMENT</b>", content))
+        placement = QtWidgets.QHBoxLayout()
+        placement.setContentsMargins(0, 0, 0, 0)
+        self.auto_arrange = QtWidgets.QCheckBox("Auto-arrange", content)
+        self.ensure_on_bed = QtWidgets.QCheckBox("Ensure on bed", content)
         remembered = self._remembered
         self.auto_arrange.setChecked(
             remembered.auto_arrange if remembered is not None else True
@@ -128,45 +139,24 @@ class PrintPanelWidget(QtWidgets.QWidget):
         )
         self.auto_arrange.toggled.connect(self._update_actions)
         self.ensure_on_bed.toggled.connect(self._update_actions)
-        placement_layout.addWidget(self.auto_arrange)
-        placement_layout.addWidget(self.ensure_on_bed)
-        content_layout.addWidget(placement_group)
+        placement.addWidget(self.auto_arrange)
+        placement.addWidget(self.ensure_on_bed)
+        placement.addStretch(1)
+        content_layout.addLayout(placement)
 
-        storage_group = QtWidgets.QGroupBox("3MF handoff location", content)
-        storage_layout = QtWidgets.QVBoxLayout(storage_group)
-        self.managed_storage = QtWidgets.QRadioButton(
-            "Managed VibeCAD cache", storage_group
-        )
-        self.folder_storage = QtWidgets.QRadioButton(
-            "Choose a folder", storage_group
-        )
-        storage_layout.addWidget(self.managed_storage)
-        storage_layout.addWidget(self.folder_storage)
-        folder_row = QtWidgets.QHBoxLayout()
-        self.folder_edit = QtWidgets.QLineEdit(storage_group)
-        self.folder_edit.setObjectName("VibeCADPrintHandoffDirectory")
-        self.folder_edit.setPlaceholderText("Folder for persistent 3MF files")
-        browse = QtWidgets.QPushButton("Browse…", storage_group)
-        browse.clicked.connect(self._browse_folder)
-        folder_row.addWidget(self.folder_edit, 1)
-        folder_row.addWidget(browse)
-        storage_layout.addLayout(folder_row)
-        storage_note = _wrapped(
+        content_layout.addWidget(QtWidgets.QLabel("<b>3MF OUTPUT</b>", content))
+        self.output_location = _wrapped(QtWidgets.QLabel(content))
+        self.output_location.setObjectName("VibeCADPrintOutputLocation")
+        self.output_location.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+        content_layout.addWidget(self.output_location)
+        automatic = _wrapped(
             QtWidgets.QLabel(
-                "Managed files are automatically limited to recent handoffs. "
-                "Files in your chosen folder are never pruned by VibeCAD.",
-                storage_group,
+                "Selections are saved automatically. Change the slicer or output "
+                "location in Setup.",
+                content,
             )
         )
-        storage_layout.addWidget(storage_note)
-        storage = PrintPreferences.load_handoff_storage()
-        self.folder_edit.setText(storage.directory)
-        self.folder_edit.textChanged.connect(self._update_actions)
-        self.managed_storage.setChecked(storage.mode == "managed")
-        self.folder_storage.setChecked(storage.mode == "folder")
-        self.managed_storage.toggled.connect(self._storage_changed)
-        self.folder_storage.toggled.connect(self._storage_changed)
-        content_layout.addWidget(storage_group)
+        content_layout.addWidget(automatic)
         content_layout.addStretch(1)
         scroll.setWidget(content)
         outer.addWidget(scroll, 1)
@@ -176,34 +166,52 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self.status.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
         outer.addWidget(self.status)
 
-        setup_actions = QtWidgets.QHBoxLayout()
-        self.apply_button = QtWidgets.QPushButton("Apply setup", self)
-        self.apply_button.clicked.connect(self._save)
-        self.open_button = QtWidgets.QPushButton("Open selected", self)
-        self.open_button.clicked.connect(self._open_selected)
-        setup_actions.addWidget(self.apply_button)
-        setup_actions.addWidget(self.open_button)
-        outer.addLayout(setup_actions)
-        save_3mf = QtWidgets.QPushButton("Save selected 3MF…", self)
-        save_3mf.clicked.connect(self._save_selected)
-        outer.addWidget(save_3mf)
+        self.print_button = QtWidgets.QPushButton("Print", self)
+        self.print_button.setObjectName("VibeCADPrintPrimaryAction")
+        self.print_button.setMinimumHeight(38)
+        self.print_button.setToolTip(
+            "Export the selection and open it with these exact profiles"
+        )
+        self.print_button.clicked.connect(self._open_selected)
+        outer.addWidget(self.print_button)
 
+        self.export_button = QtWidgets.QPushButton("Export 3MF…", self)
+        self.export_button.clicked.connect(self._save_selected)
+        outer.addWidget(self.export_button)
+
+        # Compatibility aliases for callers of the prototype widget.
+        self.open_button = self.print_button
+        self.apply_button = QtWidgets.QPushButton(self)
+        self.apply_button.hide()
+        self.installation_combo = QtWidgets.QComboBox(self)
+        self.installation_combo.hide()
+
+        self._update_output_location()
         self._clear_profiles()
-        self._storage_changed()
         self._update_actions()
 
     def sizeHint(self):
-        return QtCore.QSize(390, 720)
+        return QtCore.QSize(360, 640)
 
     def refresh(self) -> None:
         self._remembered = PrintPreferences.load_confirmed_setup()
+        if self._remembered is not None:
+            self.auto_arrange.setChecked(self._remembered.auto_arrange)
+            self.ensure_on_bed.setChecked(self._remembered.ensure_on_bed)
+        self._update_output_location()
         override = PrintPreferences.executable_override()
         self._clear_profiles()
         self._start_job(
-            "Detecting PrusaSlicer and reading installed profiles…",
+            "Loading installed PrusaSlicer profiles…",
             lambda: self.backend.discover(override),
             self._installations_loaded,
         )
+
+    def _update_output_location(self) -> None:
+        storage = PrintPreferences.load_handoff_storage()
+        text = storage.directory if storage.mode == "folder" else "Managed VibeCAD cache"
+        self.output_location.setText(text)
+        self.output_location.setToolTip(text)
 
     def _start_job(
         self,
@@ -246,12 +254,12 @@ class PrintPanelWidget(QtWidgets.QWidget):
             callback(result)
 
     def _set_busy(self, busy: bool) -> None:
+        self._busy = busy
         self.refresh_button.setEnabled(not busy)
-        self.installation_combo.setEnabled(not busy)
         self.printer_combo.setEnabled(not busy)
         self.print_combo.setEnabled(not busy)
         if busy:
-            self.apply_button.setEnabled(False)
+            self.print_button.setEnabled(False)
 
     def _installations_loaded(self, values: Any) -> None:
         installations = tuple(values or ())
@@ -260,62 +268,56 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self.installation_combo.clear()
         for installation in installations:
             self.installation_combo.addItem(installation.display_name, installation)
-        if preferred is not None:
-            for index, installation in enumerate(installations):
-                if installation.gui_command == preferred.gui_command:
-                    self.installation_combo.setCurrentIndex(index)
-                    break
         self.installation_combo.blockSignals(False)
+        self.installation = preferred
         if preferred is None:
-            self.installation = None
+            self.installation_label.setText("PrusaSlicer is not configured")
+            self.status.setText("Click Setup to locate PrusaSlicer and choose profiles.")
+            self._update_actions()
+            return
+        self.installation_label.setText(preferred.display_name)
+        if not preferred.tested:
             self.status.setText(
-                "PrusaSlicer was not found. Use Initial setup to locate or install it."
+                f"PrusaSlicer {preferred.version} is below the tested 2.9.6 baseline."
             )
             self._update_actions()
             return
-        self._installation_changed(self.installation_combo.currentIndex())
-
-    def _selected_installation(self) -> VibeCADPrint.SlicerInstallation | None:
-        value = self.installation_combo.currentData()
-        return value if isinstance(value, VibeCADPrint.SlicerInstallation) else None
-
-    def _installation_changed(self, _index: int) -> None:
-        self.installation = self._selected_installation()
-        self._clear_profiles()
-        if self.installation is None:
-            self.status.setText("Choose a PrusaSlicer installation.")
-            return
-        if not self.installation.tested:
-            self.status.setText(
-                f"PrusaSlicer {self.installation.version} is below the tested 2.9.6 "
-                "profile-integration baseline."
-            )
-            return
         self._start_job(
-            "Reading exact installed printer profiles…",
-            lambda: self.backend.query_printers(self.installation),
+            "Loading printer profiles…",
+            lambda: self.backend.query_printers(preferred),
             self._printers_loaded,
         )
+
+    def _selected_installation(self) -> VibeCADPrint.SlicerInstallation | None:
+        return self.installation
+
+    def _installation_changed(self, _index: int) -> None:
+        value = self.installation_combo.currentData()
+        self.installation = (
+            value if isinstance(value, VibeCADPrint.SlicerInstallation) else None
+        )
+        self._clear_profiles()
+        self._update_actions()
 
     def _clear_profiles(self) -> None:
         self.printers = ()
         self.catalog = None
         self.printer_combo.blockSignals(True)
         self.printer_combo.clear()
-        self.printer_combo.addItem("Choose a printer profile…", None)
+        self.printer_combo.addItem("Choose printer…", None)
         self.printer_combo.blockSignals(False)
         self.print_combo.blockSignals(True)
         self.print_combo.clear()
-        self.print_combo.addItem("Choose a print profile…", None)
+        self.print_combo.addItem("Choose quality…", None)
         self.print_combo.blockSignals(False)
-        self.bed_details.setText("No printer selected.")
+        self.bed_details.setText("")
         self._clear_materials()
 
     def _printers_loaded(self, values: Any) -> None:
         self.printers = tuple(values or ())
         self.printer_combo.blockSignals(True)
         self.printer_combo.clear()
-        self.printer_combo.addItem("Choose a printer profile…", None)
+        self.printer_combo.addItem("Choose printer…", None)
         selected = 0
         for index, printer in enumerate(self.printers, start=1):
             self.printer_combo.addItem(
@@ -328,7 +330,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
         if selected:
             self._printer_changed(selected)
         else:
-            self.status.setText("Choose the exact installed printer profile.")
+            self.status.setText("Choose the exact printer profile.")
             self._update_actions()
 
     def _selected_printer(self) -> VibeCADPrint.PrinterProfile | None:
@@ -340,23 +342,23 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self.catalog = None
         self.print_combo.blockSignals(True)
         self.print_combo.clear()
-        self.print_combo.addItem("Choose a print profile…", None)
+        self.print_combo.addItem("Choose quality…", None)
         self.print_combo.blockSignals(False)
         self._clear_materials()
         if printer is None:
-            self.bed_details.setText("No printer selected.")
-            self.status.setText("Choose the exact installed printer profile.")
+            self.bed_details.setText("")
+            self.status.setText("Choose the exact printer profile.")
             self._update_actions()
             return
         bed = printer.bed
         self.bed_details.setText(
-            f"{bed.width:g} × {bed.height:g} × {bed.max_print_height:g} mm; "
+            f"{bed.width:g} × {bed.height:g} × {bed.max_print_height:g} mm · "
             f"{printer.extruders} extruder(s)"
         )
         if self.installation is None:
             return
         self._start_job(
-            f"Reading profiles compatible with {printer.name}…",
+            f"Loading profiles for {printer.name}…",
             lambda: self.backend.query_profiles(self.installation, printer.name),
             self._profiles_loaded,
         )
@@ -365,19 +367,21 @@ class PrintPanelWidget(QtWidgets.QWidget):
         if not isinstance(value, VibeCADPrint.ProfileCatalog):
             self.status.setText("PrusaSlicer returned an invalid profile catalog.")
             return
+        printer = self._selected_printer()
+        if printer is None or value.printer_profile != printer.name:
+            self.status.setText("PrusaSlicer returned profiles for another printer.")
+            return
         self.catalog = value
         self.print_combo.blockSignals(True)
         self.print_combo.clear()
-        self.print_combo.addItem("Choose a print profile…", None)
+        self.print_combo.addItem("Choose quality…", None)
         selected = 0
-        printer = self._selected_printer()
         for index, profile in enumerate(value.print_profiles, start=1):
             self.print_combo.addItem(
                 profile.name + (" — user" if profile.is_user else ""), profile
             )
             if (
                 self._remembered
-                and printer is not None
                 and self._remembered.printer_profile == printer.name
                 and profile.name == self._remembered.print_profile
             ):
@@ -387,7 +391,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
         if selected:
             self._print_changed(selected)
         else:
-            self.status.setText("Choose the exact compatible print profile.")
+            self.status.setText("Choose the exact compatible quality profile.")
             self._update_actions()
 
     def _selected_print(self) -> VibeCADPrint.PrintProfile | None:
@@ -410,8 +414,8 @@ class PrintPanelWidget(QtWidgets.QWidget):
             self._update_actions()
             return
         for extruder in range(printer.extruders):
-            combo = QtWidgets.QComboBox(self.material_widget)
-            combo.addItem("Choose a material profile…", None)
+            combo = _compact_combo(QtWidgets.QComboBox(self.material_widget))
+            combo.addItem("Choose material…", None)
             for material in profile.materials:
                 combo.addItem(
                     material.name + (" — user" if material.is_user else ""),
@@ -427,9 +431,9 @@ class PrintPanelWidget(QtWidgets.QWidget):
                 if index >= 0:
                     combo.setCurrentIndex(index)
             combo.currentIndexChanged.connect(self._update_actions)
-            self.material_layout.addRow(f"Extruder {extruder + 1}", combo)
+            label = "" if printer.extruders == 1 else f"Extruder {extruder + 1}"
+            self.material_layout.addRow(label, combo)
             self.material_combos.append(combo)
-        self.status.setText("Review the exact setup, then click Apply setup.")
         self._update_actions()
 
     def _current_setup(self) -> VibeCADPrint.PrintSetup | None:
@@ -449,61 +453,50 @@ class PrintPanelWidget(QtWidgets.QWidget):
         )
         return None if VibeCADPrint.validate_setup(setup, printer, self.catalog) else setup
 
-    def _current_storage(self) -> PrintPreferences.HandoffStorage | None:
-        directory = self.folder_edit.text().strip()
-        if self.folder_storage.isChecked():
-            if not directory:
-                return None
-            return PrintPreferences.HandoffStorage("folder", directory)
-        return PrintPreferences.HandoffStorage("managed", directory)
+    def _current_storage(self) -> PrintPreferences.HandoffStorage:
+        return PrintPreferences.load_handoff_storage()
 
     def _storage_changed(self, *_args) -> None:
-        folder = self.folder_storage.isChecked()
-        self.folder_edit.setEnabled(folder)
+        self._update_output_location()
         self._update_actions()
 
     def _update_actions(self, *_args) -> None:
-        ready = self._current_setup() is not None and self._current_storage() is not None
-        self.apply_button.setEnabled(ready)
-        self.open_button.setEnabled(ready)
+        setup = self._current_setup()
+        ready = setup is not None and self.installation is not None and not self._busy
+        self.print_button.setEnabled(ready)
+        if setup is not None:
+            PrintPreferences.save_confirmed_setup(setup)
+            self._remembered = setup
+            self.status.setText("Ready · selections saved automatically")
+        elif not self._busy and self.status.text().startswith("Ready"):
+            self.status.setText("Choose a printer, quality, and material.")
 
     def _save(self) -> bool:
         setup = self._current_setup()
-        storage = self._current_storage()
         if setup is None:
-            self.status.setText(
-                "Choose a printer, print profile, and one material per extruder."
-            )
-            return False
-        if storage is None:
-            self.status.setText("Choose a folder or select Managed VibeCAD cache.")
+            self.status.setText("Choose a printer, quality, and material.")
             return False
         PrintPreferences.save_confirmed_setup(setup)
-        PrintPreferences.save_handoff_storage(storage)
         self._remembered = setup
-        destination = (
-            storage.directory if storage.mode == "folder" else "the managed VibeCAD cache"
-        )
-        self.status.setText(f"Setup applied. New handoffs will be written to {destination}.")
+        self.status.setText("Ready · selections saved automatically")
         return True
 
     def _browse_folder(self) -> None:
-        start = self.folder_edit.text().strip() or str(Path.home())
-        selected = QtWidgets.QFileDialog.getExistingDirectory(
-            self,
-            "Choose a folder for 3MF handoffs",
-            start,
+        self._initial_setup()
+
+    def print_selected(self) -> None:
+        if not self._save() or self.installation is None:
+            return
+        import PrintCommandLoader
+
+        commands = PrintCommandLoader.command_module()
+        commands.open_selected_in_prusaslicer(
+            installation=self.installation,
+            setup=self._current_setup(),
         )
-        if selected:
-            self.folder_edit.setText(str(selected))
-            self.folder_storage.setChecked(True)
 
     def _open_selected(self) -> None:
-        if not self._save():
-            return
-        import FreeCADGui
-
-        FreeCADGui.runCommand("VibeCADPrint_OpenInPrusaSlicer")
+        self.print_selected()
 
     def _save_selected(self) -> None:
         import FreeCADGui
@@ -511,14 +504,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
         FreeCADGui.runCommand("VibeCADPrint_Save3MF")
 
     def _initial_setup(self) -> None:
-        choice = PrintSetupDialog.choose_print_setup(
-            parent=self,
-            backend=self.backend,
-            open_after_save=False,
-            initial_installation=self.installation,
-        )
-        if choice.accepted:
-            self.refresh()
+        open_setup_dialog(parent=self, backend=self.backend)
 
 
 def _main_window() -> Any:
@@ -553,16 +539,40 @@ def ensure_panel_registered() -> Any:
     return dock
 
 
-def show_panel() -> None:
+def show_panel(*, refresh: bool = True) -> PrintPanelWidget | None:
     dock = ensure_panel_registered()
     dock.show()
     dock.raise_()
     widget = dock.widget()
     if isinstance(widget, PrintPanelWidget):
-        widget.refresh()
+        if refresh:
+            widget.refresh()
+        return widget
+    return None
 
 
 def hide_panel() -> None:
     dock = _find_dock()
     if dock is not None:
         dock.hide()
+
+
+def open_setup_dialog(
+    *,
+    parent: Any | None = None,
+    backend: VibeCADPrint.PrusaSlicerBackend | None = None,
+) -> Any:
+    """Open explicit slicer configuration and refresh the daily-use panel."""
+
+    panel_dock = _find_dock()
+    panel = panel_dock.widget() if panel_dock is not None else None
+    initial = panel.installation if isinstance(panel, PrintPanelWidget) else None
+    choice = PrintSetupDialog.choose_print_setup(
+        parent=parent or _main_window(),
+        backend=backend or VibeCADPrint.PrusaSlicerBackend(),
+        open_after_save=False,
+        initial_installation=initial,
+    )
+    if choice.accepted and isinstance(panel, PrintPanelWidget):
+        panel.refresh()
+    return choice

--- a/src/Mod/VibeCADPrint/PrintPanel.py
+++ b/src/Mod/VibeCADPrint/PrintPanel.py
@@ -34,8 +34,34 @@ def _compact_combo(combo: Any) -> Any:
     return combo
 
 
+def _active_print_selection() -> tuple[Any, tuple[Any, ...]]:
+    import PrintCommandLoader
+
+    return PrintCommandLoader.command_module()._active_selection()
+
+
 class _Bridge(QtCore.QObject):
     finished = QtCore.Signal(int, object, object)
+
+
+class _SelectionObserver:
+    def __init__(self, panel: "PrintPanelWidget") -> None:
+        self.panel = panel
+
+    def _changed(self) -> None:
+        QtCore.QTimer.singleShot(0, self.panel._update_selection_summary)
+
+    def addSelection(self, *_args) -> None:
+        self._changed()
+
+    def removeSelection(self, *_args) -> None:
+        self._changed()
+
+    def setSelection(self, *_args) -> None:
+        self._changed()
+
+    def clearSelection(self, *_args) -> None:
+        self._changed()
 
 
 class PrintPanelWidget(QtWidgets.QWidget):
@@ -56,6 +82,8 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self._callback: Callable[[Any], None] | None = None
         self._futures: set[Future[Any]] = set()
         self._busy = False
+        self._print_selection_ready = False
+        self._selection_observer: _SelectionObserver | None = None
         self._bridge = _Bridge(self)
         self._bridge.finished.connect(self._job_finished)
 
@@ -92,6 +120,12 @@ class PrintPanelWidget(QtWidgets.QWidget):
         content_layout = QtWidgets.QVBoxLayout(content)
         content_layout.setContentsMargins(0, 0, 0, 0)
         content_layout.setSpacing(8)
+
+        content_layout.addWidget(QtWidgets.QLabel("<b>SELECTED OBJECTS</b>", content))
+        self.selection_summary = _wrapped(QtWidgets.QLabel(content))
+        self.selection_summary.setObjectName("VibeCADPrintSelectionSummary")
+        self.selection_summary.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+        content_layout.addWidget(self.selection_summary)
 
         content_layout.addWidget(QtWidgets.QLabel("<b>PRINT SETTINGS</b>", content))
         profiles = QtWidgets.QFormLayout()
@@ -188,6 +222,8 @@ class PrintPanelWidget(QtWidgets.QWidget):
 
         self._update_output_location()
         self._clear_profiles()
+        self._attach_selection_observer()
+        self._update_selection_summary()
         self._update_actions()
 
     def sizeHint(self):
@@ -212,6 +248,55 @@ class PrintPanelWidget(QtWidgets.QWidget):
         text = storage.directory if storage.mode == "folder" else "Managed VibeCAD cache"
         self.output_location.setText(text)
         self.output_location.setToolTip(text)
+
+    def _attach_selection_observer(self) -> None:
+        try:
+            import FreeCADGui
+
+            observer = _SelectionObserver(self)
+            FreeCADGui.Selection.addObserver(observer)
+            self._selection_observer = observer
+            self.destroyed.connect(self._detach_selection_observer)
+        except Exception:
+            self._selection_observer = None
+
+    def _detach_selection_observer(self, *_args) -> None:
+        observer = self._selection_observer
+        self._selection_observer = None
+        if observer is None:
+            return
+        try:
+            import FreeCADGui
+
+            FreeCADGui.Selection.removeObserver(observer)
+        except Exception:
+            pass
+
+    def _update_selection_summary(self) -> None:
+        try:
+            _document, objects = _active_print_selection()
+        except (VibeCADPrint.PrintSelectionError, RuntimeError) as exc:
+            self._print_selection_ready = False
+            self.selection_summary.setText(str(exc))
+            self.selection_summary.setToolTip(str(exc))
+        except Exception:
+            self._print_selection_ready = False
+            message = "Select one or more printable objects."
+            self.selection_summary.setText(message)
+            self.selection_summary.setToolTip(message)
+        else:
+            labels = tuple(
+                str(getattr(obj, "Label", "") or getattr(obj, "Name", "") or "Object")
+                for obj in objects
+            )
+            count = len(labels)
+            heading = f"{count} object{'s' if count != 1 else ''} will be sent"
+            self.selection_summary.setText(
+                heading + "\n" + "\n".join(f"• {label}" for label in labels)
+            )
+            self.selection_summary.setToolTip("\n".join(labels))
+            self._print_selection_ready = bool(objects)
+        self._update_actions()
 
     def _start_job(
         self,
@@ -462,8 +547,14 @@ class PrintPanelWidget(QtWidgets.QWidget):
 
     def _update_actions(self, *_args) -> None:
         setup = self._current_setup()
-        ready = setup is not None and self.installation is not None and not self._busy
+        ready = (
+            setup is not None
+            and self.installation is not None
+            and self._print_selection_ready
+            and not self._busy
+        )
         self.print_button.setEnabled(ready)
+        self.export_button.setEnabled(self._print_selection_ready)
         if setup is not None:
             PrintPreferences.save_confirmed_setup(setup)
             self._remembered = setup
@@ -485,6 +576,9 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self._initial_setup()
 
     def print_selected(self) -> None:
+        self._update_selection_summary()
+        if not self._print_selection_ready:
+            return
         if not self._save() or self.installation is None:
             return
         import PrintCommandLoader
@@ -529,11 +623,9 @@ def ensure_panel_registered() -> Any:
     main = _main_window()
     if main is None:
         raise RuntimeError("FreeCAD main window is unavailable.")
-    dock = QtWidgets.QDockWidget("3D Print", main)
-    dock.setObjectName(DOCK_NAME)
+    contents = PrintPanelWidget()
+    dock = main.addDockWindow(contents, DOCK_NAME, area="right")
     dock.setAllowedAreas(QtCore.Qt.LeftDockWidgetArea | QtCore.Qt.RightDockWidgetArea)
-    dock.setWidget(PrintPanelWidget(dock))
-    main.addDockWidget(QtCore.Qt.RightDockWidgetArea, dock)
     dock.toggleViewAction().setVisible(True)
     dock.hide()
     return dock
@@ -545,6 +637,7 @@ def show_panel(*, refresh: bool = True) -> PrintPanelWidget | None:
     dock.raise_()
     widget = dock.widget()
     if isinstance(widget, PrintPanelWidget):
+        widget._update_selection_summary()
         if refresh:
             widget.refresh()
         return widget

--- a/src/Mod/VibeCADPrint/PrintPanel.py
+++ b/src/Mod/VibeCADPrint/PrintPanel.py
@@ -83,6 +83,9 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self._futures: set[Future[Any]] = set()
         self._busy = False
         self._print_selection_ready = False
+        self._selection_document: Any | None = None
+        self._selection_items: list[tuple[Any, Any, tuple[Any, ...]]] = []
+        self.object_checkboxes: list[Any] = []
         self._selection_observer: _SelectionObserver | None = None
         self._bridge = _Bridge(self)
         self._bridge.finished.connect(self._job_finished)
@@ -120,12 +123,6 @@ class PrintPanelWidget(QtWidgets.QWidget):
         content_layout = QtWidgets.QVBoxLayout(content)
         content_layout.setContentsMargins(0, 0, 0, 0)
         content_layout.setSpacing(8)
-
-        content_layout.addWidget(QtWidgets.QLabel("<b>SELECTED OBJECTS</b>", content))
-        self.selection_summary = _wrapped(QtWidgets.QLabel(content))
-        self.selection_summary.setObjectName("VibeCADPrintSelectionSummary")
-        self.selection_summary.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
-        content_layout.addWidget(self.selection_summary)
 
         content_layout.addWidget(QtWidgets.QLabel("<b>PRINT SETTINGS</b>", content))
         profiles = QtWidgets.QFormLayout()
@@ -178,19 +175,26 @@ class PrintPanelWidget(QtWidgets.QWidget):
         placement.addStretch(1)
         content_layout.addLayout(placement)
 
-        content_layout.addWidget(QtWidgets.QLabel("<b>3MF OUTPUT</b>", content))
-        self.output_location = _wrapped(QtWidgets.QLabel(content))
+        self.selection_group = QtWidgets.QGroupBox("Objects to be sent", content)
+        self.selection_group.setObjectName("VibeCADPrintObjectChoices")
+        selection_layout = QtWidgets.QVBoxLayout(self.selection_group)
+        selection_layout.setContentsMargins(8, 8, 8, 8)
+        selection_layout.setSpacing(4)
+        self.selection_summary = _wrapped(QtWidgets.QLabel(self.selection_group))
+        self.selection_summary.setObjectName("VibeCADPrintSelectionSummary")
+        selection_layout.addWidget(self.selection_summary)
+        self.selection_choices_layout = QtWidgets.QVBoxLayout()
+        self.selection_choices_layout.setContentsMargins(0, 0, 0, 0)
+        self.selection_choices_layout.setSpacing(2)
+        selection_layout.addLayout(self.selection_choices_layout)
+        content_layout.addWidget(self.selection_group)
+
+        # Kept as a hidden compatibility surface for prototype callers. The
+        # everyday panel no longer spends space describing its output path;
+        # that choice remains available in Setup.
+        self.output_location = _wrapped(QtWidgets.QLabel(self))
         self.output_location.setObjectName("VibeCADPrintOutputLocation")
-        self.output_location.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
-        content_layout.addWidget(self.output_location)
-        automatic = _wrapped(
-            QtWidgets.QLabel(
-                "Selections are saved automatically. Change the slicer or output "
-                "location in Setup.",
-                content,
-            )
-        )
-        content_layout.addWidget(automatic)
+        self.output_location.hide()
         content_layout.addStretch(1)
         scroll.setWidget(content)
         outer.addWidget(scroll, 1)
@@ -272,9 +276,54 @@ class PrintPanelWidget(QtWidgets.QWidget):
         except Exception:
             pass
 
+    @staticmethod
+    def _selection_key(obj: Any) -> tuple[Any, ...]:
+        document = getattr(obj, "Document", None)
+        name = str(getattr(obj, "Name", "") or "")
+        if document is not None and name:
+            return ("document-object", id(document), name)
+        return ("python-object", id(obj))
+
+    def _clear_object_choices(self) -> None:
+        self._selection_items.clear()
+        self.object_checkboxes.clear()
+        while self.selection_choices_layout.count():
+            item = self.selection_choices_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def _selection_choices_changed(self, *_args) -> None:
+        selected = sum(choice.isChecked() for choice in self.object_checkboxes)
+        total = len(self.object_checkboxes)
+        if total:
+            self.selection_summary.setText(
+                f"{selected} of {total} object{'s' if total != 1 else ''} will be sent"
+            )
+            self.selection_summary.setToolTip(
+                "Uncheck any selected object you do not want to send."
+            )
+        self._print_selection_ready = selected > 0
+        self._update_actions()
+
+    def _checked_print_selection(self) -> tuple[Any, tuple[Any, ...]]:
+        objects = tuple(
+            obj for choice, obj, _key in self._selection_items if choice.isChecked()
+        )
+        if self._selection_document is None or not objects:
+            raise VibeCADPrint.PrintSelectionError(
+                "Check at least one printable object to send."
+            )
+        return self._selection_document, objects
+
     def _update_selection_summary(self) -> None:
+        previous = {
+            key: choice.isChecked() for choice, _obj, key in self._selection_items
+        }
+        self._selection_document = None
+        self._clear_object_choices()
         try:
-            _document, objects = _active_print_selection()
+            document, objects = _active_print_selection()
         except (VibeCADPrint.PrintSelectionError, RuntimeError) as exc:
             self._print_selection_ready = False
             self.selection_summary.setText(str(exc))
@@ -285,17 +334,21 @@ class PrintPanelWidget(QtWidgets.QWidget):
             self.selection_summary.setText(message)
             self.selection_summary.setToolTip(message)
         else:
-            labels = tuple(
-                str(getattr(obj, "Label", "") or getattr(obj, "Name", "") or "Object")
-                for obj in objects
-            )
-            count = len(labels)
-            heading = f"{count} object{'s' if count != 1 else ''} will be sent"
-            self.selection_summary.setText(
-                heading + "\n" + "\n".join(f"• {label}" for label in labels)
-            )
-            self.selection_summary.setToolTip("\n".join(labels))
-            self._print_selection_ready = bool(objects)
+            self._selection_document = document
+            for obj in objects:
+                key = self._selection_key(obj)
+                label = str(
+                    getattr(obj, "Label", "") or getattr(obj, "Name", "") or "Object"
+                )
+                choice = QtWidgets.QCheckBox(label, self.selection_group)
+                choice.setObjectName("VibeCADPrintObjectChoice")
+                choice.setChecked(previous.get(key, True))
+                choice.toggled.connect(self._selection_choices_changed)
+                self.selection_choices_layout.addWidget(choice)
+                self.object_checkboxes.append(choice)
+                self._selection_items.append((choice, obj, key))
+            self._selection_choices_changed()
+            return
         self._update_actions()
 
     def _start_job(
@@ -579,6 +632,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self._update_selection_summary()
         if not self._print_selection_ready:
             return
+        selection = self._checked_print_selection()
         if not self._save() or self.installation is None:
             return
         import PrintCommandLoader
@@ -587,15 +641,20 @@ class PrintPanelWidget(QtWidgets.QWidget):
         commands.open_selected_in_prusaslicer(
             installation=self.installation,
             setup=self._current_setup(),
+            selection=selection,
         )
 
     def _open_selected(self) -> None:
         self.print_selected()
 
     def _save_selected(self) -> None:
-        import FreeCADGui
+        self._update_selection_summary()
+        if not self._print_selection_ready:
+            return
+        import PrintCommandLoader
 
-        FreeCADGui.runCommand("VibeCADPrint_Save3MF")
+        commands = PrintCommandLoader.command_module()
+        commands._save_selected_3mf(selection=self._checked_print_selection())
 
     def _initial_setup(self) -> None:
         open_setup_dialog(parent=self, backend=self.backend)

--- a/src/Mod/VibeCADPrint/PrintPanel.py
+++ b/src/Mod/VibeCADPrint/PrintPanel.py
@@ -16,6 +16,7 @@ import VibeCADPrint
 
 DOCK_NAME = "VibeCADPrintPanel"
 _EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="vibecad-print-panel")
+_BACKEND_INSTANCES: dict[str, Any] = {}
 
 
 def _wrapped(label: Any) -> Any:
@@ -43,13 +44,23 @@ def _active_print_selection() -> tuple[Any, tuple[Any, ...]]:
 def _backend_for_id(backend_id: str) -> Any:
     """Create a supported slicer adapter without loading unused integrations."""
 
+    cached = _BACKEND_INSTANCES.get(backend_id)
+    if cached is not None:
+        return cached
     if backend_id == "bambustudio":
         import BambuStudio
 
-        return BambuStudio.BambuStudioBackend()
-    if backend_id == "prusaslicer":
-        return VibeCADPrint.PrusaSlicerBackend()
-    raise ValueError(f"Unsupported slicer backend: {backend_id}")
+        backend = BambuStudio.BambuStudioBackend()
+    elif backend_id == "orcaslicer":
+        import OrcaSlicer
+
+        backend = OrcaSlicer.OrcaSlicerBackend()
+    elif backend_id == "prusaslicer":
+        backend = VibeCADPrint.PrusaSlicerBackend()
+    else:
+        raise ValueError(f"Unsupported slicer backend: {backend_id}")
+    _BACKEND_INSTANCES[backend_id] = backend
+    return backend
 
 
 def _backend_display_name(backend: Any) -> str:
@@ -58,6 +69,7 @@ def _backend_display_name(backend: Any) -> str:
         return value
     return {
         "bambustudio": "Bambu Studio",
+        "orcaslicer": "OrcaSlicer",
         "prusaslicer": "PrusaSlicer",
     }.get(str(getattr(backend, "backend_id", "")), "PrusaSlicer")
 
@@ -127,7 +139,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self.title_label = QtWidgets.QLabel("<b>3D Print</b>", self)
         header.addWidget(self.title_label, 1)
         self.refresh_button = QtWidgets.QPushButton("Refresh", self)
-        self.refresh_button.clicked.connect(self.refresh)
+        self.refresh_button.clicked.connect(self._manual_refresh)
         self.setup_button = QtWidgets.QPushButton("Setup…", self)
         self.setup_button.clicked.connect(self._initial_setup)
         header.addWidget(self.refresh_button)
@@ -140,6 +152,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self.slicer_combo.setObjectName("VibeCADPrintSlicerBackend")
         self.slicer_combo.addItem("PrusaSlicer", "prusaslicer")
         self.slicer_combo.addItem("Bambu Studio", "bambustudio")
+        self.slicer_combo.addItem("OrcaSlicer", "orcaslicer")
         selected_backend = self.slicer_combo.findData(self.backend_id)
         self.slicer_combo.setCurrentIndex(max(0, selected_backend))
         self.slicer_combo.currentIndexChanged.connect(self._slicer_changed)
@@ -286,6 +299,12 @@ class PrintPanelWidget(QtWidgets.QWidget):
             lambda: self.backend.discover(override),
             self._installations_loaded,
         )
+
+    def _manual_refresh(self, *_args) -> None:
+        invalidate = getattr(self.backend, "invalidate_cache", None)
+        if callable(invalidate):
+            invalidate()
+        self.refresh()
 
     def _update_backend_ui(self) -> None:
         display_name = _backend_display_name(self.backend)

--- a/src/Mod/VibeCADPrint/PrintPanel.py
+++ b/src/Mod/VibeCADPrint/PrintPanel.py
@@ -127,6 +127,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
         self._selection_document: Any | None = None
         self._selection_items: list[tuple[Any, Any, tuple[Any, ...]]] = []
         self.object_checkboxes: list[Any] = []
+        self.object_filament_combos: list[Any] = []
         self._selection_observer: _SelectionObserver | None = None
         self._bridge = _Bridge(self)
         self._bridge.finished.connect(self._job_finished)
@@ -388,6 +389,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
     def _clear_object_choices(self) -> None:
         self._selection_items.clear()
         self.object_checkboxes.clear()
+        self.object_filament_combos.clear()
         while self.selection_choices_layout.count():
             item = self.selection_choices_layout.takeAt(0)
             widget = item.widget()
@@ -397,6 +399,11 @@ class PrintPanelWidget(QtWidgets.QWidget):
     def _selection_choices_changed(self, *_args) -> None:
         selected = sum(choice.isChecked() for choice in self.object_checkboxes)
         total = len(self.object_checkboxes)
+        for choice, combo in zip(
+            self.object_checkboxes,
+            self.object_filament_combos,
+        ):
+            combo.setEnabled(choice.isChecked())
         if total:
             self.selection_summary.setText(
                 f"{selected} of {total} object{'s' if total != 1 else ''} will be sent"
@@ -420,6 +427,13 @@ class PrintPanelWidget(QtWidgets.QWidget):
     def _update_selection_summary(self) -> None:
         previous = {
             key: choice.isChecked() for choice, _obj, key in self._selection_items
+        }
+        previous_filaments = {
+            key: combo.currentData()
+            for (_choice, _obj, key), combo in zip(
+                self._selection_items,
+                self.object_filament_combos,
+            )
         }
         self._selection_document = None
         self._clear_object_choices()
@@ -445,9 +459,20 @@ class PrintPanelWidget(QtWidgets.QWidget):
                 choice.setObjectName("VibeCADPrintObjectChoice")
                 choice.setChecked(previous.get(key, True))
                 choice.toggled.connect(self._selection_choices_changed)
-                self.selection_choices_layout.addWidget(choice)
+                filament = _compact_combo(QtWidgets.QComboBox(self.selection_group))
+                filament.setObjectName("VibeCADPrintObjectFilament")
+                filament.currentIndexChanged.connect(self._update_actions)
+                row = QtWidgets.QWidget(self.selection_group)
+                row_layout = QtWidgets.QHBoxLayout(row)
+                row_layout.setContentsMargins(0, 0, 0, 0)
+                row_layout.setSpacing(6)
+                row_layout.addWidget(choice, 1)
+                row_layout.addWidget(filament)
+                self.selection_choices_layout.addWidget(row)
                 self.object_checkboxes.append(choice)
+                self.object_filament_combos.append(filament)
                 self._selection_items.append((choice, obj, key))
+            self._refresh_object_filament_choices(previous_filaments)
             self._selection_choices_changed()
             return
         self._update_actions()
@@ -656,6 +681,51 @@ class PrintPanelWidget(QtWidgets.QWidget):
             widget = item.widget()
             if widget is not None:
                 widget.deleteLater()
+        self._refresh_object_filament_choices()
+
+    def _supports_object_filament_assignment(self) -> bool:
+        return "object_filament_assignment" in tuple(
+            getattr(self.backend, "capabilities", ()) or ()
+        )
+
+    def _refresh_object_filament_choices(
+        self,
+        remembered: dict[tuple[Any, ...], Any] | None = None,
+    ) -> None:
+        materials = tuple(
+            str(combo.currentData() or "") for combo in self.material_combos
+        )
+        available = (
+            self._supports_object_filament_assignment()
+            and bool(materials)
+            and all(materials)
+        )
+        for index, combo in enumerate(self.object_filament_combos):
+            key = self._selection_items[index][2]
+            previous = (
+                remembered.get(key)
+                if remembered is not None
+                else combo.currentData()
+            )
+            combo.blockSignals(True)
+            combo.clear()
+            if available and len(materials) == 1:
+                combo.addItem(materials[0], 1)
+                combo.hide()
+            elif available:
+                combo.addItem("Choose filament…", None)
+                for filament_id, material in enumerate(materials, start=1):
+                    combo.addItem(f"Filament {filament_id} — {material}", filament_id)
+                selected = combo.findData(previous)
+                combo.setCurrentIndex(selected if selected >= 0 else 0)
+                combo.show()
+            else:
+                combo.hide()
+            combo.blockSignals(False)
+
+    def _materials_changed(self, *_args) -> None:
+        self._refresh_object_filament_choices()
+        self._update_actions()
 
     def _print_changed(self, _index: int) -> None:
         self._clear_materials()
@@ -681,13 +751,18 @@ class PrintPanelWidget(QtWidgets.QWidget):
                 index = combo.findData(self._remembered.material_profiles[extruder])
                 if index >= 0:
                     combo.setCurrentIndex(index)
-            combo.currentIndexChanged.connect(self._update_actions)
+            combo.currentIndexChanged.connect(self._materials_changed)
             label = "" if printer.extruders == 1 else f"Extruder {extruder + 1}"
             self.material_layout.addRow(label, combo)
             self.material_combos.append(combo)
+        self._refresh_object_filament_choices()
         self._update_actions()
 
-    def _current_setup(self) -> VibeCADPrint.PrintSetup | None:
+    def _current_setup(
+        self,
+        *,
+        require_object_assignments: bool = False,
+    ) -> VibeCADPrint.PrintSetup | None:
         printer = self._selected_printer()
         profile = self._selected_print()
         if printer is None or profile is None or self.catalog is None:
@@ -695,12 +770,27 @@ class PrintPanelWidget(QtWidgets.QWidget):
         materials = tuple(str(combo.currentData() or "") for combo in self.material_combos)
         if len(materials) != printer.extruders or any(not value for value in materials):
             return None
+        object_filament_ids: tuple[int, ...] = ()
+        if self._supports_object_filament_assignment():
+            selected_ids = tuple(
+                combo.currentData()
+                for (choice, _obj, _key), combo in zip(
+                    self._selection_items,
+                    self.object_filament_combos,
+                )
+                if choice.isChecked()
+            )
+            if selected_ids and all(isinstance(value, int) for value in selected_ids):
+                object_filament_ids = tuple(int(value) for value in selected_ids)
+            elif require_object_assignments and selected_ids:
+                return None
         setup = VibeCADPrint.PrintSetup(
             printer_profile=printer.name,
             print_profile=profile.name,
             material_profiles=materials,
             auto_arrange=self.auto_arrange.isChecked(),
             ensure_on_bed=self.ensure_on_bed.isChecked(),
+            object_filament_ids=object_filament_ids,
         )
         return None if VibeCADPrint.validate_setup(setup, printer, self.catalog) else setup
 
@@ -713,8 +803,9 @@ class PrintPanelWidget(QtWidgets.QWidget):
 
     def _update_actions(self, *_args) -> None:
         setup = self._current_setup()
+        print_setup = self._current_setup(require_object_assignments=True)
         ready = (
-            setup is not None
+            print_setup is not None
             and self.installation is not None
             and self._print_selection_ready
             and not self._busy
@@ -727,14 +818,20 @@ class PrintPanelWidget(QtWidgets.QWidget):
                 backend_id=self.backend_id,
             )
             self._remembered = setup
-            self.status.setText("Ready · selections saved automatically")
+            if print_setup is not None:
+                self.status.setText("Ready · selections saved automatically")
+            elif self._print_selection_ready:
+                self.status.setText("Assign a filament to each checked object.")
         elif not self._busy and self.status.text().startswith("Ready"):
             self.status.setText("Choose a printer, quality, and material.")
 
     def _save(self) -> bool:
-        setup = self._current_setup()
+        setup = self._current_setup(require_object_assignments=True)
         if setup is None:
-            self.status.setText("Choose a printer, quality, and material.")
+            if self._current_setup() is not None and self._print_selection_ready:
+                self.status.setText("Assign a filament to each checked object.")
+            else:
+                self.status.setText("Choose a printer, quality, and material.")
             return False
         PrintPreferences.save_confirmed_setup(
             setup,
@@ -760,7 +857,7 @@ class PrintPanelWidget(QtWidgets.QWidget):
         commands.open_selected_in_slicer(
             backend=self.backend,
             installation=self.installation,
-            setup=self._current_setup(),
+            setup=self._current_setup(require_object_assignments=True),
             selection=selection,
         )
 

--- a/src/Mod/VibeCADPrint/PrintPreferences.py
+++ b/src/Mod/VibeCADPrint/PrintPreferences.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Persistent preferences for the additive PrusaSlicer integration."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import VibeCADPrint
+
+
+PREFERENCES_PATH = "User parameter:BaseApp/Preferences/VibeCAD/Print"
+EXECUTABLE_KEY = "PrusaSlicerExecutable"
+PRINTER_PROFILE_KEY = "PrinterProfile"
+PRINT_PROFILE_KEY = "PrintProfile"
+MATERIAL_PROFILES_KEY = "MaterialProfilesJson"
+AUTO_ARRANGE_KEY = "AutoArrange"
+ENSURE_ON_BED_KEY = "EnsureOnBed"
+
+
+def preferences() -> Any:
+    import FreeCAD
+
+    return FreeCAD.ParamGet(PREFERENCES_PATH)
+
+
+def executable_override(*, params: Any | None = None) -> str:
+    group = params or preferences()
+    return str(group.GetString(EXECUTABLE_KEY, "") or "").strip()
+
+
+def set_executable_override(value: str, *, params: Any | None = None) -> None:
+    group = params or preferences()
+    group.SetString(EXECUTABLE_KEY, str(value or "").strip())
+
+
+def load_confirmed_setup(
+    *, params: Any | None = None
+) -> VibeCADPrint.PrintSetup | None:
+    """Load a complete setup or None; malformed state never gains defaults."""
+
+    group = params or preferences()
+    printer = str(group.GetString(PRINTER_PROFILE_KEY, "") or "").strip()
+    print_profile = str(group.GetString(PRINT_PROFILE_KEY, "") or "").strip()
+    raw_materials = str(group.GetString(MATERIAL_PROFILES_KEY, "") or "").strip()
+    if not printer or not print_profile or not raw_materials:
+        return None
+    try:
+        decoded = json.loads(raw_materials)
+    except (TypeError, ValueError, json.JSONDecodeError):
+        return None
+    if not isinstance(decoded, list):
+        return None
+    materials = tuple(str(value or "").strip() for value in decoded)
+    if not materials or any(not value for value in materials):
+        return None
+    return VibeCADPrint.PrintSetup(
+        printer_profile=printer,
+        print_profile=print_profile,
+        material_profiles=materials,
+        auto_arrange=bool(group.GetBool(AUTO_ARRANGE_KEY, True)),
+        ensure_on_bed=bool(group.GetBool(ENSURE_ON_BED_KEY, True)),
+    )
+
+
+def save_confirmed_setup(
+    setup: VibeCADPrint.PrintSetup, *, params: Any | None = None
+) -> None:
+    group = params or preferences()
+    group.SetString(PRINTER_PROFILE_KEY, setup.printer_profile)
+    group.SetString(PRINT_PROFILE_KEY, setup.print_profile)
+    group.SetString(MATERIAL_PROFILES_KEY, json.dumps(list(setup.material_profiles)))
+    group.SetBool(AUTO_ARRANGE_KEY, bool(setup.auto_arrange))
+    group.SetBool(ENSURE_ON_BED_KEY, bool(setup.ensure_on_bed))
+
+
+def clear_confirmed_setup(*, params: Any | None = None) -> None:
+    group = params or preferences()
+    for key in (PRINTER_PROFILE_KEY, PRINT_PROFILE_KEY, MATERIAL_PROFILES_KEY):
+        group.RemString(key)
+    for key in (AUTO_ARRANGE_KEY, ENSURE_ON_BED_KEY):
+        group.RemBool(key)

--- a/src/Mod/VibeCADPrint/PrintPreferences.py
+++ b/src/Mod/VibeCADPrint/PrintPreferences.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""Persistent preferences for the additive PrusaSlicer integration."""
+"""Persistent preferences for additive external-slicer integrations."""
 
 from __future__ import annotations
 
@@ -13,6 +13,8 @@ import VibeCADPrint
 
 PREFERENCES_PATH = "User parameter:BaseApp/Preferences/VibeCAD/Print"
 EXECUTABLE_KEY = "PrusaSlicerExecutable"
+ACTIVE_BACKEND_KEY = "SlicerBackend"
+BAMBU_EXECUTABLE_KEY = "BambuStudioExecutable"
 PRINTER_PROFILE_KEY = "PrinterProfile"
 PRINT_PROFILE_KEY = "PrintProfile"
 MATERIAL_PROFILES_KEY = "MaterialProfilesJson"
@@ -20,6 +22,34 @@ AUTO_ARRANGE_KEY = "AutoArrange"
 ENSURE_ON_BED_KEY = "EnsureOnBed"
 HANDOFF_STORAGE_MODE_KEY = "HandoffStorageMode"
 HANDOFF_DIRECTORY_KEY = "HandoffDirectory"
+
+SUPPORTED_BACKENDS = ("prusaslicer", "bambustudio", "orcaslicer")
+_BACKEND_KEYS = {
+    "prusaslicer": (
+        EXECUTABLE_KEY,
+        PRINTER_PROFILE_KEY,
+        PRINT_PROFILE_KEY,
+        MATERIAL_PROFILES_KEY,
+        AUTO_ARRANGE_KEY,
+        ENSURE_ON_BED_KEY,
+    ),
+    "bambustudio": (
+        BAMBU_EXECUTABLE_KEY,
+        "BambuStudioPrinterProfile",
+        "BambuStudioPrintProfile",
+        "BambuStudioMaterialProfilesJson",
+        "BambuStudioAutoArrange",
+        "BambuStudioEnsureOnBed",
+    ),
+    "orcaslicer": (
+        "OrcaSlicerExecutable",
+        "OrcaSlicerPrinterProfile",
+        "OrcaSlicerPrintProfile",
+        "OrcaSlicerMaterialProfilesJson",
+        "OrcaSlicerAutoArrange",
+        "OrcaSlicerEnsureOnBed",
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -36,14 +66,45 @@ def preferences() -> Any:
     return FreeCAD.ParamGet(PREFERENCES_PATH)
 
 
-def executable_override(*, params: Any | None = None) -> str:
-    group = params or preferences()
-    return str(group.GetString(EXECUTABLE_KEY, "") or "").strip()
+def _keys(backend_id: str) -> tuple[str, str, str, str, str, str]:
+    try:
+        return _BACKEND_KEYS[str(backend_id)]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported slicer backend: {backend_id}") from exc
 
 
-def set_executable_override(value: str, *, params: Any | None = None) -> None:
+def active_backend(*, params: Any | None = None) -> str:
     group = params or preferences()
-    group.SetString(EXECUTABLE_KEY, str(value or "").strip())
+    value = str(group.GetString(ACTIVE_BACKEND_KEY, "prusaslicer") or "prusaslicer")
+    return value if value in SUPPORTED_BACKENDS else "prusaslicer"
+
+
+def set_active_backend(value: str, *, params: Any | None = None) -> None:
+    backend_id = str(value or "").strip()
+    _keys(backend_id)
+    group = params or preferences()
+    group.SetString(ACTIVE_BACKEND_KEY, backend_id)
+
+
+def executable_override(
+    *,
+    backend_id: str = "prusaslicer",
+    params: Any | None = None,
+) -> str:
+    group = params or preferences()
+    executable_key, *_rest = _keys(backend_id)
+    return str(group.GetString(executable_key, "") or "").strip()
+
+
+def set_executable_override(
+    value: str,
+    *,
+    backend_id: str = "prusaslicer",
+    params: Any | None = None,
+) -> None:
+    group = params or preferences()
+    executable_key, *_rest = _keys(backend_id)
+    group.SetString(executable_key, str(value or "").strip())
 
 
 def load_handoff_storage(*, params: Any | None = None) -> HandoffStorage:
@@ -72,14 +133,24 @@ def save_handoff_storage(
 
 
 def load_confirmed_setup(
-    *, params: Any | None = None
+    *,
+    backend_id: str = "prusaslicer",
+    params: Any | None = None,
 ) -> VibeCADPrint.PrintSetup | None:
     """Load a complete setup or None; malformed state never gains defaults."""
 
     group = params or preferences()
-    printer = str(group.GetString(PRINTER_PROFILE_KEY, "") or "").strip()
-    print_profile = str(group.GetString(PRINT_PROFILE_KEY, "") or "").strip()
-    raw_materials = str(group.GetString(MATERIAL_PROFILES_KEY, "") or "").strip()
+    (
+        _executable_key,
+        printer_key,
+        print_key,
+        materials_key,
+        arrange_key,
+        bed_key,
+    ) = _keys(backend_id)
+    printer = str(group.GetString(printer_key, "") or "").strip()
+    print_profile = str(group.GetString(print_key, "") or "").strip()
+    raw_materials = str(group.GetString(materials_key, "") or "").strip()
     if not printer or not print_profile or not raw_materials:
         return None
     try:
@@ -95,25 +166,48 @@ def load_confirmed_setup(
         printer_profile=printer,
         print_profile=print_profile,
         material_profiles=materials,
-        auto_arrange=bool(group.GetBool(AUTO_ARRANGE_KEY, True)),
-        ensure_on_bed=bool(group.GetBool(ENSURE_ON_BED_KEY, True)),
+        auto_arrange=bool(group.GetBool(arrange_key, True)),
+        ensure_on_bed=bool(group.GetBool(bed_key, True)),
     )
 
 
 def save_confirmed_setup(
-    setup: VibeCADPrint.PrintSetup, *, params: Any | None = None
+    setup: VibeCADPrint.PrintSetup,
+    *,
+    backend_id: str = "prusaslicer",
+    params: Any | None = None,
 ) -> None:
     group = params or preferences()
-    group.SetString(PRINTER_PROFILE_KEY, setup.printer_profile)
-    group.SetString(PRINT_PROFILE_KEY, setup.print_profile)
-    group.SetString(MATERIAL_PROFILES_KEY, json.dumps(list(setup.material_profiles)))
-    group.SetBool(AUTO_ARRANGE_KEY, bool(setup.auto_arrange))
-    group.SetBool(ENSURE_ON_BED_KEY, bool(setup.ensure_on_bed))
+    (
+        _executable_key,
+        printer_key,
+        print_key,
+        materials_key,
+        arrange_key,
+        bed_key,
+    ) = _keys(backend_id)
+    group.SetString(printer_key, setup.printer_profile)
+    group.SetString(print_key, setup.print_profile)
+    group.SetString(materials_key, json.dumps(list(setup.material_profiles)))
+    group.SetBool(arrange_key, bool(setup.auto_arrange))
+    group.SetBool(bed_key, bool(setup.ensure_on_bed))
 
 
-def clear_confirmed_setup(*, params: Any | None = None) -> None:
+def clear_confirmed_setup(
+    *,
+    backend_id: str = "prusaslicer",
+    params: Any | None = None,
+) -> None:
     group = params or preferences()
-    for key in (PRINTER_PROFILE_KEY, PRINT_PROFILE_KEY, MATERIAL_PROFILES_KEY):
+    (
+        _executable_key,
+        printer_key,
+        print_key,
+        materials_key,
+        arrange_key,
+        bed_key,
+    ) = _keys(backend_id)
+    for key in (printer_key, print_key, materials_key):
         group.RemString(key)
-    for key in (AUTO_ARRANGE_KEY, ENSURE_ON_BED_KEY):
+    for key in (arrange_key, bed_key):
         group.RemBool(key)

--- a/src/Mod/VibeCADPrint/PrintPreferences.py
+++ b/src/Mod/VibeCADPrint/PrintPreferences.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 import json
 from typing import Any
 
@@ -17,6 +18,16 @@ PRINT_PROFILE_KEY = "PrintProfile"
 MATERIAL_PROFILES_KEY = "MaterialProfilesJson"
 AUTO_ARRANGE_KEY = "AutoArrange"
 ENSURE_ON_BED_KEY = "EnsureOnBed"
+HANDOFF_STORAGE_MODE_KEY = "HandoffStorageMode"
+HANDOFF_DIRECTORY_KEY = "HandoffDirectory"
+
+
+@dataclass(frozen=True)
+class HandoffStorage:
+    """Explicit location policy for automatically generated handoff files."""
+
+    mode: str = "managed"
+    directory: str = ""
 
 
 def preferences() -> Any:
@@ -33,6 +44,31 @@ def executable_override(*, params: Any | None = None) -> str:
 def set_executable_override(value: str, *, params: Any | None = None) -> None:
     group = params or preferences()
     group.SetString(EXECUTABLE_KEY, str(value or "").strip())
+
+
+def load_handoff_storage(*, params: Any | None = None) -> HandoffStorage:
+    group = params or preferences()
+    mode = str(group.GetString(HANDOFF_STORAGE_MODE_KEY, "managed") or "managed")
+    directory = str(group.GetString(HANDOFF_DIRECTORY_KEY, "") or "").strip()
+    if mode not in {"managed", "folder"} or (mode == "folder" and not directory):
+        return HandoffStorage()
+    return HandoffStorage(mode=mode, directory=directory)
+
+
+def save_handoff_storage(
+    storage: HandoffStorage,
+    *,
+    params: Any | None = None,
+) -> None:
+    mode = str(storage.mode or "").strip()
+    directory = str(storage.directory or "").strip()
+    if mode not in {"managed", "folder"}:
+        raise ValueError("3MF storage mode must be 'managed' or 'folder'.")
+    if mode == "folder" and not directory:
+        raise ValueError("Choose a folder for persistent 3MF handoffs.")
+    group = params or preferences()
+    group.SetString(HANDOFF_STORAGE_MODE_KEY, mode)
+    group.SetString(HANDOFF_DIRECTORY_KEY, directory)
 
 
 def load_confirmed_setup(

--- a/src/Mod/VibeCADPrint/PrintSetupDialog.py
+++ b/src/Mod/VibeCADPrint/PrintSetupDialog.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""Guided, non-blocking PrusaSlicer profile and placement setup."""
+"""Guided, non-blocking external-slicer profile and placement setup."""
 
 from __future__ import annotations
 
@@ -18,7 +18,11 @@ import VibeCADPrint
 
 
 DOWNLOAD_URL = "https://www.prusa3d.com/page/prusaslicer_424/"
-_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="vibecad-prusa")
+DOWNLOAD_URLS = {
+    "prusaslicer": DOWNLOAD_URL,
+    "bambustudio": "https://github.com/bambulab/BambuStudio/releases",
+}
+_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="vibecad-print-setup")
 
 
 def _qt_exec(value: Any) -> int:
@@ -63,7 +67,7 @@ def run_with_progress(
     progress.close()
     if was_canceled:
         future.cancel()
-        raise VibeCADPrint.SlicerQueryError("PrusaSlicer profile check was canceled.")
+        raise VibeCADPrint.SlicerQueryError("Slicer profile check was canceled.")
     return future.result()
 
 
@@ -116,18 +120,22 @@ class VibeCADPrintPreferencesPage:
 
 
 def _browse_for_prusaslicer(parent: Any, initial: str = "") -> str:
+    return _browse_for_slicer(parent, "PrusaSlicer", initial)
+
+
+def _browse_for_slicer(parent: Any, display_name: str, initial: str = "") -> str:
     start = initial or str(Path.home())
     if sys.platform == "darwin":
         selected = QtWidgets.QFileDialog.getExistingDirectory(
             parent,
-            "Locate PrusaSlicer.app",
+            f"Locate {display_name}.app",
             start,
         )
         if selected:
             return str(selected)
     selected, _filter = QtWidgets.QFileDialog.getOpenFileName(
         parent,
-        "Locate the PrusaSlicer application",
+        f"Locate the {display_name} application",
         start,
         "Executables (*);;All files (*)",
     )
@@ -135,13 +143,13 @@ def _browse_for_prusaslicer(parent: Any, initial: str = "") -> str:
 
 
 class PrintSetupDialog(QtWidgets.QDialog):
-    """Explicit profile selection backed by PrusaSlicer's installed presets."""
+    """Explicit profile selection backed by a slicer's installed presets."""
 
     def __init__(
         self,
         *,
         parent: Any,
-        backend: VibeCADPrint.PrusaSlicerBackend,
+        backend: Any,
         open_after_save: bool,
         initial_installation: VibeCADPrint.SlicerInstallation | None = None,
         initial_message: str = "",
@@ -150,11 +158,16 @@ class PrintSetupDialog(QtWidgets.QDialog):
         self.setObjectName("VibeCADPrintSetupDialog")
         self.setWindowTitle("Print Setup")
         self.backend = backend
+        self.backend_id = str(getattr(backend, "backend_id", "prusaslicer"))
+        self.slicer_name = str(getattr(backend, "display_name", "PrusaSlicer"))
+        self.download_url = DOWNLOAD_URLS.get(self.backend_id, "")
         self.open_after_save = open_after_save
         self.initial_installation = initial_installation
         self.result_installation: VibeCADPrint.SlicerInstallation | None = None
         self.result_setup: VibeCADPrint.PrintSetup | None = None
-        self._remembered = PrintPreferences.load_confirmed_setup()
+        self._remembered = PrintPreferences.load_confirmed_setup(
+            backend_id=self.backend_id
+        )
         self._printers: tuple[VibeCADPrint.PrinterProfile, ...] = ()
         self._catalog: VibeCADPrint.ProfileCatalog | None = None
         self._material_combos: list[Any] = []
@@ -170,20 +183,22 @@ class PrintSetupDialog(QtWidgets.QDialog):
 
         layout = QtWidgets.QVBoxLayout(self)
         intro = QtWidgets.QLabel(
-            "VibeCAD reads profiles installed by PrusaSlicer. Nothing is selected "
-            "or substituted on your behalf.",
+            f"VibeCAD reads profiles installed by {self.slicer_name}. Nothing is "
+            "selected or substituted on your behalf.",
             self,
         )
         _configure_wrapped_label(intro)
         layout.addWidget(intro)
 
-        executable_group = QtWidgets.QGroupBox("PrusaSlicer", self)
+        executable_group = QtWidgets.QGroupBox(self.slicer_name, self)
         executable_layout = QtWidgets.QFormLayout(executable_group)
         executable_row = QtWidgets.QWidget(executable_group)
         executable_row_layout = QtWidgets.QHBoxLayout(executable_row)
         executable_row_layout.setContentsMargins(0, 0, 0, 0)
         self.executable = QtWidgets.QLineEdit(executable_row)
-        self.executable.setText(PrintPreferences.executable_override())
+        self.executable.setText(
+            PrintPreferences.executable_override(backend_id=self.backend_id)
+        )
         self.executable.setPlaceholderText("Auto-detect")
         locate = QtWidgets.QPushButton("Locate", executable_row)
         locate.clicked.connect(self._locate)
@@ -200,9 +215,12 @@ class PrintSetupDialog(QtWidgets.QDialog):
         action_row = QtWidgets.QWidget(executable_group)
         action_layout = QtWidgets.QHBoxLayout(action_row)
         action_layout.setContentsMargins(0, 0, 0, 0)
-        self.open_slicer_button = QtWidgets.QPushButton("Open PrusaSlicer", action_row)
+        self.open_slicer_button = QtWidgets.QPushButton(
+            f"Open {self.slicer_name}", action_row
+        )
         self.open_slicer_button.clicked.connect(self._open_prusaslicer)
         download = QtWidgets.QPushButton("Download", action_row)
+        download.setEnabled(bool(self.download_url))
         download.clicked.connect(self._download)
         retry = QtWidgets.QPushButton("Retry", action_row)
         retry.clicked.connect(self._detect)
@@ -231,7 +249,7 @@ class PrintSetupDialog(QtWidgets.QDialog):
         profiles_layout.addRow("Materials", self.material_widget)
         material_note = QtWidgets.QLabel(
             "Choose one material profile for every extruder. Object-to-extruder "
-            "assignment remains explicit in PrusaSlicer.",
+            f"assignment remains explicit in {self.slicer_name}.",
             profiles_group,
         )
         _configure_wrapped_label(material_note)
@@ -242,12 +260,12 @@ class PrintSetupDialog(QtWidgets.QDialog):
         placement_layout = QtWidgets.QVBoxLayout(placement_group)
         self.auto_arrange = QtWidgets.QCheckBox("Auto-arrange", placement_group)
         self.auto_arrange.setToolTip(
-            "Allow PrusaSlicer to arrange imported objects in XY. Turn this off "
+            f"Allow {self.slicer_name} to arrange imported objects in XY. Turn this off "
             "to retain their exact CAD XY positions."
         )
         self.ensure_on_bed = QtWidgets.QCheckBox("Ensure on bed", placement_group)
         self.ensure_on_bed.setToolTip(
-            "Allow PrusaSlicer to lift objects that extend below the build plate."
+            f"Allow {self.slicer_name} to lift objects that extend below the build plate."
         )
         remembered = self._remembered
         self.auto_arrange.setChecked(
@@ -414,7 +432,11 @@ class PrintSetupDialog(QtWidgets.QDialog):
             self.folder_storage.setChecked(True)
 
     def _locate(self) -> None:
-        selected = _browse_for_prusaslicer(self, self.executable.text())
+        selected = _browse_for_slicer(
+            self,
+            self.slicer_name,
+            self.executable.text(),
+        )
         if selected:
             self.executable.setText(selected)
             self._detect()
@@ -426,7 +448,7 @@ class PrintSetupDialog(QtWidgets.QDialog):
     def _detect(self) -> None:
         override = self.executable.text().strip()
         self._start_async(
-            "Detecting PrusaSlicer installations...",
+            f"Detecting {self.slicer_name} installations...",
             lambda: self.backend.discover(override),
             self._installations_loaded,
         )
@@ -459,7 +481,7 @@ class PrintSetupDialog(QtWidgets.QDialog):
         self.installation_combo.blockSignals(False)
         if preferred is None:
             self._set_status(
-                "PrusaSlicer was not found. Use Locate or Download, then Retry."
+                f"{self.slicer_name} was not found. Use Locate or Download, then Retry."
             )
             self._clear_profiles()
             self._update_actions()
@@ -474,12 +496,13 @@ class PrintSetupDialog(QtWidgets.QDialog):
         installation = self._selected_installation()
         self._clear_profiles()
         if installation is None:
-            self._set_status("Choose a detected PrusaSlicer installation.")
+            self._set_status(f"Choose a detected {self.slicer_name} installation.")
         elif not installation.tested:
+            baseline = ".".join(str(part) for part in installation.tested_version)
             self._set_status(
-                f"PrusaSlicer {installation.version} is older than the tested "
-                "2.9.6 baseline. Basic 3MF handoff remains available, but VibeCAD "
-                "will not pass profiles."
+                f"{self.slicer_name} {installation.version} is older than the tested "
+                f"{baseline} baseline. Basic 3MF handoff remains available, but "
+                "VibeCAD will not pass profiles."
             )
         else:
             self._start_async(
@@ -565,12 +588,14 @@ class PrintSetupDialog(QtWidgets.QDialog):
 
     def _profiles_loaded(self, catalog: Any) -> None:
         if not isinstance(catalog, VibeCADPrint.ProfileCatalog):
-            self._set_status("PrusaSlicer returned an invalid profile catalog.")
+            self._set_status(
+                f"{self.slicer_name} returned an invalid profile catalog."
+            )
             return
         printer = self._selected_printer()
         if printer is None or catalog.printer_profile != printer.name:
             self._set_status(
-                "PrusaSlicer returned profiles for a different printer."
+                f"{self.slicer_name} returned profiles for a different printer."
             )
             return
         self._catalog = catalog
@@ -718,8 +743,14 @@ class PrintSetupDialog(QtWidgets.QDialog):
                 "material profile for every extruder, plus a 3MF handoff location.",
             )
             return
-        PrintPreferences.set_executable_override(self.executable.text())
-        PrintPreferences.save_confirmed_setup(setup)
+        PrintPreferences.set_executable_override(
+            self.executable.text(),
+            backend_id=self.backend_id,
+        )
+        PrintPreferences.save_confirmed_setup(
+            setup,
+            backend_id=self.backend_id,
+        )
         PrintPreferences.save_handoff_storage(storage)
         self.result_installation = installation
         self.result_setup = setup
@@ -730,7 +761,10 @@ class PrintSetupDialog(QtWidgets.QDialog):
         storage = self._selected_storage()
         if installation is None or storage is None:
             return
-        PrintPreferences.set_executable_override(self.executable.text())
+        PrintPreferences.set_executable_override(
+            self.executable.text(),
+            backend_id=self.backend_id,
+        )
         PrintPreferences.save_handoff_storage(storage)
         self.result_installation = installation
         self.result_setup = None
@@ -755,20 +789,21 @@ class PrintSetupDialog(QtWidgets.QDialog):
                 creationflags=creationflags,
             )
             self._set_status(
-                "PrusaSlicer opened. Complete its Configuration Wizard if needed, "
+                f"{self.slicer_name} opened. Complete its Configuration Wizard if needed, "
                 "then return here and click Retry."
             )
         except OSError as exc:
-            self._set_status(f"Could not open PrusaSlicer: {exc}")
+            self._set_status(f"Could not open {self.slicer_name}: {exc}")
 
     def _download(self) -> None:
-        QtGui.QDesktopServices.openUrl(QtCore.QUrl(DOWNLOAD_URL))
+        if self.download_url:
+            QtGui.QDesktopServices.openUrl(QtCore.QUrl(self.download_url))
 
 
 def choose_print_setup(
     *,
     parent: Any,
-    backend: VibeCADPrint.PrusaSlicerBackend,
+    backend: Any,
     open_after_save: bool,
     initial_installation: VibeCADPrint.SlicerInstallation | None = None,
     initial_message: str = "",

--- a/src/Mod/VibeCADPrint/PrintSetupDialog.py
+++ b/src/Mod/VibeCADPrint/PrintSetupDialog.py
@@ -261,6 +261,40 @@ class PrintSetupDialog(QtWidgets.QDialog):
         placement_layout.addWidget(self.ensure_on_bed)
         layout.addWidget(placement_group)
 
+        storage_group = QtWidgets.QGroupBox("3MF handoff location", self)
+        storage_layout = QtWidgets.QVBoxLayout(storage_group)
+        self.managed_storage = QtWidgets.QRadioButton(
+            "Managed VibeCAD cache", storage_group
+        )
+        self.folder_storage = QtWidgets.QRadioButton("Choose a folder", storage_group)
+        storage_layout.addWidget(self.managed_storage)
+        storage_layout.addWidget(self.folder_storage)
+        folder_row = QtWidgets.QWidget(storage_group)
+        folder_layout = QtWidgets.QHBoxLayout(folder_row)
+        folder_layout.setContentsMargins(0, 0, 0, 0)
+        self.folder_edit = QtWidgets.QLineEdit(folder_row)
+        self.folder_edit.setPlaceholderText("Folder for persistent 3MF files")
+        browse_folder = QtWidgets.QPushButton("Browse…", folder_row)
+        browse_folder.clicked.connect(self._browse_handoff_folder)
+        folder_layout.addWidget(self.folder_edit, 1)
+        folder_layout.addWidget(browse_folder)
+        storage_layout.addWidget(folder_row)
+        storage_note = QtWidgets.QLabel(
+            "Managed files are automatically limited to recent handoffs. Files "
+            "in your chosen folder are never pruned by VibeCAD.",
+            storage_group,
+        )
+        _configure_wrapped_label(storage_note)
+        storage_layout.addWidget(storage_note)
+        storage = PrintPreferences.load_handoff_storage()
+        self.folder_edit.setText(storage.directory)
+        self.folder_edit.textChanged.connect(self._update_actions)
+        self.managed_storage.setChecked(storage.mode == "managed")
+        self.folder_storage.setChecked(storage.mode == "folder")
+        self.managed_storage.toggled.connect(self._storage_changed)
+        self.folder_storage.toggled.connect(self._storage_changed)
+        layout.addWidget(storage_group)
+
         self.summary = QtWidgets.QLabel(self)
         _configure_wrapped_label(self.summary)
         self.summary.setObjectName("VibeCADPrintSetupSummary")
@@ -287,6 +321,7 @@ class PrintSetupDialog(QtWidgets.QDialog):
         layout.addWidget(self.buttons)
 
         self._clear_profiles()
+        self._storage_changed()
         self._update_summary()
         self.resize(700, 590)
         self._ensure_layout_room()
@@ -348,8 +383,34 @@ class PrintSetupDialog(QtWidgets.QDialog):
         self.printer_combo.setEnabled(not busy)
         self.print_combo.setEnabled(not busy)
         self.save_button.setEnabled(
-            False if busy else self._selected_setup() is not None
+            False
+            if busy
+            else self._selected_setup() is not None
+            and self._selected_storage() is not None
         )
+
+    def _selected_storage(self) -> PrintPreferences.HandoffStorage | None:
+        directory = self.folder_edit.text().strip()
+        if self.folder_storage.isChecked():
+            if not directory:
+                return None
+            return PrintPreferences.HandoffStorage("folder", directory)
+        return PrintPreferences.HandoffStorage("managed", directory)
+
+    def _storage_changed(self, *_args) -> None:
+        self.folder_edit.setEnabled(self.folder_storage.isChecked())
+        self._update_actions()
+
+    def _browse_handoff_folder(self) -> None:
+        start = self.folder_edit.text().strip() or str(Path.home())
+        selected = QtWidgets.QFileDialog.getExistingDirectory(
+            self,
+            "Choose a folder for 3MF handoffs",
+            start,
+        )
+        if selected:
+            self.folder_edit.setText(str(selected))
+            self.folder_storage.setChecked(True)
 
     def _locate(self) -> None:
         selected = _browse_for_prusaslicer(self, self.executable.text())
@@ -605,13 +666,17 @@ class PrintSetupDialog(QtWidgets.QDialog):
         installation = self._selected_installation()
         self.open_slicer_button.setEnabled(installation is not None)
         self.basic_button.setEnabled(self.open_after_save and installation is not None)
-        self.save_button.setEnabled(self._selected_setup() is not None)
+        self.save_button.setEnabled(
+            self._selected_setup() is not None
+            and self._selected_storage() is not None
+        )
         self._update_summary()
 
     def _update_summary(self, *_args) -> None:
         installation = self._selected_installation()
         printer = self._selected_printer()
         print_profile = self._selected_print_profile()
+        storage = self._selected_storage()
         materials = [
             str(combo.currentData() or "Not selected")
             for combo in self._material_combos
@@ -623,34 +688,49 @@ class PrintSetupDialog(QtWidgets.QDialog):
             f"{print_profile.name if print_profile else 'No print profile'} | "
             f"materials: {', '.join(materials) if materials else 'not selected'} | "
             f"Auto-arrange: {'on' if self.auto_arrange.isChecked() else 'off'} | "
-            f"Ensure on bed: {'on' if self.ensure_on_bed.isChecked() else 'off'}"
+            f"Ensure on bed: {'on' if self.ensure_on_bed.isChecked() else 'off'} | "
+            "3MF: "
+            + (
+                storage.directory
+                if storage is not None and storage.mode == "folder"
+                else "managed cache"
+                if storage is not None
+                else "choose a folder"
+            )
         )
         if hasattr(self, "save_button"):
-            self.save_button.setEnabled(self._selected_setup() is not None)
+            self.save_button.setEnabled(
+                self._selected_setup() is not None
+                and self._selected_storage() is not None
+            )
             QtCore.QTimer.singleShot(0, self._ensure_layout_room)
 
     def _accept_setup(self) -> None:
         setup = self._selected_setup()
+        storage = self._selected_storage()
         installation = self._selected_installation()
-        if setup is None or installation is None:
+        if setup is None or storage is None or installation is None:
             QtWidgets.QMessageBox.warning(
                 self,
                 "Incomplete Print Setup",
                 "Explicitly select a printer, print profile, and one compatible "
-                "material profile for every extruder.",
+                "material profile for every extruder, plus a 3MF handoff location.",
             )
             return
         PrintPreferences.set_executable_override(self.executable.text())
         PrintPreferences.save_confirmed_setup(setup)
+        PrintPreferences.save_handoff_storage(storage)
         self.result_installation = installation
         self.result_setup = setup
         self.accept()
 
     def _accept_basic(self) -> None:
         installation = self._selected_installation()
-        if installation is None:
+        storage = self._selected_storage()
+        if installation is None or storage is None:
             return
         PrintPreferences.set_executable_override(self.executable.text())
+        PrintPreferences.save_handoff_storage(storage)
         self.result_installation = installation
         self.result_setup = None
         self.accept()

--- a/src/Mod/VibeCADPrint/PrintSetupDialog.py
+++ b/src/Mod/VibeCADPrint/PrintSetupDialog.py
@@ -21,6 +21,7 @@ DOWNLOAD_URL = "https://www.prusa3d.com/page/prusaslicer_424/"
 DOWNLOAD_URLS = {
     "prusaslicer": DOWNLOAD_URL,
     "bambustudio": "https://github.com/bambulab/BambuStudio/releases",
+    "orcaslicer": "https://github.com/OrcaSlicer/OrcaSlicer/releases",
 }
 _EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="vibecad-print-setup")
 
@@ -223,7 +224,7 @@ class PrintSetupDialog(QtWidgets.QDialog):
         download.setEnabled(bool(self.download_url))
         download.clicked.connect(self._download)
         retry = QtWidgets.QPushButton("Retry", action_row)
-        retry.clicked.connect(self._detect)
+        retry.clicked.connect(self._retry_detect)
         action_layout.addWidget(self.open_slicer_button)
         action_layout.addWidget(download)
         action_layout.addWidget(retry)
@@ -443,6 +444,12 @@ class PrintSetupDialog(QtWidgets.QDialog):
 
     def _auto_detect(self) -> None:
         self.executable.clear()
+        self._retry_detect()
+
+    def _retry_detect(self, *_args) -> None:
+        invalidate = getattr(self.backend, "invalidate_cache", None)
+        if callable(invalidate):
+            invalidate()
         self._detect()
 
     def _detect(self) -> None:

--- a/src/Mod/VibeCADPrint/PrintSetupDialog.py
+++ b/src/Mod/VibeCADPrint/PrintSetupDialog.py
@@ -59,8 +59,9 @@ def run_with_progress(
     progress.show()
     _qt_exec(loop)
     timer.stop()
+    was_canceled = progress.wasCanceled()
     progress.close()
-    if progress.wasCanceled():
+    if was_canceled:
         future.cancel()
         raise VibeCADPrint.SlicerQueryError("PrusaSlicer profile check was canceled.")
     return future.result()

--- a/src/Mod/VibeCADPrint/PrintSetupDialog.py
+++ b/src/Mod/VibeCADPrint/PrintSetupDialog.py
@@ -1,0 +1,707 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Guided, non-blocking PrusaSlicer profile and placement setup."""
+
+from __future__ import annotations
+
+from concurrent.futures import Future, ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any, Callable
+
+from PySide import QtCore, QtGui, QtWidgets
+
+import PrintPreferences
+import VibeCADPrint
+
+
+DOWNLOAD_URL = "https://www.prusa3d.com/page/prusaslicer_424/"
+_EXECUTOR = ThreadPoolExecutor(max_workers=2, thread_name_prefix="vibecad-prusa")
+
+
+def _qt_exec(value: Any) -> int:
+    execute = getattr(value, "exec", None) or getattr(value, "exec_", None)
+    return int(execute())
+
+
+def _configure_wrapped_label(label: Any) -> None:
+    """Keep wrapped text from being vertically collapsed by parent layouts."""
+
+    label.setWordWrap(True)
+    policy = label.sizePolicy()
+    policy.setVerticalPolicy(QtWidgets.QSizePolicy.Minimum)
+    label.setSizePolicy(policy)
+
+
+def run_with_progress(
+    parent: Any,
+    label: str,
+    operation: Callable[[], Any],
+) -> Any:
+    """Run a bounded backend call while keeping the Qt event loop responsive."""
+
+    future = _EXECUTOR.submit(operation)
+    progress = QtWidgets.QProgressDialog(label, "Cancel", 0, 0, parent)
+    progress.setWindowTitle("3D Print")
+    progress.setWindowModality(QtCore.Qt.WindowModal)
+    progress.setMinimumDuration(150)
+    loop = QtCore.QEventLoop()
+    timer = QtCore.QTimer(progress)
+
+    def poll() -> None:
+        if future.done() or progress.wasCanceled():
+            loop.quit()
+
+    timer.timeout.connect(poll)
+    timer.start(40)
+    progress.show()
+    _qt_exec(loop)
+    timer.stop()
+    progress.close()
+    if progress.wasCanceled():
+        future.cancel()
+        raise VibeCADPrint.SlicerQueryError("PrusaSlicer profile check was canceled.")
+    return future.result()
+
+
+@dataclass(frozen=True)
+class SetupChoice:
+    accepted: bool
+    installation: VibeCADPrint.SlicerInstallation | None = None
+    setup: VibeCADPrint.PrintSetup | None = None
+
+
+class VibeCADPrintPreferencesPage:
+    """Persistent executable override; profile choices stay in Print Setup."""
+
+    def __init__(self, parent=None) -> None:
+        self.form = QtWidgets.QWidget(parent)
+        self.form.setObjectName("VibeCADPrintPreferencesPage")
+        self.form.setWindowTitle("3D Printing")
+        layout = QtWidgets.QFormLayout(self.form)
+        row = QtWidgets.QWidget(self.form)
+        row_layout = QtWidgets.QHBoxLayout(row)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+        self.executable = QtWidgets.QLineEdit(row)
+        self.executable.setObjectName("VibeCADPrintExecutablePreference")
+        self.executable.setPlaceholderText("Auto-detect PrusaSlicer")
+        browse = QtWidgets.QPushButton("Locate", row)
+        browse.clicked.connect(self._browse)
+        row_layout.addWidget(self.executable, 1)
+        row_layout.addWidget(browse)
+        layout.addRow("PrusaSlicer executable", row)
+        note = QtWidgets.QLabel(
+            "Leave this empty to auto-detect native installations and the official "
+            "Linux Flatpak. Printer, print, and material profiles are confirmed in "
+            "the 3D Print ribbon's Print Setup dialog.",
+            self.form,
+        )
+        note.setWordWrap(True)
+        layout.addRow("Detection", note)
+        self.loadSettings()
+
+    def _browse(self) -> None:
+        selected = _browse_for_prusaslicer(self.form, self.executable.text())
+        if selected:
+            self.executable.setText(selected)
+
+    def saveSettings(self) -> None:
+        PrintPreferences.set_executable_override(self.executable.text())
+
+    def loadSettings(self) -> None:
+        self.executable.setText(PrintPreferences.executable_override())
+
+
+def _browse_for_prusaslicer(parent: Any, initial: str = "") -> str:
+    start = initial or str(Path.home())
+    if sys.platform == "darwin":
+        selected = QtWidgets.QFileDialog.getExistingDirectory(
+            parent,
+            "Locate PrusaSlicer.app",
+            start,
+        )
+        if selected:
+            return str(selected)
+    selected, _filter = QtWidgets.QFileDialog.getOpenFileName(
+        parent,
+        "Locate the PrusaSlicer application",
+        start,
+        "Executables (*);;All files (*)",
+    )
+    return str(selected or "")
+
+
+class PrintSetupDialog(QtWidgets.QDialog):
+    """Explicit profile selection backed by PrusaSlicer's installed presets."""
+
+    def __init__(
+        self,
+        *,
+        parent: Any,
+        backend: VibeCADPrint.PrusaSlicerBackend,
+        open_after_save: bool,
+        initial_installation: VibeCADPrint.SlicerInstallation | None = None,
+        initial_message: str = "",
+    ) -> None:
+        super().__init__(parent)
+        self.setObjectName("VibeCADPrintSetupDialog")
+        self.setWindowTitle("Print Setup")
+        self.backend = backend
+        self.open_after_save = open_after_save
+        self.initial_installation = initial_installation
+        self.result_installation: VibeCADPrint.SlicerInstallation | None = None
+        self.result_setup: VibeCADPrint.PrintSetup | None = None
+        self._remembered = PrintPreferences.load_confirmed_setup()
+        self._printers: tuple[VibeCADPrint.PrinterProfile, ...] = ()
+        self._catalog: VibeCADPrint.ProfileCatalog | None = None
+        self._material_combos: list[Any] = []
+        self._job_id = 0
+        self._callbacks: dict[int, Callable[[Any], None]] = {}
+        self._futures: set[Future[Any]] = set()
+
+        class _AsyncBridge(QtCore.QObject):
+            finished = QtCore.Signal(int, object, object)
+
+        self._bridge = _AsyncBridge(self)
+        self._bridge.finished.connect(self._async_finished)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        intro = QtWidgets.QLabel(
+            "VibeCAD reads profiles installed by PrusaSlicer. Nothing is selected "
+            "or substituted on your behalf.",
+            self,
+        )
+        _configure_wrapped_label(intro)
+        layout.addWidget(intro)
+
+        executable_group = QtWidgets.QGroupBox("PrusaSlicer", self)
+        executable_layout = QtWidgets.QFormLayout(executable_group)
+        executable_row = QtWidgets.QWidget(executable_group)
+        executable_row_layout = QtWidgets.QHBoxLayout(executable_row)
+        executable_row_layout.setContentsMargins(0, 0, 0, 0)
+        self.executable = QtWidgets.QLineEdit(executable_row)
+        self.executable.setText(PrintPreferences.executable_override())
+        self.executable.setPlaceholderText("Auto-detect")
+        locate = QtWidgets.QPushButton("Locate", executable_row)
+        locate.clicked.connect(self._locate)
+        auto_detect = QtWidgets.QPushButton("Auto-detect", executable_row)
+        auto_detect.clicked.connect(self._auto_detect)
+        executable_row_layout.addWidget(self.executable, 1)
+        executable_row_layout.addWidget(locate)
+        executable_row_layout.addWidget(auto_detect)
+        executable_layout.addRow("Executable", executable_row)
+
+        self.installation_combo = QtWidgets.QComboBox(executable_group)
+        self.installation_combo.currentIndexChanged.connect(self._installation_changed)
+        executable_layout.addRow("Detected installation", self.installation_combo)
+        action_row = QtWidgets.QWidget(executable_group)
+        action_layout = QtWidgets.QHBoxLayout(action_row)
+        action_layout.setContentsMargins(0, 0, 0, 0)
+        self.open_slicer_button = QtWidgets.QPushButton("Open PrusaSlicer", action_row)
+        self.open_slicer_button.clicked.connect(self._open_prusaslicer)
+        download = QtWidgets.QPushButton("Download", action_row)
+        download.clicked.connect(self._download)
+        retry = QtWidgets.QPushButton("Retry", action_row)
+        retry.clicked.connect(self._detect)
+        action_layout.addWidget(self.open_slicer_button)
+        action_layout.addWidget(download)
+        action_layout.addWidget(retry)
+        action_layout.addStretch(1)
+        executable_layout.addRow("Actions", action_row)
+        layout.addWidget(executable_group)
+
+        profiles_group = QtWidgets.QGroupBox("Installed profiles", self)
+        profiles_layout = QtWidgets.QFormLayout(profiles_group)
+        profiles_layout.setRowWrapPolicy(QtWidgets.QFormLayout.DontWrapRows)
+        self.printer_combo = QtWidgets.QComboBox(profiles_group)
+        self.printer_combo.currentIndexChanged.connect(self._printer_changed)
+        profiles_layout.addRow("Printer profile", self.printer_combo)
+        self.bed_details = QtWidgets.QLabel("Choose a printer profile.", profiles_group)
+        _configure_wrapped_label(self.bed_details)
+        profiles_layout.addRow("Build volume", self.bed_details)
+        self.print_combo = QtWidgets.QComboBox(profiles_group)
+        self.print_combo.currentIndexChanged.connect(self._print_changed)
+        profiles_layout.addRow("Print profile", self.print_combo)
+        self.material_widget = QtWidgets.QWidget(profiles_group)
+        self.material_layout = QtWidgets.QFormLayout(self.material_widget)
+        self.material_layout.setContentsMargins(0, 0, 0, 0)
+        profiles_layout.addRow("Materials", self.material_widget)
+        material_note = QtWidgets.QLabel(
+            "Choose one material profile for every extruder. Object-to-extruder "
+            "assignment remains explicit in PrusaSlicer.",
+            profiles_group,
+        )
+        _configure_wrapped_label(material_note)
+        profiles_layout.addRow("Multi-extruder", material_note)
+        layout.addWidget(profiles_group)
+
+        placement_group = QtWidgets.QGroupBox("Placement", self)
+        placement_layout = QtWidgets.QVBoxLayout(placement_group)
+        self.auto_arrange = QtWidgets.QCheckBox("Auto-arrange", placement_group)
+        self.auto_arrange.setToolTip(
+            "Allow PrusaSlicer to arrange imported objects in XY. Turn this off "
+            "to retain their exact CAD XY positions."
+        )
+        self.ensure_on_bed = QtWidgets.QCheckBox("Ensure on bed", placement_group)
+        self.ensure_on_bed.setToolTip(
+            "Allow PrusaSlicer to lift objects that extend below the build plate."
+        )
+        remembered = self._remembered
+        self.auto_arrange.setChecked(
+            remembered.auto_arrange if remembered is not None else True
+        )
+        self.ensure_on_bed.setChecked(
+            remembered.ensure_on_bed if remembered is not None else True
+        )
+        self.auto_arrange.toggled.connect(self._update_summary)
+        self.ensure_on_bed.toggled.connect(self._update_summary)
+        placement_layout.addWidget(self.auto_arrange)
+        placement_layout.addWidget(self.ensure_on_bed)
+        layout.addWidget(placement_group)
+
+        self.summary = QtWidgets.QLabel(self)
+        _configure_wrapped_label(self.summary)
+        self.summary.setObjectName("VibeCADPrintSetupSummary")
+        layout.addWidget(self.summary)
+        self.status = QtWidgets.QLabel(initial_message, self)
+        _configure_wrapped_label(self.status)
+        self.status.setObjectName("VibeCADPrintSetupStatus")
+        layout.addWidget(self.status)
+
+        self.buttons = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.Save | QtWidgets.QDialogButtonBox.Cancel,
+            self,
+        )
+        self.save_button = self.buttons.button(QtWidgets.QDialogButtonBox.Save)
+        self.save_button.setText("Save & Open" if open_after_save else "Save Setup")
+        self.save_button.clicked.connect(self._accept_setup)
+        self.buttons.rejected.connect(self.reject)
+        self.basic_button = self.buttons.addButton(
+            "Open without profiles",
+            QtWidgets.QDialogButtonBox.ActionRole,
+        )
+        self.basic_button.setVisible(open_after_save)
+        self.basic_button.clicked.connect(self._accept_basic)
+        layout.addWidget(self.buttons)
+
+        self._clear_profiles()
+        self._update_summary()
+        self.resize(700, 590)
+        self._ensure_layout_room()
+        QtCore.QTimer.singleShot(0, self._detect)
+
+    def _ensure_layout_room(self) -> None:
+        """Grow to the current styled size hint; never compress wrapped rows."""
+
+        current_layout = self.layout()
+        if current_layout is not None:
+            current_layout.activate()
+        hint = self.sizeHint()
+        self.resize(max(self.width(), hint.width()), max(self.height(), hint.height()))
+
+    def _set_status(self, message: str) -> None:
+        self.status.setText(message)
+        QtCore.QTimer.singleShot(0, self._ensure_layout_room)
+
+    def _start_async(
+        self,
+        label: str,
+        operation: Callable[[], Any],
+        callback: Callable[[Any], None],
+    ) -> None:
+        self._job_id += 1
+        job = self._job_id
+        self._callbacks = {job: callback}
+        self._set_status(label)
+        self._set_busy(True)
+        future = _EXECUTOR.submit(operation)
+        self._futures.add(future)
+
+        def completed(value: Future[Any]) -> None:
+            try:
+                result, error = value.result(), None
+            except Exception as exc:
+                result, error = None, exc
+            try:
+                self._bridge.finished.emit(job, result, error)
+            except RuntimeError:
+                pass
+
+        future.add_done_callback(completed)
+
+    def _async_finished(self, job: int, result: Any, error: Any) -> None:
+        if job != self._job_id:
+            return
+        callback = self._callbacks.pop(job, None)
+        self._set_busy(False)
+        if error is not None:
+            self._set_status(str(error))
+            self._update_actions()
+            return
+        if callback is not None:
+            callback(result)
+
+    def _set_busy(self, busy: bool) -> None:
+        self.installation_combo.setEnabled(not busy)
+        self.printer_combo.setEnabled(not busy)
+        self.print_combo.setEnabled(not busy)
+        self.save_button.setEnabled(
+            False if busy else self._selected_setup() is not None
+        )
+
+    def _locate(self) -> None:
+        selected = _browse_for_prusaslicer(self, self.executable.text())
+        if selected:
+            self.executable.setText(selected)
+            self._detect()
+
+    def _auto_detect(self) -> None:
+        self.executable.clear()
+        self._detect()
+
+    def _detect(self) -> None:
+        override = self.executable.text().strip()
+        self._start_async(
+            "Detecting PrusaSlicer installations...",
+            lambda: self.backend.discover(override),
+            self._installations_loaded,
+        )
+
+    def _installations_loaded(self, values: Any) -> None:
+        installations = list(values or ())
+        if self.initial_installation is not None and all(
+            value.gui_command != self.initial_installation.gui_command
+            for value in installations
+        ):
+            installations.append(self.initial_installation)
+        preferred = VibeCADPrint.preferred_installation(installations)
+        self.installation_combo.blockSignals(True)
+        self.installation_combo.clear()
+        for installation in installations:
+            suffix = "" if installation.tested else " — update recommended"
+            self.installation_combo.addItem(
+                installation.display_name + suffix, installation
+            )
+        if preferred is not None:
+            index = next(
+                (
+                    position
+                    for position, installation in enumerate(installations)
+                    if installation.gui_command == preferred.gui_command
+                ),
+                0,
+            )
+            self.installation_combo.setCurrentIndex(index)
+        self.installation_combo.blockSignals(False)
+        if preferred is None:
+            self._set_status(
+                "PrusaSlicer was not found. Use Locate or Download, then Retry."
+            )
+            self._clear_profiles()
+            self._update_actions()
+            return
+        self._installation_changed(self.installation_combo.currentIndex())
+
+    def _selected_installation(self) -> VibeCADPrint.SlicerInstallation | None:
+        value = self.installation_combo.currentData()
+        return value if isinstance(value, VibeCADPrint.SlicerInstallation) else None
+
+    def _installation_changed(self, _index: int) -> None:
+        installation = self._selected_installation()
+        self._clear_profiles()
+        if installation is None:
+            self._set_status("Choose a detected PrusaSlicer installation.")
+        elif not installation.tested:
+            self._set_status(
+                f"PrusaSlicer {installation.version} is older than the tested "
+                "2.9.6 baseline. Basic 3MF handoff remains available, but VibeCAD "
+                "will not pass profiles."
+            )
+        else:
+            self._start_async(
+                "Reading installed printer profiles...",
+                lambda: self.backend.query_printers(installation),
+                self._printers_loaded,
+            )
+        self._update_actions()
+
+    def _clear_profiles(self) -> None:
+        self._printers = ()
+        self._catalog = None
+        self.printer_combo.blockSignals(True)
+        self.printer_combo.clear()
+        self.printer_combo.addItem("Choose a printer profile...", None)
+        self.printer_combo.blockSignals(False)
+        self.print_combo.blockSignals(True)
+        self.print_combo.clear()
+        self.print_combo.addItem("Choose a print profile...", None)
+        self.print_combo.blockSignals(False)
+        self._clear_materials()
+        self.bed_details.setText("Choose a printer profile.")
+        self._update_summary()
+
+    def _printers_loaded(self, values: Any) -> None:
+        self._printers = tuple(values or ())
+        self.printer_combo.blockSignals(True)
+        self.printer_combo.clear()
+        self.printer_combo.addItem("Choose a printer profile...", None)
+        for printer in self._printers:
+            label = printer.name + (" — user" if printer.is_user else "")
+            self.printer_combo.addItem(label, printer)
+        remembered = self._remembered
+        selected_index = 0
+        if remembered is not None:
+            for index in range(1, self.printer_combo.count()):
+                printer = self.printer_combo.itemData(index)
+                if printer is not None and printer.name == remembered.printer_profile:
+                    selected_index = index
+                    break
+        self.printer_combo.setCurrentIndex(selected_index)
+        self.printer_combo.blockSignals(False)
+        self._set_status(
+            "Select the exact installed printer profile."
+            if selected_index == 0
+            else "Refreshing compatible print and material profiles..."
+        )
+        if selected_index:
+            self._printer_changed(selected_index)
+        self._update_actions()
+
+    def _selected_printer(self) -> VibeCADPrint.PrinterProfile | None:
+        value = self.printer_combo.currentData()
+        return value if isinstance(value, VibeCADPrint.PrinterProfile) else None
+
+    def _printer_changed(self, _index: int) -> None:
+        printer = self._selected_printer()
+        self._catalog = None
+        self.print_combo.blockSignals(True)
+        self.print_combo.clear()
+        self.print_combo.addItem("Choose a print profile...", None)
+        self.print_combo.blockSignals(False)
+        self._clear_materials()
+        if printer is None:
+            self.bed_details.setText("Choose a printer profile.")
+            self._set_status("Select the exact installed printer profile.")
+            self._update_actions()
+            return
+        bed = printer.bed
+        self.bed_details.setText(
+            f"{bed.kind or 'Build plate'} — {bed.width:g} × {bed.height:g} × "
+            f"{bed.max_print_height:g} mm; origin {bed.origin[0]:g}, "
+            f"{bed.origin[1]:g}; {printer.extruders} extruder(s)"
+        )
+        installation = self._selected_installation()
+        if installation is None:
+            return
+        self._start_async(
+            f"Reading profiles compatible with {printer.name}...",
+            lambda: self.backend.query_profiles(installation, printer.name),
+            self._profiles_loaded,
+        )
+
+    def _profiles_loaded(self, catalog: Any) -> None:
+        if not isinstance(catalog, VibeCADPrint.ProfileCatalog):
+            self._set_status("PrusaSlicer returned an invalid profile catalog.")
+            return
+        printer = self._selected_printer()
+        if printer is None or catalog.printer_profile != printer.name:
+            self._set_status(
+                "PrusaSlicer returned profiles for a different printer."
+            )
+            return
+        self._catalog = catalog
+        self.print_combo.blockSignals(True)
+        self.print_combo.clear()
+        self.print_combo.addItem("Choose a print profile...", None)
+        for profile in catalog.print_profiles:
+            label = profile.name + (" — user" if profile.is_user else "")
+            self.print_combo.addItem(label, profile)
+        selected_index = 0
+        remembered = self._remembered
+        if remembered is not None and remembered.printer_profile == printer.name:
+            for index in range(1, self.print_combo.count()):
+                profile = self.print_combo.itemData(index)
+                if profile is not None and profile.name == remembered.print_profile:
+                    selected_index = index
+                    break
+        self.print_combo.setCurrentIndex(selected_index)
+        self.print_combo.blockSignals(False)
+        self._set_status(
+            "Select the exact print profile."
+            if selected_index == 0
+            else "Confirmed profile names were found; review the setup before saving."
+        )
+        if selected_index:
+            self._print_changed(selected_index)
+        self._update_actions()
+
+    def _selected_print_profile(self) -> VibeCADPrint.PrintProfile | None:
+        value = self.print_combo.currentData()
+        return value if isinstance(value, VibeCADPrint.PrintProfile) else None
+
+    def _clear_materials(self) -> None:
+        self._material_combos.clear()
+        while self.material_layout.count():
+            item = self.material_layout.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def _print_changed(self, _index: int) -> None:
+        self._clear_materials()
+        printer = self._selected_printer()
+        profile = self._selected_print_profile()
+        if printer is None or profile is None:
+            self._update_actions()
+            return
+        for extruder in range(printer.extruders):
+            combo = QtWidgets.QComboBox(self.material_widget)
+            combo.addItem("Choose a material profile...", None)
+            for material in profile.materials:
+                label = material.name + (" — user" if material.is_user else "")
+                combo.addItem(label, material.name)
+            combo.currentIndexChanged.connect(self._update_summary)
+            remembered = self._remembered
+            if (
+                remembered is not None
+                and remembered.printer_profile == printer.name
+                and remembered.print_profile == profile.name
+                and extruder < len(remembered.material_profiles)
+            ):
+                exact = remembered.material_profiles[extruder]
+                index = combo.findData(exact)
+                if index >= 0:
+                    combo.setCurrentIndex(index)
+            self.material_layout.addRow(f"Extruder {extruder + 1}", combo)
+            self._material_combos.append(combo)
+        self._update_actions()
+
+    def _selected_setup(self) -> VibeCADPrint.PrintSetup | None:
+        printer = self._selected_printer()
+        print_profile = self._selected_print_profile()
+        if printer is None or print_profile is None:
+            return None
+        materials = tuple(
+            str(combo.currentData() or "") for combo in self._material_combos
+        )
+        if len(materials) != printer.extruders or any(not name for name in materials):
+            return None
+        setup = VibeCADPrint.PrintSetup(
+            printer_profile=printer.name,
+            print_profile=print_profile.name,
+            material_profiles=materials,
+            auto_arrange=self.auto_arrange.isChecked(),
+            ensure_on_bed=self.ensure_on_bed.isChecked(),
+        )
+        if self._catalog is None or VibeCADPrint.validate_setup(
+            setup, printer, self._catalog
+        ):
+            return None
+        return setup
+
+    def _update_actions(self) -> None:
+        installation = self._selected_installation()
+        self.open_slicer_button.setEnabled(installation is not None)
+        self.basic_button.setEnabled(self.open_after_save and installation is not None)
+        self.save_button.setEnabled(self._selected_setup() is not None)
+        self._update_summary()
+
+    def _update_summary(self, *_args) -> None:
+        installation = self._selected_installation()
+        printer = self._selected_printer()
+        print_profile = self._selected_print_profile()
+        materials = [
+            str(combo.currentData() or "Not selected")
+            for combo in self._material_combos
+        ]
+        self.summary.setText(
+            "Active setup: "
+            f"{installation.display_name if installation else 'No slicer'} | "
+            f"{printer.name if printer else 'No printer'} | "
+            f"{print_profile.name if print_profile else 'No print profile'} | "
+            f"materials: {', '.join(materials) if materials else 'not selected'} | "
+            f"Auto-arrange: {'on' if self.auto_arrange.isChecked() else 'off'} | "
+            f"Ensure on bed: {'on' if self.ensure_on_bed.isChecked() else 'off'}"
+        )
+        if hasattr(self, "save_button"):
+            self.save_button.setEnabled(self._selected_setup() is not None)
+            QtCore.QTimer.singleShot(0, self._ensure_layout_room)
+
+    def _accept_setup(self) -> None:
+        setup = self._selected_setup()
+        installation = self._selected_installation()
+        if setup is None or installation is None:
+            QtWidgets.QMessageBox.warning(
+                self,
+                "Incomplete Print Setup",
+                "Explicitly select a printer, print profile, and one compatible "
+                "material profile for every extruder.",
+            )
+            return
+        PrintPreferences.set_executable_override(self.executable.text())
+        PrintPreferences.save_confirmed_setup(setup)
+        self.result_installation = installation
+        self.result_setup = setup
+        self.accept()
+
+    def _accept_basic(self) -> None:
+        installation = self._selected_installation()
+        if installation is None:
+            return
+        PrintPreferences.set_executable_override(self.executable.text())
+        self.result_installation = installation
+        self.result_setup = None
+        self.accept()
+
+    def _open_prusaslicer(self) -> None:
+        installation = self._selected_installation()
+        if installation is None:
+            return
+        creationflags = 0
+        if sys.platform == "win32":
+            creationflags = int(getattr(subprocess, "DETACHED_PROCESS", 0)) | int(
+                getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            )
+        try:
+            subprocess.Popen(
+                list(installation.gui_command),
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=(sys.platform != "win32"),
+                creationflags=creationflags,
+            )
+            self._set_status(
+                "PrusaSlicer opened. Complete its Configuration Wizard if needed, "
+                "then return here and click Retry."
+            )
+        except OSError as exc:
+            self._set_status(f"Could not open PrusaSlicer: {exc}")
+
+    def _download(self) -> None:
+        QtGui.QDesktopServices.openUrl(QtCore.QUrl(DOWNLOAD_URL))
+
+
+def choose_print_setup(
+    *,
+    parent: Any,
+    backend: VibeCADPrint.PrusaSlicerBackend,
+    open_after_save: bool,
+    initial_installation: VibeCADPrint.SlicerInstallation | None = None,
+    initial_message: str = "",
+) -> SetupChoice:
+    dialog = PrintSetupDialog(
+        parent=parent,
+        backend=backend,
+        open_after_save=open_after_save,
+        initial_installation=initial_installation,
+        initial_message=initial_message,
+    )
+    accepted = _qt_exec(dialog) == QtWidgets.QDialog.Accepted
+    return SetupChoice(
+        accepted=accepted,
+        installation=dialog.result_installation if accepted else None,
+        setup=dialog.result_setup if accepted else None,
+    )

--- a/src/Mod/VibeCADPrint/VibeCADPrint.py
+++ b/src/Mod/VibeCADPrint/VibeCADPrint.py
@@ -1097,18 +1097,50 @@ class PrusaSlicerBackend:
     display_name = "PrusaSlicer"
     capabilities = BACKEND_CAPABILITIES
 
+    def __init__(self) -> None:
+        self._installation_cache: dict[str, tuple[SlicerInstallation, ...]] = {}
+        self._printer_cache: dict[
+            SlicerInstallation,
+            tuple[PrinterProfile, ...],
+        ] = {}
+        self._catalog_cache: dict[
+            tuple[SlicerInstallation, str],
+            ProfileCatalog,
+        ] = {}
+
+    def invalidate_cache(self) -> None:
+        """Forget query results so an explicit Refresh rereads PrusaSlicer."""
+
+        self._installation_cache.clear()
+        self._printer_cache.clear()
+        self._catalog_cache.clear()
+
     def discover(self, explicit_executable: str = "") -> tuple[SlicerInstallation, ...]:
-        return discover_prusaslicer_installations(explicit_executable)
+        key = str(explicit_executable or "").strip()
+        value = self._installation_cache.get(key)
+        if value is None:
+            value = discover_prusaslicer_installations(key)
+            self._installation_cache[key] = value
+        return value
 
     def query_printers(
         self, installation: SlicerInstallation
     ) -> tuple[PrinterProfile, ...]:
-        return query_printer_profiles(installation)
+        value = self._printer_cache.get(installation)
+        if value is None:
+            value = query_printer_profiles(installation)
+            self._printer_cache[installation] = value
+        return value
 
     def query_profiles(
         self, installation: SlicerInstallation, printer_profile: str
     ) -> ProfileCatalog:
-        return query_compatible_profiles(installation, printer_profile)
+        key = (installation, printer_profile)
+        value = self._catalog_cache.get(key)
+        if value is None:
+            value = query_compatible_profiles(installation, printer_profile)
+            self._catalog_cache[key] = value
+        return value
 
     def launch(
         self,

--- a/src/Mod/VibeCADPrint/VibeCADPrint.py
+++ b/src/Mod/VibeCADPrint/VibeCADPrint.py
@@ -922,6 +922,38 @@ def launch_prusaslicer(
     return LaunchResult(command=command, process_id=getattr(process, "pid", None))
 
 
+def launch_slicer_gui(
+    installation: SlicerInstallation,
+    handoff_file: str | os.PathLike[str],
+    *,
+    slicer_name: str,
+    popen: Callable[..., subprocess.Popen[Any]] = subprocess.Popen,
+    platform: str | None = None,
+) -> LaunchResult:
+    """Launch a GUI slicer detached and preserve the path as one argument."""
+
+    command = (*installation.gui_command, str(Path(handoff_file)))
+    current_platform = platform or sys.platform
+    creationflags = 0
+    if current_platform == "win32":
+        creationflags = int(getattr(subprocess, "DETACHED_PROCESS", 0)) | int(
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        )
+    try:
+        process = popen(
+            list(command),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            start_new_session=(current_platform != "win32"),
+            creationflags=creationflags,
+        )
+    except OSError as exc:
+        raise SlicerError(f"Could not start {slicer_name}: {exc}") from exc
+    return LaunchResult(command=command, process_id=getattr(process, "pid", None))
+
+
 def _is_printable_object(obj: Any) -> bool:
     shape = getattr(obj, "Shape", None)
     if shape is not None:

--- a/src/Mod/VibeCADPrint/VibeCADPrint.py
+++ b/src/Mod/VibeCADPrint/VibeCADPrint.py
@@ -1,0 +1,977 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""PrusaSlicer discovery, profiles, 3MF handoff, and launch services.
+
+The module intentionally has no FreeCAD or Qt dependency at import time.  The
+GUI commands adapt these services to the running application, while tests and
+future slicing backends can use the same contracts without starting a GUI.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+import hashlib
+import json
+import ntpath
+import os
+from pathlib import Path
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from typing import Any, Callable, Iterable, Mapping, Sequence
+from uuid import uuid4
+
+
+TESTED_PRUSASLICER_VERSION = (2, 9, 6)
+MANAGED_HANDOFF_PREFIX = "vibecad-print-"
+DEFAULT_HANDOFF_LIMIT = 10
+BACKEND_CAPABILITIES = (
+    "gui_handoff",
+    "profile_query",
+    # Reserved additive capabilities keep the UI independent of one engine.
+    "future_plate_metadata",
+    "future_headless_slice",
+    "future_toolpath_preview",
+)
+
+_VERSION_RE = re.compile(r"(?<!\d)(\d+)\.(\d+)(?:\.(\d+))?")
+_PRERELEASE_RE = re.compile(r"(?:alpha|beta|\brc\d*|dev|nightly)", re.IGNORECASE)
+_SAFE_NAME_RE = re.compile(r"[^A-Za-z0-9._-]+")
+
+
+class SlicerError(RuntimeError):
+    """Base error for an external slicer operation."""
+
+
+class SlicerQueryError(SlicerError):
+    """An installed slicer's profile query failed or returned invalid JSON."""
+
+
+class PrintSelectionError(SlicerError):
+    """The explicit document selection cannot be exported for printing."""
+
+
+class PrintExportError(SlicerError):
+    """The selected geometry could not be exported as a complete 3MF."""
+
+
+@dataclass(frozen=True)
+class BedInfo:
+    """Build-volume summary returned by PrusaSlicer's profile query."""
+
+    kind: str = ""
+    width: float = 0.0
+    height: float = 0.0
+    origin: tuple[float, float] = (0.0, 0.0)
+    max_print_height: float = 0.0
+
+
+@dataclass(frozen=True)
+class PrinterProfile:
+    """One exact, installed printer preset."""
+
+    name: str
+    model_id: str = ""
+    model_name: str = ""
+    variant_name: str = ""
+    vendor_id: str = ""
+    vendor_name: str = ""
+    technology: str = "FFF"
+    extruders: int = 1
+    bed: BedInfo = field(default_factory=BedInfo)
+    is_user: bool = False
+
+
+@dataclass(frozen=True)
+class MaterialProfile:
+    """One exact material preset compatible with a print preset."""
+
+    name: str
+    is_user: bool = False
+
+
+@dataclass(frozen=True)
+class PrintProfile:
+    """One print preset and the material presets compatible with it."""
+
+    name: str
+    materials: tuple[MaterialProfile, ...] = ()
+    is_user: bool = False
+
+
+@dataclass(frozen=True)
+class ProfileCatalog:
+    """Compatible print and material profiles for one printer preset."""
+
+    printer_profile: str
+    print_profiles: tuple[PrintProfile, ...] = ()
+
+    def find_print_profile(self, name: str) -> PrintProfile | None:
+        return next(
+            (profile for profile in self.print_profiles if profile.name == name), None
+        )
+
+
+@dataclass(frozen=True)
+class PrintSetup:
+    """The user's explicitly confirmed handoff configuration."""
+
+    printer_profile: str
+    print_profile: str
+    material_profiles: tuple[str, ...]
+    auto_arrange: bool = True
+    ensure_on_bed: bool = True
+
+
+@dataclass(frozen=True)
+class CandidateSpec:
+    """An unprobed platform-specific PrusaSlicer command pair."""
+
+    gui_command: tuple[str, ...]
+    cli_command: tuple[str, ...]
+    source: str
+    display_name: str = "PrusaSlicer"
+    config_dir: str = ""
+    explicit: bool = False
+
+
+@dataclass(frozen=True)
+class SlicerInstallation:
+    """A probed external slicing installation."""
+
+    backend_id: str
+    version: str
+    gui_command: tuple[str, ...]
+    cli_command: tuple[str, ...]
+    source: str
+    display_name: str
+    config_dir: str = ""
+    capabilities: tuple[str, ...] = BACKEND_CAPABILITIES
+
+    @property
+    def tested(self) -> bool:
+        return version_key(self.version) >= TESTED_PRUSASLICER_VERSION
+
+
+@dataclass(frozen=True)
+class LaunchResult:
+    """Result of starting an external slicer process."""
+
+    command: tuple[str, ...]
+    process_id: int | None
+
+
+def version_key(value: str) -> tuple[int, int, int]:
+    """Return a sortable three-part version from PrusaSlicer output."""
+
+    match = _VERSION_RE.search(str(value or ""))
+    if not match:
+        return (0, 0, 0)
+    return tuple(int(part or 0) for part in match.groups())  # type: ignore[return-value]
+
+
+def _is_stable_version(value: str) -> bool:
+    return not bool(_PRERELEASE_RE.search(str(value or "")))
+
+
+def _as_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _as_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _parse_origin(value: Any) -> tuple[float, float]:
+    if isinstance(value, str):
+        try:
+            value = json.loads(value)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            values = re.findall(r"[-+]?(?:\d+(?:\.\d*)?|\.\d+)", value)
+            value = values[:2]
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        values = list(value)
+        if len(values) >= 2:
+            return (_as_float(values[0]), _as_float(values[1]))
+    return (0.0, 0.0)
+
+
+def _bed_info(value: Any) -> BedInfo:
+    raw = value if isinstance(value, Mapping) else {}
+    return BedInfo(
+        kind=str(raw.get("type", "") or ""),
+        width=_as_float(raw.get("width")),
+        height=_as_float(raw.get("height")),
+        origin=_parse_origin(raw.get("origin")),
+        max_print_height=_as_float(raw.get("max_print_height")),
+    )
+
+
+def _printer_profile(
+    value: Any,
+    *,
+    model: Mapping[str, Any],
+    variant_name: str,
+    is_user: bool,
+) -> PrinterProfile | None:
+    raw = value if isinstance(value, Mapping) else {}
+    name = str(raw.get("name", "") or "").strip()
+    if not name:
+        return None
+    technology = str(model.get("technology", "FFF") or "FFF")
+    default_extruders = 0 if technology.upper() == "SLA" else 1
+    return PrinterProfile(
+        name=name,
+        model_id=str(model.get("id", "") or ""),
+        model_name=str(model.get("name", "") or name),
+        variant_name=variant_name,
+        vendor_id=str(model.get("vendor_id", "") or ""),
+        vendor_name=str(model.get("vendor_name", "") or ""),
+        technology=technology,
+        extruders=_as_int(raw.get("extruders_cnt"), default_extruders),
+        bed=_bed_info(raw.get("bed")),
+        is_user=is_user,
+    )
+
+
+def parse_printer_models(payload: Mapping[str, Any]) -> tuple[PrinterProfile, ...]:
+    """Flatten PrusaSlicer's model/variant JSON into exact printer presets."""
+
+    parsed: list[PrinterProfile] = []
+    models = payload.get("printer_models", [])
+    if not isinstance(models, Sequence) or isinstance(models, (str, bytes)):
+        raise SlicerQueryError(
+            "PrusaSlicer printer query did not contain printer_models."
+        )
+    for value in models:
+        if not isinstance(value, Mapping):
+            continue
+        variants = value.get("variants")
+        containers: list[tuple[Mapping[str, Any], str]] = []
+        if isinstance(variants, Sequence) and not isinstance(variants, (str, bytes)):
+            containers.extend(
+                (variant, str(variant.get("name", "") or ""))
+                for variant in variants
+                if isinstance(variant, Mapping)
+            )
+        else:
+            containers.append((value, ""))
+        for container, variant_name in containers:
+            for key, is_user in (
+                ("printer_profiles", False),
+                ("user_printer_profiles", True),
+            ):
+                values = container.get(key, [])
+                if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+                    continue
+                for raw_profile in values:
+                    profile = _printer_profile(
+                        raw_profile,
+                        model=value,
+                        variant_name=variant_name,
+                        is_user=is_user,
+                    )
+                    if profile is not None:
+                        parsed.append(profile)
+    return tuple(parsed)
+
+
+def _material_profiles(raw: Mapping[str, Any]) -> tuple[MaterialProfile, ...]:
+    materials: list[MaterialProfile] = []
+    for key, is_user in (
+        ("filament_profiles", False),
+        ("sla_material_profiles", False),
+        ("user_filament_profiles", True),
+        ("user_sla_material_profiles", True),
+    ):
+        values = raw.get(key, [])
+        if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+            continue
+        for value in values:
+            name = str(value or "").strip()
+            if name and all(item.name != name for item in materials):
+                materials.append(MaterialProfile(name=name, is_user=is_user))
+    return tuple(materials)
+
+
+def parse_compatible_profiles(payload: Mapping[str, Any]) -> ProfileCatalog:
+    """Parse print profiles while retaining their material compatibility sets."""
+
+    printer_profile = str(payload.get("printer_profile", "") or "").strip()
+    if not printer_profile:
+        raise SlicerQueryError("PrusaSlicer profile query omitted printer_profile.")
+    profiles: list[PrintProfile] = []
+    for key, is_user in (("print_profiles", False), ("user_print_profiles", True)):
+        values = payload.get(key, [])
+        if not isinstance(values, Sequence) or isinstance(values, (str, bytes)):
+            continue
+        for value in values:
+            if not isinstance(value, Mapping):
+                continue
+            name = str(value.get("name", "") or "").strip()
+            if name:
+                profiles.append(
+                    PrintProfile(
+                        name=name,
+                        materials=_material_profiles(value),
+                        is_user=is_user,
+                    )
+                )
+    return ProfileCatalog(
+        printer_profile=printer_profile, print_profiles=tuple(profiles)
+    )
+
+
+def default_config_directory(
+    *, platform: str | None = None, environ: Mapping[str, str] | None = None
+) -> str:
+    """Return PrusaSlicer's normal per-platform configuration directory."""
+
+    platform = platform or sys.platform
+    env = dict(os.environ if environ is None else environ)
+    if platform == "win32":
+        base = env.get("APPDATA", "")
+        return ntpath.join(base, "PrusaSlicer") if base else ""
+    home = env.get("HOME", "")
+    if platform == "darwin":
+        return (
+            str(Path(home) / "Library/Application Support/PrusaSlicer") if home else ""
+        )
+    base = env.get("XDG_CONFIG_HOME", "")
+    if base:
+        return str(Path(base) / "PrusaSlicer")
+    return str(Path(home) / ".config/PrusaSlicer") if home else ""
+
+
+def default_candidate_specs(
+    *, platform: str | None = None, environ: Mapping[str, str] | None = None
+) -> tuple[CandidateSpec, ...]:
+    """Return narrow, predictable PrusaSlicer candidates for an OS."""
+
+    platform = platform or sys.platform
+    env = dict(os.environ if environ is None else environ)
+    config_dir = default_config_directory(platform=platform, environ=env)
+    candidates: list[CandidateSpec] = []
+    if platform == "win32":
+        roots = [env.get("ProgramFiles", r"C:\Program Files")]
+        if env.get("LOCALAPPDATA"):
+            roots.append(env["LOCALAPPDATA"])
+        for root in roots:
+            gui = ntpath.join(root, "Prusa3D", "PrusaSlicer", "prusa-slicer.exe")
+            console = ntpath.join(
+                root, "Prusa3D", "PrusaSlicer", "prusa-slicer-console.exe"
+            )
+            candidates.append(
+                CandidateSpec(
+                    gui_command=(gui,),
+                    cli_command=(console,),
+                    source="standard",
+                    config_dir=config_dir,
+                )
+            )
+        candidates.append(
+            CandidateSpec(
+                gui_command=("prusa-slicer.exe",),
+                cli_command=("prusa-slicer-console.exe",),
+                source="path",
+                config_dir=config_dir,
+            )
+        )
+    elif platform == "darwin":
+        executable = "/Applications/PrusaSlicer.app/Contents/MacOS/PrusaSlicer"
+        candidates.extend(
+            [
+                CandidateSpec(
+                    gui_command=(executable,),
+                    cli_command=(executable,),
+                    source="standard",
+                    config_dir=config_dir,
+                ),
+                CandidateSpec(
+                    gui_command=("prusa-slicer",),
+                    cli_command=("prusa-slicer",),
+                    source="path",
+                    config_dir=config_dir,
+                ),
+            ]
+        )
+    else:
+        candidates.extend(
+            [
+                CandidateSpec(
+                    gui_command=("prusa-slicer",),
+                    cli_command=("prusa-slicer",),
+                    source="path",
+                    config_dir=config_dir,
+                ),
+                CandidateSpec(
+                    gui_command=("/usr/local/bin/prusa-slicer",),
+                    cli_command=("/usr/local/bin/prusa-slicer",),
+                    source="standard",
+                    config_dir=config_dir,
+                ),
+                CandidateSpec(
+                    gui_command=("/usr/bin/prusa-slicer",),
+                    cli_command=("/usr/bin/prusa-slicer",),
+                    source="standard",
+                    config_dir=config_dir,
+                ),
+                CandidateSpec(
+                    gui_command=(
+                        "flatpak",
+                        "--user",
+                        "run",
+                        "com.prusa3d.PrusaSlicer",
+                    ),
+                    cli_command=(
+                        "flatpak",
+                        "--user",
+                        "run",
+                        "--command=/app/bin/prusa-slicer",
+                        "com.prusa3d.PrusaSlicer",
+                    ),
+                    source="flatpak-user",
+                    display_name="PrusaSlicer (Flatpak)",
+                ),
+                CandidateSpec(
+                    gui_command=(
+                        "flatpak",
+                        "--system",
+                        "run",
+                        "com.prusa3d.PrusaSlicer",
+                    ),
+                    cli_command=(
+                        "flatpak",
+                        "--system",
+                        "run",
+                        "--command=/app/bin/prusa-slicer",
+                        "com.prusa3d.PrusaSlicer",
+                    ),
+                    source="flatpak-system",
+                    display_name="PrusaSlicer (Flatpak)",
+                ),
+            ]
+        )
+    return tuple(candidates)
+
+
+def explicit_candidate_spec(
+    executable: str,
+    *,
+    platform: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> CandidateSpec | None:
+    """Create a GUI/CLI pair from a user-selected executable or macOS app."""
+
+    raw = str(executable or "").strip()
+    if not raw:
+        return None
+    platform = platform or sys.platform
+    if platform == "darwin" and raw.endswith(".app"):
+        raw = str(Path(raw) / "Contents/MacOS/PrusaSlicer")
+    cli = raw
+    if platform == "win32" and ntpath.basename(raw).lower() == "prusa-slicer.exe":
+        cli = ntpath.join(ntpath.dirname(raw), "prusa-slicer-console.exe")
+    return CandidateSpec(
+        gui_command=(raw,),
+        cli_command=(cli,),
+        source="explicit",
+        config_dir=default_config_directory(platform=platform, environ=environ),
+        explicit=True,
+    )
+
+
+def _resolve_program(
+    command: tuple[str, ...], which: Callable[[str], str | None]
+) -> tuple[str, ...] | None:
+    if not command:
+        return None
+    first = command[0]
+    if os.path.isabs(first) or (len(first) > 2 and first[1:3] == ":\\"):
+        if Path(first).is_file():
+            return command
+        return None
+    found = which(first)
+    if not found:
+        return None
+    return (found, *command[1:])
+
+
+def probe_candidate(
+    candidate: CandidateSpec,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    which: Callable[[str], str | None] = shutil.which,
+    timeout: float = 10.0,
+) -> SlicerInstallation | None:
+    """Validate a candidate and read its version without starting its GUI."""
+
+    gui_command = _resolve_program(candidate.gui_command, which)
+    cli_command = _resolve_program(candidate.cli_command, which)
+    if gui_command is None:
+        return None
+    # Windows installers occasionally omit the console binary.  The GUI
+    # executable still accepts CLI actions, so it is a safe query fallback.
+    if cli_command is None and candidate.source != "explicit":
+        cli_command = gui_command
+    elif cli_command is None:
+        cli_command = gui_command
+    try:
+        completed = runner(
+            [*cli_command, "--version"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    output = "\n".join(
+        str(value or "") for value in (completed.stdout, completed.stderr)
+    )
+    match = _VERSION_RE.search(output)
+    if match is None:
+        return None
+    version = match.group(0)
+    return SlicerInstallation(
+        backend_id="prusaslicer",
+        version=version,
+        gui_command=tuple(gui_command),
+        cli_command=tuple(cli_command),
+        source=candidate.source,
+        display_name=f"{candidate.display_name} {version}",
+        config_dir=candidate.config_dir,
+    )
+
+
+def discover_prusaslicer_installations(
+    explicit_executable: str = "",
+    *,
+    platform: str | None = None,
+    environ: Mapping[str, str] | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    which: Callable[[str], str | None] = shutil.which,
+) -> tuple[SlicerInstallation, ...]:
+    """Discover and probe supported native and Flatpak installations."""
+
+    specs: list[CandidateSpec] = []
+    explicit = explicit_candidate_spec(
+        explicit_executable,
+        platform=platform,
+        environ=environ,
+    )
+    if explicit is not None:
+        specs.append(explicit)
+    specs.extend(default_candidate_specs(platform=platform, environ=environ))
+    installations: list[SlicerInstallation] = []
+    seen: set[tuple[str, ...]] = set()
+    for spec in specs:
+        installation = probe_candidate(spec, runner=runner, which=which)
+        if installation is None or installation.gui_command in seen:
+            continue
+        seen.add(installation.gui_command)
+        installations.append(installation)
+    return tuple(installations)
+
+
+def preferred_installation(
+    installations: Iterable[SlicerInstallation],
+    *,
+    explicit_gui_command: tuple[str, ...] | None = None,
+) -> SlicerInstallation | None:
+    """Prefer an explicit installation, otherwise the newest stable build."""
+
+    values = list(installations)
+    configured = next((item for item in values if item.source == "explicit"), None)
+    if configured is not None and explicit_gui_command is None:
+        return configured
+    if explicit_gui_command:
+        explicit = next(
+            (item for item in values if item.gui_command == explicit_gui_command), None
+        )
+        if explicit is not None:
+            return explicit
+    stable = [item for item in values if _is_stable_version(item.version)]
+    candidates = stable or values
+    return max(candidates, key=lambda item: version_key(item.version), default=None)
+
+
+def _query_failure_message(
+    completed: subprocess.CompletedProcess[str], detail: str = ""
+) -> str:
+    pieces = [f"PrusaSlicer profile query failed with status {completed.returncode}."]
+    if detail:
+        pieces.append(detail)
+    if completed.stdout:
+        pieces.append(f"stdout: {completed.stdout.strip()}")
+    if completed.stderr:
+        pieces.append(f"stderr: {completed.stderr.strip()}")
+    return " ".join(piece for piece in pieces if piece)
+
+
+def run_json_query(
+    installation: SlicerInstallation,
+    arguments: Sequence[str],
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    temporary_directory: str | os.PathLike[str] | None = None,
+    timeout: float = 30.0,
+) -> Mapping[str, Any]:
+    """Run a PrusaSlicer JSON query, accepting valid output despite status 1."""
+
+    if temporary_directory is None:
+        with tempfile.TemporaryDirectory(prefix="vibecad-prusa-query-") as directory:
+            return run_json_query(
+                installation,
+                arguments,
+                runner=runner,
+                temporary_directory=directory,
+                timeout=timeout,
+            )
+    directory = Path(temporary_directory)
+    directory.mkdir(parents=True, exist_ok=True)
+    output = directory / f"profiles-{uuid4().hex}.json"
+    command = [*installation.cli_command, *arguments]
+    if installation.config_dir:
+        command.extend(("--datadir", installation.config_dir))
+    # Flatpak gives the slicer a private /tmp, so a path created by the host is
+    # not the same path inside the sandbox.  Profile-sharing actions natively
+    # emit the same JSON to stdout when --output is omitted.
+    query_via_stdout = installation.source.startswith("flatpak")
+    if not query_via_stdout:
+        command.extend(("--output", str(output)))
+    try:
+        completed = runner(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SlicerQueryError(
+            f"Could not run PrusaSlicer profile query: {exc}"
+        ) from exc
+    if query_via_stdout and completed.stdout:
+        try:
+            payload = json.loads(completed.stdout)
+        except json.JSONDecodeError as exc:
+            raise SlicerQueryError(
+                _query_failure_message(completed, f"Invalid JSON output: {exc}")
+            ) from exc
+        if isinstance(payload, Mapping):
+            return payload
+        raise SlicerQueryError(
+            _query_failure_message(completed, "JSON output was not an object.")
+        )
+    if output.is_file():
+        try:
+            payload = json.loads(output.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise SlicerQueryError(
+                _query_failure_message(completed, f"Invalid JSON output: {exc}")
+            ) from exc
+        if isinstance(payload, Mapping):
+            return payload
+        raise SlicerQueryError(
+            _query_failure_message(completed, "JSON output was not an object.")
+        )
+    raise SlicerQueryError(_query_failure_message(completed))
+
+
+def query_printer_profiles(
+    installation: SlicerInstallation,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> tuple[PrinterProfile, ...]:
+    payload = run_json_query(
+        installation,
+        ("--query-printer-models", "--printer-technology", "FFF"),
+        runner=runner,
+    )
+    return parse_printer_models(payload)
+
+
+def query_compatible_profiles(
+    installation: SlicerInstallation,
+    printer_profile: str,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> ProfileCatalog:
+    payload = run_json_query(
+        installation,
+        (
+            "--query-print-filament-profiles",
+            "--printer-profile",
+            printer_profile,
+        ),
+        runner=runner,
+    )
+    return parse_compatible_profiles(payload)
+
+
+def validate_setup(
+    setup: PrintSetup,
+    printer: PrinterProfile,
+    catalog: ProfileCatalog,
+) -> tuple[str, ...]:
+    """Validate exact names without substituting a compatible-looking preset."""
+
+    errors: list[str] = []
+    if setup.printer_profile != printer.name or catalog.printer_profile != printer.name:
+        errors.append(
+            f"Printer profile '{setup.printer_profile}' is no longer available."
+        )
+        return tuple(errors)
+    print_profile = catalog.find_print_profile(setup.print_profile)
+    if print_profile is None:
+        errors.append(
+            f"Print profile '{setup.print_profile}' is not compatible with this printer."
+        )
+        return tuple(errors)
+    required = max(0, printer.extruders)
+    if len(setup.material_profiles) != required:
+        errors.append(
+            f"Select one material profile for each of the printer's {required} extruders."
+        )
+        return tuple(errors)
+    compatible = {material.name for material in print_profile.materials}
+    unavailable = [name for name in setup.material_profiles if name not in compatible]
+    if unavailable:
+        joined = ", ".join(dict.fromkeys(unavailable))
+        errors.append(
+            f"Material profile(s) {joined} are not compatible with '{setup.print_profile}'."
+        )
+    return tuple(errors)
+
+
+def build_launch_command(
+    installation: SlicerInstallation,
+    handoff_file: str | os.PathLike[str],
+    setup: PrintSetup | None,
+) -> tuple[str, ...]:
+    """Build the exact shell-free GUI handoff command."""
+
+    command = list(installation.gui_command)
+    if setup is not None:
+        if not setup.auto_arrange:
+            command.append("--dont-arrange")
+        command.append(
+            "--ensure-on-bed" if setup.ensure_on_bed else "--no-ensure-on-bed"
+        )
+        command.extend(("--printer-profile", setup.printer_profile))
+        command.extend(("--print-profile", setup.print_profile))
+        command.extend(("--material-profile", ";".join(setup.material_profiles)))
+    command.append(str(Path(handoff_file)))
+    return tuple(command)
+
+
+def launch_prusaslicer(
+    installation: SlicerInstallation,
+    handoff_file: str | os.PathLike[str],
+    setup: PrintSetup | None,
+    *,
+    popen: Callable[..., subprocess.Popen[Any]] = subprocess.Popen,
+) -> LaunchResult:
+    """Launch PrusaSlicer detached from VibeCAD without invoking a shell."""
+
+    command = build_launch_command(installation, handoff_file, setup)
+    creationflags = 0
+    if sys.platform == "win32":
+        creationflags = int(getattr(subprocess, "DETACHED_PROCESS", 0)) | int(
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        )
+    try:
+        process = popen(
+            list(command),
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=(sys.platform != "win32"),
+            creationflags=creationflags,
+        )
+    except OSError as exc:
+        raise SlicerError(f"Could not launch PrusaSlicer: {exc}") from exc
+    return LaunchResult(command=command, process_id=getattr(process, "pid", None))
+
+
+def _is_printable_object(obj: Any) -> bool:
+    shape = getattr(obj, "Shape", None)
+    if shape is not None:
+        is_null = getattr(shape, "isNull", None)
+        try:
+            if not callable(is_null) or not bool(is_null()):
+                return True
+        except Exception:
+            pass
+    mesh = getattr(obj, "Mesh", None)
+    if mesh is None:
+        return False
+    count = getattr(mesh, "CountFacets", None)
+    try:
+        return int(count) > 0
+    except (TypeError, ValueError):
+        facets = getattr(mesh, "Facets", ())
+        try:
+            return len(facets) > 0
+        except TypeError:
+            return False
+
+
+def _object_label(obj: Any) -> str:
+    return str(getattr(obj, "Label", "") or getattr(obj, "Name", "") or repr(obj))
+
+
+def collect_printable_objects(
+    selection: Iterable[Any], *, active_document: Any
+) -> tuple[Any, ...]:
+    """Validate an explicit selection; never fall back to visible/all objects."""
+
+    if active_document is None:
+        raise PrintSelectionError(
+            "Open an active document before exporting for printing."
+        )
+    unique: list[Any] = []
+    seen: set[int] = set()
+    for obj in selection:
+        identity = id(obj)
+        if identity not in seen:
+            seen.add(identity)
+            unique.append(obj)
+    if not unique:
+        raise PrintSelectionError("Select at least one printable object.")
+    unsupported = [
+        _object_label(obj)
+        for obj in unique
+        if getattr(obj, "Document", None) is not active_document
+        or not _is_printable_object(obj)
+    ]
+    if unsupported:
+        raise PrintSelectionError(
+            "These selected objects cannot be exported for printing: "
+            + ", ".join(unsupported)
+        )
+    return tuple(unique)
+
+
+def export_selection_3mf(
+    objects: Iterable[Any],
+    destination: str | os.PathLike[str],
+    *,
+    mesh_exporter: Callable[[Sequence[Any], str], Any] | None = None,
+) -> Path:
+    """Export all objects together and atomically publish a complete 3MF."""
+
+    selected = tuple(objects)
+    if not selected:
+        raise PrintExportError("No selected objects were provided for 3MF export.")
+    target = Path(destination)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    partial = target.with_name(f"{target.stem}.{uuid4().hex}.partial.3mf")
+    if mesh_exporter is None:
+        import Mesh
+
+        mesh_exporter = Mesh.export
+    try:
+        mesh_exporter(list(selected), str(partial))
+        if not partial.is_file() or partial.stat().st_size <= 0:
+            raise PrintExportError("3MF export did not produce a non-empty file.")
+        os.replace(partial, target)
+    except PrintExportError:
+        raise
+    except Exception as exc:
+        raise PrintExportError(
+            f"Could not export the selected objects as 3MF: {exc}"
+        ) from exc
+    finally:
+        if partial.exists():
+            try:
+                partial.unlink()
+            except OSError:
+                pass
+    return target
+
+
+def _safe_name(value: str, fallback: str = "Untitled") -> str:
+    sanitized = _SAFE_NAME_RE.sub("-", str(value or "").strip()).strip("-._")
+    return (sanitized or fallback)[:80]
+
+
+def prune_managed_handoffs(
+    directory: str | os.PathLike[str], *, keep: int = DEFAULT_HANDOFF_LIMIT
+) -> None:
+    """Remove only old 3MF files carrying this feature's private prefix."""
+
+    root = Path(directory)
+    if not root.is_dir():
+        return
+    owned = sorted(
+        (
+            path
+            for path in root.glob(f"{MANAGED_HANDOFF_PREFIX}*.3mf")
+            if path.is_file()
+        ),
+        key=lambda path: (path.stat().st_mtime_ns, path.name),
+        reverse=True,
+    )
+    for path in owned[max(0, keep) :]:
+        try:
+            path.unlink()
+        except OSError:
+            continue
+
+
+def managed_handoff_path(
+    cache_directory: str | os.PathLike[str],
+    *,
+    document_label: str,
+    object_names: Sequence[str],
+    keep: int = DEFAULT_HANDOFF_LIMIT,
+) -> Path:
+    """Create a collision-resistant managed handoff path and prune old files."""
+
+    root = Path(cache_directory)
+    root.mkdir(parents=True, exist_ok=True)
+    prune_managed_handoffs(root, keep=keep)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    identity = "\0".join(str(name) for name in object_names)
+    digest = hashlib.sha256(identity.encode("utf-8", errors="replace")).hexdigest()[:10]
+    label = _safe_name(document_label)
+    return root / f"{MANAGED_HANDOFF_PREFIX}{label}-{stamp}-{digest}.3mf"
+
+
+class PrusaSlicerBackend:
+    """Adapter used by today's GUI and future plate/slice coordinators."""
+
+    backend_id = "prusaslicer"
+    capabilities = BACKEND_CAPABILITIES
+
+    def discover(self, explicit_executable: str = "") -> tuple[SlicerInstallation, ...]:
+        return discover_prusaslicer_installations(explicit_executable)
+
+    def query_printers(
+        self, installation: SlicerInstallation
+    ) -> tuple[PrinterProfile, ...]:
+        return query_printer_profiles(installation)
+
+    def query_profiles(
+        self, installation: SlicerInstallation, printer_profile: str
+    ) -> ProfileCatalog:
+        return query_compatible_profiles(installation, printer_profile)
+
+    def launch(
+        self,
+        installation: SlicerInstallation,
+        handoff_file: str | os.PathLike[str],
+        setup: PrintSetup | None,
+    ) -> LaunchResult:
+        return launch_prusaslicer(installation, handoff_file, setup)

--- a/src/Mod/VibeCADPrint/VibeCADPrint.py
+++ b/src/Mod/VibeCADPrint/VibeCADPrint.py
@@ -152,10 +152,12 @@ class SlicerInstallation:
     display_name: str
     config_dir: str = ""
     capabilities: tuple[str, ...] = BACKEND_CAPABILITIES
+    resource_dir: str = ""
+    tested_version: tuple[int, int, int] = TESTED_PRUSASLICER_VERSION
 
     @property
     def tested(self) -> bool:
-        return version_key(self.version) >= TESTED_PRUSASLICER_VERSION
+        return version_key(self.version) >= self.tested_version
 
 
 @dataclass(frozen=True)
@@ -1092,6 +1094,7 @@ class PrusaSlicerBackend:
     """Adapter used by today's GUI and future plate/slice coordinators."""
 
     backend_id = "prusaslicer"
+    display_name = "PrusaSlicer"
     capabilities = BACKEND_CAPABILITIES
 
     def discover(self, explicit_executable: str = "") -> tuple[SlicerInstallation, ...]:

--- a/src/Mod/VibeCADPrint/VibeCADPrint.py
+++ b/src/Mod/VibeCADPrint/VibeCADPrint.py
@@ -126,6 +126,7 @@ class PrintSetup:
     material_profiles: tuple[str, ...]
     auto_arrange: bool = True
     ensure_on_bed: bool = True
+    object_filament_ids: tuple[int, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -936,8 +937,8 @@ def launch_slicer_gui(
     current_platform = platform or sys.platform
     creationflags = 0
     if current_platform == "win32":
-        creationflags = int(getattr(subprocess, "DETACHED_PROCESS", 0)) | int(
-            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+        creationflags = int(getattr(subprocess, "DETACHED_PROCESS", 0x00000008)) | int(
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
         )
     try:
         process = popen(
@@ -978,6 +979,12 @@ def _is_printable_object(obj: Any) -> bool:
 
 
 def _object_label(obj: Any) -> str:
+    return printable_object_name(obj)
+
+
+def printable_object_name(obj: Any) -> str:
+    """Return the exact user-visible name used for a printable object."""
+
     return str(getattr(obj, "Label", "") or getattr(obj, "Name", "") or repr(obj))
 
 
@@ -1055,6 +1062,44 @@ def export_selection_3mf(
             except OSError:
                 pass
     return target
+
+
+def export_objects_stl(
+    objects: Iterable[Any],
+    directory: str | os.PathLike[str],
+    *,
+    mesh_exporter: Callable[[Sequence[Any], str], Any] | None = None,
+) -> tuple[Path, ...]:
+    """Export one temporary STL per object for slicers that assign by input file."""
+
+    selected = tuple(objects)
+    if not selected:
+        raise PrintExportError("No selected objects were provided for STL export.")
+    target_directory = Path(directory)
+    target_directory.mkdir(parents=True, exist_ok=True)
+    if mesh_exporter is None:
+        import Mesh
+
+        mesh_exporter = Mesh.export
+    exported: list[Path] = []
+    try:
+        for index, obj in enumerate(selected, start=1):
+            label = _object_label(obj)
+            filename = f"{index:04d}-{_safe_name(label, f'Object-{index}')}.stl"
+            target = target_directory / filename
+            mesh_exporter([obj], str(target))
+            if not target.is_file() or target.stat().st_size <= 0:
+                raise PrintExportError(
+                    f"STL export for '{label}' did not produce a non-empty file."
+                )
+            exported.append(target)
+    except PrintExportError:
+        raise
+    except Exception as exc:
+        raise PrintExportError(
+            f"Could not export '{_object_label(selected[len(exported)])}' as STL: {exc}"
+        ) from exc
+    return tuple(exported)
 
 
 def _safe_name(value: str, fallback: str = "Untitled") -> str:

--- a/src/Mod/VibeCADPrint/VibeCADPrint.py
+++ b/src/Mod/VibeCADPrint/VibeCADPrint.py
@@ -23,6 +23,8 @@ import sys
 import tempfile
 from typing import Any, Callable, Iterable, Mapping, Sequence
 from uuid import uuid4
+import xml.etree.ElementTree as ET
+import zipfile
 
 
 TESTED_PRUSASLICER_VERSION = (2, 9, 6)
@@ -775,6 +777,120 @@ def build_launch_command(
     return tuple(command)
 
 
+def build_prepare_project_command(
+    installation: SlicerInstallation,
+    source_file: str | os.PathLike[str],
+    output_file: str | os.PathLike[str],
+    setup: PrintSetup,
+) -> tuple[str, ...]:
+    """Build a shell-free command that turns generic 3MF into a slicer project."""
+
+    command = list(installation.cli_command)
+    if installation.config_dir:
+        command.extend(("--datadir", installation.config_dir))
+    if setup.auto_arrange:
+        # PrusaSlicer 2.9 has no standalone --arrange switch. Its one-copy
+        # transform invokes the same bed-aware arranger without adding copies.
+        command.extend(("--duplicate", "1"))
+    else:
+        command.append("--dont-arrange")
+    command.append("--ensure-on-bed" if setup.ensure_on_bed else "--no-ensure-on-bed")
+    command.extend(("--printer-profile", setup.printer_profile))
+    command.extend(("--print-profile", setup.print_profile))
+    command.extend(("--material-profile", ";".join(setup.material_profiles)))
+    command.extend(
+        (
+            "--export-3mf",
+            "--output",
+            str(Path(output_file)),
+            str(Path(source_file)),
+        )
+    )
+    return tuple(command)
+
+
+def prepare_prusaslicer_project(
+    installation: SlicerInstallation,
+    source_file: str | os.PathLike[str],
+    destination: str | os.PathLike[str],
+    setup: PrintSetup,
+    *,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    timeout: float = 120.0,
+) -> Path:
+    """Atomically prepare a named, multi-object PrusaSlicer 3MF project."""
+
+    source = Path(source_file)
+    target = Path(destination)
+    try:
+        with zipfile.ZipFile(source) as archive:
+            source_model = ET.fromstring(archive.read("3D/3dmodel.model"))
+    except (ET.ParseError, OSError, KeyError, zipfile.BadZipFile) as exc:
+        raise SlicerError(
+            "Could not prepare the PrusaSlicer project because the source 3MF "
+            "does not contain a valid object model."
+        ) from exc
+    source_object_count = len(source_model.findall("./{*}resources/{*}object"))
+    if source_object_count == 0:
+        raise SlicerError(
+            "Could not prepare the PrusaSlicer project because the source 3MF "
+            "does not contain printable objects."
+        )
+    target.parent.mkdir(parents=True, exist_ok=True)
+    partial = target.with_name(f"{target.stem}.{uuid4().hex}.partial.3mf")
+    command = build_prepare_project_command(installation, source, partial, setup)
+    try:
+        completed = runner(
+            list(command),
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        if completed.returncode != 0 or not partial.is_file():
+            details = " ".join(
+                value.strip()
+                for value in (completed.stdout or "", completed.stderr or "")
+                if value.strip()
+            )
+            suffix = f" {details}" if details else ""
+            raise SlicerError(
+                "PrusaSlicer could not prepare the 3MF project "
+                f"(status {completed.returncode}).{suffix}"
+            )
+        try:
+            with zipfile.ZipFile(partial) as archive:
+                metadata = archive.read("Metadata/Slic3r_PE_model.config")
+            prepared_metadata = ET.fromstring(metadata)
+        except (ET.ParseError, OSError, KeyError, zipfile.BadZipFile) as exc:
+            raise SlicerError(
+                "PrusaSlicer produced an invalid project 3MF without object metadata."
+            ) from exc
+        prepared_object_count = len(prepared_metadata.findall("./{*}object"))
+        if prepared_object_count == 0:
+            raise SlicerError(
+                "PrusaSlicer produced a project 3MF without printable objects."
+            )
+        if prepared_object_count != source_object_count:
+            raise SlicerError(
+                "PrusaSlicer changed the project object count from "
+                f"{source_object_count} to {prepared_object_count}; the original "
+                "3MF was preserved."
+            )
+        os.replace(partial, target)
+    except SlicerError:
+        raise
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise SlicerError(f"Could not prepare the PrusaSlicer project: {exc}") from exc
+    finally:
+        if partial.exists():
+            try:
+                partial.unlink()
+            except OSError:
+                pass
+    return target
+
+
 def launch_prusaslicer(
     installation: SlicerInstallation,
     handoff_file: str | os.PathLike[str],
@@ -841,9 +957,15 @@ def collect_printable_objects(
             "Open an active document before exporting for printing."
         )
     unique: list[Any] = []
-    seen: set[int] = set()
+    seen: set[tuple[Any, ...]] = set()
     for obj in selection:
-        identity = id(obj)
+        document = getattr(obj, "Document", None)
+        name = str(getattr(obj, "Name", "") or "")
+        identity = (
+            ("document-object", id(document), name)
+            if document is not None and name
+            else ("python-object", id(obj))
+        )
         if identity not in seen:
             seen.add(identity)
             unique.append(obj)
@@ -992,3 +1114,17 @@ class PrusaSlicerBackend:
         setup: PrintSetup | None,
     ) -> LaunchResult:
         return launch_prusaslicer(installation, handoff_file, setup)
+
+    def prepare_project(
+        self,
+        installation: SlicerInstallation,
+        source_file: str | os.PathLike[str],
+        destination: str | os.PathLike[str],
+        setup: PrintSetup,
+    ) -> Path:
+        return prepare_prusaslicer_project(
+            installation,
+            source_file,
+            destination,
+            setup,
+        )

--- a/src/Mod/VibeCADPrint/VibeCADPrint.py
+++ b/src/Mod/VibeCADPrint/VibeCADPrint.py
@@ -949,6 +949,23 @@ def managed_handoff_path(
     return root / f"{MANAGED_HANDOFF_PREFIX}{label}-{stamp}-{digest}.3mf"
 
 
+def persistent_handoff_path(
+    directory: str | os.PathLike[str],
+    *,
+    document_label: str,
+    object_names: Sequence[str],
+) -> Path:
+    """Create a unique user-owned handoff path without deleting older files."""
+
+    root = Path(directory).expanduser()
+    root.mkdir(parents=True, exist_ok=True)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    identity = "\0".join(str(name) for name in object_names)
+    digest = hashlib.sha256(identity.encode("utf-8", errors="replace")).hexdigest()[:10]
+    label = _safe_name(document_label)
+    return root / f"{label}-{stamp}-{digest}.3mf"
+
+
 class PrusaSlicerBackend:
     """Adapter used by today's GUI and future plate/slice coordinators."""
 

--- a/src/Mod/VibeCADPrint/icons/vibecad-print-open.svg
+++ b/src/Mod/VibeCADPrint/icons/vibecad-print-open.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="VibeCAD open in slicer">
+  <path d="M12 10h34v11H12z" fill="#343a40" stroke="#74c0fc" stroke-width="3"/>
+  <path d="M17 21v27h24V21M21 42h16l-3-14H24z" fill="#212529" stroke="#adb5bd" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M38 47h14M47 41l6 6-6 6" fill="none" stroke="#51cf66" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/Mod/VibeCADPrint/icons/vibecad-print-save.svg
+++ b/src/Mod/VibeCADPrint/icons/vibecad-print-save.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="VibeCAD save 3MF">
+  <path d="M10 47h44v8H10z" fill="#343a40" stroke="#adb5bd" stroke-width="3"/>
+  <path d="M20 38h24l-4-18H24z" fill="#212529" stroke="#74c0fc" stroke-width="3" stroke-linejoin="round"/>
+  <path d="M32 7v25M24 24l8 8 8-8" fill="none" stroke="#51cf66" stroke-width="4" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/Mod/VibeCADPrint/icons/vibecad-print-setup.svg
+++ b/src/Mod/VibeCADPrint/icons/vibecad-print-setup.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="VibeCAD print setup">
+  <path d="M8 10h38v12H8zM14 22v28h26V22" fill="#212529" stroke="#74c0fc" stroke-width="3"/>
+  <path d="M20 43h15l-3-14h-9z" fill="#343a40" stroke="#adb5bd" stroke-width="3" stroke-linejoin="round"/>
+  <circle cx="47" cy="45" r="9" fill="#343a40" stroke="#51cf66" stroke-width="3"/>
+  <path d="M47 32v5M47 53v5M34 45h5M55 45h5M38 36l4 4M52 50l4 4M38 54l4-4M52 40l4-4" stroke="#51cf66" stroke-width="3" stroke-linecap="round"/>
+</svg>

--- a/src/Mod/VibeCADPrint/tests/__init__.py
+++ b/src/Mod/VibeCADPrint/tests/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later

--- a/src/Mod/VibeCADPrint/tests/conftest.py
+++ b/src/Mod/VibeCADPrint/tests/conftest.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+MODULE = Path(__file__).resolve().parents[1]
+if str(MODULE) not in sys.path:
+    sys.path.insert(0, str(MODULE))

--- a/src/Mod/VibeCADPrint/tests/qt_backend_switch_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_backend_switch_integration.py
@@ -22,10 +22,15 @@ import VibeCADPrint  # noqa: E402
 
 
 def _setup(prefix: str) -> VibeCADPrint.PrintSetup:
+    materials = (
+        (f"{prefix} Material 1", f"{prefix} Material 2")
+        if prefix in {"Bambu", "Orca"}
+        else (f"{prefix} Material",)
+    )
     return VibeCADPrint.PrintSetup(
         f"{prefix} Printer",
         f"{prefix} Quality",
-        (f"{prefix} Material",),
+        materials,
     )
 
 
@@ -53,11 +58,13 @@ def _backend_data(backend_id: str):
             "orcaslicer": (2, 4, 2),
         }[backend_id],
     )
-    material = VibeCADPrint.MaterialProfile(setup.material_profiles[0])
-    quality = VibeCADPrint.PrintProfile(setup.print_profile, (material,))
+    materials = tuple(
+        VibeCADPrint.MaterialProfile(name) for name in setup.material_profiles
+    )
+    quality = VibeCADPrint.PrintProfile(setup.print_profile, materials)
     printer = VibeCADPrint.PrinterProfile(
         setup.printer_profile,
-        extruders=1,
+        extruders=len(materials),
         bed=VibeCADPrint.BedInfo(width=250, height=250, max_print_height=250),
     )
     catalog = VibeCADPrint.ProfileCatalog(printer.name, (quality,))
@@ -72,6 +79,11 @@ class _Backend:
             "bambustudio": "Bambu Studio",
             "orcaslicer": "OrcaSlicer",
         }[backend_id]
+        self.capabilities = (
+            ("object_filament_assignment",)
+            if backend_id in {"bambustudio", "orcaslicer"}
+            else ()
+        )
         self.setup, self.installation, self.printer, self.catalog = _backend_data(
             backend_id
         )
@@ -126,7 +138,10 @@ def _run() -> None:
         )
         PrintPanel._active_print_selection = lambda: (
             SimpleNamespace(Name="Fan"),
-            (SimpleNamespace(Name="Body", Label="Fan Frame"),),
+            (
+                SimpleNamespace(Name="Body", Label="Fan Frame"),
+                SimpleNamespace(Name="Body001", Label="Fan Rotor"),
+            ),
         )
 
         panel = PrintPanel.PrintPanelWidget()
@@ -151,8 +166,24 @@ def _run() -> None:
         assert panel.installation.backend_id == "bambustudio"
         assert panel.printer_combo.currentText() == "Bambu Printer"
         assert panel.print_combo.currentText() == "Bambu Quality"
-        assert panel.material_combos[0].currentText() == "Bambu Material"
+        assert [combo.currentText() for combo in panel.material_combos] == [
+            "Bambu Material 1",
+            "Bambu Material 2",
+        ]
         assert panel.object_checkboxes[0].isChecked()
+        assert len(panel.object_filament_combos) == 2
+        assert not panel.print_button.isEnabled()
+        panel.object_filament_combos[0].setCurrentIndex(
+            panel.object_filament_combos[0].findData(1)
+        )
+        panel.object_filament_combos[1].setCurrentIndex(
+            panel.object_filament_combos[1].findData(2)
+        )
+        application.processEvents()
+        assert panel._current_setup(
+            require_object_assignments=True
+        ).object_filament_ids == (1, 2)
+        assert panel.print_button.isEnabled()
 
         orca_index = panel.slicer_combo.findData("orcaslicer")
         assert orca_index >= 0
@@ -162,7 +193,23 @@ def _run() -> None:
         assert panel.backend.backend_id == "orcaslicer"
         assert panel.printer_combo.currentText() == "Orca Printer"
         assert panel.print_combo.currentText() == "Orca Quality"
-        assert panel.material_combos[0].currentText() == "Orca Material"
+        assert [combo.currentText() for combo in panel.material_combos] == [
+            "Orca Material 1",
+            "Orca Material 2",
+        ]
+        assert len(panel.object_filament_combos) == 2
+        assert not panel.print_button.isEnabled()
+        panel.object_filament_combos[0].setCurrentIndex(
+            panel.object_filament_combos[0].findData(2)
+        )
+        panel.object_filament_combos[1].setCurrentIndex(
+            panel.object_filament_combos[1].findData(1)
+        )
+        application.processEvents()
+        assert panel._current_setup(
+            require_object_assignments=True
+        ).object_filament_ids == (2, 1)
+        assert panel.print_button.isEnabled()
         panel._manual_refresh()
         assert backends["orcaslicer"].invalidations == 1
         assert panel.object_checkboxes[0].isChecked()

--- a/src/Mod/VibeCADPrint/tests/qt_backend_switch_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_backend_switch_integration.py
@@ -30,16 +30,28 @@ def _setup(prefix: str) -> VibeCADPrint.PrintSetup:
 
 
 def _backend_data(backend_id: str):
-    prefix = "Prusa" if backend_id == "prusaslicer" else "Bambu"
+    prefix = {
+        "prusaslicer": "Prusa",
+        "bambustudio": "Bambu",
+        "orcaslicer": "Orca",
+    }[backend_id]
     setup = _setup(prefix)
     installation = VibeCADPrint.SlicerInstallation(
         backend_id=backend_id,
-        version="2.9.6" if backend_id == "prusaslicer" else "2.8.2.61",
+        version={
+            "prusaslicer": "2.9.6",
+            "bambustudio": "2.8.2.61",
+            "orcaslicer": "2.4.2",
+        }[backend_id],
         gui_command=(backend_id,),
         cli_command=(backend_id,),
         source="test",
         display_name=f"{prefix} Installed",
-        tested_version=(2, 9, 6) if backend_id == "prusaslicer" else (2, 8, 2),
+        tested_version={
+            "prusaslicer": (2, 9, 6),
+            "bambustudio": (2, 8, 2),
+            "orcaslicer": (2, 4, 2),
+        }[backend_id],
     )
     material = VibeCADPrint.MaterialProfile(setup.material_profiles[0])
     quality = VibeCADPrint.PrintProfile(setup.print_profile, (material,))
@@ -55,10 +67,18 @@ def _backend_data(backend_id: str):
 class _Backend:
     def __init__(self, backend_id: str) -> None:
         self.backend_id = backend_id
-        self.display_name = "PrusaSlicer" if backend_id == "prusaslicer" else "Bambu Studio"
+        self.display_name = {
+            "prusaslicer": "PrusaSlicer",
+            "bambustudio": "Bambu Studio",
+            "orcaslicer": "OrcaSlicer",
+        }[backend_id]
         self.setup, self.installation, self.printer, self.catalog = _backend_data(
             backend_id
         )
+        self.invalidations = 0
+
+    def invalidate_cache(self):
+        self.invalidations += 1
 
     def discover(self, _override=""):
         return (self.installation,)
@@ -77,7 +97,7 @@ def _run() -> None:
     try:
         backends = {
             backend_id: _Backend(backend_id)
-            for backend_id in ("prusaslicer", "bambustudio")
+            for backend_id in ("prusaslicer", "bambustudio", "orcaslicer")
         }
         state = {
             "active": "prusaslicer",
@@ -132,6 +152,19 @@ def _run() -> None:
         assert panel.printer_combo.currentText() == "Bambu Printer"
         assert panel.print_combo.currentText() == "Bambu Quality"
         assert panel.material_combos[0].currentText() == "Bambu Material"
+        assert panel.object_checkboxes[0].isChecked()
+
+        orca_index = panel.slicer_combo.findData("orcaslicer")
+        assert orca_index >= 0
+        panel.slicer_combo.setCurrentIndex(orca_index)
+        application.processEvents()
+        assert state["active"] == "orcaslicer"
+        assert panel.backend.backend_id == "orcaslicer"
+        assert panel.printer_combo.currentText() == "Orca Printer"
+        assert panel.print_combo.currentText() == "Orca Quality"
+        assert panel.material_combos[0].currentText() == "Orca Material"
+        panel._manual_refresh()
+        assert backends["orcaslicer"].invalidations == 1
         assert panel.object_checkboxes[0].isChecked()
         print("VIBECAD_PRINT_BACKEND_SWITCH_OK", flush=True)
         exit_code = 0

--- a/src/Mod/VibeCADPrint/tests/qt_backend_switch_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_backend_switch_integration.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Live contract for switching exact-profile slicer backends in the panel."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import traceback
+from types import SimpleNamespace
+
+
+TESTS = Path(__file__).resolve().parent
+MODULE = TESTS.parent
+if str(MODULE) not in sys.path:
+    sys.path.insert(0, str(MODULE))
+
+from PySide import QtCore, QtWidgets  # noqa: E402
+
+import PrintPanel  # noqa: E402
+import VibeCADPrint  # noqa: E402
+
+
+def _setup(prefix: str) -> VibeCADPrint.PrintSetup:
+    return VibeCADPrint.PrintSetup(
+        f"{prefix} Printer",
+        f"{prefix} Quality",
+        (f"{prefix} Material",),
+    )
+
+
+def _backend_data(backend_id: str):
+    prefix = "Prusa" if backend_id == "prusaslicer" else "Bambu"
+    setup = _setup(prefix)
+    installation = VibeCADPrint.SlicerInstallation(
+        backend_id=backend_id,
+        version="2.9.6" if backend_id == "prusaslicer" else "2.8.2.61",
+        gui_command=(backend_id,),
+        cli_command=(backend_id,),
+        source="test",
+        display_name=f"{prefix} Installed",
+        tested_version=(2, 9, 6) if backend_id == "prusaslicer" else (2, 8, 2),
+    )
+    material = VibeCADPrint.MaterialProfile(setup.material_profiles[0])
+    quality = VibeCADPrint.PrintProfile(setup.print_profile, (material,))
+    printer = VibeCADPrint.PrinterProfile(
+        setup.printer_profile,
+        extruders=1,
+        bed=VibeCADPrint.BedInfo(width=250, height=250, max_print_height=250),
+    )
+    catalog = VibeCADPrint.ProfileCatalog(printer.name, (quality,))
+    return setup, installation, printer, catalog
+
+
+class _Backend:
+    def __init__(self, backend_id: str) -> None:
+        self.backend_id = backend_id
+        self.display_name = "PrusaSlicer" if backend_id == "prusaslicer" else "Bambu Studio"
+        self.setup, self.installation, self.printer, self.catalog = _backend_data(
+            backend_id
+        )
+
+    def discover(self, _override=""):
+        return (self.installation,)
+
+    def query_printers(self, _installation):
+        return (self.printer,)
+
+    def query_profiles(self, _installation, _printer):
+        return self.catalog
+
+
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    exit_code = 1
+    panel = None
+    try:
+        backends = {
+            backend_id: _Backend(backend_id)
+            for backend_id in ("prusaslicer", "bambustudio")
+        }
+        state = {
+            "active": "prusaslicer",
+            "setups": {
+                backend_id: backend.setup for backend_id, backend in backends.items()
+            },
+        }
+        PrintPanel._backend_for_id = lambda backend_id: backends[backend_id]
+        PrintPanel.PrintPreferences.active_backend = lambda: state["active"]
+        PrintPanel.PrintPreferences.set_active_backend = lambda value: state.__setitem__(
+            "active", value
+        )
+        PrintPanel.PrintPreferences.load_confirmed_setup = (
+            lambda *, backend_id="prusaslicer": state["setups"].get(backend_id)
+        )
+        PrintPanel.PrintPreferences.save_confirmed_setup = (
+            lambda setup, *, backend_id="prusaslicer": state["setups"].__setitem__(
+                backend_id, setup
+            )
+        )
+        PrintPanel.PrintPreferences.executable_override = (
+            lambda *, backend_id="prusaslicer": ""
+        )
+        PrintPanel.PrintPreferences.load_handoff_storage = lambda: SimpleNamespace(
+            mode="managed", directory=""
+        )
+        PrintPanel._active_print_selection = lambda: (
+            SimpleNamespace(Name="Fan"),
+            (SimpleNamespace(Name="Body", Label="Fan Frame"),),
+        )
+
+        panel = PrintPanel.PrintPanelWidget()
+
+        def immediate(_message, operation, callback):
+            callback(operation())
+
+        panel._start_job = immediate
+        panel.refresh()
+        application.processEvents()
+        assert panel.slicer_combo.currentData() == "prusaslicer"
+        assert panel.printer_combo.currentText() == "Prusa Printer"
+        assert panel.object_checkboxes[0].text() == "Fan Frame"
+
+        bambu_index = panel.slicer_combo.findData("bambustudio")
+        assert bambu_index >= 0
+        panel.slicer_combo.setCurrentIndex(bambu_index)
+        application.processEvents()
+
+        assert state["active"] == "bambustudio"
+        assert panel.backend.backend_id == "bambustudio"
+        assert panel.installation.backend_id == "bambustudio"
+        assert panel.printer_combo.currentText() == "Bambu Printer"
+        assert panel.print_combo.currentText() == "Bambu Quality"
+        assert panel.material_combos[0].currentText() == "Bambu Material"
+        assert panel.object_checkboxes[0].isChecked()
+        print("VIBECAD_PRINT_BACKEND_SWITCH_OK", flush=True)
+        exit_code = 0
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+    finally:
+        if panel is not None:
+            panel.close()
+        application.exit(exit_code)
+
+
+QtCore.QTimer.singleShot(1200, _run)

--- a/src/Mod/VibeCADPrint/tests/qt_bambu_setup_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_bambu_setup_integration.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Live contract for the shared setup dialog's selected slicer identity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import traceback
+from types import SimpleNamespace
+
+
+TESTS = Path(__file__).resolve().parent
+MODULE = TESTS.parent
+if str(MODULE) not in sys.path:
+    sys.path.insert(0, str(MODULE))
+
+from PySide import QtCore, QtWidgets  # noqa: E402
+
+import PrintSetupDialog  # noqa: E402
+
+
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    exit_code = 1
+    dialog = None
+    try:
+        loaded = []
+        PrintSetupDialog.PrintPreferences.load_confirmed_setup = (
+            lambda *, backend_id="prusaslicer": loaded.append(backend_id) or None
+        )
+        PrintSetupDialog.PrintPreferences.executable_override = (
+            lambda *, backend_id="prusaslicer": ""
+        )
+        PrintSetupDialog.PrintPreferences.load_handoff_storage = lambda: SimpleNamespace(
+            mode="managed", directory=""
+        )
+        backend = SimpleNamespace(
+            backend_id="bambustudio",
+            display_name="Bambu Studio",
+        )
+        real_single_shot = PrintSetupDialog.QtCore.QTimer.singleShot
+        PrintSetupDialog.QtCore.QTimer.singleShot = lambda *_args: None
+        try:
+            dialog = PrintSetupDialog.PrintSetupDialog(
+                parent=None,
+                backend=backend,
+                open_after_save=False,
+            )
+        finally:
+            PrintSetupDialog.QtCore.QTimer.singleShot = real_single_shot
+
+        titles = {group.title() for group in dialog.findChildren(QtWidgets.QGroupBox)}
+        labels = " ".join(
+            label.text() for label in dialog.findChildren(QtWidgets.QLabel)
+        )
+        assert loaded == ["bambustudio"]
+        assert "Bambu Studio" in titles
+        assert dialog.open_slicer_button.text() == "Open Bambu Studio"
+        assert "Bambu Studio" in labels
+        assert "Bambu Studio" in dialog.auto_arrange.toolTip()
+        print("VIBECAD_PRINT_BAMBU_SETUP_OK", flush=True)
+        exit_code = 0
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+    finally:
+        if dialog is not None:
+            dialog.close()
+        application.exit(exit_code)
+
+
+QtCore.QTimer.singleShot(1200, _run)

--- a/src/Mod/VibeCADPrint/tests/qt_dialog_layout.py
+++ b/src/Mod/VibeCADPrint/tests/qt_dialog_layout.py
@@ -34,8 +34,8 @@ def main() -> None:
         + (styles / "VibeDark.qss").read_text(encoding="utf-8")
     )
 
-    PrintPreferences.load_confirmed_setup = lambda: None
-    PrintPreferences.executable_override = lambda: ""
+    PrintPreferences.load_confirmed_setup = lambda **_kwargs: None
+    PrintPreferences.executable_override = lambda **_kwargs: ""
     real_single_shot = PrintSetupDialog.QtCore.QTimer.singleShot
     PrintSetupDialog.QtCore.QTimer.singleShot = lambda *_args: None
 

--- a/src/Mod/VibeCADPrint/tests/qt_dialog_layout.py
+++ b/src/Mod/VibeCADPrint/tests/qt_dialog_layout.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Offscreen regression check for the styled Print Setup dialog geometry."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+TESTS = Path(__file__).resolve().parent
+MODULE = TESTS.parent
+REPO = MODULE.parents[2]
+if str(MODULE) not in sys.path:
+    sys.path.insert(0, str(MODULE))
+
+from PySide import QtCore, QtWidgets  # noqa: E402
+
+import PrintPreferences  # noqa: E402
+import PrintSetupDialog  # noqa: E402
+
+
+def _interval(widget, dialog) -> tuple[int, int]:
+    top = widget.mapTo(dialog, QtCore.QPoint(0, 0)).y()
+    return top, top + widget.height()
+
+
+def main() -> None:
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    styles = REPO / "src" / "Gui" / "Stylesheets"
+    app.setStyleSheet(
+        (styles / "defaults.qss").read_text(encoding="utf-8")
+        + "\n"
+        + (styles / "VibeDark.qss").read_text(encoding="utf-8")
+    )
+
+    PrintPreferences.load_confirmed_setup = lambda: None
+    PrintPreferences.executable_override = lambda: ""
+    real_single_shot = PrintSetupDialog.QtCore.QTimer.singleShot
+    PrintSetupDialog.QtCore.QTimer.singleShot = lambda *_args: None
+
+    dialog = PrintSetupDialog.PrintSetupDialog(
+        parent=None,
+        backend=object(),
+        open_after_save=True,
+    )
+    PrintSetupDialog.QtCore.QTimer.singleShot = real_single_shot
+    dialog.show()
+    app.processEvents()
+
+    assert dialog.height() >= dialog.sizeHint().height(), (
+        f"Print Setup opened at {dialog.height()} px, below its styled "
+        f"{dialog.sizeHint().height()} px size hint"
+    )
+
+    rows = [dialog.printer_combo, dialog.bed_details, dialog.print_combo]
+    for upper, lower in zip(rows, rows[1:]):
+        assert _interval(upper, dialog)[1] <= _interval(lower, dialog)[0], (
+            f"{type(upper).__name__} overlaps {type(lower).__name__}"
+        )
+
+    dialog._set_status(
+        "PrusaSlicer profile query failed with status 1. stdout: diagnostic "
+        "timestamp and details. stderr: Configuration was not found; this is "
+        "intentionally long enough to wrap onto multiple lines."
+    )
+    app.processEvents()
+    assert dialog.height() >= dialog.sizeHint().height()
+
+    dialog.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Offscreen integration check for the persistent 3D Print panel."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+TESTS = Path(__file__).resolve().parent
+MODULE = TESTS.parent
+REPO = MODULE.parents[2]
+if str(MODULE) not in sys.path:
+    sys.path.insert(0, str(MODULE))
+
+from PySide import QtWidgets  # noqa: E402
+
+import PrintPanel  # noqa: E402
+import PrintPreferences  # noqa: E402
+import VibeCADPrint  # noqa: E402
+
+
+def main() -> None:
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    styles = REPO / "src" / "Gui" / "Stylesheets"
+    app.setStyleSheet(
+        (styles / "defaults.qss").read_text(encoding="utf-8")
+        + "\n"
+        + (styles / "VibeDark.qss").read_text(encoding="utf-8")
+    )
+
+    setup = VibeCADPrint.PrintSetup(
+        printer_profile="Prusa CORE One 0.4 nozzle",
+        print_profile="0.20mm STRUCTURAL @COREONE 0.4",
+        material_profiles=("Prusament PLA @COREONE",),
+        auto_arrange=True,
+        ensure_on_bed=True,
+    )
+    storage = PrintPreferences.HandoffStorage("folder", "/tmp/print-projects")
+    saved: dict[str, object] = {}
+    PrintPanel.PrintPreferences.load_confirmed_setup = lambda: setup
+    PrintPanel.PrintPreferences.load_handoff_storage = lambda: storage
+    PrintPanel.PrintPreferences.executable_override = lambda: ""
+    PrintPanel.PrintPreferences.save_confirmed_setup = lambda value: saved.setdefault(
+        "setup", value
+    )
+    PrintPanel.PrintPreferences.save_handoff_storage = lambda value: saved.setdefault(
+        "storage", value
+    )
+
+    installation = VibeCADPrint.SlicerInstallation(
+        backend_id="prusaslicer",
+        version="2.9.6",
+        gui_command=("prusa-slicer",),
+        cli_command=("prusa-slicer",),
+        source="path",
+        display_name="PrusaSlicer 2.9.6",
+    )
+    printer = VibeCADPrint.PrinterProfile(
+        name=setup.printer_profile,
+        extruders=1,
+        bed=VibeCADPrint.BedInfo(
+            kind="Rectangle",
+            width=250,
+            height=220,
+            max_print_height=270,
+        ),
+    )
+    material = VibeCADPrint.MaterialProfile(name=setup.material_profiles[0])
+    profile = VibeCADPrint.PrintProfile(
+        name=setup.print_profile,
+        materials=(material,),
+    )
+    catalog = VibeCADPrint.ProfileCatalog(
+        printer_profile=printer.name,
+        print_profiles=(profile,),
+    )
+
+    class Backend:
+        def discover(self, _override=""):
+            return (installation,)
+
+        def query_printers(self, _installation):
+            return (printer,)
+
+        def query_profiles(self, _installation, _printer):
+            return catalog
+
+    panel = PrintPanel.PrintPanelWidget()
+    panel.backend = Backend()
+
+    def immediate(_message, operation, callback):
+        callback(operation())
+
+    panel._start_job = immediate
+    panel.resize(390, 720)
+    panel.show()
+    panel.refresh()
+    app.processEvents()
+
+    assert panel.printer_combo.currentData() == printer
+    assert panel.print_combo.currentData() == profile
+    assert len(panel.material_combos) == 1
+    assert panel.material_combos[0].currentData() == material.name
+    assert panel.folder_storage.isChecked()
+    assert panel.folder_edit.text() == storage.directory
+    assert panel._save()
+    assert saved == {"setup": setup, "storage": storage}
+    assert panel.findChild(QtWidgets.QScrollArea, "VibeCADPrintPanelScroll") is not None
+
+    panel.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import sys
+import traceback
+from types import SimpleNamespace
 
 
 TESTS = Path(__file__).resolve().parent
@@ -48,6 +50,13 @@ def main() -> None:
     )
     PrintPanel.PrintPreferences.save_handoff_storage = lambda value: saved.__setitem__(
         "storage", value
+    )
+    PrintPanel._active_print_selection = lambda: (
+        SimpleNamespace(Name="FanDocument"),
+        (
+            SimpleNamespace(Name="Body", Label="120 mm Fan Frame"),
+            SimpleNamespace(Name="Body001", Label="120 mm Fan Rotor"),
+        ),
     )
 
     installation = VibeCADPrint.SlicerInstallation(
@@ -105,6 +114,9 @@ def main() -> None:
     assert len(panel.material_combos) == 1
     assert panel.material_combos[0].currentData() == material.name
     assert panel.output_location.text() == storage.directory
+    assert "120 mm Fan Frame" in panel.selection_summary.text()
+    assert "120 mm Fan Rotor" in panel.selection_summary.text()
+    assert "BodyResult" not in panel.selection_summary.text()
     assert panel.print_button.text() == "Print"
     assert panel.setup_button.text().startswith("Setup")
     assert panel.export_button.text() == "Export 3MF…"
@@ -140,5 +152,17 @@ def main() -> None:
     remembered.close()
 
 
-if __name__ == "__main__":
-    main()
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    exit_code = 1
+    try:
+        main()
+        print("VIBECAD_PRINT_PANEL_GUI_OK", flush=True)
+        exit_code = 0
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+    finally:
+        application.exit(exit_code)
+
+
+QtCore.QTimer.singleShot(1200, _run)

--- a/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
@@ -42,11 +42,13 @@ def main() -> None:
     )
     storage = PrintPreferences.HandoffStorage("folder", "/tmp/print-projects")
     saved: dict[str, object] = {"setup": setup, "storage": storage}
-    PrintPanel.PrintPreferences.load_confirmed_setup = lambda: saved["setup"]
+    PrintPanel.PrintPreferences.load_confirmed_setup = (
+        lambda **_kwargs: saved["setup"]
+    )
     PrintPanel.PrintPreferences.load_handoff_storage = lambda: saved["storage"]
-    PrintPanel.PrintPreferences.executable_override = lambda: ""
-    PrintPanel.PrintPreferences.save_confirmed_setup = lambda value: saved.__setitem__(
-        "setup", value
+    PrintPanel.PrintPreferences.executable_override = lambda **_kwargs: ""
+    PrintPanel.PrintPreferences.save_confirmed_setup = (
+        lambda value, **_kwargs: saved.__setitem__("setup", value)
     )
     PrintPanel.PrintPreferences.save_handoff_storage = lambda value: saved.__setitem__(
         "storage", value
@@ -88,6 +90,9 @@ def main() -> None:
     )
 
     class Backend:
+        backend_id = "prusaslicer"
+        display_name = "PrusaSlicer"
+
         def discover(self, _override=""):
             return (installation,)
 

--- a/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import sys
 
@@ -14,7 +15,7 @@ REPO = MODULE.parents[2]
 if str(MODULE) not in sys.path:
     sys.path.insert(0, str(MODULE))
 
-from PySide import QtWidgets  # noqa: E402
+from PySide import QtCore, QtWidgets  # noqa: E402
 
 import PrintPanel  # noqa: E402
 import PrintPreferences  # noqa: E402
@@ -38,14 +39,14 @@ def main() -> None:
         ensure_on_bed=True,
     )
     storage = PrintPreferences.HandoffStorage("folder", "/tmp/print-projects")
-    saved: dict[str, object] = {}
-    PrintPanel.PrintPreferences.load_confirmed_setup = lambda: setup
-    PrintPanel.PrintPreferences.load_handoff_storage = lambda: storage
+    saved: dict[str, object] = {"setup": setup, "storage": storage}
+    PrintPanel.PrintPreferences.load_confirmed_setup = lambda: saved["setup"]
+    PrintPanel.PrintPreferences.load_handoff_storage = lambda: saved["storage"]
     PrintPanel.PrintPreferences.executable_override = lambda: ""
-    PrintPanel.PrintPreferences.save_confirmed_setup = lambda value: saved.setdefault(
+    PrintPanel.PrintPreferences.save_confirmed_setup = lambda value: saved.__setitem__(
         "setup", value
     )
-    PrintPanel.PrintPreferences.save_handoff_storage = lambda value: saved.setdefault(
+    PrintPanel.PrintPreferences.save_handoff_storage = lambda value: saved.__setitem__(
         "storage", value
     )
 
@@ -103,13 +104,40 @@ def main() -> None:
     assert panel.print_combo.currentData() == profile
     assert len(panel.material_combos) == 1
     assert panel.material_combos[0].currentData() == material.name
-    assert panel.folder_storage.isChecked()
-    assert panel.folder_edit.text() == storage.directory
+    assert panel.output_location.text() == storage.directory
+    assert panel.print_button.text() == "Print"
+    assert panel.setup_button.text().startswith("Setup")
+    assert panel.export_button.text() == "Export 3MF…"
+    assert not panel.apply_button.isVisible()
     assert panel._save()
     assert saved == {"setup": setup, "storage": storage}
-    assert panel.findChild(QtWidgets.QScrollArea, "VibeCADPrintPanelScroll") is not None
+    scroll = panel.findChild(QtWidgets.QScrollArea, "VibeCADPrintPanelScroll")
+    assert scroll is not None
+    assert scroll.horizontalScrollBarPolicy() == QtCore.Qt.ScrollBarAlwaysOff
+    assert scroll.horizontalScrollBar().maximum() == 0
+
+    panel.auto_arrange.setChecked(False)
+    app.processEvents()
+    assert saved["setup"].auto_arrange is False
 
     panel.close()
+
+    remembered = PrintPanel.PrintPanelWidget()
+    remembered.backend = Backend()
+    remembered._start_job = immediate
+    remembered.resize(320, 720)
+    remembered.show()
+    remembered.refresh()
+    app.processEvents()
+
+    assert remembered.printer_combo.currentData() == printer
+    assert remembered.print_combo.currentData() == profile
+    assert remembered.material_combos[0].currentData() == material.name
+    assert not remembered.auto_arrange.isChecked()
+    screenshot = os.environ.get("VIBECAD_PRINT_PANEL_SCREENSHOT")
+    if screenshot:
+        assert remembered.grab().save(screenshot)
+    remembered.close()
 
 
 if __name__ == "__main__":

--- a/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_panel_integration.py
@@ -114,9 +114,19 @@ def main() -> None:
     assert len(panel.material_combos) == 1
     assert panel.material_combos[0].currentData() == material.name
     assert panel.output_location.text() == storage.directory
-    assert "120 mm Fan Frame" in panel.selection_summary.text()
-    assert "120 mm Fan Rotor" in panel.selection_summary.text()
-    assert "BodyResult" not in panel.selection_summary.text()
+    assert not panel.output_location.isVisible()
+    assert panel.selection_group.title() == "Objects to be sent"
+    assert [choice.text() for choice in panel.object_checkboxes] == [
+        "120 mm Fan Frame",
+        "120 mm Fan Rotor",
+    ]
+    assert all(choice.isChecked() for choice in panel.object_checkboxes)
+    panel.object_checkboxes[0].setChecked(False)
+    app.processEvents()
+    _document, chosen = panel._checked_print_selection()
+    assert [obj.Label for obj in chosen] == ["120 mm Fan Rotor"]
+    assert "1 of 2 objects will be sent" in panel.selection_summary.text()
+    panel.object_checkboxes[0].setChecked(True)
     assert panel.print_button.text() == "Print"
     assert panel.setup_button.text().startswith("Setup")
     assert panel.export_button.text() == "Export 3MF…"
@@ -146,6 +156,10 @@ def main() -> None:
     assert remembered.print_combo.currentData() == profile
     assert remembered.material_combos[0].currentData() == material.name
     assert not remembered.auto_arrange.isChecked()
+    assert [choice.text() for choice in remembered.object_checkboxes] == [
+        "120 mm Fan Frame",
+        "120 mm Fan Rotor",
+    ]
     screenshot = os.environ.get("VIBECAD_PRINT_PANEL_SCREENSHOT")
     if screenshot:
         assert remembered.grab().save(screenshot)

--- a/src/Mod/VibeCADPrint/tests/qt_panel_persistence_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_panel_persistence_integration.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Two-process release gate for persisted 3D Print dock placement."""
+
+from __future__ import annotations
+
+import os
+import sys
+import traceback
+
+import FreeCADGui as Gui
+from PySide import QtCore, QtWidgets
+
+
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    exit_code = 1
+    main = None
+    try:
+        import PrintPanel
+
+        stage = os.environ.get("VIBECAD_PRINT_PERSISTENCE_STAGE", "")
+        assert stage in {"write", "read"}
+        assert Gui.activateWorkbench("VibeCADPrintWorkbench")
+        QtWidgets.QApplication.processEvents()
+        main = Gui.getMainWindow()
+        dock = main.findChild(QtWidgets.QDockWidget, PrintPanel.DOCK_NAME)
+        assert dock is not None
+        if stage == "write":
+            main.addDockWidget(QtCore.Qt.LeftDockWidgetArea, dock)
+            QtWidgets.QApplication.processEvents()
+            assert main.dockWidgetArea(dock) == QtCore.Qt.LeftDockWidgetArea
+            print("VIBECAD_PRINT_PANEL_POSITION_SAVED", flush=True)
+        else:
+            assert main.dockWidgetArea(dock) == QtCore.Qt.LeftDockWidgetArea
+            print("VIBECAD_PRINT_PANEL_POSITION_RESTORED", flush=True)
+        exit_code = 0
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+    finally:
+        if exit_code == 0 and main is not None:
+            main.close()
+            QtWidgets.QApplication.processEvents()
+        application.exit(exit_code)
+
+
+QtCore.QTimer.singleShot(1200, _run)

--- a/src/Mod/VibeCADPrint/tests/qt_progress_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_progress_integration.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Live regression for completed progress operations not becoming cancellations."""
+
+from __future__ import annotations
+
+import sys
+import time
+import traceback
+
+import FreeCADGui as Gui
+from PySide import QtCore, QtWidgets
+
+
+def _slow_success() -> str:
+    time.sleep(0.35)
+    return "prepared"
+
+
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    exit_code = 1
+    try:
+        import PrintSetupDialog
+
+        result = PrintSetupDialog.run_with_progress(
+            Gui.getMainWindow(),
+            "Preparing a slicer project…",
+            _slow_success,
+        )
+        assert result == "prepared"
+        print("VIBECAD_PRINT_PROGRESS_OK", flush=True)
+        exit_code = 0
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+    finally:
+        application.exit(exit_code)
+
+
+QtCore.QTimer.singleShot(1200, _run)

--- a/src/Mod/VibeCADPrint/tests/qt_selection_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_selection_integration.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Live regression for whole-body plus subelement print selection."""
+
+from __future__ import annotations
+
+import sys
+import traceback
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import Part
+from PySide import QtCore, QtWidgets
+
+
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    exit_code = 1
+    document = None
+    try:
+        import PrintCommandLoader
+
+        document = App.newDocument("VibeCADPrintSelectionTest")
+        frame = document.addObject("PartDesign::Body", "Frame")
+        frame_result = frame.newObject("PartDesign::Feature", "FrameResult")
+        frame_result.Shape = Part.makeBox(20, 20, 5)
+        rotor = document.addObject("PartDesign::Body", "Rotor")
+        rotor_result = rotor.newObject("PartDesign::Feature", "RotorResult")
+        rotor_result.Shape = Part.makeCylinder(5, 8)
+        document.recompute()
+
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(document.Name, frame.Name)
+        Gui.Selection.addSelection(document.Name, rotor.Name)
+        Gui.Selection.addSelection(document.Name, frame_result.Name, "Edge1")
+
+        entries = tuple(Gui.Selection.getSelectionEx() or ())
+        assert any(tuple(entry.SubElementNames or ()) for entry in entries)
+        commands = PrintCommandLoader.command_module()
+        actual_document, objects = commands._active_selection()
+        assert actual_document is document
+        assert [obj.Name for obj in objects] == [frame.Name, rotor.Name]
+
+        import PrintPanel
+
+        panel = PrintPanel.PrintPanelWidget()
+        panel._update_selection_summary()
+        assert "Frame" in panel.selection_summary.text()
+        assert "Rotor" in panel.selection_summary.text()
+        assert "FrameResult" not in panel.selection_summary.text()
+        panel.close()
+        print("VIBECAD_PRINT_SELECTION_GUI_OK", flush=True)
+        exit_code = 0
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+    finally:
+        Gui.Selection.clearSelection()
+        if document is not None:
+            App.closeDocument(document.Name)
+        application.exit(exit_code)
+
+
+QtCore.QTimer.singleShot(1200, _run)

--- a/src/Mod/VibeCADPrint/tests/qt_selection_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_selection_integration.py
@@ -45,9 +45,15 @@ def _run() -> None:
 
         panel = PrintPanel.PrintPanelWidget()
         panel._update_selection_summary()
-        assert "Frame" in panel.selection_summary.text()
-        assert "Rotor" in panel.selection_summary.text()
-        assert "FrameResult" not in panel.selection_summary.text()
+        assert [choice.text() for choice in panel.object_checkboxes] == [
+            "Frame",
+            "Rotor",
+        ]
+        assert all(choice.isChecked() for choice in panel.object_checkboxes)
+        assert all(
+            "FrameResult" not in choice.text()
+            for choice in panel.object_checkboxes
+        )
         panel.close()
         print("VIBECAD_PRINT_SELECTION_GUI_OK", flush=True)
         exit_code = 0

--- a/src/Mod/VibeCADPrint/tests/qt_workbench_panel_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_workbench_panel_integration.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Live GUI release gate for the 3D Print workbench's persistent panel."""
+
+from __future__ import annotations
+
+import sys
+import traceback
+
+import FreeCADGui as Gui
+from PySide import QtCore, QtWidgets
+
+
+def _process_events() -> None:
+    QtWidgets.QApplication.processEvents()
+
+
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    exit_code = 1
+    try:
+        import PrintPanel
+
+        class EmptyBackend:
+            def discover(self, _override=""):
+                return ()
+
+        PrintPanel.VibeCADPrint.PrusaSlicerBackend = EmptyBackend
+
+        assert Gui.activateWorkbench("VibeCADPrintWorkbench")
+        _process_events()
+        main_window = Gui.getMainWindow()
+        dock = main_window.findChild(
+            QtWidgets.QDockWidget,
+            PrintPanel.DOCK_NAME,
+        )
+        assert dock is not None
+        assert dock.isVisible()
+        assert isinstance(dock.widget(), PrintPanel.PrintPanelWidget)
+        assert dock.widget().findChild(
+            QtWidgets.QScrollArea,
+            "VibeCADPrintPanelScroll",
+        ) is not None
+
+        assert Gui.activateWorkbench("PartDesignWorkbench")
+        _process_events()
+        assert not dock.isVisible()
+
+        assert Gui.activateWorkbench("VibeCADPrintWorkbench")
+        _process_events()
+        assert dock.isVisible()
+        print("VIBECAD_PRINT_PANEL_GUI_OK", flush=True)
+        exit_code = 0
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+    finally:
+        application.exit(exit_code)
+
+
+QtCore.QTimer.singleShot(1200, _run)

--- a/src/Mod/VibeCADPrint/tests/qt_workbench_panel_integration.py
+++ b/src/Mod/VibeCADPrint/tests/qt_workbench_panel_integration.py
@@ -36,6 +36,7 @@ def _run() -> None:
         )
         assert dock is not None
         assert dock.isVisible()
+        assert dock.toggleViewAction().data() == PrintPanel.DOCK_NAME
         assert isinstance(dock.widget(), PrintPanel.PrintPanelWidget)
         assert dock.widget().findChild(
             QtWidgets.QScrollArea,

--- a/src/Mod/VibeCADPrint/tests/test_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_backend.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+
+import pytest
+
+import VibeCADPrint
+
+
+PRINTERS_JSON = {
+    "printer_models": [
+        {
+            "id": "MK4S",
+            "name": "Original Prusa MK4S",
+            "technology": "FFF",
+            "vendor_name": "Prusa Research",
+            "vendor_id": "PRUSA",
+            "variants": [
+                {
+                    "name": "0.4",
+                    "printer_profiles": [
+                        {
+                            "name": "Original Prusa MK4S 0.4 nozzle",
+                            "extruders_cnt": "1",
+                            "bed": {
+                                "type": "Rectangle",
+                                "width": "250",
+                                "height": "210",
+                                "origin": "[0, 0]",
+                                "max_print_height": "220",
+                            },
+                        }
+                    ],
+                    "user_printer_profiles": [
+                        {
+                            "name": "My MK4S",
+                            "extruders_cnt": "1",
+                            "bed": {
+                                "type": "Rectangle",
+                                "width": "250",
+                                "height": "210",
+                                "origin": "[0, 0]",
+                                "max_print_height": "220",
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+        {
+            "id": "XL",
+            "name": "Original Prusa XL",
+            "technology": "FFF",
+            "vendor_name": "Prusa Research",
+            "vendor_id": "PRUSA",
+            "variants": [
+                {
+                    "name": "5T 0.4",
+                    "printer_profiles": [
+                        {
+                            "name": "Original Prusa XL - 5T 0.4 nozzle",
+                            "extruders_cnt": 5,
+                            "bed": {
+                                "type": "Rectangle",
+                                "width": 360,
+                                "height": 360,
+                                "origin": "[0, 0]",
+                                "max_print_height": 360,
+                            },
+                        }
+                    ],
+                }
+            ],
+        },
+    ]
+}
+
+
+PROFILES_JSON = {
+    "printer_profile": "Original Prusa XL - 5T 0.4 nozzle",
+    "print_profiles": [
+        {
+            "name": "0.20mm SPEED @XL 0.4",
+            "filament_profiles": ["Generic PLA @XL", "Generic PETG @XL"],
+            "user_filament_profiles": ["My PLA @XL"],
+        },
+        {
+            "name": "0.15mm QUALITY @XL 0.4",
+            "filament_profiles": ["Generic PLA @XL"],
+        },
+    ],
+    "user_print_profiles": [
+        {
+            "name": "My Fast XL",
+            "filament_profiles": ["Generic PLA @XL"],
+        }
+    ],
+}
+
+
+def _installation(*, version: str = "2.9.6") -> VibeCADPrint.SlicerInstallation:
+    return VibeCADPrint.SlicerInstallation(
+        backend_id="prusaslicer",
+        version=version,
+        gui_command=("prusa-slicer",),
+        cli_command=("prusa-slicer",),
+        source="path",
+        display_name=f"PrusaSlicer {version}",
+    )
+
+
+def test_parse_printer_models_flattens_system_and_user_profiles() -> None:
+    profiles = VibeCADPrint.parse_printer_models(PRINTERS_JSON)
+
+    assert [profile.name for profile in profiles] == [
+        "Original Prusa MK4S 0.4 nozzle",
+        "My MK4S",
+        "Original Prusa XL - 5T 0.4 nozzle",
+    ]
+    custom = profiles[1]
+    assert custom.is_user is True
+    assert custom.model_name == "Original Prusa MK4S"
+    assert custom.variant_name == "0.4"
+    assert custom.extruders == 1
+    assert custom.bed.width == 250.0
+    assert custom.bed.origin == (0.0, 0.0)
+    assert profiles[2].extruders == 5
+
+
+def test_parse_compatible_profiles_preserves_per_print_material_compatibility() -> None:
+    catalog = VibeCADPrint.parse_compatible_profiles(PROFILES_JSON)
+
+    assert catalog.printer_profile == "Original Prusa XL - 5T 0.4 nozzle"
+    assert [profile.name for profile in catalog.print_profiles] == [
+        "0.20mm SPEED @XL 0.4",
+        "0.15mm QUALITY @XL 0.4",
+        "My Fast XL",
+    ]
+    speed = catalog.print_profiles[0]
+    assert [(item.name, item.is_user) for item in speed.materials] == [
+        ("Generic PLA @XL", False),
+        ("Generic PETG @XL", False),
+        ("My PLA @XL", True),
+    ]
+    assert catalog.print_profiles[2].is_user is True
+
+
+def test_valid_query_json_wins_over_nonzero_process_status(tmp_path: Path) -> None:
+    def runner(command, **kwargs):
+        output = Path(command[command.index("--output") + 1])
+        output.write_text(json.dumps(PRINTERS_JSON), encoding="utf-8")
+        return subprocess.CompletedProcess(command, 1, "", "query action returned 1")
+
+    result = VibeCADPrint.run_json_query(
+        _installation(),
+        ("--query-printer-models",),
+        runner=runner,
+        temporary_directory=tmp_path,
+    )
+
+    assert result == PRINTERS_JSON
+
+
+def test_flatpak_query_reads_stdout_across_private_tmp_boundary(
+    tmp_path: Path,
+) -> None:
+    installation = VibeCADPrint.SlicerInstallation(
+        backend_id="prusaslicer",
+        version="2.9.6",
+        gui_command=("flatpak", "run", "com.prusa3d.PrusaSlicer"),
+        cli_command=(
+            "flatpak",
+            "run",
+            "--command=/app/bin/prusa-slicer",
+            "com.prusa3d.PrusaSlicer",
+        ),
+        source="flatpak-user",
+        display_name="PrusaSlicer (Flatpak) 2.9.6",
+    )
+
+    def runner(command, **kwargs):
+        assert "--output" not in command
+        return subprocess.CompletedProcess(command, 1, json.dumps(PRINTERS_JSON), "")
+
+    result = VibeCADPrint.run_json_query(
+        installation,
+        ("--query-printer-models",),
+        runner=runner,
+        temporary_directory=tmp_path,
+    )
+
+    assert result == PRINTERS_JSON
+
+
+def test_invalid_query_reports_stdout_stderr_and_status(tmp_path: Path) -> None:
+    def runner(command, **kwargs):
+        return subprocess.CompletedProcess(command, 2, "bad out", "bad err")
+
+    with pytest.raises(VibeCADPrint.SlicerQueryError) as error:
+        VibeCADPrint.run_json_query(
+            _installation(),
+            ("--query-printer-models",),
+            runner=runner,
+            temporary_directory=tmp_path,
+        )
+
+    assert "status 2" in str(error.value)
+    assert "bad out" in str(error.value)
+    assert "bad err" in str(error.value)
+
+
+@pytest.mark.parametrize(
+    ("auto_arrange", "ensure_on_bed", "expected", "unexpected"),
+    [
+        (True, True, "--ensure-on-bed", "--dont-arrange"),
+        (True, False, "--no-ensure-on-bed", "--dont-arrange"),
+        (False, True, "--dont-arrange", "--no-ensure-on-bed"),
+        (False, False, "--dont-arrange", "--ensure-on-bed"),
+    ],
+)
+def test_launch_command_maps_explicit_placement_choices(
+    auto_arrange: bool,
+    ensure_on_bed: bool,
+    expected: str,
+    unexpected: str,
+) -> None:
+    setup = VibeCADPrint.PrintSetup(
+        printer_profile="Original Prusa XL - 5T 0.4 nozzle",
+        print_profile="0.20mm SPEED @XL 0.4",
+        material_profiles=("Generic PLA @XL",) * 5,
+        auto_arrange=auto_arrange,
+        ensure_on_bed=ensure_on_bed,
+    )
+
+    command = VibeCADPrint.build_launch_command(
+        _installation(), Path("/tmp/Plate With Spaces.3mf"), setup
+    )
+
+    assert expected in command
+    assert unexpected not in command
+    assert command[-1] == "/tmp/Plate With Spaces.3mf"
+    material_index = command.index("--material-profile")
+    assert command[material_index + 1] == ";".join(("Generic PLA @XL",) * 5)
+
+
+def test_basic_launch_does_not_invent_profiles() -> None:
+    command = VibeCADPrint.build_launch_command(
+        _installation(version="2.7.2"), Path("/tmp/part.3mf"), None
+    )
+
+    assert command == ("prusa-slicer", "/tmp/part.3mf")
+
+
+def test_validate_setup_requires_exact_compatible_names_and_each_extruder() -> None:
+    printer = VibeCADPrint.parse_printer_models(PRINTERS_JSON)[2]
+    catalog = VibeCADPrint.parse_compatible_profiles(PROFILES_JSON)
+    setup = VibeCADPrint.PrintSetup(
+        printer_profile=printer.name,
+        print_profile="0.20mm SPEED @XL 0.4",
+        material_profiles=("Generic PLA @XL",) * 5,
+    )
+
+    assert VibeCADPrint.validate_setup(setup, printer, catalog) == ()
+    missing = VibeCADPrint.PrintSetup(
+        printer_profile=printer.name,
+        print_profile=setup.print_profile,
+        material_profiles=("Generic PLA @XL",) * 4,
+    )
+    assert VibeCADPrint.validate_setup(missing, printer, catalog) == (
+        "Select one material profile for each of the printer's 5 extruders.",
+    )
+    incompatible = VibeCADPrint.PrintSetup(
+        printer_profile=printer.name,
+        print_profile=setup.print_profile,
+        material_profiles=("Generic ABS @XL",) * 5,
+    )
+    assert (
+        "Generic ABS @XL"
+        in VibeCADPrint.validate_setup(incompatible, printer, catalog)[0]
+    )
+
+
+def test_default_candidates_cover_all_supported_platforms() -> None:
+    windows = VibeCADPrint.default_candidate_specs(
+        platform="win32",
+        environ={"ProgramFiles": r"C:\Program Files"},
+    )
+    macos = VibeCADPrint.default_candidate_specs(platform="darwin", environ={})
+    linux = VibeCADPrint.default_candidate_specs(platform="linux", environ={})
+
+    assert any(
+        spec.gui_command[-1].endswith(r"Prusa3D\PrusaSlicer\prusa-slicer.exe")
+        for spec in windows
+    )
+    assert any(
+        "PrusaSlicer.app/Contents/MacOS/PrusaSlicer" in spec.gui_command[-1]
+        for spec in macos
+    )
+    assert any(spec.gui_command == ("prusa-slicer",) for spec in linux)
+    assert any(
+        spec.gui_command[-1] == "com.prusa3d.PrusaSlicer"
+        and "--command=/app/bin/prusa-slicer" in spec.cli_command
+        for spec in linux
+    )
+
+
+def test_preferred_installation_honors_explicit_then_uses_newest() -> None:
+    old = _installation(version="2.7.2")
+    current = _installation(version="2.9.6")
+    newer = _installation(version="2.10.0")
+
+    assert VibeCADPrint.preferred_installation([old, newer, current]) is newer
+    assert (
+        VibeCADPrint.preferred_installation(
+            [old, newer, current], explicit_gui_command=old.gui_command
+        )
+        is old
+    )

--- a/src/Mod/VibeCADPrint/tests/test_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_backend.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 import subprocess
+import zipfile
 
 import pytest
 
@@ -253,6 +254,98 @@ def test_basic_launch_does_not_invent_profiles() -> None:
     )
 
     assert command == ("prusa-slicer", "/tmp/part.3mf")
+
+
+@pytest.mark.parametrize(
+    ("auto_arrange", "expected", "unexpected"),
+    [
+        (True, "--duplicate", "--dont-arrange"),
+        (False, "--dont-arrange", "--duplicate"),
+    ],
+)
+def test_prepare_project_preserves_objects_and_maps_arrangement_choice(
+    tmp_path: Path,
+    auto_arrange: bool,
+    expected: str,
+    unexpected: str,
+) -> None:
+    source = tmp_path / "geometry.3mf"
+    with zipfile.ZipFile(source, "w") as archive:
+        archive.writestr(
+            "3D/3dmodel.model",
+            '<model><resources><object id="1"/><object id="2"/></resources></model>',
+        )
+    destination = tmp_path / "prepared.3mf"
+    setup = VibeCADPrint.PrintSetup(
+        printer_profile="Original Prusa MK4S 0.4 nozzle",
+        print_profile="0.20mm QUALITY @MK4S 0.4",
+        material_profiles=("Generic PLA @MK4S",),
+        auto_arrange=auto_arrange,
+        ensure_on_bed=True,
+    )
+    commands = []
+
+    def runner(command, **_kwargs):
+        commands.append(tuple(command))
+        output = Path(command[command.index("--output") + 1])
+        with zipfile.ZipFile(output, "w") as archive:
+            archive.writestr("3D/3dmodel.model", "<model/>")
+            archive.writestr(
+                "Metadata/Slic3r_PE_model.config",
+                '<config><object id="1"/><object id="2"/></config>',
+            )
+        return subprocess.CompletedProcess(command, 0, "prepared", "")
+
+    result = VibeCADPrint.prepare_prusaslicer_project(
+        _installation(),
+        source,
+        destination,
+        setup,
+        runner=runner,
+    )
+
+    assert result == destination
+    assert expected in commands[0]
+    assert unexpected not in commands[0]
+    assert commands[0][-1] == str(source)
+    assert "--export-3mf" in commands[0]
+    assert destination.is_file()
+    assert not list(tmp_path.glob("*.partial.3mf"))
+
+
+def test_prepare_project_rejects_object_collapse_and_preserves_source(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "plate.3mf"
+    with zipfile.ZipFile(source, "w") as archive:
+        archive.writestr(
+            "3D/3dmodel.model",
+            '<model><resources><object id="1"/><object id="2"/></resources></model>',
+        )
+    original = source.read_bytes()
+    setup = VibeCADPrint.PrintSetup("Printer", "Quality", ("Material",))
+
+    def runner(command, **_kwargs):
+        output = Path(command[command.index("--output") + 1])
+        with zipfile.ZipFile(output, "w") as archive:
+            archive.writestr("3D/3dmodel.model", "<model/>")
+            archive.writestr(
+                "Metadata/Slic3r_PE_model.config",
+                '<config><object id="1"/></config>',
+            )
+        return subprocess.CompletedProcess(command, 0, "prepared", "")
+
+    with pytest.raises(VibeCADPrint.SlicerError, match="object count"):
+        VibeCADPrint.prepare_prusaslicer_project(
+            _installation(),
+            source,
+            source,
+            setup,
+            runner=runner,
+        )
+
+    assert source.read_bytes() == original
+    assert not list(tmp_path.glob("*.partial.3mf"))
 
 
 def test_validate_setup_requires_exact_compatible_names_and_each_extruder() -> None:

--- a/src/Mod/VibeCADPrint/tests/test_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_backend.py
@@ -243,7 +243,7 @@ def test_launch_command_maps_explicit_placement_choices(
 
     assert expected in command
     assert unexpected not in command
-    assert command[-1] == "/tmp/Plate With Spaces.3mf"
+    assert command[-1] == str(Path("/tmp/Plate With Spaces.3mf"))
     material_index = command.index("--material-profile")
     assert command[material_index + 1] == ";".join(("Generic PLA @XL",) * 5)
 
@@ -253,7 +253,7 @@ def test_basic_launch_does_not_invent_profiles() -> None:
         _installation(version="2.7.2"), Path("/tmp/part.3mf"), None
     )
 
-    assert command == ("prusa-slicer", "/tmp/part.3mf")
+    assert command == ("prusa-slicer", str(Path("/tmp/part.3mf")))
 
 
 @pytest.mark.parametrize(

--- a/src/Mod/VibeCADPrint/tests/test_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_backend.py
@@ -413,3 +413,40 @@ def test_preferred_installation_honors_explicit_then_uses_newest() -> None:
         )
         is old
     )
+
+
+def test_prusa_backend_caches_all_queries_until_invalidated(monkeypatch) -> None:
+    installation = _installation()
+    printers = VibeCADPrint.parse_printer_models(PRINTERS_JSON)
+    catalog = VibeCADPrint.parse_compatible_profiles(PROFILES_JSON)
+    calls = {"discover": 0, "printers": 0, "profiles": 0}
+
+    def discover(_override=""):
+        calls["discover"] += 1
+        return (installation,)
+
+    def query_printers(_installation):
+        calls["printers"] += 1
+        return printers
+
+    def query_profiles(_installation, _printer_name):
+        calls["profiles"] += 1
+        return catalog
+
+    monkeypatch.setattr(VibeCADPrint, "discover_prusaslicer_installations", discover)
+    monkeypatch.setattr(VibeCADPrint, "query_printer_profiles", query_printers)
+    monkeypatch.setattr(VibeCADPrint, "query_compatible_profiles", query_profiles)
+    backend = VibeCADPrint.PrusaSlicerBackend()
+
+    assert backend.discover() is backend.discover()
+    assert backend.query_printers(installation) is backend.query_printers(installation)
+    assert backend.query_profiles(installation, "Printer") is backend.query_profiles(
+        installation, "Printer"
+    )
+    assert calls == {"discover": 1, "printers": 1, "profiles": 1}
+
+    backend.invalidate_cache()
+    backend.discover()
+    backend.query_printers(installation)
+    backend.query_profiles(installation, "Printer")
+    assert calls == {"discover": 2, "printers": 2, "profiles": 2}

--- a/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
@@ -180,6 +180,58 @@ def test_bambu_catalog_resolves_inheritance_and_exact_compatibility(
     assert resolved["printer_model"] == "Test Printer"
 
 
+def test_profile_store_uses_its_index_for_exact_name_queries(tmp_path: Path) -> None:
+    root = tmp_path / "profiles"
+    _profile_store(root)
+    store = BambuStudio._load_profile_store(_installation(root))
+
+    class NoFullScan:
+        def __iter__(self):
+            raise AssertionError("exact profile lookup scanned the complete store")
+
+    object.__setattr__(store, "records", NoFullScan())
+
+    records = store.records_for("machine", "Test Printer 0.4 nozzle")
+    assert len(records) == 1
+    assert records[0].name == "Test Printer 0.4 nozzle"
+
+
+def test_backend_caches_discovery_and_all_profile_data_until_invalidated(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "profiles"
+    _profile_store(root)
+    installation = _installation(root)
+    calls = {"discover": 0, "store": 0}
+    real_load = BambuStudio._load_profile_store
+
+    def discover(_override=""):
+        calls["discover"] += 1
+        return (installation,)
+
+    def load(actual_installation):
+        calls["store"] += 1
+        return real_load(actual_installation)
+
+    monkeypatch.setattr(BambuStudio, "discover_bambu_installations", discover)
+    monkeypatch.setattr(BambuStudio, "_load_profile_store", load)
+    backend = BambuStudio.BambuStudioBackend()
+
+    assert backend.discover() == (installation,)
+    assert backend.discover() == (installation,)
+    printers = backend.query_printers(installation)
+    assert backend.query_printers(installation) is printers
+    catalog = backend.query_profiles(installation, printers[0].name)
+    assert backend.query_profiles(installation, printers[0].name) is catalog
+    assert calls == {"discover": 1, "store": 1}
+
+    backend.invalidate_cache()
+    backend.discover()
+    backend.query_printers(installation)
+    assert calls == {"discover": 2, "store": 2}
+
+
 @pytest.mark.parametrize(
     ("auto_arrange", "arrange_value"),
     [(True, "1"), (False, "0")],
@@ -202,9 +254,14 @@ def test_prepare_bambu_project_uses_full_profiles_and_preserves_named_objects(
         ensure_on_bed=True,
     )
     commands = []
+    working_directories = []
 
-    def runner(command, **_kwargs):
+    def runner(command, **kwargs):
         commands.append(tuple(command))
+        working_directory = Path(kwargs["cwd"])
+        working_directories.append(working_directory)
+        assert working_directory.parent == destination.parent
+        assert working_directory.name.startswith(".vibecad-slicer-")
         settings = command[command.index("--load-settings") + 1].split(";")
         machine = json.loads(Path(settings[0]).read_text(encoding="utf-8"))
         process = json.loads(Path(settings[1]).read_text(encoding="utf-8"))
@@ -231,6 +288,7 @@ def test_prepare_bambu_project_uses_full_profiles_and_preserves_named_objects(
     assert commands[0][arrange_index + 1] == arrange_value
     assert "--ensure-on-bed" in commands[0]
     assert destination.is_file()
+    assert all(not path.exists() for path in working_directories)
     assert not list(tmp_path.glob("*.partial.3mf"))
     assert not list(tmp_path.glob("*.profile.json"))
 

--- a/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
@@ -129,6 +129,61 @@ def _installation(root: Path) -> VibeCADPrint.SlicerInstallation:
     )
 
 
+def test_windows_discovery_uses_file_version_when_gui_help_is_silent(
+    tmp_path: Path,
+) -> None:
+    program_files = tmp_path / "Program Files"
+    executable = program_files / "Bambu Studio" / "bambu-studio.exe"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"MZ")
+    profiles = executable.parent / "resources" / "profiles"
+    profiles.mkdir(parents=True)
+    appdata = tmp_path / "Donn\u00fd User" / "AppData" / "Roaming"
+
+    def runner(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    installations = BambuStudio.discover_bambu_installations(
+        platform="win32",
+        environ={"ProgramFiles": str(program_files), "APPDATA": str(appdata)},
+        runner=runner,
+        which=lambda _name: None,
+        windows_version_reader=lambda _path, _product: "2.7.1.62",
+    )
+
+    assert len(installations) == 1
+    assert installations[0].version == "2.7.1.62"
+    assert installations[0].gui_command == (str(executable),)
+    assert installations[0].resource_dir == str(profiles)
+    assert installations[0].config_dir == str(appdata / "BambuStudio")
+
+
+def test_windows_launch_is_detached_and_preserves_unicode_path(tmp_path: Path) -> None:
+    handoff = tmp_path / "M\u00f8del With Spaces.3mf"
+    calls = []
+
+    class Process:
+        pid = 42
+
+    def popen(command, **kwargs):
+        calls.append((tuple(command), kwargs))
+        return Process()
+
+    result = BambuStudio.launch_bambu_studio(
+        _installation(tmp_path),
+        handoff,
+        popen=popen,
+        platform="win32",
+    )
+
+    assert result.command[-1] == str(handoff)
+    assert result.process_id == 42
+    assert calls[0][0][-1] == str(handoff)
+    assert calls[0][1]["creationflags"]
+    assert calls[0][1]["close_fds"] is True
+    assert calls[0][1]["start_new_session"] is False
+
+
 def _source_3mf(path: Path) -> None:
     with zipfile.ZipFile(path, "w") as archive:
         archive.writestr(

--- a/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import zipfile
+
+import pytest
+
+import BambuStudio
+import VibeCADPrint
+
+
+def _write_profile(root: Path, folder: str, data: dict) -> None:
+    target = root / "TestVendor" / folder / f"{data['name']}.json"
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(data), encoding="utf-8")
+
+
+def _profile_store(root: Path) -> None:
+    _write_profile(
+        root,
+        "machine",
+        {
+            "name": "test_machine_end_gcode",
+            "instantiation": "false",
+            "machine_end_gcode": "M84",
+        },
+    )
+    _write_profile(
+        root,
+        "machine",
+        {
+            "type": "machine",
+            "name": "test_machine_base",
+            "printable_area": ["0x0", "256x0", "256x256", "0x256"],
+            "printable_height": "250",
+            "machine_start_gcode": "G28",
+        },
+    )
+    _write_profile(
+        root,
+        "machine",
+        {
+            "type": "machine",
+            "name": "Test Printer 0.4 nozzle",
+            "inherits": "test_machine_base",
+            "include": ["test_machine_end_gcode"],
+            "instantiation": "true",
+            "printer_model": "Test Printer",
+            "printer_variant": "0.4",
+            "nozzle_diameter": ["0.4"],
+        },
+    )
+    _write_profile(
+        root,
+        "process",
+        {
+            "type": "process",
+            "name": "test_process_base",
+            "layer_height": "0.2",
+        },
+    )
+    _write_profile(
+        root,
+        "process",
+        {
+            "type": "process",
+            "name": "0.20mm Standard @TEST",
+            "inherits": "test_process_base",
+            "instantiation": "true",
+            "compatible_printers": ["Test Printer 0.4 nozzle"],
+        },
+    )
+    _write_profile(
+        root,
+        "process",
+        {
+            "type": "process",
+            "name": "Wrong printer quality",
+            "instantiation": "true",
+            "compatible_printers": ["Another Printer"],
+        },
+    )
+    _write_profile(
+        root,
+        "filament",
+        {
+            "type": "filament",
+            "name": "test_filament_base",
+            "filament_type": ["PLA"],
+        },
+    )
+    _write_profile(
+        root,
+        "filament",
+        {
+            "type": "filament",
+            "name": "Generic PLA @TEST",
+            "inherits": "test_filament_base",
+            "instantiation": "true",
+            "compatible_printers": ["Test Printer 0.4 nozzle"],
+        },
+    )
+    _write_profile(
+        root,
+        "filament",
+        {
+            "type": "filament",
+            "name": "Wrong printer filament",
+            "instantiation": "true",
+            "compatible_printers": ["Another Printer"],
+        },
+    )
+
+
+def _installation(root: Path) -> VibeCADPrint.SlicerInstallation:
+    return VibeCADPrint.SlicerInstallation(
+        backend_id="bambustudio",
+        version="2.8.2.61",
+        gui_command=("bambu-studio",),
+        cli_command=("bambu-studio",),
+        source="path",
+        display_name="Bambu Studio",
+        resource_dir=str(root),
+        tested_version=(2, 8, 2),
+    )
+
+
+def _source_3mf(path: Path) -> None:
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr(
+            "3D/3dmodel.model",
+            '<model><resources><object id="1" name="Frame"/>'
+            '<object id="2" name="Rotor"/></resources></model>',
+        )
+
+
+def _prepared_3mf(path: Path, names: tuple[str, ...]) -> None:
+    objects = "".join(
+        f'<object id="{index}"><metadata key="name" value="{name}"/></object>'
+        for index, name in enumerate(names, start=1)
+    )
+    with zipfile.ZipFile(path, "w") as archive:
+        archive.writestr("3D/3dmodel.model", "<model/>")
+        archive.writestr("Metadata/model_settings.config", f"<config>{objects}</config>")
+        archive.writestr("Metadata/project_settings.config", "{}")
+
+
+def test_bambu_catalog_resolves_inheritance_and_exact_compatibility(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "profiles"
+    _profile_store(root)
+    backend = BambuStudio.BambuStudioBackend()
+    installation = _installation(root)
+
+    printers = backend.query_printers(installation)
+    catalog = backend.query_profiles(installation, printers[0].name)
+    resolved = BambuStudio.resolved_profile(
+        installation,
+        "machine",
+        printers[0].name,
+    )
+
+    assert [printer.name for printer in printers] == ["Test Printer 0.4 nozzle"]
+    assert printers[0].bed.width == 256
+    assert printers[0].bed.height == 256
+    assert printers[0].bed.max_print_height == 250
+    assert [profile.name for profile in catalog.print_profiles] == [
+        "0.20mm Standard @TEST"
+    ]
+    assert [
+        material.name for material in catalog.print_profiles[0].materials
+    ] == ["Generic PLA @TEST"]
+    assert resolved["machine_start_gcode"] == "G28"
+    assert resolved["machine_end_gcode"] == "M84"
+    assert resolved["printer_model"] == "Test Printer"
+
+
+@pytest.mark.parametrize(
+    ("auto_arrange", "arrange_value"),
+    [(True, "1"), (False, "0")],
+)
+def test_prepare_bambu_project_uses_full_profiles_and_preserves_named_objects(
+    tmp_path: Path,
+    auto_arrange: bool,
+    arrange_value: str,
+) -> None:
+    root = tmp_path / "profiles"
+    _profile_store(root)
+    source = tmp_path / "fan.3mf"
+    destination = tmp_path / "fan-bambu.3mf"
+    _source_3mf(source)
+    setup = VibeCADPrint.PrintSetup(
+        "Test Printer 0.4 nozzle",
+        "0.20mm Standard @TEST",
+        ("Generic PLA @TEST",),
+        auto_arrange=auto_arrange,
+        ensure_on_bed=True,
+    )
+    commands = []
+
+    def runner(command, **_kwargs):
+        commands.append(tuple(command))
+        settings = command[command.index("--load-settings") + 1].split(";")
+        machine = json.loads(Path(settings[0]).read_text(encoding="utf-8"))
+        process = json.loads(Path(settings[1]).read_text(encoding="utf-8"))
+        filament_path = Path(command[command.index("--load-filaments") + 1])
+        filament = json.loads(filament_path.read_text(encoding="utf-8"))
+        assert machine["printable_area"][-1] == "0x256"
+        assert machine["machine_start_gcode"] == "G28"
+        assert process["layer_height"] == "0.2"
+        assert filament["filament_type"] == ["PLA"]
+        output = Path(command[command.index("--export-3mf") + 1])
+        _prepared_3mf(output, ("Frame", "Rotor"))
+        return subprocess.CompletedProcess(command, 0, "prepared", "")
+
+    actual = BambuStudio.prepare_bambu_project(
+        _installation(root),
+        source,
+        destination,
+        setup,
+        runner=runner,
+    )
+
+    assert actual == destination
+    arrange_index = commands[0].index("--arrange")
+    assert commands[0][arrange_index + 1] == arrange_value
+    assert "--ensure-on-bed" in commands[0]
+    assert destination.is_file()
+    assert not list(tmp_path.glob("*.partial.3mf"))
+    assert not list(tmp_path.glob("*.profile.json"))
+
+
+def test_prepare_bambu_project_rejects_object_collapse_and_preserves_source(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "profiles"
+    _profile_store(root)
+    source = tmp_path / "fan.3mf"
+    _source_3mf(source)
+    original = source.read_bytes()
+    setup = VibeCADPrint.PrintSetup(
+        "Test Printer 0.4 nozzle",
+        "0.20mm Standard @TEST",
+        ("Generic PLA @TEST",),
+    )
+
+    def runner(command, **_kwargs):
+        output = Path(command[command.index("--export-3mf") + 1])
+        _prepared_3mf(output, ("Frame",))
+        return subprocess.CompletedProcess(command, 0, "prepared", "")
+
+    with pytest.raises(VibeCADPrint.SlicerError, match="object count"):
+        BambuStudio.prepare_bambu_project(
+            _installation(root),
+            source,
+            source,
+            setup,
+            runner=runner,
+        )
+
+    assert source.read_bytes() == original
+    assert not list(tmp_path.glob("*.partial.3mf"))

--- a/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
@@ -193,15 +193,34 @@ def _source_3mf(path: Path) -> None:
         )
 
 
-def _prepared_3mf(path: Path, names: tuple[str, ...]) -> None:
+def _prepared_3mf(
+    path: Path,
+    names: tuple[str, ...],
+    *,
+    filament_ids: tuple[int, ...] | None = None,
+    project_settings: dict | None = None,
+) -> None:
+    filament_ids = filament_ids or (1,) * len(names)
     objects = "".join(
-        f'<object id="{index}"><metadata key="name" value="{name}"/></object>'
+        f'<object id="{index}"><metadata key="name" value="{name}"/>'
+        f'<metadata key="extruder" value="{filament_ids[index - 1]}"/></object>'
         for index, name in enumerate(names, start=1)
     )
     with zipfile.ZipFile(path, "w") as archive:
         archive.writestr("3D/3dmodel.model", "<model/>")
         archive.writestr("Metadata/model_settings.config", f"<config>{objects}</config>")
-        archive.writestr("Metadata/project_settings.config", "{}")
+        archive.writestr(
+            "Metadata/project_settings.config",
+            json.dumps(
+                project_settings
+                or {
+                    "filament_settings_id": [
+                        f"Filament {index}"
+                        for index in range(1, max(filament_ids, default=1) + 1)
+                    ]
+                }
+            ),
+        )
 
 
 def test_bambu_catalog_resolves_inheritance_and_exact_compatibility(
@@ -326,15 +345,21 @@ def test_prepare_bambu_project_uses_full_profiles_and_preserves_named_objects(
         assert machine["machine_start_gcode"] == "G28"
         assert process["layer_height"] == "0.2"
         assert filament["filament_type"] == ["PLA"]
+        filament_ids = command[command.index("--load-filament-ids") + 1]
+        assert filament_ids == "1,1"
         output = Path(command[command.index("--export-3mf") + 1])
-        _prepared_3mf(output, ("Frame", "Rotor"))
+        _prepared_3mf(output, ("Frame", "Rotor"), filament_ids=(1, 1))
         return subprocess.CompletedProcess(command, 0, "prepared", "")
 
+    model_files = (tmp_path / "frame.stl", tmp_path / "rotor.stl")
+    for model_file in model_files:
+        model_file.write_bytes(b"solid model")
     actual = BambuStudio.prepare_bambu_project(
         _installation(root),
         source,
         destination,
         setup,
+        model_files=model_files,
         runner=runner,
     )
 
@@ -346,6 +371,141 @@ def test_prepare_bambu_project_uses_full_profiles_and_preserves_named_objects(
     assert all(not path.exists() for path in working_directories)
     assert not list(tmp_path.glob("*.partial.3mf"))
     assert not list(tmp_path.glob("*.profile.json"))
+
+
+def test_multi_filament_command_assigns_a_filament_to_every_object(
+    tmp_path: Path,
+) -> None:
+    installation = _installation(tmp_path / "profiles")
+    setup = VibeCADPrint.PrintSetup(
+        "Dual Printer",
+        "Quality",
+        ("PLA", "PETG"),
+        object_filament_ids=(2, 1, 2),
+    )
+
+    command = BambuStudio.build_prepare_project_command(
+        installation,
+        tmp_path / "input.3mf",
+        tmp_path / "output.3mf",
+        setup,
+        tmp_path / "machine.json",
+        tmp_path / "process.json",
+        (tmp_path / "pla.json", tmp_path / "petg.json"),
+        model_files=(
+            tmp_path / "frame.stl",
+            tmp_path / "rotor.stl",
+            tmp_path / "guard.stl",
+        ),
+    )
+
+    assert command[command.index("--load-filament-ids") + 1] == "2,1,2"
+    assert command[-3:] == (
+        str(tmp_path / "frame.stl"),
+        str(tmp_path / "rotor.stl"),
+        str(tmp_path / "guard.stl"),
+    )
+    assert str(tmp_path / "input.3mf") not in command
+
+
+def test_multi_filament_command_preserves_legacy_3mf_input_without_models(
+    tmp_path: Path,
+) -> None:
+    setup = VibeCADPrint.PrintSetup(
+        "Dual Printer",
+        "Quality",
+        ("PLA", "PETG"),
+        object_filament_ids=(1, 2),
+    )
+
+    command = BambuStudio.build_prepare_project_command(
+        _installation(tmp_path / "profiles"),
+        tmp_path / "input.3mf",
+        tmp_path / "output.3mf",
+        setup,
+        tmp_path / "machine.json",
+        tmp_path / "process.json",
+        (tmp_path / "pla.json", tmp_path / "petg.json"),
+    )
+
+    assert command[-1] == str(tmp_path / "input.3mf")
+    assert "--load-filament-ids" not in command
+
+
+def test_project_metadata_normalization_preserves_exact_assignments(tmp_path: Path) -> None:
+    project = tmp_path / "prepared.3mf"
+    _prepared_3mf(
+        project,
+        ("frame.stl", "rotor.stl"),
+        filament_ids=(1, 2),
+        project_settings={
+            "filament_settings_id": ["ABS-GF", "PC"],
+            "filament_colour": ["#F2754E"],
+            "filament_map": ["1"],
+            "filament_is_support": ["0"],
+            "nozzle_diameter": ["0.4", "0.4"],
+            "default_nozzle_volume_type": ["Standard", "Standard"],
+            "nozzle_volume_type": ["Standard"],
+        },
+    )
+    setup = VibeCADPrint.PrintSetup(
+        "Bambu Lab H2D 0.4 nozzle",
+        "Quality",
+        ("ABS-GF", "PC"),
+        object_filament_ids=(1, 2),
+    )
+
+    BambuStudio._normalize_project_metadata(
+        project,
+        source_names=("Fan Frame", "Fan Rotor"),
+        setup=setup,
+        filament_keys={"filament_is_support"},
+    )
+
+    with zipfile.ZipFile(project) as archive:
+        settings = json.loads(archive.read("Metadata/project_settings.config"))
+        model = BambuStudio.ET.fromstring(
+            archive.read("Metadata/model_settings.config")
+        )
+    objects = model.findall("./{*}object")
+    assert [
+        obj.find('./{*}metadata[@key="name"]').attrib["value"] for obj in objects
+    ] == ["Fan Frame", "Fan Rotor"]
+    assert [
+        obj.find('./{*}metadata[@key="extruder"]').attrib["value"]
+        for obj in objects
+    ] == ["1", "2"]
+    assert settings["filament_colour"] == ["#F2754E", "#F2754E"]
+    assert settings["filament_map"] == ["1", "1"]
+    assert settings["filament_is_support"] == ["0", "0"]
+    assert settings["nozzle_volume_type"] == ["Standard", "Standard"]
+
+
+def test_project_setup_keeps_only_used_filaments_and_remaps_ids() -> None:
+    setup = VibeCADPrint.PrintSetup(
+        "Dual Printer",
+        "Quality",
+        ("PLA", "PETG", "Support"),
+        object_filament_ids=(3, 1, 3),
+    )
+
+    project = BambuStudio._project_setup(setup, object_count=3)
+
+    assert project.material_profiles == ("PLA", "Support")
+    assert project.object_filament_ids == (2, 1, 2)
+
+
+@pytest.mark.parametrize("ids", [(), (1,), (1, 3)])
+def test_multi_filament_project_requires_a_valid_id_for_every_object(ids) -> None:
+    setup = VibeCADPrint.PrintSetup(
+        "Dual Printer",
+        "Quality",
+        ("PLA", "PETG"),
+        object_filament_ids=ids,
+    )
+
+    with pytest.raises(VibeCADPrint.SlicerError, match="filament.*each object"):
+        BambuStudio._project_setup(setup, object_count=2)
 
 
 def test_prepare_bambu_project_rejects_object_collapse_and_preserves_source(

--- a/src/Mod/VibeCADPrint/tests/test_commands.py
+++ b/src/Mod/VibeCADPrint/tests/test_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 import sys
 from types import SimpleNamespace
 
@@ -174,6 +175,107 @@ def test_shared_handoff_uses_the_selected_slicer_backend(
     )
     assert events[2] == ("launch", installation, handoff, setup)
     assert "Bambu Studio" in events[3][1]
+
+
+def test_object_filament_backend_prepares_from_temporary_separate_models(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    commands = PrintCommandLoader.command_module()
+    installation = VibeCADPrint.SlicerInstallation(
+        backend_id="orcaslicer",
+        version="2.4.2",
+        gui_command=("orca-slicer",),
+        cli_command=("orca-slicer",),
+        source="path",
+        display_name="OrcaSlicer 2.4.2",
+        tested_version=(2, 4, 2),
+    )
+    setup = _setup()
+    document = SimpleNamespace(Label="Fan")
+
+    class Shape:
+        def isNull(self):
+            return False
+
+    objects = (
+        SimpleNamespace(
+            Name="Frame",
+            Label="Fan Frame",
+            Document=document,
+            Shape=Shape(),
+        ),
+        SimpleNamespace(
+            Name="Rotor",
+            Label="Fan Rotor",
+            Document=document,
+            Shape=Shape(),
+        ),
+    )
+    handoff = tmp_path / "fan.3mf"
+    model_root = None
+
+    class Backend:
+        display_name = "OrcaSlicer"
+        capabilities = ("object_filament_assignment",)
+
+        def prepare_project(
+            self,
+            _installation,
+            _source,
+            _destination,
+            _setup,
+            *,
+            model_files=(),
+            source_names=(),
+        ):
+            nonlocal model_root
+            assert len(model_files) == 2
+            assert all(path.is_file() for path in model_files)
+            assert source_names == ("Fan Frame", "Fan Rotor")
+            model_root = model_files[0].parent
+            return handoff
+
+        def launch(self, *_args):
+            return VibeCADPrint.LaunchResult(("orca-slicer",), 84)
+
+    def export_models(actual_objects, directory):
+        assert actual_objects == objects
+        paths = tuple(
+            Path(directory) / f"{index}-{obj.Name}.stl"
+            for index, obj in enumerate(actual_objects, start=1)
+        )
+        for path in paths:
+            path.write_bytes(b"stl")
+        return paths
+
+    monkeypatch.setattr(
+        commands,
+        "_handoff_destination",
+        lambda _document, _objects: (handoff, False),
+    )
+    monkeypatch.setattr(
+        commands.VibeCADPrint,
+        "export_selection_3mf",
+        lambda _objects, destination: Path(destination).write_bytes(b"3mf"),
+    )
+    monkeypatch.setattr(commands.VibeCADPrint, "export_objects_stl", export_models)
+    monkeypatch.setattr(commands, "_main_window", lambda: None)
+    monkeypatch.setattr(commands, "_status", lambda _message: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "PrintSetupDialog",
+        SimpleNamespace(run_with_progress=lambda _parent, _label, operation: operation()),
+    )
+
+    assert commands.open_selected_in_slicer(
+        backend=Backend(),
+        installation=installation,
+        setup=setup,
+        selection=(document, objects),
+    )
+    assert model_root is not None
+    assert not model_root.exists()
 
 
 def test_active_selection_deduplicates_a_body_and_its_picked_subelement(

--- a/src/Mod/VibeCADPrint/tests/test_commands.py
+++ b/src/Mod/VibeCADPrint/tests/test_commands.py
@@ -149,3 +149,63 @@ def test_active_selection_deduplicates_a_body_and_its_picked_subelement(
 
     assert actual_document is document
     assert objects == (frame, rotor)
+
+
+def test_explicit_panel_choices_override_the_live_selection(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    commands = PrintCommandLoader.command_module()
+    installation = _installation()
+    setup = _setup()
+    document = SimpleNamespace(Label="Fan")
+
+    class Shape:
+        def isNull(self):
+            return False
+
+    frame = SimpleNamespace(Name="Body", Document=document, Shape=Shape())
+    rotor = SimpleNamespace(Name="Body001", Document=document, Shape=Shape())
+    handoff = tmp_path / "fan.3mf"
+    exported = []
+
+    class Backend:
+        def prepare_project(self, *_args):
+            return handoff
+
+        def launch(self, *_args):
+            return VibeCADPrint.LaunchResult(("prusa-slicer",), 42)
+
+    monkeypatch.setattr(commands.VibeCADPrint, "PrusaSlicerBackend", Backend)
+    monkeypatch.setattr(
+        commands,
+        "_active_selection",
+        lambda: (_ for _ in ()).throw(
+            AssertionError("Panel choices unexpectedly reread the live selection")
+        ),
+    )
+    monkeypatch.setattr(
+        commands,
+        "_handoff_destination",
+        lambda _document, _objects: (handoff, False),
+    )
+    monkeypatch.setattr(
+        commands.VibeCADPrint,
+        "export_selection_3mf",
+        lambda objects, _destination: exported.append(objects),
+    )
+    monkeypatch.setattr(commands, "_main_window", lambda: None)
+    monkeypatch.setattr(commands, "_status", lambda _message: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "PrintSetupDialog",
+        SimpleNamespace(run_with_progress=lambda _parent, _label, operation: operation()),
+    )
+
+    assert commands.open_selected_in_prusaslicer(
+        installation=installation,
+        setup=setup,
+        selection=(document, (rotor,)),
+    )
+    assert exported == [(rotor,)]
+    assert frame not in exported[0]

--- a/src/Mod/VibeCADPrint/tests/test_commands.py
+++ b/src/Mod/VibeCADPrint/tests/test_commands.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import PrintCommandLoader
+import VibeCADPrint
+
+
+def _installation() -> VibeCADPrint.SlicerInstallation:
+    return VibeCADPrint.SlicerInstallation(
+        backend_id="prusaslicer",
+        version="2.9.6",
+        gui_command=("prusa-slicer",),
+        cli_command=("prusa-slicer",),
+        source="path",
+        display_name="PrusaSlicer 2.9.6",
+    )
+
+
+def _setup() -> VibeCADPrint.PrintSetup:
+    return VibeCADPrint.PrintSetup(
+        printer_profile="Printer",
+        print_profile="Quality",
+        material_profiles=("Material",),
+    )
+
+
+def test_panel_validated_print_does_not_reopen_or_revalidate_setup(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    commands = PrintCommandLoader.command_module()
+    installation = _installation()
+    setup = _setup()
+    handoff = tmp_path / "part.3mf"
+    events = []
+
+    class Backend:
+        def launch(self, actual_installation, actual_handoff, actual_setup):
+            events.append(
+                ("launch", actual_installation, actual_handoff, actual_setup)
+            )
+            return VibeCADPrint.LaunchResult(("prusa-slicer",), 42)
+
+    monkeypatch.setattr(commands.VibeCADPrint, "PrusaSlicerBackend", Backend)
+    monkeypatch.setattr(
+        commands,
+        "_active_selection",
+        lambda: (SimpleNamespace(Label="Part"), (SimpleNamespace(Name="Body"),)),
+    )
+    monkeypatch.setattr(
+        commands,
+        "_handoff_destination",
+        lambda _document, _objects: (handoff, False),
+    )
+    monkeypatch.setattr(
+        commands.VibeCADPrint,
+        "export_selection_3mf",
+        lambda objects, destination: events.append(("export", objects, destination)),
+    )
+    monkeypatch.setattr(
+        commands,
+        "_resolve_handoff_configuration",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("Print unexpectedly returned to Setup")
+        ),
+    )
+    monkeypatch.setattr(commands, "_status", lambda message: events.append(("status", message)))
+
+    assert commands.open_selected_in_prusaslicer(
+        installation=installation,
+        setup=setup,
+    )
+    assert events[0][0] == "export"
+    assert events[1] == ("launch", installation, handoff, setup)
+    assert events[2][0] == "status"

--- a/src/Mod/VibeCADPrint/tests/test_commands.py
+++ b/src/Mod/VibeCADPrint/tests/test_commands.py
@@ -103,6 +103,79 @@ def test_panel_validated_print_does_not_reopen_or_revalidate_setup(
     assert events[3][0] == "status"
 
 
+def test_shared_handoff_uses_the_selected_slicer_backend(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    commands = PrintCommandLoader.command_module()
+    installation = VibeCADPrint.SlicerInstallation(
+        backend_id="bambustudio",
+        version="2.8.2.61",
+        gui_command=("bambu-studio",),
+        cli_command=("bambu-studio",),
+        source="flatpak-user",
+        display_name="Bambu Studio 2.8.2.61",
+        tested_version=(2, 8, 2),
+    )
+    setup = _setup()
+    document = SimpleNamespace(Label="Fan")
+
+    class Shape:
+        def isNull(self):
+            return False
+
+    body = SimpleNamespace(Name="Rotor", Document=document, Shape=Shape())
+    handoff = tmp_path / "fan.3mf"
+    events = []
+
+    class Backend:
+        backend_id = "bambustudio"
+        display_name = "Bambu Studio"
+
+        def prepare_project(self, *args):
+            events.append(("prepare", *args))
+            return handoff
+
+        def launch(self, *args):
+            events.append(("launch", *args))
+            return VibeCADPrint.LaunchResult(("bambu-studio",), 84)
+
+    monkeypatch.setattr(
+        commands,
+        "_handoff_destination",
+        lambda _document, _objects: (handoff, False),
+    )
+    monkeypatch.setattr(
+        commands.VibeCADPrint,
+        "export_selection_3mf",
+        lambda objects, destination: events.append(("export", objects, destination)),
+    )
+    monkeypatch.setattr(commands, "_main_window", lambda: None)
+    monkeypatch.setattr(commands, "_status", lambda message: events.append(("status", message)))
+    monkeypatch.setitem(
+        sys.modules,
+        "PrintSetupDialog",
+        SimpleNamespace(run_with_progress=lambda _parent, _label, operation: operation()),
+    )
+
+    assert commands.open_selected_in_slicer(
+        backend=Backend(),
+        installation=installation,
+        setup=setup,
+        selection=(document, (body,)),
+    )
+    assert events[0] == ("export", (body,), handoff)
+    assert events[1] == (
+        "prepare",
+        installation,
+        handoff,
+        handoff,
+        setup,
+    )
+    assert events[2] == ("launch", installation, handoff, setup)
+    assert "Bambu Studio" in events[3][1]
+
+
 def test_active_selection_deduplicates_a_body_and_its_picked_subelement(
     monkeypatch,
 ) -> None:

--- a/src/Mod/VibeCADPrint/tests/test_commands.py
+++ b/src/Mod/VibeCADPrint/tests/test_commands.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from types import SimpleNamespace
 
 import PrintCommandLoader
@@ -38,6 +39,23 @@ def test_panel_validated_print_does_not_reopen_or_revalidate_setup(
     events = []
 
     class Backend:
+        def prepare_project(
+            self,
+            actual_installation,
+            source,
+            destination,
+            actual_setup,
+        ):
+            events.append(
+                (
+                    "prepare",
+                    actual_installation,
+                    source,
+                    destination,
+                    actual_setup,
+                )
+            )
+
         def launch(self, actual_installation, actual_handoff, actual_setup):
             events.append(
                 ("launch", actual_installation, actual_handoff, actual_setup)
@@ -55,6 +73,7 @@ def test_panel_validated_print_does_not_reopen_or_revalidate_setup(
         "_handoff_destination",
         lambda _document, _objects: (handoff, False),
     )
+    monkeypatch.setattr(commands, "_main_window", lambda: "main-window")
     monkeypatch.setattr(
         commands.VibeCADPrint,
         "export_selection_3mf",
@@ -68,11 +87,65 @@ def test_panel_validated_print_does_not_reopen_or_revalidate_setup(
         ),
     )
     monkeypatch.setattr(commands, "_status", lambda message: events.append(("status", message)))
+    monkeypatch.setitem(
+        sys.modules,
+        "PrintSetupDialog",
+        SimpleNamespace(run_with_progress=lambda _parent, _label, operation: operation()),
+    )
 
     assert commands.open_selected_in_prusaslicer(
         installation=installation,
         setup=setup,
     )
     assert events[0][0] == "export"
-    assert events[1] == ("launch", installation, handoff, setup)
-    assert events[2][0] == "status"
+    assert events[1] == ("prepare", installation, handoff, handoff, setup)
+    assert events[2] == ("launch", installation, handoff, setup)
+    assert events[3][0] == "status"
+
+
+def test_active_selection_deduplicates_a_body_and_its_picked_subelement(
+    monkeypatch,
+) -> None:
+    commands = PrintCommandLoader.command_module()
+    document = SimpleNamespace(Name="FanDocument")
+
+    class Shape:
+        def isNull(self):
+            return False
+
+    frame = SimpleNamespace(
+        Name="Body",
+        Label="120 mm Fan Frame",
+        TypeId="PartDesign::Body",
+        Document=document,
+        Shape=Shape(),
+    )
+    rotor = SimpleNamespace(
+        Name="Body001",
+        Label="120 mm Fan Rotor",
+        TypeId="PartDesign::Body",
+        Document=document,
+        Shape=Shape(),
+    )
+    frame_result = SimpleNamespace(
+        Name="BodyResult",
+        Label="BodyResult",
+        TypeId="PartDesign::DesignBodyPublication",
+        Document=document,
+        Shape=Shape(),
+        getParentGeoFeatureGroup=lambda: frame,
+    )
+    selection = SimpleNamespace(
+        getSelectionEx=lambda: (
+            SimpleNamespace(Object=frame, SubElementNames=()),
+            SimpleNamespace(Object=rotor, SubElementNames=()),
+            SimpleNamespace(Object=frame_result, SubElementNames=("Edge1",)),
+        )
+    )
+    monkeypatch.setitem(sys.modules, "FreeCAD", SimpleNamespace(ActiveDocument=document))
+    monkeypatch.setitem(sys.modules, "FreeCADGui", SimpleNamespace(Selection=selection))
+
+    actual_document, objects = commands._active_selection()
+
+    assert actual_document is document
+    assert objects == (frame, rotor)

--- a/src/Mod/VibeCADPrint/tests/test_export.py
+++ b/src/Mod/VibeCADPrint/tests/test_export.py
@@ -78,6 +78,35 @@ def test_export_selection_is_atomic_and_keeps_separate_objects(tmp_path: Path) -
     assert not list(tmp_path.glob("*.partial.3mf"))
 
 
+def test_export_objects_stl_writes_one_named_model_per_object(tmp_path: Path) -> None:
+    document = object()
+    objects = [
+        _object("Fan Frame", document=document),
+        _object("Fan/Frame", document=document),
+    ]
+    calls = []
+
+    def mesh_export(selected, path):
+        calls.append((tuple(selected), Path(path)))
+        Path(path).write_bytes(b"solid model")
+
+    result = VibeCADPrint.export_objects_stl(
+        objects,
+        tmp_path,
+        mesh_exporter=mesh_export,
+    )
+
+    assert result == (
+        tmp_path / "0001-Fan-Frame.stl",
+        tmp_path / "0002-Fan-Frame.stl",
+    )
+    assert [selected for selected, _path in calls] == [
+        (objects[0],),
+        (objects[1],),
+    ]
+    assert all(path.read_bytes() == b"solid model" for path in result)
+
+
 def test_managed_handoff_prunes_only_owned_old_files(tmp_path: Path) -> None:
     for index in range(12):
         path = tmp_path / f"vibecad-print-old-{index:02d}.3mf"

--- a/src/Mod/VibeCADPrint/tests/test_export.py
+++ b/src/Mod/VibeCADPrint/tests/test_export.py
@@ -97,3 +97,19 @@ def test_managed_handoff_prunes_only_owned_old_files(tmp_path: Path) -> None:
     assert destination.name.startswith("vibecad-print-A-Plate-With-Spaces-")
     assert unrelated.exists()
     assert len(list(tmp_path.glob("vibecad-print-*.3mf"))) == 10
+
+
+def test_persistent_handoff_path_never_prunes_user_folder(tmp_path: Path) -> None:
+    existing = tmp_path / "previous-print.3mf"
+    existing.write_bytes(b"keep")
+
+    destination = VibeCADPrint.persistent_handoff_path(
+        tmp_path,
+        document_label="Gearbox / Rev B",
+        object_names=("Housing", "Cover"),
+    )
+
+    assert destination.parent == tmp_path
+    assert destination.name.startswith("Gearbox-Rev-B-")
+    assert destination.suffix == ".3mf"
+    assert existing.read_bytes() == b"keep"

--- a/src/Mod/VibeCADPrint/tests/test_export.py
+++ b/src/Mod/VibeCADPrint/tests/test_export.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import VibeCADPrint
+
+
+class _Shape:
+    def __init__(self, null: bool = False) -> None:
+        self._null = null
+
+    def isNull(self) -> bool:
+        return self._null
+
+
+def _object(name: str, *, document=None, printable: bool = True):
+    return SimpleNamespace(
+        Name=name,
+        Label=name,
+        Document=document,
+        Shape=_Shape(null=not printable),
+    )
+
+
+def test_collect_printable_objects_deduplicates_owners_and_rejects_mixed_selection() -> (
+    None
+):
+    document = object()
+    first = _object("First", document=document)
+    unsupported = _object("Spreadsheet", document=document, printable=False)
+
+    with pytest.raises(VibeCADPrint.PrintSelectionError) as error:
+        VibeCADPrint.collect_printable_objects(
+            [first, first, unsupported], active_document=document
+        )
+
+    assert "Spreadsheet" in str(error.value)
+    assert "First" not in str(error.value)
+
+
+def test_collect_printable_objects_requires_explicit_selection_and_active_document() -> (
+    None
+):
+    with pytest.raises(VibeCADPrint.PrintSelectionError, match="active document"):
+        VibeCADPrint.collect_printable_objects([], active_document=None)
+    with pytest.raises(VibeCADPrint.PrintSelectionError, match="Select at least one"):
+        VibeCADPrint.collect_printable_objects([], active_document=object())
+
+
+def test_export_selection_is_atomic_and_keeps_separate_objects(tmp_path: Path) -> None:
+    document = object()
+    objects = [
+        _object("First", document=document),
+        _object("Second", document=document),
+    ]
+    calls = []
+
+    def mesh_export(selected, path):
+        calls.append((tuple(selected), path))
+        Path(path).write_bytes(b"3MF payload")
+
+    destination = tmp_path / "plate.3mf"
+    result = VibeCADPrint.export_selection_3mf(
+        objects,
+        destination,
+        mesh_exporter=mesh_export,
+    )
+
+    assert result == destination
+    assert destination.read_bytes() == b"3MF payload"
+    assert calls[0][0] == tuple(objects)
+    assert calls[0][1].endswith(".partial.3mf")
+    assert not list(tmp_path.glob("*.partial.3mf"))
+
+
+def test_managed_handoff_prunes_only_owned_old_files(tmp_path: Path) -> None:
+    for index in range(12):
+        path = tmp_path / f"vibecad-print-old-{index:02d}.3mf"
+        path.write_text(str(index), encoding="utf-8")
+        path.touch()
+    unrelated = tmp_path / "keep-me.3mf"
+    unrelated.write_text("user", encoding="utf-8")
+
+    destination = VibeCADPrint.managed_handoff_path(
+        tmp_path,
+        document_label="A Plate / With Spaces",
+        object_names=("First", "Second"),
+        keep=10,
+    )
+
+    assert destination.parent == tmp_path
+    assert destination.name.startswith("vibecad-print-A-Plate-With-Spaces-")
+    assert unrelated.exists()
+    assert len(list(tmp_path.glob("vibecad-print-*.3mf"))) == 10

--- a/src/Mod/VibeCADPrint/tests/test_orca_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_orca_backend.py
@@ -115,6 +115,7 @@ def test_orca_project_command_keeps_explicit_placement_and_profiles(
         ("PLA", "PETG"),
         auto_arrange=False,
         ensure_on_bed=True,
+        object_filament_ids=(1, 2),
     )
     command = OrcaSlicer.build_prepare_project_command(
         installation,
@@ -124,6 +125,7 @@ def test_orca_project_command_keeps_explicit_placement_and_profiles(
         tmp_path / "machine.json",
         tmp_path / "process.json",
         (tmp_path / "pla.json", tmp_path / "petg.json"),
+        model_files=(tmp_path / "frame.stl", tmp_path / "rotor.stl"),
     )
 
     assert command[:3] == ("orca-slicer", "--debug", "2")
@@ -134,6 +136,11 @@ def test_orca_project_command_keeps_explicit_placement_and_profiles(
     )
     assert command[command.index("--load-filaments") + 1].endswith(
         "pla.json;" + str(tmp_path / "petg.json")
+    )
+    assert command[command.index("--load-filament-ids") + 1] == "1,2"
+    assert command[-2:] == (
+        str(tmp_path / "frame.stl"),
+        str(tmp_path / "rotor.stl"),
     )
 
 

--- a/src/Mod/VibeCADPrint/tests/test_orca_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_orca_backend.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+import OrcaSlicer
+import VibeCADPrint
+
+
+def test_orca_flatpak_discovery_uses_its_own_profile_and_config_roots(
+    tmp_path: Path,
+) -> None:
+    location = tmp_path / "flatpak-orca"
+    profiles = location / "files/share/OrcaSlicer/profiles"
+    profiles.mkdir(parents=True)
+    probe_directories = []
+
+    def runner(command, **kwargs):
+        if "--show-location" in command:
+            return subprocess.CompletedProcess(command, 0, str(location), "")
+        probe_directories.append(Path(kwargs["cwd"]))
+        return subprocess.CompletedProcess(command, 0, "OrcaSlicer-2.4.2:\n", "")
+
+    installations = OrcaSlicer.discover_orca_installations(
+        platform="linux",
+        environ={"HOME": "/home/test"},
+        runner=runner,
+        which=lambda name: "/usr/bin/flatpak" if name == "flatpak" else None,
+    )
+
+    assert {value.source for value in installations} == {
+        "flatpak-user",
+        "flatpak-system",
+    }
+    assert all(value.backend_id == "orcaslicer" for value in installations)
+    assert all(value.version == "2.4.2" for value in installations)
+    assert all(value.resource_dir == str(profiles) for value in installations)
+    assert all("com.orcaslicer.OrcaSlicer" in value.gui_command for value in installations)
+    assert all(value.tested_version == (2, 4, 2) for value in installations)
+    assert installations[0].config_dir == (
+        "/home/test/.var/app/com.orcaslicer.OrcaSlicer/config/OrcaSlicer"
+    )
+    assert probe_directories
+    assert all(not path.exists() for path in probe_directories)
+
+
+def test_orca_discovery_has_native_macos_and_windows_candidates() -> None:
+    mac = OrcaSlicer._candidate_specs(
+        "",
+        platform="darwin",
+        environ={"HOME": "/Users/test"},
+    )
+    windows = OrcaSlicer._candidate_specs(
+        "",
+        platform="win32",
+        environ={
+            "APPDATA": r"C:\Users\test\AppData\Roaming",
+            "LOCALAPPDATA": r"C:\Users\test\AppData\Local",
+            "ProgramFiles": r"C:\Program Files",
+        },
+    )
+
+    assert any("/Applications/OrcaSlicer.app/" in value.gui_command[0] for value in mac)
+    assert any(value.gui_command[0].lower().endswith("orcaslicer.exe") for value in windows)
+    assert any(value.gui_command[0].lower().endswith("orca-slicer.exe") for value in windows)
+
+
+def test_orca_project_command_keeps_explicit_placement_and_profiles(
+    tmp_path: Path,
+) -> None:
+    installation = VibeCADPrint.SlicerInstallation(
+        backend_id="orcaslicer",
+        version="2.4.2",
+        gui_command=("orca-slicer",),
+        cli_command=("orca-slicer",),
+        source="path",
+        display_name="OrcaSlicer 2.4.2",
+        tested_version=(2, 4, 2),
+    )
+    setup = VibeCADPrint.PrintSetup(
+        "Printer",
+        "Quality",
+        ("PLA", "PETG"),
+        auto_arrange=False,
+        ensure_on_bed=True,
+    )
+    command = OrcaSlicer.build_prepare_project_command(
+        installation,
+        tmp_path / "input.3mf",
+        tmp_path / "output.3mf",
+        setup,
+        tmp_path / "machine.json",
+        tmp_path / "process.json",
+        (tmp_path / "pla.json", tmp_path / "petg.json"),
+    )
+
+    assert command[:3] == ("orca-slicer", "--debug", "2")
+    assert command[command.index("--arrange") + 1] == "0"
+    assert "--ensure-on-bed" in command
+    assert command[command.index("--load-settings") + 1].endswith(
+        "machine.json;" + str(tmp_path / "process.json")
+    )
+    assert command[command.index("--load-filaments") + 1].endswith(
+        "pla.json;" + str(tmp_path / "petg.json")
+    )
+
+
+def test_orca_backend_delegates_profile_project_work_without_bambu_identity(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    calls = []
+    expected = tmp_path / "prepared.3mf"
+
+    def prepare(*args, **kwargs):
+        calls.append((args, kwargs))
+        return expected
+
+    monkeypatch.setattr(OrcaSlicer.BambuStudio, "prepare_bambu_project", prepare)
+    backend = OrcaSlicer.OrcaSlicerBackend()
+    installation = VibeCADPrint.SlicerInstallation(
+        backend_id="orcaslicer",
+        version="2.4.2",
+        gui_command=("orca-slicer",),
+        cli_command=("orca-slicer",),
+        source="path",
+        display_name="OrcaSlicer 2.4.2",
+        tested_version=(2, 4, 2),
+    )
+    setup = VibeCADPrint.PrintSetup("Printer", "Quality", ("PLA",))
+
+    actual = backend.prepare_project(
+        installation,
+        tmp_path / "source.3mf",
+        expected,
+        setup,
+    )
+
+    assert actual == expected
+    assert backend.backend_id == "orcaslicer"
+    assert backend.display_name == "OrcaSlicer"
+    assert calls[0][0] == (
+        installation,
+        tmp_path / "source.3mf",
+        expected,
+        setup,
+    )

--- a/src/Mod/VibeCADPrint/tests/test_orca_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_orca_backend.py
@@ -39,8 +39,9 @@ def test_orca_flatpak_discovery_uses_its_own_profile_and_config_roots(
     assert all(value.resource_dir == str(profiles) for value in installations)
     assert all("com.orcaslicer.OrcaSlicer" in value.gui_command for value in installations)
     assert all(value.tested_version == (2, 4, 2) for value in installations)
-    assert installations[0].config_dir == (
-        "/home/test/.var/app/com.orcaslicer.OrcaSlicer/config/OrcaSlicer"
+    assert installations[0].config_dir == str(
+        Path("/home/test")
+        / ".var/app/com.orcaslicer.OrcaSlicer/config/OrcaSlicer"
     )
     assert probe_directories
     assert all(not path.exists() for path in probe_directories)
@@ -65,6 +66,35 @@ def test_orca_discovery_has_native_macos_and_windows_candidates() -> None:
     assert any("/Applications/OrcaSlicer.app/" in value.gui_command[0] for value in mac)
     assert any(value.gui_command[0].lower().endswith("orcaslicer.exe") for value in windows)
     assert any(value.gui_command[0].lower().endswith("orca-slicer.exe") for value in windows)
+
+
+def test_windows_discovery_finds_hyphenated_installer_and_registry_version(
+    tmp_path: Path,
+) -> None:
+    program_files = tmp_path / "Program Files"
+    executable = program_files / "OrcaSlicer" / "orca-slicer.exe"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"MZ")
+    profiles = executable.parent / "resources" / "profiles"
+    profiles.mkdir(parents=True)
+    appdata = tmp_path / "Donn\u00fd User" / "AppData" / "Roaming"
+
+    def runner(command, **_kwargs):
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    installations = OrcaSlicer.discover_orca_installations(
+        platform="win32",
+        environ={"ProgramFiles": str(program_files), "APPDATA": str(appdata)},
+        runner=runner,
+        which=lambda _name: None,
+        windows_version_reader=lambda _path, _product: "2.4.2",
+    )
+
+    assert len(installations) == 1
+    assert installations[0].version == "2.4.2"
+    assert installations[0].gui_command == (str(executable),)
+    assert installations[0].resource_dir == str(profiles)
+    assert installations[0].config_dir == str(appdata / "OrcaSlicer")
 
 
 def test_orca_project_command_keeps_explicit_placement_and_profiles(

--- a/src/Mod/VibeCADPrint/tests/test_preferences.py
+++ b/src/Mod/VibeCADPrint/tests/test_preferences.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+import PrintPreferences
+import VibeCADPrint
+
+
+class _Params:
+    def __init__(self) -> None:
+        self.values = {}
+
+    def SetString(self, key, value) -> None:
+        self.values[key] = str(value)
+
+    def GetString(self, key, default="") -> str:
+        return str(self.values.get(key, default))
+
+    def SetBool(self, key, value) -> None:
+        self.values[key] = bool(value)
+
+    def GetBool(self, key, default=False) -> bool:
+        return bool(self.values.get(key, default))
+
+    def RemString(self, key) -> None:
+        self.values.pop(key, None)
+
+    def RemBool(self, key) -> None:
+        self.values.pop(key, None)
+
+
+def _setup() -> VibeCADPrint.PrintSetup:
+    return VibeCADPrint.PrintSetup(
+        printer_profile="Original Prusa XL - 5T 0.4 nozzle",
+        print_profile="0.20mm SPEED @XL 0.4",
+        material_profiles=("Generic PLA @XL", "Generic PETG @XL"),
+        auto_arrange=False,
+        ensure_on_bed=True,
+    )
+
+
+def test_confirmed_setup_round_trips_exact_names_and_placement() -> None:
+    params = _Params()
+
+    PrintPreferences.save_confirmed_setup(_setup(), params=params)
+
+    assert PrintPreferences.load_confirmed_setup(params=params) == _setup()
+    assert params.values["MaterialProfilesJson"] == (
+        '["Generic PLA @XL", "Generic PETG @XL"]'
+    )
+
+
+def test_incomplete_or_invalid_persisted_setup_is_not_guessed() -> None:
+    params = _Params()
+    params.values.update(
+        {
+            "PrinterProfile": "Printer",
+            "PrintProfile": "Print",
+            "MaterialProfilesJson": "not JSON",
+        }
+    )
+
+    assert PrintPreferences.load_confirmed_setup(params=params) is None
+
+
+def test_placement_defaults_are_on_only_after_an_explicit_complete_setup() -> None:
+    params = _Params()
+    params.values.update(
+        {
+            "PrinterProfile": "Printer",
+            "PrintProfile": "Print",
+            "MaterialProfilesJson": '["Material"]',
+        }
+    )
+
+    setup = PrintPreferences.load_confirmed_setup(params=params)
+
+    assert setup is not None
+    assert setup.auto_arrange is True
+    assert setup.ensure_on_bed is True
+
+
+def test_executable_override_and_clear_are_additive_preferences() -> None:
+    params = _Params()
+
+    PrintPreferences.set_executable_override(
+        " /opt/Prusa Slicer/prusa-slicer ", params=params
+    )
+    PrintPreferences.save_confirmed_setup(_setup(), params=params)
+    PrintPreferences.clear_confirmed_setup(params=params)
+
+    assert PrintPreferences.executable_override(params=params) == (
+        "/opt/Prusa Slicer/prusa-slicer"
+    )
+    assert PrintPreferences.load_confirmed_setup(params=params) is None
+    assert params.values == {"PrusaSlicerExecutable": "/opt/Prusa Slicer/prusa-slicer"}

--- a/src/Mod/VibeCADPrint/tests/test_preferences.py
+++ b/src/Mod/VibeCADPrint/tests/test_preferences.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import PrintPreferences
 import VibeCADPrint
+import pytest
 
 
 class _Params:
@@ -94,3 +95,29 @@ def test_executable_override_and_clear_are_additive_preferences() -> None:
     )
     assert PrintPreferences.load_confirmed_setup(params=params) is None
     assert params.values == {"PrusaSlicerExecutable": "/opt/Prusa Slicer/prusa-slicer"}
+
+
+def test_handoff_storage_round_trips_managed_or_explicit_folder() -> None:
+    params = _Params()
+
+    assert PrintPreferences.load_handoff_storage(params=params) == (
+        PrintPreferences.HandoffStorage(mode="managed", directory="")
+    )
+
+    storage = PrintPreferences.HandoffStorage(
+        mode="folder",
+        directory="/home/maker/Print Projects",
+    )
+    PrintPreferences.save_handoff_storage(storage, params=params)
+
+    assert PrintPreferences.load_handoff_storage(params=params) == storage
+
+
+def test_custom_handoff_storage_requires_an_explicit_folder() -> None:
+    params = _Params()
+
+    with pytest.raises(ValueError, match="folder"):
+        PrintPreferences.save_handoff_storage(
+            PrintPreferences.HandoffStorage(mode="folder", directory=""),
+            params=params,
+        )

--- a/src/Mod/VibeCADPrint/tests/test_preferences.py
+++ b/src/Mod/VibeCADPrint/tests/test_preferences.py
@@ -121,3 +121,52 @@ def test_custom_handoff_storage_requires_an_explicit_folder() -> None:
             PrintPreferences.HandoffStorage(mode="folder", directory=""),
             params=params,
         )
+
+
+def test_backend_preferences_are_separate_and_prusa_keys_remain_compatible() -> None:
+    params = _Params()
+    bambu = VibeCADPrint.PrintSetup(
+        printer_profile="Bambu Lab X1 Carbon 0.4 nozzle",
+        print_profile="0.20mm Standard @BBL X1C",
+        material_profiles=("Generic PLA",),
+    )
+
+    assert PrintPreferences.active_backend(params=params) == "prusaslicer"
+    PrintPreferences.set_active_backend("bambustudio", params=params)
+    PrintPreferences.set_executable_override(
+        "/opt/BambuStudio/bin/bambu-studio",
+        backend_id="bambustudio",
+        params=params,
+    )
+    PrintPreferences.save_confirmed_setup(
+        _setup(),
+        backend_id="prusaslicer",
+        params=params,
+    )
+    PrintPreferences.save_confirmed_setup(
+        bambu,
+        backend_id="bambustudio",
+        params=params,
+    )
+
+    assert PrintPreferences.active_backend(params=params) == "bambustudio"
+    assert PrintPreferences.load_confirmed_setup(
+        backend_id="prusaslicer", params=params
+    ) == _setup()
+    assert PrintPreferences.load_confirmed_setup(
+        backend_id="bambustudio", params=params
+    ) == bambu
+    assert PrintPreferences.executable_override(
+        backend_id="bambustudio", params=params
+    ) == "/opt/BambuStudio/bin/bambu-studio"
+    assert params.values["PrinterProfile"] == _setup().printer_profile
+    assert params.values["BambuStudioPrinterProfile"] == bambu.printer_profile
+
+
+def test_unknown_backend_preference_is_rejected_without_changing_state() -> None:
+    params = _Params()
+
+    with pytest.raises(ValueError, match="backend"):
+        PrintPreferences.set_active_backend("unknown", params=params)
+
+    assert params.values == {}

--- a/src/Mod/VibeCADPrint/tests/test_workbench.py
+++ b/src/Mod/VibeCADPrint/tests/test_workbench.py
@@ -91,6 +91,7 @@ def test_cmake_installs_module_tests_and_icons() -> None:
     assert "tests/test_backend.py" in cmake
     assert "tests/qt_selection_integration.py" in cmake
     assert "tests/qt_panel_persistence_integration.py" in cmake
+    assert "tests/qt_progress_integration.py" in cmake
     assert "Mod/VibeCADPrint/icons" in cmake
 
 
@@ -146,8 +147,10 @@ def test_print_workbench_registers_and_opens_persistent_panel() -> None:
     assert "main.addDockWindow(contents, DOCK_NAME" in panel
     assert 'QPushButton("Print"' in panel
     assert 'QPushButton("Export 3MF…"' in panel
-    assert "Selections are saved automatically" in panel
-    assert "SELECTED OBJECTS" in panel
+    assert "Selections are saved automatically" not in panel
+    assert "self.output_location.hide()" in panel
+    assert 'QGroupBox("Objects to be sent"' in panel
+    assert "object_checkboxes" in panel
     assert 'setObjectName("VibeCADPrintSelectionSummary")' in panel
     assert "ScrollBarAlwaysOff" in panel
     assert "Auto-arrange" in panel

--- a/src/Mod/VibeCADPrint/tests/test_workbench.py
+++ b/src/Mod/VibeCADPrint/tests/test_workbench.py
@@ -79,6 +79,7 @@ def test_cmake_installs_module_tests_and_icons() -> None:
     assert "add_subdirectory(VibeCADPrint)" in parent
     for filename in (
         "InitGui.py",
+        "BambuStudio.py",
         "VibeCADPrint.py",
         "PrintPreferences.py",
         "PrintPanel.py",
@@ -89,6 +90,9 @@ def test_cmake_installs_module_tests_and_icons() -> None:
         assert filename in cmake
     assert "icons/vibecad-print-open.svg" in cmake
     assert "tests/test_backend.py" in cmake
+    assert "tests/test_bambu_backend.py" in cmake
+    assert "tests/qt_bambu_setup_integration.py" in cmake
+    assert "tests/qt_backend_switch_integration.py" in cmake
     assert "tests/qt_selection_integration.py" in cmake
     assert "tests/qt_panel_persistence_integration.py" in cmake
     assert "tests/qt_progress_integration.py" in cmake
@@ -115,7 +119,7 @@ def test_setup_dialog_exposes_guided_detection_profiles_and_placement() -> None:
     for text in (
         "Auto-detect",
         "Locate",
-        "Open PrusaSlicer",
+        'f"Open {self.slicer_name}"',
         "Download",
         "Retry",
         "Printer profile",

--- a/src/Mod/VibeCADPrint/tests/test_workbench.py
+++ b/src/Mod/VibeCADPrint/tests/test_workbench.py
@@ -83,6 +83,7 @@ def test_cmake_installs_module_tests_and_icons() -> None:
         "InitGui.py",
         "VibeCADPrint.py",
         "PrintPreferences.py",
+        "PrintPanel.py",
         "PrintSetupDialog.py",
         "Commands.py",
         "PrintCommandLoader.py",
@@ -125,3 +126,19 @@ def test_setup_dialog_exposes_guided_detection_profiles_and_placement() -> None:
         assert text in source
     assert "ThreadPoolExecutor" in source
     assert "one material profile for every extruder" in source
+
+
+def test_print_workbench_registers_and_opens_persistent_panel() -> None:
+    init_gui = (ROOT / "InitGui.py").read_text(encoding="utf-8")
+    commands = (ROOT / "Commands.py").read_text(encoding="utf-8")
+    panel = (ROOT / "PrintPanel.py").read_text(encoding="utf-8")
+
+    assert "PrintPanel.ensure_panel_registered()" in init_gui
+    assert "PrintPanel.show_panel()" in init_gui
+    assert "PrintPanel.hide_panel()" in init_gui
+    assert "PrintPanel.show_panel()" in commands
+    assert 'DOCK_NAME = "VibeCADPrintPanel"' in panel
+    assert "Managed VibeCAD cache" in panel
+    assert "Choose a folder" in panel
+    assert "Auto-arrange" in panel
+    assert "Ensure on bed" in panel

--- a/src/Mod/VibeCADPrint/tests/test_workbench.py
+++ b/src/Mod/VibeCADPrint/tests/test_workbench.py
@@ -89,6 +89,8 @@ def test_cmake_installs_module_tests_and_icons() -> None:
         assert filename in cmake
     assert "icons/vibecad-print-open.svg" in cmake
     assert "tests/test_backend.py" in cmake
+    assert "tests/qt_selection_integration.py" in cmake
+    assert "tests/qt_panel_persistence_integration.py" in cmake
     assert "Mod/VibeCADPrint/icons" in cmake
 
 
@@ -141,9 +143,12 @@ def test_print_workbench_registers_and_opens_persistent_panel() -> None:
     )[0]
     assert "choose_print_setup" not in resolver
     assert 'DOCK_NAME = "VibeCADPrintPanel"' in panel
+    assert "main.addDockWindow(contents, DOCK_NAME" in panel
     assert 'QPushButton("Print"' in panel
     assert 'QPushButton("Export 3MF…"' in panel
     assert "Selections are saved automatically" in panel
+    assert "SELECTED OBJECTS" in panel
+    assert 'setObjectName("VibeCADPrintSelectionSummary")' in panel
     assert "ScrollBarAlwaysOff" in panel
     assert "Auto-arrange" in panel
     assert "Ensure on bed" in panel

--- a/src/Mod/VibeCADPrint/tests/test_workbench.py
+++ b/src/Mod/VibeCADPrint/tests/test_workbench.py
@@ -65,9 +65,7 @@ def test_commands_have_specific_labels_tooltips_and_repo_icons(monkeypatch) -> N
     PrintCommandLoader.ensure_commands_registered(gui=gui)
     resources = {name: command.GetResources() for name, command in registered.items()}
 
-    assert resources["VibeCADPrint_OpenInPrusaSlicer"]["MenuText"] == (
-        "Open in PrusaSlicer"
-    )
+    assert resources["VibeCADPrint_OpenInPrusaSlicer"]["MenuText"] == "Print"
     assert "selected" in resources["VibeCADPrint_OpenInPrusaSlicer"]["ToolTip"].lower()
     assert resources["VibeCADPrint_Save3MF"]["MenuText"] == "Save 3MF"
     assert resources["VibeCADPrint_Setup"]["MenuText"] == "Print Setup"
@@ -136,9 +134,44 @@ def test_print_workbench_registers_and_opens_persistent_panel() -> None:
     assert "PrintPanel.ensure_panel_registered()" in init_gui
     assert "PrintPanel.show_panel()" in init_gui
     assert "PrintPanel.hide_panel()" in init_gui
-    assert "PrintPanel.show_panel()" in commands
+    assert "PrintPanel.open_setup_dialog" in commands
+    assert "PrintPanel.show_panel(refresh=False)" in commands
+    resolver = commands.split("def _resolve_handoff_configuration", 1)[1].split(
+        "def _managed_cache_directory", 1
+    )[0]
+    assert "choose_print_setup" not in resolver
     assert 'DOCK_NAME = "VibeCADPrintPanel"' in panel
-    assert "Managed VibeCAD cache" in panel
-    assert "Choose a folder" in panel
+    assert 'QPushButton("Print"' in panel
+    assert 'QPushButton("Export 3MF…"' in panel
+    assert "Selections are saved automatically" in panel
+    assert "ScrollBarAlwaysOff" in panel
     assert "Auto-arrange" in panel
     assert "Ensure on bed" in panel
+
+
+def test_print_and_setup_commands_use_separate_daily_and_configuration_surfaces(
+    monkeypatch,
+) -> None:
+    registered = {}
+    gui = SimpleNamespace(
+        addCommand=lambda name, command: registered.__setitem__(name, command),
+        listCommands=lambda: list(registered),
+        getMainWindow=lambda: "main-window",
+    )
+    calls = []
+    daily_panel = SimpleNamespace(print_selected=lambda: calls.append("print"))
+    print_panel = SimpleNamespace(
+        show_panel=lambda *, refresh: calls.append(("show", refresh)) or daily_panel,
+        open_setup_dialog=lambda *, parent: calls.append(("setup", parent)),
+    )
+    monkeypatch.setitem(sys.modules, "FreeCADGui", gui)
+    monkeypatch.setitem(sys.modules, "PrintPanel", print_panel)
+    monkeypatch.delitem(sys.modules, "_vibecad_print_commands", raising=False)
+
+    import PrintCommandLoader
+
+    PrintCommandLoader.ensure_commands_registered(gui=gui)
+    registered["VibeCADPrint_OpenInPrusaSlicer"].Activated()
+    registered["VibeCADPrint_Setup"].Activated()
+
+    assert calls == [("show", False), "print", ("setup", "main-window")]

--- a/src/Mod/VibeCADPrint/tests/test_workbench.py
+++ b/src/Mod/VibeCADPrint/tests/test_workbench.py
@@ -67,6 +67,7 @@ def test_commands_have_specific_labels_tooltips_and_repo_icons(monkeypatch) -> N
 
     assert resources["VibeCADPrint_OpenInPrusaSlicer"]["MenuText"] == "Print"
     assert "selected" in resources["VibeCADPrint_OpenInPrusaSlicer"]["ToolTip"].lower()
+    assert "external slicer" in resources["VibeCADPrint_OpenInPrusaSlicer"]["ToolTip"].lower()
     assert resources["VibeCADPrint_Save3MF"]["MenuText"] == "Save 3MF"
     assert resources["VibeCADPrint_Setup"]["MenuText"] == "Print Setup"
     assert all(Path(value["Pixmap"]).is_file() for value in resources.values())
@@ -80,6 +81,7 @@ def test_cmake_installs_module_tests_and_icons() -> None:
     for filename in (
         "InitGui.py",
         "BambuStudio.py",
+        "OrcaSlicer.py",
         "VibeCADPrint.py",
         "PrintPreferences.py",
         "PrintPanel.py",
@@ -91,6 +93,7 @@ def test_cmake_installs_module_tests_and_icons() -> None:
     assert "icons/vibecad-print-open.svg" in cmake
     assert "tests/test_backend.py" in cmake
     assert "tests/test_bambu_backend.py" in cmake
+    assert "tests/test_orca_backend.py" in cmake
     assert "tests/qt_bambu_setup_integration.py" in cmake
     assert "tests/qt_backend_switch_integration.py" in cmake
     assert "tests/qt_selection_integration.py" in cmake

--- a/src/Mod/VibeCADPrint/tests/test_workbench.py
+++ b/src/Mod/VibeCADPrint/tests/test_workbench.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+
+ROOT = Path(__file__).resolve().parents[1]
+REPO = ROOT.parents[2]
+
+
+def test_initgui_registers_first_class_print_workbench_and_preferences() -> None:
+    source = (ROOT / "InitGui.py").read_text(encoding="utf-8")
+
+    assert "class VibeCADPrintWorkbench" in source
+    assert 'MenuText = "3D Print"' in source
+    assert 'self.appendToolbar("Send"' in source
+    assert 'self.appendToolbar("Setup"' in source
+    assert (
+        'Gui.addPreferencePage(PrintSetupDialog.VibeCADPrintPreferencesPage, "VibeCAD")'
+        in source
+    )
+    assert "Gui.addWorkbench(VibeCADPrintWorkbench())" in source
+
+
+def test_workbench_commands_are_registered_without_global_commands_collision(
+    monkeypatch,
+) -> None:
+    registered = {}
+    gui = SimpleNamespace(
+        addCommand=lambda name, command: registered.__setitem__(name, command),
+        listCommands=lambda: list(registered),
+    )
+    generic_commands = SimpleNamespace(owner="another workbench")
+    monkeypatch.setitem(sys.modules, "FreeCADGui", gui)
+    monkeypatch.setitem(sys.modules, "Commands", generic_commands)
+    monkeypatch.delitem(sys.modules, "PrintCommandLoader", raising=False)
+    monkeypatch.delitem(sys.modules, "_vibecad_print_commands", raising=False)
+
+    import PrintCommandLoader
+
+    PrintCommandLoader.ensure_commands_registered(gui=gui)
+
+    assert set(registered) == {
+        "VibeCADPrint_OpenInPrusaSlicer",
+        "VibeCADPrint_Save3MF",
+        "VibeCADPrint_Setup",
+    }
+    assert sys.modules["Commands"] is generic_commands
+
+
+def test_commands_have_specific_labels_tooltips_and_repo_icons(monkeypatch) -> None:
+    registered = {}
+    gui = SimpleNamespace(
+        addCommand=lambda name, command: registered.__setitem__(name, command),
+        listCommands=lambda: list(registered),
+    )
+    monkeypatch.setitem(sys.modules, "FreeCADGui", gui)
+    monkeypatch.delitem(sys.modules, "_vibecad_print_commands", raising=False)
+
+    import PrintCommandLoader
+
+    PrintCommandLoader.ensure_commands_registered(gui=gui)
+    resources = {name: command.GetResources() for name, command in registered.items()}
+
+    assert resources["VibeCADPrint_OpenInPrusaSlicer"]["MenuText"] == (
+        "Open in PrusaSlicer"
+    )
+    assert "selected" in resources["VibeCADPrint_OpenInPrusaSlicer"]["ToolTip"].lower()
+    assert resources["VibeCADPrint_Save3MF"]["MenuText"] == "Save 3MF"
+    assert resources["VibeCADPrint_Setup"]["MenuText"] == "Print Setup"
+    assert all(Path(value["Pixmap"]).is_file() for value in resources.values())
+
+
+def test_cmake_installs_module_tests_and_icons() -> None:
+    cmake = (ROOT / "CMakeLists.txt").read_text(encoding="utf-8")
+    parent = (ROOT.parent / "CMakeLists.txt").read_text(encoding="utf-8")
+
+    assert "add_subdirectory(VibeCADPrint)" in parent
+    for filename in (
+        "InitGui.py",
+        "VibeCADPrint.py",
+        "PrintPreferences.py",
+        "PrintSetupDialog.py",
+        "Commands.py",
+        "PrintCommandLoader.py",
+    ):
+        assert filename in cmake
+    assert "icons/vibecad-print-open.svg" in cmake
+    assert "tests/test_backend.py" in cmake
+    assert "Mod/VibeCADPrint/icons" in cmake
+
+
+def test_native_ribbon_owns_dedicated_3d_print_domain() -> None:
+    ribbon = (REPO / "src/Gui/VibeCADRibbon.cpp").read_text(encoding="utf-8")
+    integration = (
+        REPO / "src/Mod/VibeCAD/vibecad_tests/qt_ribbon_theme_integration.py"
+    ).read_text(encoding="utf-8")
+
+    assert "std::array<DomainDefinition, 9>" in ribbon
+    assert '{"3D Print", "VibeCADPrintWorkbench", "print"}' in ribbon
+    assert '"VibeCADPrintWorkbench": "print"' in integration
+    assert '"VibeCADPrint_OpenInPrusaSlicer"' in integration
+    assert '"VibeCADPrint_Save3MF"' in integration
+    assert '"VibeCADPrint_Setup"' in integration
+
+
+def test_setup_dialog_exposes_guided_detection_profiles_and_placement() -> None:
+    source = (ROOT / "PrintSetupDialog.py").read_text(encoding="utf-8")
+
+    for text in (
+        "Auto-detect",
+        "Locate",
+        "Open PrusaSlicer",
+        "Download",
+        "Retry",
+        "Printer profile",
+        "Print profile",
+        "Auto-arrange",
+        "Ensure on bed",
+        "Open without profiles",
+    ):
+        assert text in source
+    assert "ThreadPoolExecutor" in source
+    assert "one material profile for every extruder" in source


### PR DESCRIPTION
## Summary

Adds a first-class 3D Print workflow to VibeCAD for PrusaSlicer, Bambu Studio, and OrcaSlicer without guessing print settings.

Users can choose exact installed printer, process, and material profiles; select the CAD objects to send; control auto-arrange and ensure-on-bed; choose where handoff 3MF files are saved; and open the prepared project in their slicer. Bambu Studio and OrcaSlicer also support an explicit filament choice for every checked object.

## User experience

- The 3D Print ribbon opens a persistent dock panel rather than reopening setup for every print.
- The panel lists printable selected objects by name with individual checkboxes.
- Faces, edges, and other sub-element selections resolve to their owning body and do not create duplicate exports.
- Multiple selected bodies remain separate, exactly named slicer objects.
- Bambu/Orca users explicitly map each checked object to a selected filament; Print remains disabled until every mapping is complete.
- Printer, process, material, placement, slicer, panel position, and handoff-location choices are remembered where appropriate.
- Slicer discovery/profile data is cached for the VibeCAD session; Refresh explicitly invalidates the cache.
- Setup remains available for changing or repairing a slicer installation.

## Supported slicers

- PrusaSlicer
- Bambu Studio
- OrcaSlicer

Linux native/Flatpak execution has been exercised with real slicers and real multi-object handoffs. Native discovery and command construction for macOS and Windows are covered by automated tests; live Windows/macOS validation is still requested before merge.

## Implementation notes

- Preserves the existing `VibeCADPrint_OpenInPrusaSlicer` command ID and all existing setup/preparation call patterns.
- Adds optional backend arguments and capabilities for per-object filament assignment; the legacy generic-3MF preparation path remains available.
- Exports one temporary STL per selected object for Bambu/Orca CLI assignment, while retaining the user-selected 3MF as the atomic saved handoff.
- Normalizes Bambu-format project metadata shared by Bambu Studio and OrcaSlicer, including exact object names/extruders, undersized per-filament arrays, and the malformed dual-nozzle `nozzle_volume_type` vector that caused OrcaSlicer to assert and exit.
- Streams unchanged ZIP entries while atomically rewriting only project metadata, avoiding whole-project memory duplication.
- Reuses each backend's cached profile store during preparation instead of rescanning slicer data.
- Includes the Windows discovery/launch follow-up: executable file/registry version fallback, hyphenated Orca installer discovery, Unicode/space-safe arguments, and detached GUI launch.

## Deliberate non-goals

- VibeCAD does not infer or silently select print settings.
- VibeCAD does not bundle a slicer or slicing engine.
- Direct printer/cloud submission is not included.
- Explicit per-object filament mapping is currently enabled for the shared Bambu/Orca project format; PrusaSlicer keeps its existing exact-profile handoff.

## TDD and verification

Code was developed red/green as required.

Representative red gates:

- `python -m pytest -q src/Mod/VibeCADPrint/tests/test_export.py src/Mod/VibeCADPrint/tests/test_bambu_backend.py src/Mod/VibeCADPrint/tests/test_commands.py` — 5 failed, 19 passed before separate-model export/normalization was implemented.
- `python -m pytest -q src/Mod/VibeCADPrint/tests` — 3 failed, 61 passed after integrating the concurrent Windows commit, exposing cross-platform path/flag assumptions.

Final automated verification:

- `python -m pytest -q src/Mod/VibeCADPrint/tests` — 64 passed.
- `python -m ruff check src/Mod/VibeCADPrint/BambuStudio.py src/Mod/VibeCADPrint/Commands.py src/Mod/VibeCADPrint/OrcaSlicer.py src/Mod/VibeCADPrint/PrintPanel.py src/Mod/VibeCADPrint/VibeCADPrint.py src/Mod/VibeCADPrint/tests` — passed.
- `cmake --build build-print --target VibeCADPrint -j16` — passed.
- `cmake --build build-print -j16` — passed.
- `QT_QPA_PLATFORM=offscreen timeout 45s ./build-print/bin/FreeCAD src/Mod/VibeCADPrint/tests/qt_backend_switch_integration.py` — `VIBECAD_PRINT_BACKEND_SWITCH_OK`.
- Two-process dock persistence gate with `VIBECAD_PRINT_PERSISTENCE_STAGE=write/read` and isolated `-u /tmp/vibecad-print-persistence-gate.cfg` — position saved and restored.
- `QT_QPA_PLATFORM=offscreen timeout 30s ./build-print/bin/FreeCADCmd src/Mod/VibeCADPrint/tests/qt_dialog_layout.py` — passed.
- `git diff --check` — passed.

Other live Qt gates passed for setup/profile loading, panel/workbench lifecycle, progress behavior, and selection/sub-element filtering.

## Live Linux validation

- PrusaSlicer opens separate named fan-frame and fan-rotor objects with the selected exact profiles.
- Bambu Studio 2.8.2.61 and OrcaSlicer 2.4.2 both opened the same production-generated H2D project with:
  - `120 mm Fan Frame` assigned to filament 1;
  - `120 mm Fan Rotor` assigned to filament 2;
  - `Bambu ABS-GF @BBL H2D` and `Bambu PC @BBL H2D 0.4 nozzle`;
  - `0.20mm Balanced Strength @BBL H2D`;
  - two `0.4` nozzles with two `Standard` nozzle-volume entries.
- Both slicers displayed the two bodies independently on the plate. OrcaSlicer remained alive beyond the former assertion/crash window.
- Slicer-generated material/plate safety warnings remain visible; VibeCAD does not override them.

## Windows/macOS validation requested

Please verify on Windows, and macOS when available:

1. Native slicer executable discovery and manual Locate fallback.
2. User and bundled profile directory discovery.
3. Printer/process/material compatibility lists.
4. Separate named objects and Bambu/Orca per-object filament assignments.
5. Auto-arrange and ensure-on-bed behavior.
6. Paths containing spaces and non-ASCII characters.
7. Panel/preferences persistence after restarting VibeCAD.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] Existing command IDs, preference keys, tool names, and schema fields are not renamed or removed.
- [x] Existing call signatures remain valid; new arguments are optional and keyword-only.
- [x] Defaults preserve the legacy generic-3MF path for callers that do not opt into per-object assignment.
- [x] No dependency was removed or added to the VibeCAD package.
- [x] No breaking changes are included.

## Risk and rollback

Primary risk is platform-specific external-slicer behavior outside the live-tested Linux environment. The handoff remains isolated in the `VibeCADPrint` workbench and backend adapters. Rollback is a normal revert of this PR; it does not migrate user documents or remove existing APIs.
