### PR TITLE
Bump VibeCAD RC5 to build 3

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 2
+  number: 3
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC5",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 2,
+  "build_version": 3,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Outcome

Bumps the canonical VibeCAD release identity from RC5 build 2 to RC5 build 3 so the full release workflow can publish `v26.3.1-RC5-build3` from the latest `main` source.

## Changes

- Set `version.json` build version to `3`.
- Keep the Rattler recipe build number synchronized at `3`.

## Verification

- `package/rattler-build/.pixi/envs/default/python.exe src/Tools/sync_version.py --check` — passed; all canonical version files are synchronized.
- Release resolver outputs: `26.3.1-RC5`, build `3`, tag `v26.3.1-RC5-build3`, title `VibeCAD 26.3.1-RC5 (Build 3)`.
- The same six release/update contract modules used by GitHub Actions — 113 tests passed, 2 skipped.
- `git diff --check` — passed.

TDD does not apply because this is a metadata-only release-number increment with no code behavior change.

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields are renamed or removed.
- [x] Defaults remain unchanged.
- [x] No deprecations or breaking changes.