### PR TITLE
Keep Analyze context preparation responsive

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 3
+  number: 4
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -69,6 +69,7 @@ set(VibeCAD_Scripts
     VibeCADNativeAnalyzeGeometryEdit.py
     VibeCADNativeAnalyzeGeometryRead.py
     VibeCADNativeAnalyzeGeometrySources.py
+    VibeCADNativeAnalyzeContext.py
     VibeCADNativeAnalyzeGeometryRuntime.py
     VibeCADNativeAnalyzeGeometrySchema.py
     VibeCADNativeAnalyzeFaceBindings.py
@@ -1213,6 +1214,7 @@ if(BUILD_TEST AND BUILD_GUI)
         vibecad_tests/link_override_visibility_gui_integration.py
         vibecad_tests/mcp_gui_integration.py
     vibecad_tests/native_background_gui_integration.py
+    vibecad_tests/native_analyze_context_responsiveness_gui_integration.py
     vibecad_tests/native_analyze_model_gui_integration.py
     vibecad_tests/analyze_study_setup_gui_integration.py
     vibecad_tests/native_analyze_geometry_gui_integration.py

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -11,7 +11,7 @@ import re
 import shutil
 import threading
 import time
-from typing import Any
+from typing import Any, Mapping, Sequence
 import uuid
 
 from VibeCADAuth import (
@@ -34,6 +34,7 @@ from VibeCADIntentMemory import (
 )
 from VibeCADModelingSurface import resolve_modeling_surface
 from VibeCADNativeBackground import NativeBackgroundManager
+from VibeCADNativeAnalyzeContext import AnalyzeContextCoordinator
 from VibeCADNativeState import NativeDocumentStateStore
 from VibeCADNativeUndo import NativeAssistantUndoLedger
 from VibeCADNativeStatePersistence import (
@@ -224,6 +225,7 @@ class VibeCADService:
         self._native_document_states = NativeDocumentStateStore()
         self._native_assistant_undo = NativeAssistantUndoLedger()
         self._native_background_jobs = NativeBackgroundManager()
+        self._native_analyze_contexts = AnalyzeContextCoordinator()
         self._native_state_restores: set[tuple[str, str]] = set()
         self._native_state_restore_errors: dict[str, str] = {}
         self._new_document_authoring_pending: set[str] = set()
@@ -697,6 +699,8 @@ class VibeCADService:
         revision = (
             self._native_document_states.note_structural_change(uid) if uid else None
         )
+        if uid:
+            self._native_analyze_contexts.invalidate_document(uid)
         self._sync_native_authority_metadata_if_active(uid)
         return revision
 
@@ -705,6 +709,8 @@ class VibeCADService:
         revision = (
             self._native_document_states.note_structural_change(uid) if uid else None
         )
+        if uid:
+            self._native_analyze_contexts.invalidate_document(uid)
         self._sync_native_authority_metadata_if_active(uid)
         return revision
 
@@ -735,6 +741,7 @@ class VibeCADService:
             property_name,
         )
         if revision != previous_revision:
+            self._native_analyze_contexts.invalidate_document(uid)
             self._sync_native_authority_metadata_if_active(uid)
         return revision
 
@@ -784,9 +791,109 @@ class VibeCADService:
             background_job=background_job,
         )
 
+    def begin_native_analyze_context_request(self) -> dict[str, Any] | None:
+        """Capture detached identity for one bounded Analyze context read."""
+
+        document = self._active_document()
+        if document is None:
+            return None
+        from VibeCADModelingSurface import provider_engine_for_ribbon
+        from VibeCADNativeAnalyzeSnapshot import begin_analyze_snapshot_capture
+        from VibeCADNativeSnapshot import capture_active_snapshot_base
+        from VibeCADRibbonSurface import read_active_ribbon_surface
+
+        surface = read_active_ribbon_surface()
+        if surface.surface_id != "analyze" or provider_engine_for_ribbon(
+            self.modeling_engine(),
+            surface.surface_id,
+        ) != "native":
+            return None
+        native_state = self.native_document_state()
+        background_job = self._native_background_jobs.latest_document_snapshot(
+            str(document.Uid),
+            capability_prefix="analyze.",
+        )
+        base = capture_active_snapshot_base(
+            document,
+            "analyze",
+            native_state,
+        )
+        details = begin_analyze_snapshot_capture(
+            document,
+            background_job=background_job,
+            defer_brep_validation=True,
+        )
+        return {
+            **details,
+            "structural_revision": int(
+                native_state.get("structural_revision", 0) or 0
+            ),
+            "base_snapshot": base,
+            "cacheable": bool(
+                background_job is None or bool(getattr(background_job, "terminal", False))
+            ),
+        }
+
+    def _validate_native_analyze_context_request(
+        self,
+        request: Mapping[str, Any],
+    ) -> Any:
+        from VibeCADModelingSurface import provider_engine_for_ribbon
+        from VibeCADNativeAnalyzeContext import AnalyzeContextStale
+        from VibeCADRibbonSurface import read_active_ribbon_surface
+
+        document = self._active_document()
+        uid = str(request.get("document_uid") or "")
+        revision = int(request.get("structural_revision", -1) or 0)
+        current_uid = str(getattr(document, "Uid", "") or "")
+        current_revision = int(
+            self.native_document_state().get("structural_revision", 0) or 0
+        )
+        surface = read_active_ribbon_surface()
+        if (
+            document is None
+            or current_uid != uid
+            or current_revision != revision
+            or surface.surface_id != "analyze"
+            or provider_engine_for_ribbon(
+                self.modeling_engine(),
+                surface.surface_id,
+            )
+            != "native"
+        ):
+            raise AnalyzeContextStale(
+                "The active Analyze document changed during context capture."
+            )
+        return document
+
+    def capture_native_analyze_context_batch(
+        self,
+        request: Mapping[str, Any],
+        object_names: Sequence[str],
+    ) -> dict[str, Any]:
+        from VibeCADNativeAnalyzeSnapshot import capture_analyze_snapshot_batch
+
+        document = self._validate_native_analyze_context_request(request)
+        return capture_analyze_snapshot_batch(document, request, object_names)
+
+    def capture_native_analyze_context_clipping(
+        self,
+        request: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        from VibeCADNativeAnalyzeSnapshot import capture_analyze_clipping
+
+        document = self._validate_native_analyze_context_request(request)
+        return capture_analyze_clipping(document, request)
+
+    def native_analyze_context_coordinator(self) -> AnalyzeContextCoordinator:
+        """Return the read-only Analyze context lane; never a provider tool."""
+
+        return self._native_analyze_contexts
+
     def close_native_document_state(self, document_uid: str) -> None:
         uid = str(document_uid or "").strip()
         self._native_background_jobs.cancel_document(uid)
+        self._native_analyze_contexts.close_document(uid)
         if uid:
             self._native_assistant_undo.close_document(uid)
         self._native_document_states.close_document(uid)

--- a/src/Mod/VibeCAD/VibeCADGeometry.py
+++ b/src/Mod/VibeCAD/VibeCADGeometry.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -12,10 +14,269 @@ import subprocess
 import sys
 import tempfile
 import time
-from typing import Any, Callable
+from typing import Any, Callable, Mapping, Sequence
 
 
 DEFAULT_DEADLINE_SECONDS = 30.0
+BREP_VALIDATION_CACHE_SCHEMA = "vibecad-brep-validation-cache-v1"
+GEOMETRY_WORKER_CPU_PERCENT = 75
+
+
+def parallel_geometry_worker_count(task_count: int) -> int:
+    """Use up to 75% of logical CPUs for isolated geometry processes."""
+
+    if isinstance(task_count, bool) or type(task_count) is not int or task_count < 0:
+        raise ValueError("task_count must be a non-negative integer")
+    if task_count == 0:
+        return 0
+    logical_cpu_count = max(1, int(os.cpu_count() or 1))
+    cpu_budget = max(
+        1,
+        logical_cpu_count * GEOMETRY_WORKER_CPU_PERCENT // 100,
+    )
+    return min(task_count, cpu_budget)
+
+
+def _validate_brep_artifact(
+    artifact: Mapping[str, Any],
+    *,
+    cancellation_check: Callable[[], bool] | None = None,
+    deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
+) -> dict[str, Any]:
+    """Validate one already-detached BREP in an isolated process."""
+
+    shape_path = Path(str(artifact.get("shape_path") or ""))
+    identity = artifact.get("identity")
+    if not shape_path.is_file() or shape_path.stat().st_size <= 0:
+        return {
+            "ok": False,
+            "valid": None,
+            "validation_status": "unknown",
+            "failure_code": "BREP_ARTIFACT_UNAVAILABLE",
+            "failure_stage": "brep_capture",
+            "error": f"The detached BREP artifact is unavailable: {shape_path}",
+            "identity": identity,
+        }
+    deadline = max(0.1, float(deadline_seconds))
+    with tempfile.TemporaryDirectory(prefix="vibecad-validation-job-") as temporary:
+        directory = Path(temporary)
+        request_path = directory / "request.json"
+        result_path = directory / "result.json"
+        request_path.write_text(
+            json.dumps(
+                {
+                    "schema": "vibecad-geometry-job-v1",
+                    "operation": "validate_brep",
+                    "shape": {"format": "brep", "path": str(shape_path)},
+                    "include_bop": False,
+                    "result_path": str(result_path),
+                    "deadline_ms": round(deadline * 1000.0),
+                },
+                separators=(",", ":"),
+            ),
+            encoding="utf-8",
+        )
+        result = execute_job(
+            request_path,
+            result_path,
+            cancellation_check=cancellation_check,
+            deadline_seconds=deadline,
+        )
+    normalized = dict(result)
+    if normalized.get("ok") is True and isinstance(normalized.get("valid"), bool):
+        normalized["validation_status"] = (
+            "valid" if normalized["valid"] else "invalid"
+        )
+    else:
+        normalized["valid"] = None
+        normalized["validation_status"] = "unknown"
+    normalized["identity"] = identity
+    return normalized
+
+
+def _brep_content_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as stream:
+        while True:
+            block = stream.read(1024 * 1024)
+            if not block:
+                break
+            digest.update(block)
+    return digest.hexdigest()
+
+
+def _validation_cache_root(value: str | Path | None) -> Path:
+    if value is not None:
+        return Path(value)
+    import FreeCAD as App
+
+    return (
+        Path(str(App.getUserAppDataDir()))
+        / "VibeCAD"
+        / "cache"
+        / BREP_VALIDATION_CACHE_SCHEMA
+    )
+
+
+def _validation_cache_path(root: Path, brep_sha256: str) -> Path:
+    return root / brep_sha256[:2] / f"{brep_sha256}.json"
+
+
+def _read_cached_validation(path: Path, brep_sha256: str) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema") != BREP_VALIDATION_CACHE_SCHEMA
+        or payload.get("brep_sha256") != brep_sha256
+        or not isinstance(payload.get("result"), dict)
+    ):
+        return None
+    result = dict(payload["result"])
+    if result.get("ok") is not True or not isinstance(result.get("valid"), bool):
+        return None
+    result["cache_hit"] = True
+    return result
+
+
+def _write_cached_validation(
+    path: Path,
+    brep_sha256: str,
+    result: Mapping[str, Any],
+) -> None:
+    if result.get("ok") is not True or not isinstance(result.get("valid"), bool):
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": BREP_VALIDATION_CACHE_SCHEMA,
+        "brep_sha256": brep_sha256,
+        "result": {
+            str(name): value
+            for name, value in result.items()
+            if name not in {"identity", "cache_hit", "coalesced"}
+        },
+    }
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        dir=path.parent,
+        text=True,
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, ensure_ascii=True, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary_name, path)
+    except BaseException:
+        try:
+            Path(temporary_name).unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def validate_brep_artifacts_parallel(
+    artifacts: Sequence[Mapping[str, Any]],
+    *,
+    cancellation_check: Callable[[], bool] | None = None,
+    deadline_seconds: float = DEFAULT_DEADLINE_SECONDS,
+    cache_root: str | Path | None = None,
+) -> list[dict[str, Any]]:
+    """Validate detached BREPs concurrently with CPU-sized process fan-out.
+
+    The executor threads only supervise isolated worker processes. They never
+    touch live FreeCAD document objects or TopoShape wrappers.
+    """
+
+    captured = list(artifacts)
+    if any(not isinstance(artifact, Mapping) for artifact in captured):
+        raise TypeError("artifacts must contain only mappings")
+    if not captured:
+        return []
+    if cancellation_check is not None and cancellation_check():
+        return [
+            {
+                "ok": False,
+                "valid": None,
+                "validation_status": "unknown",
+                "failure_code": "RUN_CANCELLED",
+                "failure_stage": "external_process",
+                "error": "The isolated geometry operation was stopped by the user.",
+                "identity": artifact.get("identity"),
+            }
+            for artifact in captured
+        ]
+    root = _validation_cache_root(cache_root)
+    entries: list[tuple[Mapping[str, Any], str]] = []
+    unique: dict[str, Mapping[str, Any]] = {}
+    resolved: dict[str, dict[str, Any]] = {}
+    for artifact in captured:
+        path = Path(str(artifact.get("shape_path") or ""))
+        if not path.is_file() or path.stat().st_size <= 0:
+            digest = ""
+        else:
+            digest = _brep_content_sha256(path)
+        entries.append((artifact, digest))
+        if not digest:
+            continue
+        cached = _read_cached_validation(_validation_cache_path(root, digest), digest)
+        if cached is not None:
+            resolved[digest] = cached
+        elif digest not in unique:
+            unique[digest] = artifact
+    worker_count = parallel_geometry_worker_count(len(unique))
+    if worker_count:
+        with ThreadPoolExecutor(
+            max_workers=worker_count,
+            thread_name_prefix="VibeCAD-geometry-worker",
+        ) as executor:
+            futures = {
+                executor.submit(
+                    _validate_brep_artifact,
+                    artifact,
+                    cancellation_check=cancellation_check,
+                    deadline_seconds=deadline_seconds,
+                ): digest
+                for digest, artifact in unique.items()
+            }
+            for future in as_completed(futures):
+                digest = futures[future]
+                result = dict(future.result())
+                result["cache_hit"] = False
+                result["brep_sha256"] = digest
+                resolved[digest] = result
+                _write_cached_validation(
+                    _validation_cache_path(root, digest),
+                    digest,
+                    result,
+                )
+    results = []
+    seen: set[str] = set()
+    for artifact, digest in entries:
+        if digest:
+            result = dict(resolved[digest])
+            result["coalesced"] = digest in seen
+            result["brep_sha256"] = digest
+        else:
+            result = {
+                "ok": False,
+                "valid": None,
+                "validation_status": "unknown",
+                "failure_code": "BREP_ARTIFACT_UNAVAILABLE",
+                "failure_stage": "brep_capture",
+                "error": "The detached BREP artifact is unavailable.",
+                "cache_hit": False,
+                "coalesced": False,
+            }
+        result["identity"] = artifact.get("identity")
+        results.append(result)
+        if digest:
+            seen.add(digest)
+    return results
 
 
 def worker_executable() -> Path:

--- a/src/Mod/VibeCAD/VibeCADGeometryWorker.cpp
+++ b/src/Mod/VibeCAD/VibeCADGeometryWorker.cpp
@@ -1522,14 +1522,15 @@ Json validateBrep(const Json& request)
     const TopoDS_Shape shape = readBrep(request.at("shape").at("path").get<std::string>());
     BRepCheck_Analyzer brepAnalyzer(shape);
     const bool brepValid = brepAnalyzer.IsValid();
+    const bool includeBop = request.value("include_bop", true);
     Json brep = {
         {"valid", brepValid},
         {"defects", brepValid ? Json::array() : brepDefects(shape, brepAnalyzer)},
     };
 
     Json bop;
-    bool valid = false;
-    if (brepValid) {
+    bool valid = brepValid;
+    if (brepValid && includeBop) {
         Json defects = bopDefects(shape);
         valid = defects.empty();
         bop = {
@@ -1538,12 +1539,20 @@ Json validateBrep(const Json& request)
             {"defects", std::move(defects)},
         };
     }
-    else {
+    else if (!brepValid) {
         bop = {
             {"performed", false},
             {"valid", nullptr},
             {"defects", Json::array()},
             {"reason", "BOP analysis skipped because BRepCheck rejected the shape."},
+        };
+    }
+    else {
+        bop = {
+            {"performed", false},
+            {"valid", nullptr},
+            {"defects", Json::array()},
+            {"reason", "BOP analysis was not requested for this BREP validity check."},
         };
     }
     return {

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -34,6 +34,7 @@ from VibeCADPromptStarters import (
 )
 from VibeCADSession import (
     _format_document_delta,
+    prewarm_analyze_context,
     rebuild_intent_memory,
     run_native_surface_continuation,
     run_prompt,
@@ -72,6 +73,8 @@ _conversation_persist_lock = threading.RLock()
 _assistant_document_refresh_scheduled = False
 _legacy_architecture_warning_documents: set[str] = set()
 _pending_document_render_refreshes: set[str] = set()
+_analyze_context_prewarm_thread: threading.Thread | None = None
+_analyze_context_prewarm_lock = threading.RLock()
 
 _IDLE_STATUS_TEXT = "Ready. Tell VibeCAD what to make or change."
 _PANEL_SPLITTER_PARAMETER = "PanelSplitterState"
@@ -1854,6 +1857,34 @@ def _set_status_line(text: str, *, dock: Any | None = None) -> None:
     label.setVisible(bool(clean) and clean != _IDLE_STATUS_TEXT)
 
 
+_ANALYZE_CONTEXT_STATUS_EVENTS = frozenset(
+    {
+        "analyze_context_cache_hit",
+        "analyze_context_progress",
+        "analyze_context_ready",
+    }
+)
+
+
+def _show_analyze_context_application_status(
+    event: dict[str, Any],
+    text: str,
+) -> None:
+    """Mirror Analyze preparation progress into FreeCAD's bottom status bar."""
+
+    event_name = str(event.get("event") or "")
+    if event_name not in _ANALYZE_CONTEXT_STATUS_EVENTS:
+        return
+    try:
+        status_bar = Gui.getMainWindow().statusBar()
+        timeout = 5000 if event_name != "analyze_context_progress" else 0
+        status_bar.showMessage(str(text or "").strip(), timeout)
+    except Exception:
+        # The assistant status line remains the fallback for headless tests and
+        # early startup, where FreeCAD may not have created its status bar yet.
+        return
+
+
 #: Failure stages where the tool call was rejected before touching the document.
 _PRE_EXECUTION_FAILURE_STAGES = frozenset(
     {"schema", "surface", "edit_state", "precondition"}
@@ -1887,6 +1918,12 @@ def _format_progress_event(event: dict[str, Any]) -> str:
         return "Looking at the current VibeCAD document..."
     if name == "context_build_completed":
         return "I have the document context."
+    if name == "analyze_context_progress":
+        message = str(event.get("message") or "").strip()
+        return message or "Analyzing objects..."
+    if name in {"analyze_context_cache_hit", "analyze_context_ready"}:
+        revision = int(event.get("structural_revision", 0) or 0)
+        return f"Analyze context is ready for document revision {revision}."
     if name == "provider_subprocess_started":
         return f"{event.get('provider', 'Provider')} process started" + (
             f" | pid {event.get('pid')}" if event.get("pid") else ""
@@ -2098,6 +2135,11 @@ _PROGRESS_THINKING_EVENTS = {
 }
 
 _PROGRESS_STATUS_ONLY_EVENTS: set[str] = {
+    "analyze_context_cache_hit",
+    "analyze_context_progress",
+    "analyze_context_ready",
+    "context_build_completed",
+    "context_build_started",
     "document_recompute_waiting",
     "geometry_worker_started",
     "intent_memory_update_started",
@@ -2159,6 +2201,7 @@ def _handle_progress_event(
         return
     if _progress_event_should_update_status(event):
         _set_status_line(text, dock=dock)
+        _show_analyze_context_application_status(event, text)
     if _progress_event_should_append_thinking(event):
         _append_thinking(text)
 
@@ -3929,6 +3972,7 @@ def _schedule_assistant_document_refresh() -> None:
                 return
             _assistant_document_refresh_scheduled = False
             _refresh_assistant_for_document_change()
+            _schedule_analyze_context_prewarm()
 
         QtCore.QTimer.singleShot(0, refresh_when_restored)
     except Exception:
@@ -4727,6 +4771,56 @@ def show_assistant_for_active_workbench() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _schedule_analyze_context_prewarm() -> None:
+    """Warm Analyze provider state without occupying Qt or Native CAD jobs."""
+
+    global _analyze_context_prewarm_thread
+    with _analyze_context_prewarm_lock:
+        if (
+            _analyze_context_prewarm_thread is not None
+            and _analyze_context_prewarm_thread.is_alive()
+        ):
+            return
+
+        def progress(event: dict[str, Any]) -> None:
+            if not _progress_event_should_update_status(event):
+                return
+            text = _format_progress_event(event)
+            try:
+                _dispatch_to_document_thread(
+                    lambda: (
+                        _set_status_line(text, dock=_find_dock()),
+                        _show_analyze_context_application_status(event, text),
+                    )
+                )
+            except RuntimeError:
+                if not _application_shutting_down.is_set():
+                    raise
+
+        def run() -> None:
+            try:
+                prewarm_analyze_context(
+                    get_service(),
+                    _dispatch_to_document_thread,
+                    progress_callback=progress,
+                )
+            except Exception as exc:
+                from VibeCADNativeAnalyzeContext import (
+                    AnalyzeContextCancelled,
+                    AnalyzeContextStale,
+                )
+
+                if not isinstance(exc, (AnalyzeContextCancelled, AnalyzeContextStale)):
+                    _warn(f"VibeCAD Analyze context prewarm failed: {exc}")
+
+        _analyze_context_prewarm_thread = threading.Thread(
+            target=run,
+            name="VibeCAD-Analyze-context-prewarm",
+            daemon=True,
+        )
+        _analyze_context_prewarm_thread.start()
+
+
 def _on_workbench_activated(workbench_name: str) -> None:
     try:
         from VibeCADMCP import get_control_mode_controller
@@ -4768,6 +4862,7 @@ def _on_workbench_activated(workbench_name: str) -> None:
         _show_panel()
 
     QtCore.QTimer.singleShot(0, refresh_or_open)
+    QtCore.QTimer.singleShot(0, _schedule_analyze_context_prewarm)
 
 
 def _connect_workbench_activation() -> None:

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeClipping.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeClipping.py
@@ -80,9 +80,15 @@ def clipping_state(document) -> dict[str, Any]:
     }
 
 
-def clipping_face_source_state(obj) -> dict[str, Any]:
+def clipping_face_source_state(
+    obj,
+    *,
+    prevalidated: bool = False,
+) -> dict[str, Any]:
     """Return an exact face-source token without serializing shape geometry."""
 
+    if type(prevalidated) is not bool:
+        raise TypeError("prevalidated must be a boolean")
     document = getattr(obj, "Document", None)
     shape = getattr(obj, "Shape", None)
     try:
@@ -91,7 +97,7 @@ def clipping_face_source_state(obj) -> dict[str, Any]:
             or document.getObject(str(obj.Name)) is not obj
             or shape is None
             or shape.isNull()
-            or not shape.isValid()
+            or (not prevalidated and not shape.isValid())
         ):
             raise ValueError
         face_count = len(shape.Faces)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeContext.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeContext.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Responsive, revision-safe preparation of Native Analyze provider context."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+import threading
+from typing import Any
+
+
+DEFAULT_ANALYZE_CONTEXT_BATCH_SIZE = 8
+MAX_ANALYZE_CONTEXT_CACHE_ENTRIES = 4
+_WAIT_POLL_SECONDS = 0.05
+
+CancellationCheck = Callable[[], bool]
+ProgressCallback = Callable[[int, str], None]
+ContextBuilder = Callable[[CancellationCheck, ProgressCallback], dict[str, Any]]
+DocumentThreadDispatcher = Callable[[Callable[[], Any]], Any]
+PartsPostprocessor = Callable[
+    [
+        Mapping[str, Any],
+        Sequence[Mapping[str, Any]],
+        CancellationCheck | None,
+        ProgressCallback | None,
+    ],
+    Sequence[Mapping[str, Any]],
+]
+
+
+class AnalyzeContextError(RuntimeError):
+    """Analyze provider context could not be prepared safely."""
+
+
+class AnalyzeContextCancelled(AnalyzeContextError):
+    """The caller stopped waiting for Analyze provider context."""
+
+
+class AnalyzeContextStale(AnalyzeContextError):
+    """Analyze provider context changed while it was being prepared."""
+
+
+@dataclass
+class _PendingContext:
+    document_uid: str
+    structural_revision: int
+    variant: str
+    invalidated: threading.Event = field(default_factory=threading.Event)
+    completed: bool = False
+    result: dict[str, Any] | None = None
+    error: BaseException | None = None
+    progress_percent: int = 0
+    progress_message: str = ""
+
+
+def _context_key(
+    document_uid: str,
+    structural_revision: int,
+    variant: str = "",
+) -> tuple[str, int, str]:
+    uid = str(document_uid or "").strip()
+    if not uid:
+        raise AnalyzeContextError("Analyze context requires an exact document UID.")
+    if isinstance(structural_revision, bool):
+        raise AnalyzeContextError("Analyze context requires an integer revision.")
+    try:
+        revision = int(structural_revision)
+    except (TypeError, ValueError) as exc:
+        raise AnalyzeContextError(
+            "Analyze context requires an integer revision."
+        ) from exc
+    if revision < 0:
+        raise AnalyzeContextError(
+            "Analyze context requires a non-negative revision."
+        )
+    return uid, revision, str(variant or "")[:160]
+
+
+class AnalyzeContextCoordinator:
+    """Coalesce and cache detached Analyze snapshots without owning CAD work.
+
+    The caller that wins a cache miss performs the capture. Other callers wait
+    for that same document/revision result. This coordinator never shares the
+    mutation/mesh/solver background lane and never receives live FreeCAD
+    objects.
+    """
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition(threading.RLock())
+        self._pending: dict[tuple[str, int, str], _PendingContext] = {}
+        self._cache: OrderedDict[
+            tuple[str, int, str],
+            dict[str, Any],
+        ] = OrderedDict()
+
+    def get_or_build(
+        self,
+        document_uid: str,
+        structural_revision: int,
+        build: ContextBuilder,
+        *,
+        variant: str = "",
+        cancellation_check: CancellationCheck | None = None,
+        progress_callback: ProgressCallback | None = None,
+    ) -> dict[str, Any]:
+        if not callable(build):
+            raise TypeError("build must be callable")
+        if cancellation_check is not None and not callable(cancellation_check):
+            raise TypeError("cancellation_check must be callable")
+        if progress_callback is not None and not callable(progress_callback):
+            raise TypeError("progress_callback must be callable")
+        key = _context_key(document_uid, structural_revision, variant)
+        with self._condition:
+            cached = self._cache.get(key)
+            if cached is not None:
+                self._cache.move_to_end(key)
+                return deepcopy(cached)
+            pending = self._pending.get(key)
+            owner = pending is None
+            if pending is None:
+                pending = _PendingContext(*key)
+                self._pending[key] = pending
+
+        if not owner:
+            return self._wait_for_pending(
+                pending,
+                cancellation_check=cancellation_check,
+                progress_callback=progress_callback,
+            )
+
+        def cancelled() -> bool:
+            return pending.invalidated.is_set() or bool(
+                cancellation_check is not None and cancellation_check()
+            )
+
+        def progress(percent: int, message: str) -> None:
+            if isinstance(percent, bool) or type(percent) is not int:
+                raise AnalyzeContextError(
+                    "Analyze context progress must be an integer."
+                )
+            clean_percent = max(0, min(100, percent))
+            clean_message = str(message or "").strip()[:160]
+            with self._condition:
+                pending.progress_percent = max(
+                    pending.progress_percent,
+                    clean_percent,
+                )
+                pending.progress_message = clean_message
+                self._condition.notify_all()
+            if progress_callback is not None:
+                progress_callback(clean_percent, clean_message)
+
+        try:
+            result = build(cancelled, progress)
+            if not isinstance(result, dict):
+                raise AnalyzeContextError(
+                    "Analyze context preparation must return an object."
+                )
+            with self._condition:
+                if pending.invalidated.is_set() or self._pending.get(key) is not pending:
+                    raise AnalyzeContextStale(
+                        "The Analyze document changed while context was prepared."
+                    )
+                pending.result = deepcopy(result)
+                self._cache[key] = deepcopy(result)
+                self._cache.move_to_end(key)
+                self._discard_other_document_revisions_locked(key)
+                while len(self._cache) > MAX_ANALYZE_CONTEXT_CACHE_ENTRIES:
+                    self._cache.popitem(last=False)
+                return deepcopy(result)
+        except BaseException as exc:
+            reported = (
+                AnalyzeContextStale(
+                    "The Analyze document changed while context was prepared."
+                )
+                if pending.invalidated.is_set()
+                and isinstance(exc, AnalyzeContextCancelled)
+                else exc
+            )
+            with self._condition:
+                pending.error = reported
+            if reported is not exc:
+                raise reported from exc
+            raise
+        finally:
+            with self._condition:
+                pending.completed = True
+                if self._pending.get(key) is pending:
+                    self._pending.pop(key, None)
+                self._condition.notify_all()
+
+    def _wait_for_pending(
+        self,
+        pending: _PendingContext,
+        *,
+        cancellation_check: CancellationCheck | None,
+        progress_callback: ProgressCallback | None,
+    ) -> dict[str, Any]:
+        reported_progress = (-1, "")
+        while True:
+            with self._condition:
+                if pending.completed:
+                    if pending.error is not None:
+                        raise pending.error
+                    if pending.result is None:
+                        raise AnalyzeContextError(
+                            "Analyze context preparation completed without a result."
+                        )
+                    return deepcopy(pending.result)
+                current_progress = (
+                    pending.progress_percent,
+                    pending.progress_message,
+                )
+                self._condition.wait(_WAIT_POLL_SECONDS)
+            if cancellation_check is not None and cancellation_check():
+                raise AnalyzeContextCancelled(
+                    "Analyze context preparation was cancelled."
+                )
+            if progress_callback is not None and current_progress != reported_progress:
+                progress_callback(*current_progress)
+                reported_progress = current_progress
+
+    def _discard_other_document_revisions_locked(
+        self,
+        keep: tuple[str, int, str],
+    ) -> None:
+        for key in list(self._cache):
+            if key[0] == keep[0] and key != keep:
+                self._cache.pop(key, None)
+
+    def invalidate_document(self, document_uid: str) -> bool:
+        uid = str(document_uid or "").strip()
+        if not uid:
+            return False
+        changed = False
+        with self._condition:
+            for key in list(self._cache):
+                if key[0] == uid:
+                    self._cache.pop(key, None)
+                    changed = True
+            for key, pending in list(self._pending.items()):
+                if key[0] == uid:
+                    pending.invalidated.set()
+                    changed = True
+            if changed:
+                self._condition.notify_all()
+        return changed
+
+    def has_cached(
+        self,
+        document_uid: str,
+        structural_revision: int,
+        *,
+        variant: str = "",
+    ) -> bool:
+        key = _context_key(document_uid, structural_revision, variant)
+        with self._condition:
+            return key in self._cache
+
+    def close_document(self, document_uid: str) -> bool:
+        return self.invalidate_document(document_uid)
+
+
+def capture_responsive_analyze_snapshot(
+    request: Mapping[str, Any],
+    *,
+    dispatch_to_document_thread: DocumentThreadDispatcher,
+    capture_batch: Callable[[Mapping[str, Any], Sequence[str]], Mapping[str, Any]],
+    capture_clipping: Callable[[Mapping[str, Any]], Mapping[str, Any]],
+    finalize: Callable[
+        [Mapping[str, Any], Sequence[Mapping[str, Any]], Mapping[str, Any]],
+        dict[str, Any],
+    ],
+    cancellation_check: CancellationCheck | None = None,
+    progress_callback: ProgressCallback | None = None,
+    postprocess_parts: PartsPostprocessor | None = None,
+    batch_size: int = DEFAULT_ANALYZE_CONTEXT_BATCH_SIZE,
+) -> dict[str, Any]:
+    """Capture live facts in bounded dispatches and finalize detached data."""
+
+    if not isinstance(request, Mapping):
+        raise TypeError("request must be a mapping")
+    for callback in (
+        dispatch_to_document_thread,
+        capture_batch,
+        capture_clipping,
+        finalize,
+    ):
+        if not callable(callback):
+            raise TypeError("Analyze context callbacks must be callable")
+    if postprocess_parts is not None and not callable(postprocess_parts):
+        raise TypeError("postprocess_parts must be callable or None")
+    if isinstance(batch_size, bool) or type(batch_size) is not int or batch_size < 1:
+        raise ValueError("batch_size must be a positive integer")
+    raw_names = request.get("object_names")
+    if not isinstance(raw_names, list) or any(
+        not isinstance(name, str) or not name for name in raw_names
+    ):
+        raise AnalyzeContextError(
+            "Analyze context request requires exact object names."
+        )
+    object_names = list(raw_names)
+
+    def check_cancelled() -> None:
+        if cancellation_check is not None and cancellation_check():
+            raise AnalyzeContextCancelled(
+                "Analyze context preparation was cancelled."
+            )
+
+    parts: list[Mapping[str, Any]] = []
+    batch_count = max(1, (len(object_names) + batch_size - 1) // batch_size)
+    for index, offset in enumerate(range(0, len(object_names), batch_size)):
+        check_cancelled()
+        names = object_names[offset : offset + batch_size]
+        part = dispatch_to_document_thread(
+            lambda names=names: capture_batch(request, names)
+        )
+        if not isinstance(part, Mapping):
+            raise AnalyzeContextError(
+                "Analyze context batch capture returned no object."
+            )
+        parts.append(dict(part))
+        if progress_callback is not None:
+            progress_callback(
+                5 + int(80 * (index + 1) / batch_count),
+                f"Analyzing objects {min(offset + len(names), len(object_names))}"
+                f" of {len(object_names)}",
+            )
+
+    if postprocess_parts is not None:
+        check_cancelled()
+        processed = postprocess_parts(
+            request,
+            parts,
+            cancellation_check,
+            progress_callback,
+        )
+        if not isinstance(processed, Sequence) or any(
+            not isinstance(part, Mapping) for part in processed
+        ):
+            raise AnalyzeContextError(
+                "Analyze context postprocessing returned invalid batch data."
+            )
+        parts = [dict(part) for part in processed]
+
+    check_cancelled()
+    clipping = dispatch_to_document_thread(lambda: capture_clipping(request))
+    if not isinstance(clipping, Mapping):
+        raise AnalyzeContextError(
+            "Analyze clipping capture returned no object."
+        )
+    check_cancelled()
+    if progress_callback is not None:
+        progress_callback(90, "Finalizing detached Analyze context")
+    result = finalize(request, parts, clipping)
+    if not isinstance(result, dict):
+        raise AnalyzeContextError(
+            "Analyze context finalization returned no object."
+        )
+    return result

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometrySources.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometrySources.py
@@ -37,8 +37,25 @@ def _is_internal_resource(obj: Any) -> bool:
     return role in {"internal", "resource"} and not _is_body(obj)
 
 
-def active_analyze_geometry_sources(document: Any) -> tuple[Any, ...]:
-    """Return each usable engineering source once at its public Body boundary."""
+def active_analyze_geometry_sources(
+    document: Any,
+    *,
+    filter_analysis_sources: bool = True,
+    validate_brep: bool = True,
+) -> tuple[Any, ...]:
+    """Return each usable engineering source once at its public Body boundary.
+
+    BREP validity remains the default usable-source contract. Responsive
+    provider discovery may defer that unbounded check; exact operations still
+    validate their chosen geometry before execution. The optional filtering
+    switch only lets bounded capture defer cross-batch domain/source
+    de-duplication until every batch has been read.
+    """
+
+    if type(filter_analysis_sources) is not bool:
+        raise TypeError("filter_analysis_sources must be a boolean")
+    if type(validate_brep) is not bool:
+        raise TypeError("validate_brep must be a boolean")
 
     try:
         import PartGui
@@ -53,9 +70,12 @@ def active_analyze_geometry_sources(document: Any) -> tuple[Any, ...]:
         try:
             if (
                 shape.isNull()
-                or not shape.isValid()
+                or (validate_brep and not shape.isValid())
                 or not PartGui.isModelingObjectActive(obj)
-                or not any((len(shape.Solids), len(shape.Faces), len(shape.Edges)))
+                or (
+                    validate_brep
+                    and not any((len(shape.Solids), len(shape.Faces), len(shape.Edges)))
+                )
             ):
                 continue
             identity = (str(document.Uid), int(obj.ID))
@@ -65,6 +85,8 @@ def active_analyze_geometry_sources(document: Any) -> tuple[Any, ...]:
             continue
         seen.add(identity)
         candidates.append(obj)
+    if not filter_analysis_sources:
+        return tuple(candidates)
     domain_sources = {
         source
         for domain in candidates

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSnapshot.py
@@ -4,7 +4,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+import hashlib
+from pathlib import Path
+import shutil
+import tempfile
+from types import SimpleNamespace
+from typing import Any, Mapping, Sequence
+import uuid
 
 from VibeCADNativeAnalyzeState import analysis_state, material_state
 from VibeCADNativeAnalyzeElementState import element_definition_state
@@ -326,14 +332,49 @@ def _materials(document: Any) -> tuple[int, list[dict[str, Any]]]:
     return count, result
 
 
-def _geometry_sources(document: Any) -> tuple[int, list[dict[str, Any]]]:
+def _geometry_sources(
+    document: Any,
+    *,
+    filter_analysis_sources: bool = True,
+    validate_brep: bool = True,
+    include_clipping_face_targets: bool = True,
+    validation_artifact_root: str = "",
+) -> tuple[int, list[dict[str, Any]], list[dict[str, Any]]]:
     result = []
+    artifacts = []
     count = 0
-    for obj in active_analyze_geometry_sources(document):
+    for obj in active_analyze_geometry_sources(
+        document,
+        filter_analysis_sources=filter_analysis_sources,
+        validate_brep=validate_brep,
+    ):
         try:
             state = mesh_object_state(obj)
-            topology = dict(state.get("topology") or {})
-            state["clipping_face_target"] = clipping_face_source_state(obj)
+            if include_clipping_face_targets:
+                state["clipping_face_target"] = clipping_face_source_state(
+                    obj,
+                    prevalidated=validate_brep,
+                )
+            if validation_artifact_root:
+                identity = hashlib.sha256(
+                    (
+                        f"{getattr(document, 'Uid', '')}\0{getattr(obj, 'Name', '')}"
+                        f"\0{state.get('state_sha256', '')}"
+                    ).encode("utf-8")
+                ).hexdigest()
+                root = Path(validation_artifact_root)
+                root.mkdir(parents=True, exist_ok=True)
+                shape_path = root / f"{identity}.brep"
+                obj.Shape.exportBrep(str(shape_path))
+                if not shape_path.is_file() or shape_path.stat().st_size <= 0:
+                    raise OSError("BREP validation capture produced no artifact.")
+                state["_brep_validation_identity"] = identity
+                artifacts.append(
+                    {
+                        "identity": identity,
+                        "shape_path": str(shape_path),
+                    }
+                )
             if bool(getattr(obj, "VibeCADAnalysisDomain", False)):
                 mode = str(getattr(obj, "AnalysisInterfaceMode", "") or "")
                 state["interface_mode"] = mode
@@ -343,12 +384,21 @@ def _geometry_sources(document: Any) -> tuple[int, list[dict[str, Any]]]:
                     and len(shape.CompSolids) == 1
                     and len(shape.CompSolids[0].Solids) == len(shape.Solids)
                 )
+                if not filter_analysis_sources:
+                    state["_is_analysis_domain"] = True
+                    state["_analysis_source_names"] = [
+                        str(getattr(source, "Name", "") or "")
+                        for source in tuple(
+                            getattr(obj, "AnalysisSources", ()) or ()
+                        )
+                        if str(getattr(source, "Name", "") or "")
+                    ]
         except Exception:
             continue
         count += 1
         if len(result) < MAX_GEOMETRY_SOURCES:
             result.append(state)
-    return count, result
+    return count, result, artifacts
 
 
 def _element_definitions(document: Any) -> tuple[int, list[dict[str, Any]]]:
@@ -579,19 +629,124 @@ def _results(
     return count, result, states
 
 
-def build_analyze_snapshot(
+_COLLECTION_LIMITS = {
+    "materials": MAX_MATERIALS,
+    "geometry_sources": MAX_GEOMETRY_SOURCES,
+    "element_definitions": MAX_ELEMENT_DEFINITIONS,
+    "electromagnetic_constraints": MAX_ELECTROMAGNETIC_CONSTRAINTS,
+    "fluid_constraints": MAX_FLUID_CONSTRAINTS,
+    "geometrical_features": MAX_GEOMETRICAL_FEATURES,
+    "support_conditions": MAX_SUPPORT_CONDITIONS,
+    "connections": MAX_CONNECTIONS,
+    "loads": MAX_LOADS,
+    "thermal_conditions": MAX_THERMAL_CONDITIONS,
+    "mesh_definitions": MAX_MESH_DEFINITIONS,
+    "mesh_refinements": MAX_MESH_REFINEMENTS,
+    "fem_mesh_outputs": MAX_FEM_MESH_OUTPUTS,
+    "mesh_filters": MAX_MESH_FILTERS,
+    "solvers": MAX_SOLVERS,
+    "equations": MAX_EQUATIONS,
+    "results": MAX_RESULTS,
+}
+
+
+def _background_job_payload(
+    document_uid: str,
+    background_job: Any | None,
+) -> dict[str, Any] | None:
+    if background_job is None:
+        return None
+    if str(getattr(background_job, "document_uid", "") or "") != document_uid:
+        raise RuntimeError("Analyze background status belongs to another document.")
+    result: dict[str, Any] = {
+        "job_id": str(background_job.job_id),
+        "capability": str(background_job.capability_name),
+        "phase": str(background_job.phase),
+        "progress_percent": int(background_job.progress_percent),
+        "progress_message": str(background_job.progress_message)[:160],
+        "terminal": bool(background_job.terminal),
+        "cancel_requested": bool(background_job.cancel_requested),
+    }
+    error = getattr(background_job, "error", None)
+    if isinstance(error, dict):
+        result["error"] = {
+            key: str(error[key])[:320]
+            for key in ("error_code", "message")
+            if key in error
+        }
+    payload = getattr(background_job, "result", None)
+    if isinstance(payload, dict):
+        solver = payload.get("solver")
+        output = payload.get("result")
+        execution = payload.get("execution")
+        if isinstance(solver, dict) and solver.get("object_name"):
+            result["solver"] = str(solver["object_name"])
+        if isinstance(output, dict) and output.get("object_name"):
+            result["result_object"] = str(output["object_name"])
+        if isinstance(execution, dict):
+            result["backend"] = str(execution.get("backend") or "")[:80]
+            result["implementation"] = str(
+                execution.get("implementation") or ""
+            )[:80]
+    return result
+
+
+def begin_analyze_snapshot_capture(
     document: Any,
     *,
     background_job: Any | None = None,
+    defer_brep_validation: bool = False,
 ) -> dict[str, Any]:
-    analyses = objects_of_type(document, "Fem::FemAnalysis")
+    """Capture only detached identity needed to schedule bounded reads."""
+
+    if type(defer_brep_validation) is not bool:
+        raise TypeError("defer_brep_validation must be a boolean")
+    document_uid = str(getattr(document, "Uid", "") or "").strip()
+    if not document_uid:
+        raise RuntimeError("Analyze context requires an exact document UID.")
+    objects = tuple(getattr(document, "Objects", ()) or ())
+    object_names = [str(getattr(obj, "Name", "") or "") for obj in objects]
+    if any(not name for name in object_names) or len(object_names) != len(
+        set(object_names)
+    ):
+        raise RuntimeError("Analyze context requires unique live object names.")
+    analyses = objects_of_type(
+        SimpleNamespace(Objects=objects),
+        "Fem::FemAnalysis",
+    )
     active = _active_analysis(document)
-    summarized = []
-    for value in analyses[:MAX_ANALYSES]:
-        state = analysis_state(value)
-        state["active"] = value is active
-        result_graph = result_purge_state(value)
-        state["result_graph"] = {
+    validation_root = (
+        str(
+            Path(tempfile.gettempdir())
+            / f"vibecad-analyze-validation-{uuid.uuid4().hex}"
+        )
+        if defer_brep_validation
+        else ""
+    )
+    return {
+        "document_uid": document_uid,
+        "object_names": object_names,
+        "analysis_names": [str(value.Name) for value in analyses],
+        "active_analysis_name": (
+            str(getattr(active, "Name", "") or "") if active is not None else ""
+        ),
+        "background_job": _background_job_payload(document_uid, background_job),
+        "defer_brep_validation": defer_brep_validation,
+        "geometry_validation_artifact_root": validation_root,
+    }
+
+
+def _analysis_capture_record(
+    analysis: Any,
+    *,
+    active_analysis_name: str,
+    include_summary: bool,
+) -> dict[str, Any]:
+    if include_summary:
+        summary = analysis_state(analysis)
+        summary["active"] = str(analysis.Name) == active_analysis_name
+        result_graph = result_purge_state(analysis)
+        summary["result_graph"] = {
             key: result_graph[key]
             for key in (
                 "object_count",
@@ -602,101 +757,491 @@ def build_analyze_snapshot(
                 "graph_sha256",
             )
         }
-        summarized.append(state)
-    material_count, materials = _materials(document)
-    geometry_count, geometry = _geometry_sources(document)
-    element_count, elements = _element_definitions(document)
-    constraint_count, constraints = _electromagnetic_constraints(document)
-    fluid_count, fluid_constraints = _fluid_constraints(document)
-    geometrical_count, geometrical_features = _geometrical_features(document)
-    support_count, support_conditions = _support_conditions(document)
-    connection_count, connections = _connections(document)
-    load_count, loads = _loads(document)
-    thermal_count, thermal_conditions = _thermal_conditions(document)
-    mesh_count, mesh_definitions, mesh_states = _mesh_definitions(document)
-    refinement_count, mesh_refinements = _mesh_refinements(document)
-    output_count, fem_mesh_outputs = _fem_mesh_outputs(document)
-    filter_count, mesh_filters = _mesh_filters(document)
-    solver_count, solvers, solver_states = _solvers(document)
-    equation_count, equations = _equations(document)
-    result_count, results, result_states = _results(document)
-    provider_scope, study_states = _provider_scope(analyses)
-    workflows = _analysis_workflows(
-        analyses,
-        summarized,
+        state = study_state(analysis)
+        member_names = [
+            str(member.Name)
+            for member in tuple(getattr(analysis, "Group", ()) or ())
+        ]
+    else:
+        summary = None
+        state = {
+            "intent": study_intent_state(analysis),
+            "inventory": study_inventory(analysis),
+        }
+        member_names = []
+    return {
+        "object_name": str(analysis.Name),
+        "summary": summary,
+        "study": state,
+        "member_names": member_names,
+    }
+
+
+def capture_analyze_snapshot_batch(
+    document: Any,
+    request: Mapping[str, Any],
+    object_names: Sequence[str],
+) -> dict[str, Any]:
+    """Read one bounded object-name batch on the owning document thread."""
+
+    document_uid = str(getattr(document, "Uid", "") or "")
+    if document_uid != str(request.get("document_uid") or ""):
+        raise RuntimeError("Analyze context request belongs to another document.")
+    get_object = getattr(document, "getObject", None)
+    if not callable(get_object):
+        raise RuntimeError("Analyze context document cannot resolve exact objects.")
+    objects = []
+    for raw_name in object_names:
+        name = str(raw_name or "")
+        obj = get_object(name)
+        if obj is None or getattr(obj, "Document", None) is not document:
+            raise RuntimeError(
+                f"Analyze context object {name!r} changed during capture."
+            )
+        objects.append(obj)
+    batch = SimpleNamespace(Uid=document_uid, Objects=objects)
+    analysis_names = [str(name) for name in list(request.get("analysis_names") or [])]
+    analysis_indexes = {name: index for index, name in enumerate(analysis_names)}
+    analyses = []
+    for obj in objects:
+        name = str(getattr(obj, "Name", "") or "")
+        index = analysis_indexes.get(name)
+        if index is None:
+            continue
+        analyses.append(
+            _analysis_capture_record(
+                obj,
+                active_analysis_name=str(request.get("active_analysis_name") or ""),
+                include_summary=index < MAX_ANALYSES,
+            )
+        )
+
+    material_count, materials = _materials(batch)
+    defer_brep_validation = bool(request.get("defer_brep_validation", False))
+    geometry_count, geometry, geometry_validation_artifacts = _geometry_sources(
+        batch,
+        filter_analysis_sources=False,
+        validate_brep=not defer_brep_validation,
+        include_clipping_face_targets=not defer_brep_validation,
+        validation_artifact_root=(
+            str(request.get("geometry_validation_artifact_root") or "")
+            if defer_brep_validation
+            else ""
+        ),
+    )
+    element_count, elements = _element_definitions(batch)
+    constraint_count, constraints = _electromagnetic_constraints(batch)
+    fluid_count, fluid_constraints = _fluid_constraints(batch)
+    geometrical_count, geometrical_features = _geometrical_features(batch)
+    support_count, support_conditions = _support_conditions(batch)
+    connection_count, connections = _connections(batch)
+    load_count, loads = _loads(batch)
+    thermal_count, thermal_conditions = _thermal_conditions(batch)
+    mesh_count, mesh_definitions, mesh_states = _mesh_definitions(batch)
+    refinement_count, mesh_refinements = _mesh_refinements(batch)
+    output_count, fem_mesh_outputs = _fem_mesh_outputs(batch)
+    filter_count, mesh_filters = _mesh_filters(batch)
+    solver_count, solvers, solver_states = _solvers(batch)
+    equation_count, equations = _equations(batch)
+    result_count, results, result_states = _results(batch)
+    return {
+        "analyses": analyses,
+        "material_count": material_count,
+        "materials": materials,
+        "geometry_source_count": geometry_count,
+        "geometry_sources": geometry,
+        "geometry_validation_artifacts": geometry_validation_artifacts,
+        "element_definition_count": element_count,
+        "element_definitions": elements,
+        "electromagnetic_constraint_count": constraint_count,
+        "electromagnetic_constraints": constraints,
+        "fluid_constraint_count": fluid_count,
+        "fluid_constraints": fluid_constraints,
+        "geometrical_feature_count": geometrical_count,
+        "geometrical_features": geometrical_features,
+        "support_condition_count": support_count,
+        "support_conditions": support_conditions,
+        "connection_count": connection_count,
+        "connections": connections,
+        "load_count": load_count,
+        "loads": loads,
+        "thermal_condition_count": thermal_count,
+        "thermal_conditions": thermal_conditions,
+        "mesh_definition_count": mesh_count,
+        "mesh_definitions": mesh_definitions,
+        "mesh_states": mesh_states,
+        "mesh_refinement_count": refinement_count,
+        "mesh_refinements": mesh_refinements,
+        "fem_mesh_output_count": output_count,
+        "fem_mesh_outputs": fem_mesh_outputs,
+        "mesh_filter_count": filter_count,
+        "mesh_filters": mesh_filters,
+        "solver_count": solver_count,
+        "solvers": solvers,
+        "solver_states": solver_states,
+        "equation_count": equation_count,
+        "equations": equations,
+        "result_count": result_count,
+        "results": results,
+        "result_states": result_states,
+    }
+
+
+def validate_analyze_snapshot_geometry(
+    request: Mapping[str, Any],
+    parts: Sequence[Mapping[str, Any]],
+    cancellation_check: Any | None,
+    progress_callback: Any | None,
+) -> list[dict[str, Any]]:
+    """Validate captured geometry off-thread and keep exact valid sources."""
+
+    copied = [dict(part) for part in parts]
+    if request.get("defer_brep_validation") is not True:
+        return copied
+    artifacts = [
+        dict(artifact)
+        for part in copied
+        for artifact in list(part.get("geometry_validation_artifacts") or [])
+        if isinstance(artifact, Mapping)
+    ]
+    if progress_callback is not None:
+        progress_callback(87, f"Validating geometry 0 of {len(artifacts)}")
+    from VibeCADGeometry import validate_brep_artifacts_parallel
+
+    validations = validate_brep_artifacts_parallel(
+        artifacts,
+        cancellation_check=cancellation_check,
+    )
+    valid = {
+        str(value.get("identity") or "")
+        for value in validations
+        if value.get("ok") is True and value.get("valid") is True
+    }
+    for part in copied:
+        sources = []
+        for raw in list(part.get("geometry_sources") or []):
+            if not isinstance(raw, Mapping):
+                continue
+            state = dict(raw)
+            identity = str(state.pop("_brep_validation_identity", "") or "")
+            if identity in valid:
+                sources.append(state)
+        part["geometry_sources"] = sources
+        part["geometry_source_count"] = len(sources)
+        part.pop("geometry_validation_artifacts", None)
+    if progress_callback is not None:
+        progress_callback(
+            89,
+            f"Validated geometry {len(valid)} of {len(artifacts)}",
+        )
+    return copied
+
+
+def discard_analyze_snapshot_capture(request: Mapping[str, Any]) -> None:
+    root = str(request.get("geometry_validation_artifact_root") or "").strip()
+    if root:
+        shutil.rmtree(Path(root), ignore_errors=True)
+
+
+def capture_analyze_clipping(
+    document: Any,
+    request: Mapping[str, Any],
+) -> dict[str, Any]:
+    if str(getattr(document, "Uid", "") or "") != str(
+        request.get("document_uid") or ""
+    ):
+        raise RuntimeError("Analyze clipping request belongs to another document.")
+    try:
+        return dict(clipping_state(document))
+    except Exception:
+        return {"available": False}
+
+
+def _merged_collection(
+    parts: Sequence[Mapping[str, Any]],
+    values_name: str,
+    count_name: str,
+) -> tuple[int, list[dict[str, Any]]]:
+    count = sum(int(part.get(count_name, 0) or 0) for part in parts)
+    values = [
+        dict(value)
+        for part in parts
+        for value in list(part.get(values_name) or [])
+        if isinstance(value, Mapping)
+    ]
+    return count, values[: _COLLECTION_LIMITS[values_name]]
+
+
+def _provider_scope_from_records(
+    records: Sequence[Mapping[str, Any]],
+) -> tuple[dict[str, Any], dict[str, dict[str, Any]]]:
+    physics = set()
+    undeclared = 0
+    totals = {
+        "mesh_definition_count": 0,
+        "generated_mesh_count": 0,
+        "solver_count": 0,
+        "result_count": 0,
+    }
+    states = {}
+    for record in records:
+        name = str(record.get("object_name") or "")
+        state = record.get("study")
+        if not name or not isinstance(state, Mapping):
+            raise RuntimeError("Analyze study capture is incomplete.")
+        intent = state.get("intent")
+        inventory = state.get("inventory")
+        if not isinstance(intent, Mapping) or not isinstance(inventory, Mapping):
+            raise RuntimeError("Analyze study capture is incomplete.")
+        if record.get("summary") is not None:
+            states[name] = dict(state)
+        if intent.get("declared") is True:
+            physics.update(list(intent.get("physics") or []))
+        else:
+            undeclared += 1
+        for field in totals:
+            totals[field] += int(inventory.get(field, 0) or 0)
+    return (
+        {
+            "analysis_count": len(records),
+            "undeclared_analysis_count": undeclared,
+            "physics": [name for name in STUDY_PHYSICS if name in physics],
+            **totals,
+        },
+        states,
+    )
+
+
+def _analysis_workflows_from_records(
+    records: Sequence[Mapping[str, Any]],
+    mesh_states: Mapping[str, dict[str, Any]],
+    solver_states: Mapping[str, dict[str, Any]],
+    result_states: Mapping[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    workflows = []
+    for record in records[:MAX_ANALYSES]:
+        analysis_summary = record.get("summary")
+        study = record.get("study")
+        if not isinstance(analysis_summary, Mapping) or not isinstance(study, Mapping):
+            raise RuntimeError("Analyze workflow capture is incomplete.")
+        name = str(record.get("object_name") or "")
+        member_names = set(str(value) for value in record.get("member_names") or [])
+        all_member_meshes = [
+            state
+            for state in mesh_states.values()
+            if state.get("object_name") in member_names
+        ]
+        all_member_solvers = [
+            state for state in solver_states.values() if state.get("analysis") == name
+        ]
+        all_member_results = [
+            state
+            for state in result_states.values()
+            if name in tuple(state.get("analysis_owners", ()) or ())
+            or state.get("object_name") in member_names
+        ]
+        member_meshes = [
+            _compact_mesh(state)
+            for state in all_member_meshes[:MAX_WORKFLOW_MESHES]
+        ]
+        member_solvers = [
+            _compact_solver(state)
+            for state in all_member_solvers[:MAX_WORKFLOW_SOLVERS]
+        ]
+        member_results = [
+            _compact_result(state)
+            for state in all_member_results[:MAX_WORKFLOW_RESULTS]
+        ]
+        generated_meshes = sum(
+            bool(state.get("generated")) for state in all_member_meshes
+        )
+        runnable_solvers = sum(
+            not bool(state.get("suppressed")) for state in all_member_solvers
+        )
+        blockers = []
+        if not all_member_solvers:
+            blockers.append("missing_solver")
+        elif not runnable_solvers:
+            blockers.append("all_solvers_suppressed")
+        if not generated_meshes:
+            blockers.append("missing_generated_mesh")
+        result_graph = dict(analysis_summary["result_graph"])
+        workflows.append(
+            {
+                "analysis": {
+                    "object_name": name,
+                    "label": analysis_summary.get("label", name),
+                    "active": bool(analysis_summary.get("active")),
+                    "state_sha256": analysis_summary["state_sha256"],
+                },
+                "graph": {
+                    "member_count": analysis_summary["member_count"],
+                    "member_counts": analysis_summary["member_counts"],
+                    "result_object_count": result_graph["object_count"],
+                    "result_graph_sha256": result_graph["graph_sha256"],
+                },
+                "readiness": {
+                    "scope": "analysis_graph",
+                    "ready": not blockers,
+                    "generated_mesh_count": generated_meshes,
+                    "runnable_solver_count": runnable_solvers,
+                    "blockers": blockers,
+                },
+                "study": dict(study["intent"]),
+                "study_inventory": dict(study["inventory"]),
+                "solver_runtimes": list(study.get("solver_runtimes") or []),
+                "engineering_readiness": dict(study.get("readiness") or {}),
+                "meshes": member_meshes,
+                "mesh_count": len(all_member_meshes),
+                "meshes_truncated": len(all_member_meshes) > len(member_meshes),
+                "solvers": member_solvers,
+                "solver_count": len(all_member_solvers),
+                "solvers_truncated": len(all_member_solvers) > len(member_solvers),
+                "results": member_results,
+                "result_count": len(all_member_results),
+                "results_truncated": len(all_member_results) > len(member_results),
+            }
+        )
+    return workflows
+
+
+def finish_analyze_snapshot_capture(
+    request: Mapping[str, Any],
+    parts: Sequence[Mapping[str, Any]],
+    clipping: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Assemble detached batch data without touching live FreeCAD objects."""
+
+    records = [
+        dict(record)
+        for part in parts
+        for record in list(part.get("analyses") or [])
+        if isinstance(record, Mapping)
+    ]
+    expected_analyses = [str(name) for name in request.get("analysis_names") or []]
+    if [str(record.get("object_name") or "") for record in records] != expected_analyses:
+        raise RuntimeError("Analyze studies changed during context capture.")
+    provider_scope, _study_states = _provider_scope_from_records(records)
+    mesh_states = {
+        str(name): dict(value)
+        for part in parts
+        for name, value in dict(part.get("mesh_states") or {}).items()
+        if isinstance(value, Mapping)
+    }
+    solver_states = {
+        str(name): dict(value)
+        for part in parts
+        for name, value in dict(part.get("solver_states") or {}).items()
+        if isinstance(value, Mapping)
+    }
+    result_states = {
+        str(name): dict(value)
+        for part in parts
+        for name, value in dict(part.get("result_states") or {}).items()
+        if isinstance(value, Mapping)
+    }
+    workflows = _analysis_workflows_from_records(
+        records,
         mesh_states,
         solver_states,
         result_states,
-        study_states,
     )
-    try:
-        clipping = clipping_state(document)
-    except Exception:
-        clipping = {"available": False}
+    summarized = [
+        dict(record["summary"])
+        for record in records[:MAX_ANALYSES]
+        if isinstance(record.get("summary"), Mapping)
+    ]
+    collections = {}
+    collection_fields = (
+        ("materials", "material_count"),
+        ("element_definitions", "element_definition_count"),
+        ("electromagnetic_constraints", "electromagnetic_constraint_count"),
+        ("fluid_constraints", "fluid_constraint_count"),
+        ("geometrical_features", "geometrical_feature_count"),
+        ("support_conditions", "support_condition_count"),
+        ("connections", "connection_count"),
+        ("loads", "load_count"),
+        ("thermal_conditions", "thermal_condition_count"),
+        ("mesh_definitions", "mesh_definition_count"),
+        ("mesh_refinements", "mesh_refinement_count"),
+        ("fem_mesh_outputs", "fem_mesh_output_count"),
+        ("mesh_filters", "mesh_filter_count"),
+        ("solvers", "solver_count"),
+        ("equations", "equation_count"),
+        ("results", "result_count"),
+    )
+    for values_name, count_name in collection_fields:
+        count, values = _merged_collection(parts, values_name, count_name)
+        collections[count_name] = count
+        collections[values_name] = values
+        collections[values_name + "_truncated"] = count > len(values)
+
+    geometry = [
+        dict(value)
+        for part in parts
+        for value in list(part.get("geometry_sources") or [])
+        if isinstance(value, Mapping)
+    ]
+    hidden_domain_sources = {
+        name
+        for value in geometry
+        if value.get("_is_analysis_domain") is True
+        for name in list(value.get("_analysis_source_names") or [])
+    }
+    geometry = [
+        value
+        for value in geometry
+        if value.get("_is_analysis_domain") is True
+        or str(value.get("object_name") or "") not in hidden_domain_sources
+    ]
+    for value in geometry:
+        value.pop("_is_analysis_domain", None)
+        value.pop("_analysis_source_names", None)
+    collections["geometry_source_count"] = len(geometry)
+    collections["geometry_sources"] = geometry[:MAX_GEOMETRY_SOURCES]
+    collections["geometry_sources_truncated"] = (
+        collections["geometry_source_count"] > len(collections["geometry_sources"])
+    )
+
+    result_count = sum(
+        int(state.get("result_count", 0) or 0) for state in solver_states.values()
+    )
+    background_job = request.get("background_job")
+    run_status = (
+        dict(background_job)
+        if isinstance(background_job, Mapping)
+        else {"phase": "idle", "terminal": True}
+    )
+    run_status["solver_result_count"] = result_count
+    analysis_count = len(expected_analyses)
     return {
         "kind": "analyze",
-        "analysis_count": len(analyses),
+        "analysis_count": analysis_count,
         "analyses": summarized,
-        "analyses_truncated": len(analyses) > len(summarized),
-        "analysis_workflow_count": len(analyses),
+        "analyses_truncated": analysis_count > len(summarized),
+        "analysis_workflow_count": analysis_count,
         "analysis_workflows": workflows,
-        "analysis_workflows_truncated": len(analyses) > len(workflows),
+        "analysis_workflows_truncated": analysis_count > len(workflows),
         "provider_scope": provider_scope,
-        "run_status": _run_status(
-            document,
-            list(solver_states.values()),
-            background_job,
-        ),
-        "material_count": material_count,
-        "materials": materials,
-        "materials_truncated": material_count > len(materials),
-        "geometry_source_count": geometry_count,
-        "geometry_sources": geometry,
-        "geometry_sources_truncated": geometry_count > len(geometry),
-        "element_definition_count": element_count,
-        "element_definitions": elements,
-        "element_definitions_truncated": element_count > len(elements),
-        "electromagnetic_constraint_count": constraint_count,
-        "electromagnetic_constraints": constraints,
-        "electromagnetic_constraints_truncated": constraint_count > len(constraints),
-        "fluid_constraint_count": fluid_count,
-        "fluid_constraints": fluid_constraints,
-        "fluid_constraints_truncated": fluid_count > len(fluid_constraints),
-        "geometrical_feature_count": geometrical_count,
-        "geometrical_features": geometrical_features,
-        "geometrical_features_truncated": geometrical_count > len(geometrical_features),
-        "support_condition_count": support_count,
-        "support_conditions": support_conditions,
-        "support_conditions_truncated": support_count > len(support_conditions),
-        "connection_count": connection_count,
-        "connections": connections,
-        "connections_truncated": connection_count > len(connections),
-        "load_count": load_count,
-        "loads": loads,
-        "loads_truncated": load_count > len(loads),
-        "thermal_condition_count": thermal_count,
-        "thermal_conditions": thermal_conditions,
-        "thermal_conditions_truncated": thermal_count > len(thermal_conditions),
-        "mesh_definition_count": mesh_count,
-        "mesh_definitions": mesh_definitions,
-        "mesh_definitions_truncated": mesh_count > len(mesh_definitions),
-        "mesh_refinement_count": refinement_count,
-        "mesh_refinements": mesh_refinements,
-        "mesh_refinements_truncated": refinement_count > len(mesh_refinements),
-        "fem_mesh_output_count": output_count,
-        "fem_mesh_outputs": fem_mesh_outputs,
-        "fem_mesh_outputs_truncated": output_count > len(fem_mesh_outputs),
-        "mesh_filter_count": filter_count,
-        "mesh_filters": mesh_filters,
-        "mesh_filters_truncated": filter_count > len(mesh_filters),
-        "solver_count": solver_count,
-        "solvers": solvers,
-        "solvers_truncated": solver_count > len(solvers),
-        "equation_count": equation_count,
-        "equations": equations,
-        "equations_truncated": equation_count > len(equations),
-        "result_count": result_count,
-        "results": results,
-        "results_truncated": result_count > len(results),
-        "clipping": clipping,
+        "run_status": run_status,
+        **collections,
+        "clipping": dict(clipping),
     }
+
+
+def build_analyze_snapshot(
+    document: Any,
+    *,
+    background_job: Any | None = None,
+) -> dict[str, Any]:
+    request = begin_analyze_snapshot_capture(
+        document,
+        background_job=background_job,
+    )
+    part = capture_analyze_snapshot_batch(
+        document,
+        request,
+        request["object_names"],
+    )
+    clipping = capture_analyze_clipping(document, request)
+    return finish_analyze_snapshot_capture(request, [part], clipping)

--- a/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
@@ -200,6 +200,32 @@ def build_active_snapshot(
     selection: Mapping[str, Any] | None = None,
     background_job: Any | None = None,
 ) -> dict[str, Any]:
+    base = capture_active_snapshot_base(
+        document,
+        surface_id,
+        native_state,
+        selection=selection,
+    )
+    selected = dict(base.pop("_selection"))
+    domain = dict(
+        _domain_builder(
+            surface_id,
+            background_job,
+            selected,
+        )(document)
+    )
+    return complete_active_snapshot(base, domain)
+
+
+def capture_active_snapshot_base(
+    document: Any,
+    surface_id: str,
+    native_state: Mapping[str, Any],
+    *,
+    selection: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Capture detached active-surface identity before domain preparation."""
+
     if surface_id not in SURFACE_IDS or surface_id == "unavailable":
         raise NativeSnapshotError(f"Invalid active Native surface {surface_id!r}.")
     if not isinstance(native_state, Mapping):
@@ -210,13 +236,6 @@ def build_active_snapshot(
     selected = dict(selection) if selection is not None else read_current_selection(document)
     if str(selected.get("document_uid") or "") != uid:
         raise NativeSnapshotError("Native selection belongs to another document.")
-    domain = dict(
-        _domain_builder(
-            surface_id,
-            background_job,
-            selected,
-        )(document)
-    )
     result: dict[str, Any] = {
         "surface_id": surface_id,
         "document": {
@@ -224,18 +243,35 @@ def build_active_snapshot(
             "document_name": str(getattr(document, "Name", "") or ""),
         },
         "structural_revision": int(native_state.get("structural_revision") or 0),
-        "domain": domain,
         "working_set": live_working_set(document, selected, native_state),
+        "_selection": selected,
     }
-    if surface_id == "sketch.edit":
-        revision = domain.pop("revision", None)
+    if selected.get("items"):
+        result["selection"] = selected
+    return result
+
+
+def complete_active_snapshot(
+    base_snapshot: Mapping[str, Any],
+    domain: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Bound and freeze a detached domain under its captured active identity."""
+
+    if not isinstance(base_snapshot, Mapping) or not isinstance(domain, Mapping):
+        raise TypeError("Active snapshot completion requires mappings.")
+    result = {
+        str(name): value
+        for name, value in dict(base_snapshot).items()
+        if name != "_selection"
+    }
+    result["domain"] = dict(domain)
+    if result.get("surface_id") == "sketch.edit":
+        revision = result["domain"].pop("revision", None)
         if not isinstance(revision, str) or not revision.startswith("sketch-v1:"):
             raise NativeSnapshotError(
                 "The active Sketch did not provide an exact provider revision."
             )
         result["revision"] = revision
-    if selected.get("items"):
-        result["selection"] = selected
     encoded = json.dumps(
         result,
         ensure_ascii=True,

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -1124,6 +1124,7 @@ def _capture_context_for_provider(
     service: VibeCADService,
     session_trigger: dict[str, Any] | None = None,
     prepared_component_catalog: Mapping[str, Any] | None = None,
+    prepared_native_state: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     raw_context = service.provider_context_summary()
     allowed_turn_facts = (
@@ -1154,7 +1155,11 @@ def _capture_context_for_provider(
             native_provider_surface,
         )
         if resolution.available:
-            captured_native_state = native_active_state(service)
+            captured_native_state = (
+                dict(prepared_native_state)
+                if prepared_native_state is not None
+                else native_active_state(service)
+            )
             native_provider_surface = provider_authorized_native_surface(
                 native_provider_surface,
                 captured_native_state,
@@ -1346,16 +1351,174 @@ def _build_context_for_provider(
     session_trigger: dict[str, Any] | None,
     document_thread_dispatch: DocumentThreadDispatch | None,
     prepared_component_catalog: Mapping[str, Any] | None = None,
+    cancellation_check: CancellationCheck | None = None,
+    progress_callback: ProgressCallback | None = None,
 ) -> dict[str, Any]:
+    prepared_native_state = _build_responsive_analyze_native_state(
+        service,
+        document_thread_dispatch,
+        cancellation_check=cancellation_check,
+        progress_callback=progress_callback,
+    )
     captured = _on_document_thread(
         document_thread_dispatch,
         lambda: _capture_context_for_provider(
             service,
             session_trigger,
             prepared_component_catalog,
+            prepared_native_state,
         ),
     )
     return _complete_context_for_provider(captured)
+
+
+def _build_responsive_analyze_native_state(
+    service: VibeCADService,
+    document_thread_dispatch: DocumentThreadDispatch | None,
+    *,
+    cancellation_check: CancellationCheck | None = None,
+    progress_callback: ProgressCallback | None = None,
+) -> dict[str, Any] | None:
+    """Build Analyze state in bounded UI dispatches from a provider worker."""
+
+    from VibeCADNativeAnalyzeContext import (
+        AnalyzeContextStale,
+        capture_responsive_analyze_snapshot,
+    )
+    from VibeCADNativeAnalyzeSnapshot import (
+        discard_analyze_snapshot_capture,
+        finish_analyze_snapshot_capture,
+        validate_analyze_snapshot_geometry,
+    )
+    from VibeCADNativeSnapshot import complete_active_snapshot
+
+    begin = getattr(service, "begin_native_analyze_context_request", None)
+    coordinator_reader = getattr(service, "native_analyze_context_coordinator", None)
+    capture_batch = getattr(service, "capture_native_analyze_context_batch", None)
+    capture_clipping = getattr(
+        service,
+        "capture_native_analyze_context_clipping",
+        None,
+    )
+    if not all(
+        callable(callback)
+        for callback in (begin, coordinator_reader, capture_batch, capture_clipping)
+    ):
+        return None
+
+    def emit_progress(percent: int, message: str) -> None:
+        _emit(
+            progress_callback,
+            {
+                "event": "analyze_context_progress",
+                "percent": int(percent),
+                "message": str(message or ""),
+            },
+        )
+
+    for attempt in range(2):
+        request = _on_document_thread(document_thread_dispatch, begin)
+        if request is None:
+            return None
+        if not isinstance(request, Mapping):
+            raise RuntimeError("Analyze context request returned no object.")
+        uid = str(request.get("document_uid") or "")
+        revision = int(request.get("structural_revision", 0) or 0)
+        cache_variant = str(request.get("active_analysis_name") or "")
+        coordinator = coordinator_reader()
+
+        def build(cancelled, report):
+            try:
+                return capture_responsive_analyze_snapshot(
+                    request,
+                    dispatch_to_document_thread=lambda operation: _on_document_thread(
+                        document_thread_dispatch,
+                        operation,
+                    ),
+                    capture_batch=capture_batch,
+                    capture_clipping=capture_clipping,
+                    finalize=finish_analyze_snapshot_capture,
+                    cancellation_check=cancelled,
+                    progress_callback=report,
+                    postprocess_parts=validate_analyze_snapshot_geometry,
+                )
+            finally:
+                discard_analyze_snapshot_capture(request)
+
+        try:
+            if request.get("cacheable") is False:
+                domain = build(
+                    lambda: bool(
+                        cancellation_check is not None and cancellation_check()
+                    ),
+                    emit_progress,
+                )
+                _emit(
+                    progress_callback,
+                    {
+                        "event": "analyze_context_ready",
+                        "structural_revision": revision,
+                    },
+                )
+                return complete_active_snapshot(request["base_snapshot"], domain)
+            cache_hit = coordinator.has_cached(
+                uid,
+                revision,
+                variant=cache_variant,
+            )
+            domain = coordinator.get_or_build(
+                uid,
+                revision,
+                build,
+                variant=cache_variant,
+                cancellation_check=cancellation_check,
+                progress_callback=emit_progress,
+            )
+            if cache_hit:
+                current_clipping = _on_document_thread(
+                    document_thread_dispatch,
+                    lambda: capture_clipping(request),
+                )
+                domain = dict(domain)
+                domain["clipping"] = dict(current_clipping)
+                _emit(
+                    progress_callback,
+                    {
+                        "event": "analyze_context_cache_hit",
+                        "structural_revision": revision,
+                    },
+                )
+            else:
+                _emit(
+                    progress_callback,
+                    {
+                        "event": "analyze_context_ready",
+                        "structural_revision": revision,
+                    },
+                )
+            return complete_active_snapshot(request["base_snapshot"], domain)
+        except AnalyzeContextStale:
+            if attempt == 0 and not (
+                cancellation_check is not None and cancellation_check()
+            ):
+                continue
+            raise
+    raise RuntimeError("Analyze context changed repeatedly during capture.")
+
+
+def prewarm_analyze_context(
+    service: VibeCADService,
+    document_thread_dispatch: DocumentThreadDispatch | None,
+    *,
+    progress_callback: ProgressCallback | None = None,
+) -> dict[str, Any] | None:
+    """Populate the read-only Analyze cache before the human presses Send."""
+
+    return _build_responsive_analyze_native_state(
+        service,
+        document_thread_dispatch,
+        progress_callback=progress_callback,
+    )
 
 
 def _consume_context_view_attachment(
@@ -5488,6 +5651,8 @@ def _run_session_turn(
         active_service,
         session_trigger,
         document_thread_dispatch,
+        cancellation_check=cancellation_check,
+        progress_callback=progress_callback,
     )
     if turn_conversation_id:
         context["_vibecad_codex_session"] = {

--- a/src/Mod/VibeCAD/vibecad_tests/native_analyze_context_responsiveness_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_analyze_context_responsiveness_gui_integration.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Qt responsiveness gate for bounded Native Analyze context capture."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+import traceback
+
+from PySide import QtCore, QtWidgets
+
+import VibeCADGui as VibeGui
+from VibeCADNativeAnalyzeContext import capture_responsive_analyze_snapshot
+
+
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    main_thread = threading.get_ident()
+    tick_timer = QtCore.QTimer()
+    poll_timer = QtCore.QTimer()
+    tick_count = 0
+    batch_count = 0
+    result: dict[str, object] = {}
+    worker = None
+    exit_code = 1
+
+    def finish(code: int) -> None:
+        nonlocal exit_code
+        exit_code = code
+        tick_timer.stop()
+        poll_timer.stop()
+        application.exit(exit_code)
+
+    try:
+        VibeGui._ensure_document_thread_invoker()
+        request = {
+            "document_uid": "responsive-gui-document",
+            "structural_revision": 1,
+            "object_names": [f"Object{index}" for index in range(80)],
+        }
+
+        def tick() -> None:
+            nonlocal tick_count
+            tick_count += 1
+
+        def capture_batch(_request, names):
+            nonlocal batch_count
+            assert threading.get_ident() == main_thread
+            batch_count += 1
+            # Model a costly live-object slice. Qt must run between slices.
+            time.sleep(0.02)
+            return {"names": list(names)}
+
+        def capture_clipping(_request):
+            assert threading.get_ident() == main_thread
+            return {"enabled": False}
+
+        def finalize(_request, parts, clipping):
+            assert threading.get_ident() != main_thread
+            return {
+                "object_count": sum(len(part["names"]) for part in parts),
+                "clipping": dict(clipping),
+            }
+
+        def prepare() -> None:
+            try:
+                result["snapshot"] = capture_responsive_analyze_snapshot(
+                    request,
+                    dispatch_to_document_thread=VibeGui._dispatch_to_document_thread,
+                    capture_batch=capture_batch,
+                    capture_clipping=capture_clipping,
+                    finalize=finalize,
+                )
+            except BaseException as exc:
+                result["error"] = exc
+                result["traceback"] = traceback.format_exc()
+
+        worker = threading.Thread(
+            target=prepare,
+            name="VibeCAD-test-Analyze-context",
+            daemon=True,
+        )
+        worker.start()
+
+        def inspect_result() -> None:
+            if worker is not None and worker.is_alive():
+                return
+            try:
+                if "error" in result:
+                    raise AssertionError(result.get("traceback")) from result["error"]
+                assert result.get("snapshot") == {
+                    "object_count": 80,
+                    "clipping": {"enabled": False},
+                }
+                assert batch_count == 10
+                assert tick_count >= 2, (
+                    "Qt timers did not run between bounded Analyze capture slices."
+                )
+                print(
+                    "VIBECAD_NATIVE_ANALYZE_CONTEXT_RESPONSIVE_GUI_OK "
+                    f"batches={batch_count} qt_ticks={tick_count}",
+                    flush=True,
+                )
+                finish(0)
+            except BaseException:
+                traceback.print_exc(file=sys.__stderr__)
+                finish(1)
+
+        tick_timer.timeout.connect(tick)
+        tick_timer.start(5)
+        poll_timer.timeout.connect(inspect_result)
+        poll_timer.start(20)
+        QtCore.QTimer.singleShot(15000, lambda: finish(1))
+    except BaseException:
+        traceback.print_exc(file=sys.__stderr__)
+        finish(1)
+
+
+QtCore.QTimer.singleShot(1000, _run)

--- a/src/Mod/VibeCAD/vibecad_tests/test_engine_contracts.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_engine_contracts.py
@@ -164,6 +164,75 @@ class TestStageAwareFailureRendering:
         assert covered == VibeCADTools.FAILURE_STAGES
 
 
+class TestAnalyzeContextStatusRendering:
+    @staticmethod
+    def _gui():
+        import VibeCADGui
+
+        return VibeCADGui
+
+    def test_analyze_capture_progress_reports_phase_count_and_percent(self) -> None:
+        gui = self._gui()
+        event = {
+            "event": "analyze_context_progress",
+            "percent": 45,
+            "message": "Analyzing objects 24 of 80",
+        }
+
+        assert gui._format_progress_event(event) == "Analyzing objects 24 of 80"
+        assert gui._progress_event_should_update_status(event) is True
+
+    def test_analyze_cache_hit_is_visible_in_the_status_line(self) -> None:
+        gui = self._gui()
+        event = {
+            "event": "analyze_context_cache_hit",
+            "structural_revision": 12,
+        }
+
+        assert gui._format_progress_event(event) == (
+            "Analyze context is ready for document revision 12."
+        )
+        assert gui._progress_event_should_update_status(event) is True
+
+    def test_analyze_progress_reaches_the_application_status_bar(
+        self,
+        monkeypatch,
+    ) -> None:
+        gui = self._gui()
+        shown: list[tuple[str, int]] = []
+        status_bar = SimpleNamespace(
+            showMessage=lambda text, timeout=0: shown.append((text, timeout))
+        )
+        main_window = SimpleNamespace(statusBar=lambda: status_bar)
+        monkeypatch.setattr(
+            gui.Gui,
+            "getMainWindow",
+            lambda: main_window,
+            raising=False,
+        )
+
+        gui._show_analyze_context_application_status(
+            {
+                "event": "analyze_context_progress",
+                "percent": 45,
+                "message": "Analyzing objects 24 of 80",
+            },
+            "Analyzing objects 24 of 80",
+        )
+        gui._show_analyze_context_application_status(
+            {
+                "event": "analyze_context_ready",
+                "structural_revision": 12,
+            },
+            "Analyze context is ready for document revision 12.",
+        )
+
+        assert shown == [
+            ("Analyzing objects 24 of 80", 0),
+            ("Analyze context is ready for document revision 12.", 5000),
+        ]
+
+
 def test_private_vibescript_carriers_are_not_provider_document_objects() -> None:
     from VibeCADCore import VibeCADService
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_geometry_worker_fallback.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_geometry_worker_fallback.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import threading
+import time
 from types import SimpleNamespace
 
 import pytest
@@ -12,6 +14,128 @@ from VibeCADGeometryInspection import complete_geometry_read
 
 
 REPO = Path(__file__).resolve().parents[4]
+
+
+def test_parallel_geometry_worker_count_tracks_available_cpus(monkeypatch) -> None:
+    import VibeCADGeometry as geometry
+
+    monkeypatch.setattr(geometry.os, "cpu_count", lambda: 12)
+
+    assert geometry.parallel_geometry_worker_count(100) == 9
+    assert geometry.parallel_geometry_worker_count(5) == 5
+    assert geometry.parallel_geometry_worker_count(0) == 0
+
+    monkeypatch.setattr(geometry.os, "cpu_count", lambda: 56)
+
+    assert geometry.parallel_geometry_worker_count(100) == 42
+
+    monkeypatch.setattr(geometry.os, "cpu_count", lambda: 1)
+
+    assert geometry.parallel_geometry_worker_count(100) == 1
+
+
+def test_brep_artifact_validation_fans_out_and_preserves_input_order(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    import VibeCADGeometry as geometry
+
+    monkeypatch.setattr(geometry.os, "cpu_count", lambda: 4)
+    lock = threading.Lock()
+    active = 0
+    maximum_active = 0
+
+    def validate(artifact, **_kwargs):
+        nonlocal active, maximum_active
+        with lock:
+            active += 1
+            maximum_active = max(maximum_active, active)
+        time.sleep(0.04)
+        with lock:
+            active -= 1
+        return {
+            "ok": True,
+            "valid": True,
+            "identity": artifact["identity"],
+        }
+
+    monkeypatch.setattr(geometry, "_validate_brep_artifact", validate)
+    artifacts = []
+    for index in range(8):
+        path = tmp_path / f"shape-{index}.brep"
+        path.write_bytes(f"BREP-{index}".encode("ascii"))
+        artifacts.append({"shape_path": str(path), "identity": index})
+
+    results = geometry.validate_brep_artifacts_parallel(
+        artifacts,
+        cache_root=tmp_path / "cache",
+    )
+
+    assert maximum_active == 3
+    assert [result["identity"] for result in results] == list(range(8))
+
+
+def test_parallel_brep_validation_deduplicates_and_persists_content_results(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    import VibeCADGeometry as geometry
+
+    first = tmp_path / "first.brep"
+    duplicate = tmp_path / "duplicate.brep"
+    first.write_bytes(b"SAME-EXACT-BREP")
+    duplicate.write_bytes(b"SAME-EXACT-BREP")
+    calls = []
+
+    def validate(artifact, **_kwargs):
+        calls.append(str(artifact["shape_path"]))
+        return {"ok": True, "valid": True, "validation_status": "valid"}
+
+    monkeypatch.setattr(geometry, "_validate_brep_artifact", validate)
+    cache_root = tmp_path / "cache"
+
+    initial = geometry.validate_brep_artifacts_parallel(
+        [
+            {"shape_path": str(first), "identity": "first"},
+            {"shape_path": str(duplicate), "identity": "duplicate"},
+        ],
+        cache_root=cache_root,
+    )
+    repeated = geometry.validate_brep_artifacts_parallel(
+        [{"shape_path": str(duplicate), "identity": "repeated"}],
+        cache_root=cache_root,
+    )
+
+    assert len(calls) == 1
+    assert [value["identity"] for value in initial] == ["first", "duplicate"]
+    assert initial[0]["cache_hit"] is False
+    assert initial[1]["coalesced"] is True
+    assert repeated[0]["cache_hit"] is True
+    assert list(cache_root.rglob("*.json"))
+
+
+def test_context_validation_requests_brep_check_without_extra_bop_analysis(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    import VibeCADGeometry as geometry
+
+    shape_path = tmp_path / "shape.brep"
+    shape_path.write_bytes(b"EXACT-BREP")
+    captured = []
+
+    def execute(request_path, _result_path, **_kwargs):
+        captured.append(json.loads(Path(request_path).read_text(encoding="utf-8")))
+        return {"ok": True, "valid": True}
+
+    monkeypatch.setattr(geometry, "execute_job", execute)
+
+    result = geometry._validate_brep_artifact(
+        {"shape_path": str(shape_path), "identity": "shape"}
+    )
+
+    assert result["valid"] is True
+    assert captured[0]["include_bop"] is False
 
 
 class _Vector:

--- a/src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py
@@ -671,7 +671,7 @@ def test_unsaved_run_prompt_reaches_provider_and_includes_active_thread_once(
     monkeypatch.setattr(
         session,
         "_build_context_for_provider",
-        lambda active_service, trigger, dispatch: dict(context),
+        lambda active_service, trigger, dispatch, **_kwargs: dict(context),
     )
     monkeypatch.setattr(
         session,

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_context.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_context.py
@@ -1,0 +1,474 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+import sys
+import threading
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from VibeCADNativeAnalyzeContext import (
+    AnalyzeContextCancelled,
+    AnalyzeContextCoordinator,
+    AnalyzeContextStale,
+    capture_responsive_analyze_snapshot,
+)
+from VibeCADNativeAnalyzeGeometrySources import active_analyze_geometry_sources
+
+
+def _request(revision: int = 7, count: int = 10) -> dict:
+    return {
+        "document_uid": "document-a",
+        "structural_revision": revision,
+        "object_names": [f"Object{index}" for index in range(count)],
+        "base_snapshot": {
+            "surface_id": "analyze",
+            "document": {
+                "document_uid": "document-a",
+                "document_name": "DocumentA",
+            },
+            "structural_revision": revision,
+            "working_set": [],
+        },
+        "background_job": None,
+    }
+
+
+def test_context_coordinator_coalesces_callers_and_reuses_the_revision() -> None:
+    coordinator = AnalyzeContextCoordinator()
+    entered = threading.Event()
+    release = threading.Event()
+    calls = []
+    results = []
+
+    def build(cancelled, progress):
+        calls.append("build")
+        entered.set()
+        progress(25, "Capturing Analyze state")
+        assert release.wait(1.0)
+        assert cancelled() is False
+        return {"revision": 7, "items": ["captured"]}
+
+    def read() -> None:
+        results.append(
+            coordinator.get_or_build(
+                "document-a",
+                7,
+                build,
+            )
+        )
+
+    first = threading.Thread(target=read)
+    second = threading.Thread(target=read)
+    first.start()
+    assert entered.wait(1.0)
+    second.start()
+    time.sleep(0.02)
+    release.set()
+    first.join(1.0)
+    second.join(1.0)
+
+    assert calls == ["build"]
+    assert results == [
+        {"revision": 7, "items": ["captured"]},
+        {"revision": 7, "items": ["captured"]},
+    ]
+    assert results[0] is not results[1]
+
+    cached = coordinator.get_or_build(
+        "document-a",
+        7,
+        lambda *_args: pytest.fail("the current revision must be cached"),
+    )
+    assert cached == results[0]
+    assert cached is not results[0]
+
+
+def test_context_coordinator_uses_revision_keys_and_discards_stale_completion() -> None:
+    coordinator = AnalyzeContextCoordinator()
+    entered = threading.Event()
+    release = threading.Event()
+    outcome = []
+
+    def build(cancelled, _progress):
+        entered.set()
+        assert release.wait(1.0)
+        assert cancelled() is True
+        return {"revision": 7}
+
+    def read() -> None:
+        try:
+            coordinator.get_or_build("document-a", 7, build)
+        except BaseException as exc:
+            outcome.append(exc)
+
+    worker = threading.Thread(target=read)
+    worker.start()
+    assert entered.wait(1.0)
+    coordinator.invalidate_document("document-a")
+    release.set()
+    worker.join(1.0)
+
+    assert len(outcome) == 1
+    assert isinstance(outcome[0], AnalyzeContextStale)
+
+    rebuilt = coordinator.get_or_build(
+        "document-a",
+        8,
+        lambda _cancelled, _progress: {"revision": 8},
+    )
+    assert rebuilt == {"revision": 8}
+
+
+def test_context_waiter_can_cancel_without_cancelling_shared_capture() -> None:
+    coordinator = AnalyzeContextCoordinator()
+    entered = threading.Event()
+    release = threading.Event()
+    owner_result = []
+
+    def build(_cancelled, _progress):
+        entered.set()
+        assert release.wait(1.0)
+        return {"revision": 7}
+
+    owner = threading.Thread(
+        target=lambda: owner_result.append(
+            coordinator.get_or_build("document-a", 7, build)
+        )
+    )
+    owner.start()
+    assert entered.wait(1.0)
+
+    with pytest.raises(AnalyzeContextCancelled):
+        coordinator.get_or_build(
+            "document-a",
+            7,
+            build,
+            cancellation_check=lambda: True,
+        )
+
+    release.set()
+    owner.join(1.0)
+    assert owner_result == [{"revision": 7}]
+
+
+def test_responsive_capture_dispatches_bounded_document_thread_batches() -> None:
+    request = _request(count=10)
+    dispatches = []
+    batches = []
+
+    def dispatch(operation):
+        dispatches.append(threading.get_ident())
+        return operation()
+
+    def capture_batch(current, names):
+        assert current == request
+        batches.append(list(names))
+        return {"captured": list(names)}
+
+    result = capture_responsive_analyze_snapshot(
+        request,
+        dispatch_to_document_thread=dispatch,
+        capture_batch=capture_batch,
+        capture_clipping=lambda current: {
+            "available": current["document_uid"] == "document-a"
+        },
+        finalize=lambda current, parts, clipping: {
+            "request": deepcopy(current),
+            "parts": list(parts),
+            "clipping": dict(clipping),
+        },
+        batch_size=3,
+    )
+
+    assert batches == [
+        ["Object0", "Object1", "Object2"],
+        ["Object3", "Object4", "Object5"],
+        ["Object6", "Object7", "Object8"],
+        ["Object9"],
+    ]
+    assert len(dispatches) == 5
+    assert result["clipping"] == {"available": True}
+    assert [part["captured"] for part in result["parts"]] == batches
+
+
+def test_responsive_capture_postprocesses_detached_parts_outside_dispatch() -> None:
+    request = _request(count=4)
+    in_dispatch = False
+    postprocessed = []
+
+    def dispatch(operation):
+        nonlocal in_dispatch
+        in_dispatch = True
+        try:
+            return operation()
+        finally:
+            in_dispatch = False
+
+    def postprocess(_request, parts, _cancelled, _progress):
+        assert in_dispatch is False
+        postprocessed.append(True)
+        return [{**part, "validated": True} for part in parts]
+
+    result = capture_responsive_analyze_snapshot(
+        request,
+        dispatch_to_document_thread=dispatch,
+        capture_batch=lambda _current, names: {"captured": list(names)},
+        capture_clipping=lambda _current: {},
+        finalize=lambda _current, parts, _clipping: {"parts": list(parts)},
+        postprocess_parts=postprocess,
+        batch_size=2,
+    )
+
+    assert postprocessed == [True]
+    assert all(part["validated"] is True for part in result["parts"])
+
+
+def test_responsive_capture_checks_cancellation_between_batches() -> None:
+    request = _request(count=5)
+    completed_batches = 0
+
+    def capture_batch(_current, names):
+        nonlocal completed_batches
+        completed_batches += 1
+        return {"captured": list(names)}
+
+    with pytest.raises(AnalyzeContextCancelled):
+        capture_responsive_analyze_snapshot(
+            request,
+            dispatch_to_document_thread=lambda operation: operation(),
+            capture_batch=capture_batch,
+            capture_clipping=lambda _current: {},
+            finalize=lambda _current, _parts, _clipping: {},
+            cancellation_check=lambda: completed_batches == 1,
+            batch_size=2,
+        )
+
+    assert completed_batches == 1
+
+
+def test_session_capture_uses_document_dispatches_then_reuses_cache(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSnapshot as analyze_snapshot_module
+    import VibeCADSession as session_module
+
+    coordinator = AnalyzeContextCoordinator()
+    request = _request(count=10)
+    request["cacheable"] = True
+    request["base_snapshot"]["_selection"] = {
+        "document_uid": "document-a",
+        "items": [],
+    }
+    capture_calls = []
+    in_dispatch = False
+    begin_calls = 0
+
+    class _Service:
+        def begin_native_analyze_context_request(self):
+            nonlocal begin_calls
+            assert in_dispatch
+            begin_calls += 1
+            current = deepcopy(request)
+            if begin_calls > 1:
+                current["base_snapshot"]["selection"] = {
+                    "document_uid": "document-a",
+                    "items": [{"object": {"object_name": "Object9"}}],
+                }
+            return current
+
+        @staticmethod
+        def native_analyze_context_coordinator():
+            return coordinator
+
+        @staticmethod
+        def capture_native_analyze_context_batch(current, names):
+            assert in_dispatch
+            capture_calls.append(list(names))
+            return {"captured": list(names)}
+
+        @staticmethod
+        def capture_native_analyze_context_clipping(current):
+            assert in_dispatch
+            return {"available": current["document_uid"] == "document-a"}
+
+    def dispatch(operation):
+        nonlocal in_dispatch
+        assert in_dispatch is False
+        in_dispatch = True
+        try:
+            return operation()
+        finally:
+            in_dispatch = False
+
+    monkeypatch.setattr(
+        analyze_snapshot_module,
+        "finish_analyze_snapshot_capture",
+        lambda current, parts, clipping: {
+            "kind": "analyze",
+            "captured_names": [
+                name for part in parts for name in part["captured"]
+            ],
+            "clipping": dict(clipping),
+        },
+    )
+    events = []
+
+    first = session_module._build_responsive_analyze_native_state(
+        _Service(),
+        dispatch,
+        progress_callback=events.append,
+    )
+    second = session_module._build_responsive_analyze_native_state(
+        _Service(),
+        dispatch,
+        progress_callback=events.append,
+    )
+
+    assert first["domain"] == second["domain"]
+    assert "selection" not in first
+    assert second["selection"]["items"][0]["object"]["object_name"] == "Object9"
+    assert first["domain"]["captured_names"] == request["object_names"]
+    assert capture_calls == [
+        request["object_names"][:8],
+        request["object_names"][8:],
+    ]
+    assert any(event["event"] == "analyze_context_progress" for event in events)
+    assert any(event["event"] == "analyze_context_ready" for event in events)
+    assert any(event["event"] == "analyze_context_cache_hit" for event in events)
+
+
+class _Shape:
+    def __init__(self) -> None:
+        self.validity_checks = 0
+        self.Solids = [object()]
+        self.Faces = []
+        self.Edges = []
+
+    def isNull(self) -> bool:
+        return False
+
+    def isValid(self) -> bool:
+        self.validity_checks += 1
+        return True
+
+
+class _GeometryObject:
+    def __init__(self, document) -> None:
+        self.Document = document
+        self.Name = "Body"
+        self.ID = 1
+        self.TypeId = "PartDesign::Body"
+        self.Shape = _Shape()
+        self.VibeCADTimelineRole = ""
+        self.VibeCADAnalysisDomain = False
+
+    def isDerivedFrom(self, type_id: str) -> bool:
+        return type_id == "PartDesign::Body"
+
+    def getParentGeoFeatureGroup(self):
+        return None
+
+
+def test_batched_geometry_discovery_keeps_shape_validation(monkeypatch) -> None:
+    document = SimpleNamespace(Uid="document-a", Objects=[])
+    obj = _GeometryObject(document)
+    document.Objects = [obj]
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    captured = active_analyze_geometry_sources(
+        document,
+        filter_analysis_sources=False,
+    )
+
+    assert captured == (obj,)
+    assert obj.Shape.validity_checks == 1
+
+
+def test_context_geometry_discovery_defers_unbounded_brep_validation(
+    monkeypatch,
+) -> None:
+    document = SimpleNamespace(Uid="document-a", Objects=[])
+    obj = _GeometryObject(document)
+    document.Objects = [obj]
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    captured = active_analyze_geometry_sources(
+        document,
+        filter_analysis_sources=False,
+        validate_brep=False,
+    )
+
+    assert captured == (obj,)
+    assert obj.Shape.validity_checks == 0
+
+
+def test_responsive_context_request_marks_geometry_validation_as_deferred() -> None:
+    import VibeCADNativeAnalyzeSnapshot as analyze_snapshot_module
+
+    document = SimpleNamespace(
+        Uid="document-a",
+        Objects=[],
+    )
+
+    request = analyze_snapshot_module.begin_analyze_snapshot_capture(
+        document,
+        defer_brep_validation=True,
+    )
+
+    assert request["defer_brep_validation"] is True
+    assert request["geometry_validation_artifact_root"]
+
+
+def test_analyze_geometry_postprocess_keeps_only_isolated_valid_results(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    import VibeCADNativeAnalyzeSnapshot as analyze_snapshot_module
+
+    artifacts = [
+        {"shape_path": str(tmp_path / "valid.brep"), "identity": "valid"},
+        {"shape_path": str(tmp_path / "invalid.brep"), "identity": "invalid"},
+    ]
+    for artifact in artifacts:
+        Path(artifact["shape_path"]).write_bytes(b"BREP")
+    monkeypatch.setattr(
+        "VibeCADGeometry.validate_brep_artifacts_parallel",
+        lambda _artifacts, **_kwargs: [
+            {"identity": "valid", "ok": True, "valid": True},
+            {"identity": "invalid", "ok": True, "valid": False},
+        ],
+    )
+    parts = [
+        {
+            "geometry_source_count": 2,
+            "geometry_sources": [
+                {"object_name": "Valid", "_brep_validation_identity": "valid"},
+                {"object_name": "Invalid", "_brep_validation_identity": "invalid"},
+            ],
+            "geometry_validation_artifacts": artifacts,
+        }
+    ]
+
+    processed = analyze_snapshot_module.validate_analyze_snapshot_geometry(
+        {"defer_brep_validation": True},
+        parts,
+        None,
+        None,
+    )
+
+    assert processed[0]["geometry_source_count"] == 1
+    assert processed[0]["geometry_sources"] == [{"object_name": "Valid"}]
+    assert "geometry_validation_artifacts" not in processed[0]

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC5",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 3,
+  "build_version": 4,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Summary

- add a document/revision-scoped Analyze context coordinator that coalesces concurrent reads, caches completed detached snapshots, and rejects stale work
- capture live FreeCAD state in bounded document-thread batches while provider preparation, validation, shaping, and hashing stay off the Qt thread
- preserve exact BREP validity by exporting detached artifacts and validating them in isolated native workers, deduplicated and persistently cached by BREP SHA-256
- use up to 75% of logical CPUs for validation (42 workers on a 56-thread machine), while never exceeding the number of pending shapes
- prewarm Analyze context on workbench activation, invalidate it on structural changes/document close, and report honest progress in the assistant and application status bars
- bump RC5 to build 4 so the merged fix can be published as a distinct update

The live profile showed the apparent freeze inside `Shape.isValid()` / OCCT `BRepCheck_Analyzer` on the UI thread. This keeps that exact validity decision, but moves it to detached worker processes and avoids repeating it for identical geometry. Existing explicit geometry operations retain their legacy full BREP+BOP worker validation.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
- [x] The PR lists the exact build and test commands and their results.

### Red

The focused coordinator/deferred-validation/status tests were added first:

```powershell
$env:PYTHONPATH=(Resolve-Path 'src\Mod\VibeCAD').Path
.\.pixi\envs\default\python.exe -m pytest src\Mod\VibeCAD\vibecad_tests\test_native_analyze_context.py src\Mod\VibeCAD\vibecad_tests\test_geometry_worker_fallback.py src\Mod\VibeCAD\vibecad_tests\test_engine_contracts.py -q
```

Result before implementation: `5 failed, 50 passed` (missing responsive coordinator, deferred validation, and status behavior).

The 75% CPU-budget test was also changed before its implementation:

```powershell
$root=(Resolve-Path '.pixi\envs\default').Path
$env:PATH="$root;$root\Library\mingw-w64\bin;$root\Library\usr\bin;$root\Library\bin;$root\Scripts;$root\bin;$env:PATH"
$env:PYTHONPATH=(Resolve-Path 'src\Mod\VibeCAD').Path
& "$root\python.exe" -m pytest src\Mod\VibeCAD\vibecad_tests\test_geometry_worker_fallback.py -q
```

Result before the worker-budget change: `2 failed, 12 passed`; the implementation still selected 12/12 and 4/4 logical CPUs instead of 9/12 and 3/4.

### Green

Focused worker tests:

```powershell
$root=(Resolve-Path '.pixi\envs\default').Path
$env:PATH="$root;$root\Library\mingw-w64\bin;$root\Library\usr\bin;$root\Library\bin;$root\Scripts;$root\bin;$env:PATH"
$env:PYTHONPATH=(Resolve-Path 'src\Mod\VibeCAD').Path
& "$root\python.exe" -m pytest src\Mod\VibeCAD\vibecad_tests\test_geometry_worker_fallback.py -q
```

Result: `14 passed in 0.98s`.

Full touched-area Analyze/geometry/context regression slice:

```powershell
$root=(Resolve-Path '.pixi\envs\default').Path
$portable=(Resolve-Path 'package\rattler-build\windows\VibeCAD-26.3.1-RC5-build3-Windows-x86_64').Path
$env:PATH="$root;$root\Library\mingw-w64\bin;$root\Library\usr\bin;$root\Library\bin;$root\Scripts;$root\bin;$env:PATH"
$env:PYTHONPATH="$(Resolve-Path 'src\Mod\VibeCAD');$portable\Mod\TechDraw;$portable\Mod\PartDesign;$portable\Mod\Fem"
$tests=@(Get-ChildItem 'src\Mod\VibeCAD\vibecad_tests' -File -Filter 'test_*analyze*.py' | ForEach-Object { $_.FullName })
$tests += (Resolve-Path 'src\Mod\VibeCAD\vibecad_tests\test_geometry_worker_fallback.py').Path
$tests += (Resolve-Path 'src\Mod\VibeCAD\vibecad_tests\test_engine_contracts.py').Path
$tests += (Resolve-Path 'src\Mod\VibeCAD\vibecad_tests\test_model_context_contract.py').Path
& "$root\python.exe" -m pytest @tests -q
```

Result: `168 passed in 8.25s`.

Full Windows native development package rebuild:

```powershell
cd package\rattler-build
pixi reinstall -e default vibecad
```

Result: exit code `0` in `1009.4s`; rebuilt and installed `VibeCADGeometryWorker.exe` and the VibeCAD Python modules.

Installed-worker runtime smoke results:

- legacy full shape validation: `ok=true`, `valid=true`
- new context BREP-only validation: `ok=true`, `valid=true`, `bop.performed=false`
- duplicate BREP artifacts: first call `cache_hit=[false,false]`, `coalesced=[false,true]`
- persistent second call: `cache_hit=[true,true]`, `coalesced=[false,true]`

Additional source checks:

```powershell
.\.pixi\envs\default\python.exe -m py_compile src\Mod\VibeCAD\VibeCADCore.py src\Mod\VibeCAD\VibeCADGeometry.py src\Mod\VibeCAD\VibeCADGui.py src\Mod\VibeCAD\VibeCADNativeAnalyzeClipping.py src\Mod\VibeCAD\VibeCADNativeAnalyzeContext.py src\Mod\VibeCAD\VibeCADNativeAnalyzeGeometrySources.py src\Mod\VibeCAD\VibeCADNativeAnalyzeSnapshot.py src\Mod\VibeCAD\VibeCADNativeSnapshot.py src\Mod\VibeCAD\VibeCADSession.py
git diff --check
```

Result: both passed with exit code `0`.

Release metadata and update contracts:

```powershell
.\.pixi\envs\default\python.exe src\Tools\sync_version.py --check
.\.pixi\envs\default\python.exe -m unittest src.Tools.tests.test_sync_version src.Tools.tests.test_release_artifact_name src.Tools.tests.test_windows_installer_version src.Tools.tests.test_generate_update_manifest src.Tools.tests.test_release_workflow src.Tools.tests.test_vibecad_update
.\.pixi\envs\default\python.exe src\Tools\resolve_release_artifact_name.py . --component release-tag
.\.pixi\envs\default\python.exe src\Tools\resolve_release_artifact_name.py . --component basename
```

Result: all canonical files synchronized; `113 tests` passed with `3` expected skips; resolved release tag `v26.3.1-RC5-build4` and artifact basename `VibeCAD-26.3.1-RC5-build4`. TDD does not apply to the two-value release metadata bump.

Manual Windows acceptance used a 2,337-object CAD document that previously stopped visibly around object 544-552. Context preparation now continues while the VibeCAD window remains responsive; the owner confirmed the experience is substantially better and acceptable.

## Risk and non-goals

- First-time exact validation still consumes CPU and I/O, but it is isolated from Qt, limited to 75% of logical CPUs, coalesced by revision, and cached by exact BREP content for later conversations/restarts.
- Live FreeCAD objects and `TopoShape` wrappers never leave the document thread; only exported BREP paths and detached mappings reach worker threads/processes.
- This does not alter mutation, mesh, solver, provider-tool, preference, or wire-schema contracts.

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed/removed without approval.
- [x] Defaults preserve previous behavior for users who do not opt into new features.
- [x] Deprecations (if any) are documented and dual-path supported. (None.)
- [x] Breaking changes are listed with owner approval reference. (None.)

## Issues

Closes #96

## Before and After Images

No static image captures the change: this fixes event-loop responsiveness during Analyze context preparation. The Windows manual test above exercised the previously freezing interaction directly.
