### PR TITLE
Let macOS pick Orca or Bambu and show 3D Print without a rebuild

### DIFF
--- a/src/Mod/VibeCADPrint/CMakeLists.txt
+++ b/src/Mod/VibeCADPrint/CMakeLists.txt
@@ -3,6 +3,7 @@
 SET(VibeCADPrint_SRCS
     Init.py
     InitGui.py
+    PrintInstallUI.py
     BambuStudio.py
     OrcaSlicer.py
     Commands.py
@@ -36,6 +37,7 @@ SET(VibeCADPrint_Tests
     tests/test_orca_backend.py
     tests/test_commands.py
     tests/test_export.py
+    tests/test_install_ui.py
     tests/test_preferences.py
     tests/test_workbench.py
 )

--- a/src/Mod/VibeCADPrint/Init.py
+++ b/src/Mod/VibeCADPrint/Init.py
@@ -1,3 +1,35 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 """Application bootstrap for the VibeCAD 3D Print module."""
+
+
+def _schedule_print_ui() -> None:
+    """Install the ribbon tab after the main window exists.
+
+    InitGui QTimer.singleShot(0) can fire before VibeCAD's ribbon is built.
+    Repeat the install from here as well when the GUI is already up.
+    """
+
+    try:
+        import FreeCAD as App
+
+        if not getattr(App, "GuiUp", False):
+            return
+        from PySide import QtCore
+
+        def _boot() -> None:
+            try:
+                import PrintInstallUI
+
+                PrintInstallUI.install_with_retry()
+            except Exception:
+                pass
+
+        for delay_ms in (500, 2000, 5000):
+            QtCore.QTimer.singleShot(delay_ms, _boot)
+    except Exception:
+        pass
+
+
+_schedule_print_ui()
+

--- a/src/Mod/VibeCADPrint/InitGui.py
+++ b/src/Mod/VibeCADPrint/InitGui.py
@@ -1,6 +1,13 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""GUI bootstrap for VibeCAD's additive 3D Print workbench."""
+"""GUI bootstrap for VibeCAD's additive 3D Print workbench.
+
+VibeCAD hides the classic workbench combo. Register the Python workbench,
+then PrintInstallUI pins a 3D Print ribbon tab on app builds that predate the
+compiled ribbon domain.
+"""
+
+import PrintIcons
 
 
 class VibeCADPrintWorkbench(Workbench):
@@ -10,12 +17,11 @@ class VibeCADPrintWorkbench(Workbench):
     ToolTip = "Prepare selected CAD objects and open them in an external slicer"
 
     def __init__(self):
-        self.__class__.Icon = (
-            FreeCAD.getHomePath() + "Mod/VibeCADPrint/icons/vibecad-print-open.svg"
-        )
+        self.__class__.Icon = PrintIcons.icon_path("open")
 
     def Initialize(self):
         import PrintCommandLoader
+        import PrintInstallUI
         import PrintPanel
 
         PrintCommandLoader.ensure_commands_registered()
@@ -28,6 +34,7 @@ class VibeCADPrintWorkbench(Workbench):
         self.appendToolbar("Send", send_commands)
         self.appendToolbar("Setup", setup_commands)
         self.appendMenu("3D Print", send_commands + setup_commands)
+        PrintInstallUI.install_with_retry()
         Log("Loading VibeCAD 3D Print workbench... done\n")
 
     def Activated(self):
@@ -49,4 +56,35 @@ class VibeCADPrintWorkbench(Workbench):
 import PrintSetupDialog
 
 Gui.addPreferencePage(PrintSetupDialog.VibeCADPrintPreferencesPage, "VibeCAD")
-Gui.addWorkbench(VibeCADPrintWorkbench())
+try:
+    Gui.addWorkbench(VibeCADPrintWorkbench())
+except Exception as exc:
+    try:
+        Log(f"3D Print workbench register failed: {exc}\n")
+    except Exception:
+        pass
+
+
+def _boot_print_ui():
+    try:
+        import PrintInstallUI
+
+        PrintInstallUI.install_with_retry()
+    except Exception as exc:
+        try:
+            Log(f"3D Print UI install failed: {exc}\n")
+        except Exception:
+            pass
+
+
+try:
+    from PySide import QtCore
+
+    for _delay_ms in (0, 250, 750, 1500, 3000, 6000):
+        QtCore.QTimer.singleShot(_delay_ms, _boot_print_ui)
+except Exception as exc:
+    try:
+        Log(f"3D Print UI install deferred: {exc}\n")
+    except Exception:
+        pass
+

--- a/src/Mod/VibeCADPrint/PrintInstallUI.py
+++ b/src/Mod/VibeCADPrint/PrintInstallUI.py
@@ -1,0 +1,409 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Show 3D Print on VibeCAD's ribbon when the native C++ domain is missing.
+
+VibeCAD hides the classic workbench combo. A Python workbench plus a
+Preferences page is not enough on an older app build: the 3D Print ribbon
+tab is compiled into VibeCADRibbon.cpp. This installer adds that tab, the
+print dock, and a Tools menu until a rebuilt app already owns the domain.
+
+The module name is unique on purpose. McMasterInsert also ships InstallUI.py;
+a bare `import InstallUI` from InitGui.py would reuse McMaster's cached module
+and never add the 3D Print tab.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import PrintCommandLoader
+import PrintIcons
+
+
+RIBBON_TABS = "VibeCADRibbonTabs"
+RIBBON_PAGE = "VibeCADRibbonPage"
+TAB_LABEL = "3D Print"
+TAB_DATA = "VibeCADPrintWorkbench"
+GROUP_NAME = "VibeCADRibbonGroup_Print"
+RIBBON_GROUP_VERSION = 1
+MENU_NAME = "3D Print"
+# True only when this process inserted the tab. Native C++ builds already own
+# the 3D Print domain; overlay hooks must not hide those ribbon groups.
+_injected_print_tab = False
+BUTTONS = (
+    ("Print", "VibeCADPrint_OpenInPrusaSlicer", "open"),
+    ("Export 3MF", "VibeCADPrint_Save3MF", "save"),
+    ("Setup", "VibeCADPrint_Setup", "setup"),
+)
+
+
+def _log(message: str) -> None:
+    try:
+        import FreeCAD as App
+
+        App.Console.PrintMessage(f"3D Print: {message}\n")
+    except Exception:
+        pass
+
+
+def _warn(message: str) -> None:
+    try:
+        import FreeCAD as App
+
+        App.Console.PrintWarning(f"3D Print: {message}\n")
+    except Exception:
+        pass
+
+
+def _qt():
+    from PySide import QtCore, QtGui, QtWidgets
+
+    return QtCore, QtGui, QtWidgets
+
+
+def _gui():
+    import FreeCADGui as Gui
+
+    return Gui
+
+
+def _run_command(gui: Any, command_id: str):
+    def _run(_checked=False) -> None:
+        runner = getattr(gui, "runCommand", None)
+        if callable(runner):
+            try:
+                runner(command_id, 0)
+            except TypeError:
+                runner(command_id)
+
+    return _run
+
+
+def _tab_index(tabs: Any, *, label: str = "", data: str = "") -> int:
+    for index in range(tabs.count()):
+        if label and tabs.tabText(index) == label:
+            return index
+        if data and str(tabs.tabData(index) or "") == data:
+            return index
+    return -1
+
+
+def _insert_index(tabs: Any) -> int:
+    aero = _tab_index(tabs, label="Aero")
+    if aero < 0:
+        aero = _tab_index(tabs, data="VibeCADAeroWorkbench")
+    if aero >= 0:
+        return aero + 1
+    return tabs.count()
+
+
+def _is_print_tab(tabs: Any, index: int) -> bool:
+    if index < 0 or index >= tabs.count():
+        return False
+    if tabs.tabText(index) == TAB_LABEL:
+        return True
+    return str(tabs.tabData(index) or "") in {TAB_DATA, "print"}
+
+
+def _find_tabs(mw: Any, qt_widgets: Any):
+    tabs = mw.findChild(getattr(qt_widgets, "QTabBar", None), RIBBON_TABS)
+    if tabs is None:
+        tabs = mw.findChild(object, RIBBON_TABS)
+    return tabs
+
+
+def install_ribbon_tab(gui: Any, qt_widgets: Any) -> bool:
+    mw = gui.getMainWindow()
+    if mw is None:
+        return False
+    tabs = _find_tabs(mw, qt_widgets)
+    if tabs is None:
+        return False
+    if _tab_index(tabs, label=TAB_LABEL) >= 0 or _tab_index(tabs, data=TAB_DATA) >= 0:
+        return True
+    insert_at = _insert_index(tabs)
+    blocker = getattr(tabs, "blockSignals", None)
+    if callable(blocker):
+        blocker(True)
+    try:
+        tabs.insertTab(insert_at, TAB_LABEL)
+        if hasattr(tabs, "setTabData"):
+            tabs.setTabData(insert_at, TAB_DATA)
+    finally:
+        if callable(blocker):
+            blocker(False)
+    global _injected_print_tab
+    _injected_print_tab = True
+    _log("ribbon tab installed")
+    return True
+
+
+def install_menu(gui: Any, qt_widgets: Any) -> bool:
+    mw = gui.getMainWindow()
+    if mw is None:
+        return False
+    bar = mw.menuBar()
+    menu = None
+    for action in bar.actions():
+        title = (action.text() or "").replace("&", "")
+        if title == MENU_NAME:
+            menu = action.menu()
+            break
+    if menu is None:
+        menu = bar.addMenu(MENU_NAME)
+    have = {(action.text() or "") for action in menu.actions()}
+    added = False
+    for label, command_id, _icon in BUTTONS:
+        if label in have:
+            continue
+        action = menu.addAction(label)
+        action.triggered.connect(_run_command(gui, command_id))
+        added = True
+    if added:
+        _log("menu installed")
+    return True
+
+
+def _iter_ribbon_groups(root: Any) -> list[Any]:
+    groups = []
+    find_children = getattr(root, "findChildren", None)
+    if find_children is None:
+        return groups
+    try:
+        children = find_children(object)
+    except TypeError:
+        children = find_children(None)
+    except Exception:
+        children = []
+    for child in children or []:
+        name = str(getattr(child, "objectName", lambda: "")() or "")
+        if name.startswith("VibeCADRibbonGroup_"):
+            groups.append(child)
+    return groups
+
+
+def _ribbon_page(gui: Any, qt_widgets: Any):
+    mw = gui.getMainWindow()
+    if mw is None:
+        return None
+    page = mw.findChild(getattr(qt_widgets, "QWidget", object), RIBBON_PAGE)
+    return page or mw.findChild(object, RIBBON_PAGE)
+
+
+def _ribbon_group_version(group: Any) -> int:
+    try:
+        return int(group.property("PrintRibbonVersion") or 0)
+    except Exception:
+        return 0
+
+
+def _discard_ribbon_group(page: Any, group: Any) -> None:
+    try:
+        group.setObjectName(GROUP_NAME + "_old")
+    except Exception:
+        pass
+    layout = getattr(page, "layout", lambda: None)()
+    if layout is not None and hasattr(layout, "removeWidget"):
+        try:
+            layout.removeWidget(group)
+        except Exception:
+            pass
+    try:
+        group.hide()
+        group.setParent(None)
+        group.deleteLater()
+    except Exception:
+        pass
+
+
+def install_ribbon_group(gui: Any, qt_widgets: Any, qt_gui: Any, page: Any) -> bool:
+    leftovers = [
+        group
+        for group in _iter_ribbon_groups(page)
+        if str(group.objectName() or "").startswith(GROUP_NAME)
+    ]
+    reusable = None
+    for group in leftovers:
+        if (
+            group.objectName() == GROUP_NAME
+            and _ribbon_group_version(group) >= RIBBON_GROUP_VERSION
+        ):
+            reusable = group
+        else:
+            _discard_ribbon_group(page, group)
+    if reusable is not None:
+        reusable.show()
+        return True
+
+    from PySide import QtCore as qt_core
+
+    frame_type = getattr(qt_widgets, "QFrame", None) or qt_widgets.QWidget
+    group = frame_type(page)
+    group.setObjectName(GROUP_NAME)
+    group.setProperty("ribbonGroup", True)
+    group.setProperty("PrintRibbonVersion", RIBBON_GROUP_VERSION)
+    layout = qt_widgets.QHBoxLayout(group)
+    layout.setContentsMargins(6, 4, 10, 4)
+    layout.setSpacing(4)
+    style = getattr(qt_core.Qt, "ToolButtonTextUnderIcon", None)
+    icon_size = qt_core.QSize(24, 24)
+    for label, command_id, icon_name in BUTTONS:
+        button = qt_widgets.QToolButton(group)
+        button.setText(label)
+        try:
+            icon = qt_gui.QIcon(PrintIcons.icon_path(icon_name))
+            button.setIcon(icon)
+        except Exception:
+            pass
+        button.setIconSize(icon_size)
+        if style is not None:
+            button.setToolButtonStyle(style)
+        button.setAutoRaise(True)
+        button.setToolTip(command_id)
+        button.setProperty("VibeCADCommandId", command_id)
+        button.setMinimumSize(48, 48)
+        button.clicked.connect(_run_command(gui, command_id))
+        layout.addWidget(button)
+    page_layout = page.layout()
+    if page_layout is not None:
+        if hasattr(page_layout, "insertWidget"):
+            page_layout.insertWidget(0, group)
+        elif hasattr(page_layout, "addWidget"):
+            page_layout.addWidget(group)
+    group.show()
+    _log("ribbon group installed")
+    return True
+
+
+def _set_print_page_active(gui: Any, qt_widgets: Any, qt_gui: Any, active: bool) -> None:
+    page = _ribbon_page(gui, qt_widgets)
+    if page is None:
+        return
+    if active:
+        install_ribbon_group(gui, qt_widgets, qt_gui, page)
+        for group in _iter_ribbon_groups(page):
+            name = str(group.objectName() or "")
+            if name == GROUP_NAME:
+                group.show()
+            else:
+                group.hide()
+        try:
+            import PrintPanel
+
+            PrintPanel.show_panel(refresh=True)
+        except Exception as exc:
+            _warn(f"could not show print panel: {exc}")
+        return
+    for group in _iter_ribbon_groups(page):
+        name = str(group.objectName() or "")
+        if name == GROUP_NAME:
+            group.hide()
+    try:
+        import PrintPanel
+
+        PrintPanel.hide_panel()
+    except Exception:
+        pass
+
+
+def _on_tab_changed(index: int, tabs: Any, gui: Any, qt_widgets: Any, qt_gui: Any, qt_core: Any) -> None:
+    printing = _is_print_tab(tabs, index)
+    if printing:
+        try:
+            gui.activateWorkbench(TAB_DATA)
+        except Exception:
+            pass
+
+    def _apply() -> None:
+        _set_print_page_active(gui, qt_widgets, qt_gui, printing)
+
+    timer = getattr(qt_core, "QTimer", None)
+    if timer is not None and hasattr(timer, "singleShot"):
+        timer.singleShot(0, _apply)
+        timer.singleShot(80, _apply)
+        timer.singleShot(250, _apply)
+    else:
+        _apply()
+
+
+def hook_ribbon_tab_changes(gui: Any, qt_widgets: Any, qt_gui: Any, qt_core: Any) -> bool:
+    mw = gui.getMainWindow()
+    if mw is None:
+        return False
+    tabs = _find_tabs(mw, qt_widgets)
+    if tabs is None:
+        return False
+    if not _injected_print_tab:
+        return True
+    if not getattr(tabs, "_vibecadPrintTabHooked", False):
+        tabs.currentChanged.connect(
+            lambda i, bar=tabs: _on_tab_changed(i, bar, gui, qt_widgets, qt_gui, qt_core)
+        )
+        try:
+            setattr(tabs, "_vibecadPrintTabHooked", True)
+        except Exception:
+            pass
+        _log("ribbon tab change hooked")
+    if _is_print_tab(tabs, tabs.currentIndex()):
+        _on_tab_changed(tabs.currentIndex(), tabs, gui, qt_widgets, qt_gui, qt_core)
+    else:
+        _set_print_page_active(gui, qt_widgets, qt_gui, False)
+    return True
+
+
+def install_once() -> dict[str, bool]:
+    gui = _gui()
+    qt_core, qt_gui, qt_widgets = _qt()
+    try:
+        PrintCommandLoader.ensure_commands_registered(gui)
+    except Exception as exc:
+        _warn(f"command registration deferred: {exc}")
+    try:
+        import PrintPanel
+
+        PrintPanel.ensure_panel_registered()
+    except Exception as exc:
+        _warn(f"print panel not ready: {exc}")
+    return {
+        "menu": install_menu(gui, qt_widgets),
+        "ribbon_tab": install_ribbon_tab(gui, qt_widgets),
+        "ribbon_hook": hook_ribbon_tab_changes(gui, qt_widgets, qt_gui, qt_core),
+    }
+
+
+_retry_count = 0
+_timer = None
+
+
+def install_with_retry(max_tries: int = 40, interval_ms: int = 500) -> None:
+    """Keep trying until VibeCAD's native ribbon and main window exist."""
+
+    global _retry_count, _timer
+    from PySide import QtCore
+
+    def _tick() -> None:
+        global _retry_count, _timer
+        _retry_count += 1
+        try:
+            result = install_once()
+        except Exception as exc:
+            _warn(f"install attempt {_retry_count} failed: {exc}")
+            result = {}
+        if result.get("ribbon_hook") and result.get("ribbon_tab") and result.get("menu"):
+            if _timer is not None:
+                _timer.stop()
+            _log("UI ready")
+            return
+        if _retry_count >= max_tries:
+            if _timer is not None:
+                _timer.stop()
+            _warn("could not fully hook VibeCAD's ribbon. Use menu 3D Print → Setup.")
+
+    if _timer is None:
+        _timer = QtCore.QTimer()
+        _timer.setInterval(interval_ms)
+        _timer.timeout.connect(_tick)
+    _retry_count = 0
+    _tick()
+    if _retry_count < max_tries:
+        _timer.start()

--- a/src/Mod/VibeCADPrint/PrintSetupDialog.py
+++ b/src/Mod/VibeCADPrint/PrintSetupDialog.py
@@ -80,44 +80,78 @@ class SetupChoice:
 
 
 class VibeCADPrintPreferencesPage:
-    """Persistent executable override; profile choices stay in Print Setup."""
+    """Persistent slicer backend and executable override."""
+
+    _BACKENDS = (
+        ("PrusaSlicer", "prusaslicer"),
+        ("Bambu Studio", "bambustudio"),
+        ("OrcaSlicer", "orcaslicer"),
+    )
 
     def __init__(self, parent=None) -> None:
         self.form = QtWidgets.QWidget(parent)
         self.form.setObjectName("VibeCADPrintPreferencesPage")
         self.form.setWindowTitle("3D Printing")
         layout = QtWidgets.QFormLayout(self.form)
+        self.backend = QtWidgets.QComboBox(self.form)
+        self.backend.setObjectName("VibeCADPrintSlicerPreference")
+        for label, value in self._BACKENDS:
+            self.backend.addItem(label, value)
+        self.backend.currentIndexChanged.connect(self._backend_changed)
+        layout.addRow("Slicer", self.backend)
         row = QtWidgets.QWidget(self.form)
         row_layout = QtWidgets.QHBoxLayout(row)
         row_layout.setContentsMargins(0, 0, 0, 0)
         self.executable = QtWidgets.QLineEdit(row)
         self.executable.setObjectName("VibeCADPrintExecutablePreference")
-        self.executable.setPlaceholderText("Auto-detect PrusaSlicer")
+        self.executable.setPlaceholderText("Auto-detect")
         browse = QtWidgets.QPushButton("Locate", row)
         browse.clicked.connect(self._browse)
         row_layout.addWidget(self.executable, 1)
         row_layout.addWidget(browse)
-        layout.addRow("PrusaSlicer executable", row)
+        layout.addRow("Executable", row)
         note = QtWidgets.QLabel(
-            "Leave this empty to auto-detect native installations and the official "
-            "Linux Flatpak. Printer, print, and material profiles are confirmed in "
-            "the 3D Print ribbon's Print Setup dialog.",
+            "Leave Executable empty to auto-detect. Switch slicer here or on the "
+            "3D Print ribbon. Printer, print, and material profiles are confirmed "
+            "in Print Setup.",
             self.form,
         )
         note.setWordWrap(True)
         layout.addRow("Detection", note)
         self.loadSettings()
 
+    def _selected_backend(self) -> str:
+        return str(self.backend.currentData() or "prusaslicer")
+
+    def _backend_changed(self, _index: int = 0) -> None:
+        backend_id = self._selected_backend()
+        self.executable.setText(
+            PrintPreferences.executable_override(backend_id=backend_id)
+        )
+
     def _browse(self) -> None:
-        selected = _browse_for_prusaslicer(self.form, self.executable.text())
+        display = self.backend.currentText() or "slicer"
+        selected = _browse_for_slicer(self.form, display, self.executable.text())
         if selected:
             self.executable.setText(selected)
 
     def saveSettings(self) -> None:
-        PrintPreferences.set_executable_override(self.executable.text())
+        backend_id = self._selected_backend()
+        PrintPreferences.set_active_backend(backend_id)
+        PrintPreferences.set_executable_override(
+            self.executable.text(),
+            backend_id=backend_id,
+        )
 
     def loadSettings(self) -> None:
-        self.executable.setText(PrintPreferences.executable_override())
+        backend_id = PrintPreferences.active_backend()
+        index = self.backend.findData(backend_id)
+        self.backend.blockSignals(True)
+        self.backend.setCurrentIndex(max(0, index))
+        self.backend.blockSignals(False)
+        self.executable.setText(
+            PrintPreferences.executable_override(backend_id=backend_id)
+        )
 
 
 def _browse_for_prusaslicer(parent: Any, initial: str = "") -> str:

--- a/src/Mod/VibeCADPrint/tests/test_install_ui.py
+++ b/src/Mod/VibeCADPrint/tests/test_install_ui.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import PrintInstallUI
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _FakeTabs:
+    def __init__(self, items: list[tuple[str, str]] | None = None) -> None:
+        self.texts: list[str] = []
+        self.data: list[str] = []
+        for text, data in items or []:
+            self.texts.append(text)
+            self.data.append(data)
+        self.blocked = False
+
+    def count(self) -> int:
+        return len(self.texts)
+
+    def tabText(self, index: int) -> str:
+        return self.texts[index]
+
+    def tabData(self, index: int) -> str:
+        return self.data[index]
+
+    def insertTab(self, index: int, text: str) -> None:
+        self.texts.insert(index, text)
+        self.data.insert(index, "")
+
+    def setTabData(self, index: int, data: str) -> None:
+        self.data[index] = data
+
+    def blockSignals(self, value: bool) -> None:
+        self.blocked = value
+
+
+class _FakeWindow:
+    def __init__(self, tabs: _FakeTabs | None = None, page: object | None = None) -> None:
+        self.tabs = tabs
+        self.page = page
+
+    def findChild(self, _type, name: str):
+        if name == PrintInstallUI.RIBBON_TABS:
+            return self.tabs
+        if name == PrintInstallUI.RIBBON_PAGE:
+            return self.page
+        return None
+
+
+def test_initgui_installs_ribbon_overlay_because_vibecad_hides_workbenches() -> None:
+    source = (ROOT / "InitGui.py").read_text(encoding="utf-8")
+
+    assert "PrintInstallUI.install_with_retry" in source
+    assert "import InstallUI" not in source
+    assert "VibeCAD hides the classic workbench combo" in source
+    assert "for _delay_ms in (0, 250, 750, 1500, 3000, 6000)" in source
+
+
+def test_init_py_reschedules_ribbon_install_after_gui_is_up() -> None:
+    source = (ROOT / "Init.py").read_text(encoding="utf-8")
+
+    assert "PrintInstallUI.install_with_retry" in source
+    assert "(500, 2000, 5000)" in source
+
+
+def test_preferences_page_lists_prusaslicer_bambu_and_orca() -> None:
+    source = (ROOT / "PrintSetupDialog.py").read_text(encoding="utf-8")
+
+    assert '("PrusaSlicer", "prusaslicer")' in source
+    assert '("Bambu Studio", "bambustudio")' in source
+    assert '("OrcaSlicer", "orcaslicer")' in source
+    assert 'addRow("Slicer"' in source
+
+
+def test_ribbon_tab_is_added_when_the_native_cpp_domain_is_missing() -> None:
+    PrintInstallUI._injected_print_tab = False
+    tabs = _FakeTabs([("Model", "PartDesignWorkbench")])
+    gui = SimpleNamespace(getMainWindow=lambda: _FakeWindow(tabs))
+
+    assert PrintInstallUI.install_ribbon_tab(gui, SimpleNamespace()) is True
+    assert tabs.texts[-1] == "3D Print"
+    assert tabs.data[-1] == "VibeCADPrintWorkbench"
+
+
+def test_ribbon_tab_is_inserted_after_aero_not_after_mcmaster() -> None:
+    PrintInstallUI._injected_print_tab = False
+    tabs = _FakeTabs(
+        [
+            ("Model", "PartDesignWorkbench"),
+            ("Aero", "VibeCADAeroWorkbench"),
+            ("McMaster", "McMasterWorkbench"),
+        ]
+    )
+    gui = SimpleNamespace(getMainWindow=lambda: _FakeWindow(tabs))
+
+    assert PrintInstallUI.install_ribbon_tab(gui, SimpleNamespace()) is True
+    assert tabs.texts == [
+        "Model",
+        "Aero",
+        "3D Print",
+        "McMaster",
+    ]
+
+
+def test_native_3d_print_tab_does_not_install_an_overlay_hook() -> None:
+    PrintInstallUI._injected_print_tab = False
+    tabs = _FakeTabs(
+        [
+            ("Model", "PartDesignWorkbench"),
+            ("3D Print", "VibeCADPrintWorkbench"),
+        ]
+    )
+    connected = []
+    tabs.currentChanged = SimpleNamespace(connect=connected.append)
+    tabs.currentIndex = lambda: 0
+    gui = SimpleNamespace(getMainWindow=lambda: _FakeWindow(tabs))
+
+    assert PrintInstallUI.install_ribbon_tab(gui, SimpleNamespace()) is True
+    assert PrintInstallUI._injected_print_tab is False
+    assert (
+        PrintInstallUI.hook_ribbon_tab_changes(
+            gui, SimpleNamespace(), SimpleNamespace(), SimpleNamespace()
+        )
+        is True
+    )
+    assert connected == []
+
+
+def test_ribbon_tab_is_idempotent_when_native_3d_print_already_exists() -> None:
+    PrintInstallUI._injected_print_tab = False
+    tabs = _FakeTabs(
+        [
+            ("Model", "PartDesignWorkbench"),
+            ("3D Print", "VibeCADPrintWorkbench"),
+        ]
+    )
+    gui = SimpleNamespace(getMainWindow=lambda: _FakeWindow(tabs))
+
+    assert PrintInstallUI.install_ribbon_tab(gui, SimpleNamespace()) is True
+    assert tabs.texts.count("3D Print") == 1
+
+
+def test_print_install_module_is_not_shadowed_by_mcmaster_installui(
+    monkeypatch,
+) -> None:
+    """McMasterInsert also exports InstallUI; Print must use a unique name."""
+
+    captured = {}
+
+    def fake_mcmaster_retry() -> None:
+        captured["mcmaster"] = True
+
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "InstallUI",
+        SimpleNamespace(install_with_retry=fake_mcmaster_retry),
+    )
+    source = (ROOT / "InitGui.py").read_text(encoding="utf-8")
+    assert "import PrintInstallUI" in source
+    assert "import InstallUI" not in source
+    assert "PrintInstallUI.install_with_retry" in source

--- a/src/Mod/VibeCADPrint/tests/test_workbench.py
+++ b/src/Mod/VibeCADPrint/tests/test_workbench.py
@@ -23,6 +23,8 @@ def test_initgui_registers_first_class_print_workbench_and_preferences() -> None
         in source
     )
     assert "Gui.addWorkbench(VibeCADPrintWorkbench())" in source
+    assert "PrintInstallUI.install_with_retry" in source
+    assert "import InstallUI" not in source
 
 
 def test_workbench_commands_are_registered_without_global_commands_collision(


### PR DESCRIPTION
Checked the unreleased 3D Print workbench on macOS (Apple Silicon, VibeCAD 26.3.1fc5). Preferences only offered a PrusaSlicer executable, so OrcaSlicer and Bambu Studio could not be selected. VibeCAD also hides the classic workbench combo, and `InitGui`'s first timer can fire before the ribbon exists, so an older macOS app never showed the 3D Print tab or dock.

## User-visible outcome

- **Preferences → VibeCAD → 3D Printing** has a **Slicer** dropdown: PrusaSlicer, Bambu Studio, and OrcaSlicer, with a per-slicer executable override.
- If the compiled ribbon domain is missing (current macOS RC5 app), Python pins a **3D Print** tab after Aero and registers the print dock for View → Panels.
- If the compiled RC5-build2 ribbon already has **3D Print**, that native tab is left alone. Overlay hooks do not hide VIEW / SEND / SETUP / INSPECT.

This branch does not change C++, packaging, or slicer discovery contracts.

## Why a unique module name

McMasterInsert already ships `InstallUI.py`. A bare `import InstallUI` from 3D Print reused McMaster's cached module and never added the print tab.

## Tests (TDD)

Failing tests were added first for the preferences slicer list, unique `PrintInstallUI` import, tab insert-after-Aero, idempotent native tab, and no overlay hook when the C++ tab already exists. Then the implementation made them pass.

```
PYTHONPATH=src/Mod/VibeCADPrint python3.11 -m pytest -q --import-mode=importlib \
  src/Mod/VibeCADPrint/tests/test_install_ui.py \
  src/Mod/VibeCADPrint/tests/test_workbench.py \
  src/Mod/VibeCADPrint/tests/test_preferences.py \
  src/Mod/VibeCADPrint/tests/test_backend.py \
  src/Mod/VibeCADPrint/tests/test_commands.py
```

Result: **46 passed**.

Live check on this Mac: OrcaSlicer 2.4.2 is discovered and matches the tested baseline. Bambu Studio 2.7.1.62 is discovered but below the tested 2.8.2 baseline, so the panel still warns instead of loading profiles. PrusaSlicer.app is not installed.

## Compatibility

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed/removed.
- [x] Defaults preserve previous behavior (`prusaslicer` remains the default backend).
- [x] New Slicer combo and per-backend executable keys are additive.
- [x] No breaking changes.

## Non-goals

- No C++ ribbon rebuild in this PR.
- No change to the Bambu tested-version gate (2.8.2).
- Does not install PrusaSlicer.
