### PR TITLE
Document macOS install and how to open a Gatekeeper-blocked VibeCAD.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ The leading `./` is required when installing a local package with `apt`.
 
 Download the Windows installer, run it, and launch VibeCAD from the Start menu.
 
+### macOS
+
+Download the Apple Silicon (`arm64`) or Intel (`x86_64`) DMG from [VibeCAD Releases](https://github.com/10-X-eng/vibecad/releases/latest). Open the DMG and drag `VibeCAD.app` to Applications.
+
+Current release DMGs are not Apple-notarized, so the first launch may show **“VibeCAD.app” Not Opened**. Use one of these paths, then open VibeCAD from Applications as usual:
+
+- **Without Terminal:** Apple menu → **System Settings** → **Privacy & Security** → scroll to the VibeCAD message → **Open Anyway**, then confirm.
+- **With Terminal** (after the app is in Applications):
+
+```bash
+xattr -dr com.apple.quarantine /Applications/VibeCAD.app
+```
+
 SHA256 files are published beside release artifacts so downloads can be verified before installation.
 
 ## Configure an AI Provider


### PR DESCRIPTION
## Outcome

Mac users can install from the release DMG and open VibeCAD when Gatekeeper shows “VibeCAD.app Not Opened”. The README previously had no macOS install section.

## Why

Downloaded VibeCAD.app is quarantined and not Apple-notarized. System Settings → Privacy & Security → Open Anyway, or `xattr -dr com.apple.quarantine /Applications/VibeCAD.app`, is enough to launch. This PR only documents that.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
- [x] The PR lists the exact build and test commands and their results.

TDD does not apply: README-only, no code or runtime behavior.

Exact check run:

```text
git diff --check
```

Result: no whitespace errors.

Manual check: read the Install section as a first-time Mac user and confirm both the Settings path and the `xattr` command are present. No app rebuild.

## Issues

Fixes #97

## Before and After Images

N/A (documentation only; Gatekeeper screenshot is on the issue).

## Compatibility

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed/removed.
- [x] Defaults unchanged.
- [x] No deprecations or breaking changes.

## Non-goals

- Does not Developer ID sign or notarize release DMGs.
- Does not change CI, entitlements, or packaging scripts.
- Does not disable Gatekeeper or recommend `sudo`.

Made with [Cursor](https://cursor.com)