### PR TITLE
Fix Codex runtime install checksums on macOS

### DIFF
--- a/package/rattler-build/scripts/install_vibecad_codex_runtime.sh
+++ b/package/rattler-build/scripts/install_vibecad_codex_runtime.sh
@@ -66,12 +66,28 @@ case "${platform}:${machine}" in
 esac
 
 archive_url="${release_root}/${archive}"
+
+# Portable SHA-256 helpers (GNU coreutils on Linux; BSD sha256sum on macOS).
+# macOS /sbin/sha256sum rejects GNU long options such as --check/--status and
+# does not read checksum lines from stdin the same way.
+sha256_file() {
+    sha256sum "$1" | awk '{print $1}'
+}
+
+sha256_matches() {
+    local expected="$1"
+    local path="$2"
+    local actual
+    actual="$(sha256_file "${path}")"
+    [[ "${actual}" == "${expected}" ]]
+}
+
 runtime_spec="$({
     printf '%s\n' \
         "version=${codex_version}" \
         "archive=${archive}:${archive_sha256}" \
         "license=${license_sha256}"
-    sha256sum "$0"
+    sha256_file "$0"
 } | sha256sum | awk '{print $1}')"
 
 smoke_runtime() {
@@ -99,14 +115,19 @@ download_verified() {
     local url="$1"
     local expected="$2"
     local destination="$3"
-    if [[ -f "${destination}" ]] \
-      && echo "${expected}  ${destination}" | sha256sum --check --status; then
+    if [[ -f "${destination}" ]] && sha256_matches "${expected}" "${destination}"; then
         return
     fi
     local temporary="${destination}.tmp"
     rm -f "${temporary}"
     curl --fail --location --retry 4 --retry-all-errors --output "${temporary}" "${url}"
-    echo "${expected}  ${temporary}" | sha256sum --check
+    if ! sha256_matches "${expected}" "${temporary}"; then
+        local actual
+        actual="$(sha256_file "${temporary}")"
+        rm -f "${temporary}"
+        echo "SHA-256 mismatch for ${url}: expected ${expected}, got ${actual}" >&2
+        exit 1
+    fi
     mv "${temporary}" "${destination}"
 }
 


### PR DESCRIPTION
## Summary

`pixi run build-release` on macOS was failing **after** a successful compile when `install_vibecad_codex_runtime.sh` verified downloads. macOS `/sbin/sha256sum` is BSD-style and rejects GNU `sha256sum --check` / `--status` (and stdin checksum lines), so the Codex app-server never installed and ChatGPT / Codex-backed paths could not start from a fresh local release.

This change compares SHA-256 digests portably by hashing the file and string-comparing the expected digest. Behavior on Linux with GNU coreutils is unchanged in outcome.

- [x] This PR is not unverified AI output, I take responsibility for it, and all communication from my side in this PR is done by me personally.

AI assistance: Grok (grok-4.5) helped diagnose the macOS `sha256sum` failure and draft the portable hash helpers. Commit includes `Assisted-by: grok-4.5`.

## Issues

None filed; found while building local release on macOS arm64.

## Test plan

- [x] On macOS arm64, `install_vibecad_codex_runtime.sh` reports runtime current / installs `codex-app-server 0.144.5`
- [x] Forced reinstall (corrupt stamp) succeeds using cached archive (hash match path)
- [x] Negative: wrong expected hash is rejected; positive: matching hash accepted
- [x] `codex-app-server --version` and FreeCADCmd Codex smoke OK after install
- [ ] Linux CI / local release still verifies archives (GNU `sha256sum` path)

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible (packaging script only)
- [x] No preference keys, tool names, or schema fields renamed/removed
- [x] Defaults preserve previous behavior for users who do not opt into new features
- [x] Breaking changes: none

## Before and After

N/A (no GUI change). Before: release script exits with `usage: sha256sum [-bctwz] [files ...]`. After: Codex runtime installs and smoke continues.