### PR TITLE
Bump VibeCAD RC5 to build 2

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 1
+  number: 2
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC5",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 1,
+  "build_version": 2,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Outcome

Bumps the canonical VibeCAD release identity from RC5 Build 1 to RC5 Build 2 so the fully merged feature set can be published as an immutable prerelease.

## Changes

- `version.json`: `build_version` 1 -> 2
- `package/rattler-build/recipe.yaml`: rattler build number 1 -> 2
- Canonical tag: `v26.3.1-RC5-build2`
- Canonical title: `VibeCAD 26.3.1-RC5 (Build 2)`

## Verification

TDD does not apply because this is release metadata only; no application behavior changed.

- `py -3.11 src/Tools/sync_version.py --check` -> passed
- Release/update contract suite -> 113 passed, 3 skipped
- `pytest -q src/Mod/VibeCADPrint/tests` -> 64 passed
- `pytest -q src/Mod/VibeCAD/vibecad_tests/test_section_view.py` -> 14 passed
- `git diff --check` -> passed

## Compatibility

- [x] Existing public functions/APIs remain unchanged.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults and runtime behavior are unchanged.
- [x] No deprecations or breaking changes.