### PR TITLE
Run Analyze solvers in the background and restore McMaster on Windows

### DIFF
--- a/package/rattler-build/windows/create_bundle.sh
+++ b/package/rattler-build/windows/create_bundle.sh
@@ -236,6 +236,10 @@ if ! "$SIGN_DIR/Mod/McMasterInsert/McMasterCatalogWebView2.exe" --smoke-test; th
   echo "VibeCAD McMaster WebView2 helper could not find the Edge WebView2 Runtime."
   exit 1
 fi
+if ! "$SIGN_DIR/Mod/McMasterInsert/McMasterCatalogWebView2.exe" --argument-parser-smoke-test --inbox=parser-smoke-inbox --profile parser-smoke-profile; then
+  echo "VibeCAD McMaster WebView2 helper could not parse its launch paths."
+  exit 1
+fi
 if ! "$SIGN_DIR/bin/freecadcmd.exe" --safe-mode -c "import importlib.util, anthropic, keyring, jsonschema, mcp, mcp_types, tuf; import keyring.backends.Windows; assert importlib.util.find_spec('openai') is None; assert importlib.util.find_spec('agents') is None; print('VibeCAD Python dependencies and OS keyring backend import ok')"; then
   echo "VibeCAD Python dependency/keyring smoke test failed; the Windows bundle is incomplete."
   exit 1

--- a/src/Mod/Fem/Gui/AppFemGui.cpp
+++ b/src/Mod/Fem/Gui/AppFemGui.cpp
@@ -25,6 +25,7 @@
 #include <Base/Console.h>
 #include <Base/PyObjectBase.h>
 #include <Gui/Application.h>
+#include <Gui/Dialogs/DlgPreferencesImp.h>
 #include <Gui/WidgetFactory.h>
 #include <Gui/Language/Translator.h>
 
@@ -35,6 +36,7 @@
 #include "DlgSettingsFemGmshImp.h"
 #include "DlgSettingsFemInOutVtkImp.h"
 #include "DlgSettingsFemMystranImp.h"
+#include "DlgSettingsFemOpenFOAMImp.h"
 #include "DlgSettingsFemZ88Imp.h"
 #include "PropertyFemMeshItem.h"
 #include "ViewProviderAnalysis.h"
@@ -191,13 +193,16 @@ PyMOD_INIT_FUNC(FemGui)
 #endif
 
 
-    // register preferences pages on FEM, the order here will be the order of the tabs in pref widget
-    new Gui::PrefPageProducer<FemGui::DlgSettingsFemGeneralImp>(QT_TRANSLATE_NOOP("QObject", "FEM"));
-    new Gui::PrefPageProducer<FemGui::DlgSettingsFemGmshImp>(QT_TRANSLATE_NOOP("QObject", "FEM"));
-    new Gui::PrefPageProducer<FemGui::DlgSettingsFemCcxImp>(QT_TRANSLATE_NOOP("QObject", "FEM"));
-    new Gui::PrefPageProducer<FemGui::DlgSettingsFemElmerImp>(QT_TRANSLATE_NOOP("QObject", "FEM"));
-    new Gui::PrefPageProducer<FemGui::DlgSettingsFemMystranImp>(QT_TRANSLATE_NOOP("QObject", "FEM"));
-    new Gui::PrefPageProducer<FemGui::DlgSettingsFemZ88Imp>(QT_TRANSLATE_NOOP("QObject", "FEM"));
+    // register preferences pages on Analyze, the order here will be the order of the tabs in pref widget
+    Gui::Dialog::DlgPreferencesImp::setGroupData(
+        "Analyze", "fem", QObject::tr("Analyze workbench"));
+    new Gui::PrefPageProducer<FemGui::DlgSettingsFemGeneralImp>(QT_TRANSLATE_NOOP("QObject", "Analyze"));
+    new Gui::PrefPageProducer<FemGui::DlgSettingsFemGmshImp>(QT_TRANSLATE_NOOP("QObject", "Analyze"));
+    new Gui::PrefPageProducer<FemGui::DlgSettingsFemCcxImp>(QT_TRANSLATE_NOOP("QObject", "Analyze"));
+    new Gui::PrefPageProducer<FemGui::DlgSettingsFemElmerImp>(QT_TRANSLATE_NOOP("QObject", "Analyze"));
+    new Gui::PrefPageProducer<FemGui::DlgSettingsFemMystranImp>(QT_TRANSLATE_NOOP("QObject", "Analyze"));
+    new Gui::PrefPageProducer<FemGui::DlgSettingsFemZ88Imp>(QT_TRANSLATE_NOOP("QObject", "Analyze"));
+    new Gui::PrefPageProducer<FemGui::DlgSettingsFemOpenFOAMImp>(QT_TRANSLATE_NOOP("QObject", "Analyze"));
 
     // register preferences pages on Import-Export
     new Gui::PrefPageProducer<FemGui::DlgSettingsFemExportAbaqusImp>(QT_TRANSLATE_NOOP("QObject", "Import-Export"));

--- a/src/Mod/Fem/Gui/CMakeLists.txt
+++ b/src/Mod/Fem/Gui/CMakeLists.txt
@@ -54,6 +54,7 @@ set(FemGui_UIC_SRCS
     DlgSettingsFemGmsh.ui
     DlgSettingsFemInOutVtk.ui
     DlgSettingsFemMystran.ui
+    DlgSettingsFemOpenFOAM.ui
     DlgSettingsFemZ88.ui
     TaskCreateElementSet.ui
     TaskCreateNodeSet.ui
@@ -122,6 +123,9 @@ SET(FemGui_DLG_SRCS
     DlgSettingsFemMystran.ui
     DlgSettingsFemMystranImp.cpp
     DlgSettingsFemMystranImp.h
+    DlgSettingsFemOpenFOAM.ui
+    DlgSettingsFemOpenFOAMImp.cpp
+    DlgSettingsFemOpenFOAMImp.h
     DlgSettingsFemZ88.ui
     DlgSettingsFemZ88Imp.cpp
     DlgSettingsFemZ88Imp.h

--- a/src/Mod/Fem/Gui/DlgSettingsFemOpenFOAM.ui
+++ b/src/Mod/Fem/Gui/DlgSettingsFemOpenFOAM.ui
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>FemGui::DlgSettingsFemOpenFOAMImp</class>
+ <widget class="QWidget" name="FemGui::DlgSettingsFemOpenFOAMImp">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>480</width>
+    <height>180</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>OpenFOAM</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="gb_openfoam_environment">
+     <property name="title">
+      <string>OpenFOAM Environment</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <item>
+       <widget class="QLabel" name="l_openfoam_description">
+        <property name="text">
+         <string>Select the OpenFOAM shell environment file, normally etc/bashrc inside the OpenFOAM installation.</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="0" column="0">
+         <widget class="QLabel" name="l_openfoam_environment_file">
+          <property name="text">
+           <string>Environment file</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="Gui::PrefFileChooser" name="fc_openfoam_environment_file" native="true">
+          <property name="toolTip">
+           <string>Leave blank to use the current OpenFOAM environment or automatically detect one installation</string>
+          </property>
+          <property name="prefEntry" stdset="0">
+           <cstring>EnvironmentFile</cstring>
+          </property>
+          <property name="prefPath" stdset="0">
+           <cstring>Mod/Fem/OpenFOAM</cstring>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>Gui::PrefFileChooser</class>
+   <extends>Gui::FileChooser</extends>
+   <header>Gui/PrefWidgets.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="Resources/Fem.qrc"/>
+ </resources>
+</ui>

--- a/src/Mod/Fem/Gui/DlgSettingsFemOpenFOAMImp.cpp
+++ b/src/Mod/Fem/Gui/DlgSettingsFemOpenFOAMImp.cpp
@@ -1,0 +1,79 @@
+/***************************************************************************
+ *   Copyright (c) 2026 VibeCAD Developers                                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QFileInfo>
+#include <QMessageBox>
+
+#include "DlgSettingsFemOpenFOAMImp.h"
+#include "ui_DlgSettingsFemOpenFOAM.h"
+
+
+using namespace FemGui;
+
+DlgSettingsFemOpenFOAMImp::DlgSettingsFemOpenFOAMImp(QWidget* parent)
+    : PreferencePage(parent)
+    , ui(new Ui_DlgSettingsFemOpenFOAMImp)
+{
+    ui->setupUi(this);
+
+    connect(
+        ui->fc_openfoam_environment_file,
+        &Gui::PrefFileChooser::fileNameSelected,
+        this,
+        &DlgSettingsFemOpenFOAMImp::onFileNameSelected
+    );
+}
+
+DlgSettingsFemOpenFOAMImp::~DlgSettingsFemOpenFOAMImp() = default;
+
+void DlgSettingsFemOpenFOAMImp::saveSettings()
+{
+    ui->fc_openfoam_environment_file->onSave();
+}
+
+void DlgSettingsFemOpenFOAMImp::loadSettings()
+{
+    ui->fc_openfoam_environment_file->onRestore();
+}
+
+void DlgSettingsFemOpenFOAMImp::changeEvent(QEvent* e)
+{
+    if (e->type() == QEvent::LanguageChange) {
+        ui->retranslateUi(this);
+    }
+    else {
+        QWidget::changeEvent(e);
+    }
+}
+
+void DlgSettingsFemOpenFOAMImp::onFileNameSelected(const QString& fileName)
+{
+    if (!fileName.isEmpty() && !QFileInfo::exists(fileName)) {
+        QMessageBox::critical(
+            this,
+            tr("OpenFOAM"),
+            tr("Environment file '%1' not found").arg(fileName)
+        );
+    }
+}
+
+#include "moc_DlgSettingsFemOpenFOAMImp.cpp"

--- a/src/Mod/Fem/Gui/DlgSettingsFemOpenFOAMImp.h
+++ b/src/Mod/Fem/Gui/DlgSettingsFemOpenFOAMImp.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *   Copyright (c) 2026 VibeCAD Developers                                 *
+ *                                                                         *
+ *   This file is part of the FreeCAD CAx development system.              *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Library General Public           *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2 of the License, or (at your option) any later version.      *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU Library General Public License for more details.                  *
+ *                                                                         *
+ *   You should have received a copy of the GNU Library General Public     *
+ *   License along with this library; see the file COPYING.LIB. If not,    *
+ *   write to the Free Software Foundation, Inc., 59 Temple Place,         *
+ *   Suite 330, Boston, MA  02111-1307, USA                                *
+ *                                                                         *
+ ***************************************************************************/
+
+#pragma once
+
+#include <Gui/PropertyPage.h>
+#include <memory>
+
+
+namespace FemGui
+{
+
+class Ui_DlgSettingsFemOpenFOAMImp;
+class DlgSettingsFemOpenFOAMImp: public Gui::Dialog::PreferencePage
+{
+    Q_OBJECT
+
+public:
+    explicit DlgSettingsFemOpenFOAMImp(QWidget* parent = nullptr);
+    ~DlgSettingsFemOpenFOAMImp() override;
+
+protected Q_SLOTS:
+    void onFileNameSelected(const QString& fileName);
+
+protected:
+    void saveSettings() override;
+    void loadSettings() override;
+    void changeEvent(QEvent* e) override;
+
+private:
+    std::unique_ptr<Ui_DlgSettingsFemOpenFOAMImp> ui;
+};
+
+}  // namespace FemGui

--- a/src/Mod/Fem/InitGui.py
+++ b/src/Mod/Fem/InitGui.py
@@ -74,8 +74,6 @@ class FemWorkbench(Workbench):
         import femcommands.commands
         import fempreferencepages
 
-        FreeCADGui.addPreferencePage(fempreferencepages.DlgSettingsNetgen, "FEM")
-
         # dummy usage to get flake8 and lgtm quiet
         False if Fem.__name__ else True
         False if FemGui.__name__ else True
@@ -93,3 +91,12 @@ class FemWorkbench(Workbench):
 
 
 FreeCADGui.addWorkbench(FemWorkbench())
+
+# Analyze preferences are application settings, so expose them at GUI startup
+# rather than waiting for the user to activate the workbench for the first time.
+# Importing FemGui registers its native preference pages; Netgen is Python-based
+# and therefore registered explicitly here.
+import FemGui
+import fempreferencepages
+
+FreeCADGui.addPreferencePage(fempreferencepages.DlgSettingsNetgen, "Analyze")

--- a/src/Mod/McMasterInsert/McMasterCatalogWebView2.cpp
+++ b/src/Mod/McMasterInsert/McMasterCatalogWebView2.cpp
@@ -60,9 +60,15 @@ void showWebViewError(const std::wstring& message)
 
 std::wstring argumentValue(const std::vector<std::wstring>& arguments, const wchar_t* name)
 {
-    for (std::size_t index = 0; index + 1 < arguments.size(); ++index) {
-        if (arguments[index] == name) {
+    const std::wstring option(name);
+    const std::wstring prefix = option + L"=";
+    for (std::size_t index = 0; index < arguments.size(); ++index) {
+        const auto& argument = arguments[index];
+        if (argument == option && index + 1 < arguments.size()) {
             return arguments[index + 1];
+        }
+        if (argument.compare(0, prefix.size(), prefix) == 0) {
+            return argument.substr(prefix.size());
         }
     }
     return {};
@@ -510,6 +516,11 @@ int WINAPI wWinMain(HINSTANCE instance, HINSTANCE, PWSTR, int commandShow)
 
     inboxPath = argumentValue(arguments, L"--inbox");
     profilePath = argumentValue(arguments, L"--profile");
+    if (hasArgument(arguments, L"--argument-parser-smoke-test")) {
+        const bool parsedRequiredPaths = !inboxPath.empty() && !profilePath.empty();
+        CoUninitialize();
+        return parsedRequiredPaths ? 0 : 4;
+    }
     const auto requestedUrl = argumentValue(arguments, L"--url");
     if (!requestedUrl.empty()) {
         initialUrl = requestedUrl;

--- a/src/Mod/McMasterInsert/tests/test_catalog.py
+++ b/src/Mod/McMasterInsert/tests/test_catalog.py
@@ -592,9 +592,19 @@ class TestCatalogLaunch(unittest.TestCase):
         self.assertIn("WebView2LoaderStatic.lib", cmake)
         self.assertIn("INSTALL(TARGETS McMasterCatalogWebView2", cmake)
         self.assertIn('McMasterCatalogWebView2.exe" --smoke-test', bundle)
+        self.assertIn(
+            'McMasterCatalogWebView2.exe" --argument-parser-smoke-test '
+            '--inbox=parser-smoke-inbox --profile parser-smoke-profile',
+            bundle,
+        )
         webview_source = source.read_text(encoding="utf-8")
         self.assertIn('L".download"', webview_source)
         self.assertIn("std::filesystem::rename", webview_source)
+        self.assertIn('L"--argument-parser-smoke-test"', webview_source)
+        self.assertIn('const std::wstring prefix = option + L"=";', webview_source)
+        self.assertIn(
+            "argument.compare(0, prefix.size(), prefix) == 0", webview_source
+        )
         self.assertTrue(source.is_file())
 
     def test_linux_build_packages_webkit_helper(self):

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -158,9 +158,12 @@ set(VibeCAD_Scripts
     VibeCADNativeAnalyzeSolverExecution.py
     VibeCADAnalyzeSolverGui.py
     VibeCADNativeAnalyzeSolverExecutionBindings.py
+    VibeCADNativeAnalyzeSolverExecutionChild.py
+    VibeCADNativeAnalyzeSolverExecutionInput.py
     VibeCADNativeAnalyzeSolverExecutionProcess.py
     VibeCADNativeAnalyzeSolverExecutionRuntime.py
     VibeCADNativeAnalyzeSolverExecutionSchema.py
+    VibeCADNativeAnalyzeSolverExecutionWorker.py
     VibeCADNativeAnalyzeStructuralLifecycleBindings.py
     VibeCADNativeAnalyzeStructuralLifecycleSchema.py
     VibeCADNativeAnalyzeSolverRuntime.py

--- a/src/Mod/VibeCAD/VibeCADAnalyzeSolverGui.py
+++ b/src/Mod/VibeCAD/VibeCADAnalyzeSolverGui.py
@@ -13,17 +13,23 @@ from PySide import QtCore, QtWidgets
 from VibeCADCore import get_service
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
 from VibeCADNativeAnalyzeSolverExecution import (
+    capture_solver_execution_request,
     commit_solver_execution,
-    discard_solver_execution_request,
-    prepare_solver_execution_request,
-    run_solver_execution,
+    validate_captured_solver_execution,
     verify_solver_execution,
+)
+from VibeCADNativeAnalyzeSolverExecutionInput import (
+    create_solver_execution_workspace,
+    freeze_solver_execution_snapshot,
+    materialize_solver_execution_snapshot,
+)
+from VibeCADNativeAnalyzeSolverExecutionWorker import (
+    execute_frozen_solver_execution,
 )
 from VibeCADNativeAnalyzeSolverState import solver_state
 from VibeCADNativeBackground import NativeBackgroundError
 from VibeCADNativeMutation import NativeMutationDraft
 import VibeCADGui
-
 
 _ACTIVE_RUNS: dict[str, "_SolverRunUi"] = {}
 _BACKEND_LABELS = {
@@ -72,11 +78,18 @@ def _commit_human_result(document: Any, prepared: Any) -> Mapping[str, Any]:
 
 
 class _SolverRunUi:
-    def __init__(self, document: Any, request: Any, manager: Any) -> None:
+    def __init__(
+        self,
+        document: Any,
+        captured: Any,
+        workspace: Any,
+        manager: Any,
+    ) -> None:
         self.document = document
-        self.request = request
+        self.captured = captured
+        self.workspace = workspace
         self.manager = manager
-        self.backend = _BACKEND_LABELS[request.target.kind]
+        self.backend = _BACKEND_LABELS[captured.target.kind]
         self.job_id = ""
         self.dialog = QtWidgets.QProgressDialog(
             f"Preparing {self.backend} case",
@@ -98,10 +111,25 @@ class _SolverRunUi:
 
     def start(self) -> str:
         document = self.document
-        request = self.request
+        captured = self.captured
+        workspace = self.workspace
 
         def prepare(cancelled: Any, progress: Any) -> Any:
-            return run_solver_execution(request, cancelled=cancelled, progress=progress)
+            progress(3, "Capturing exact FEM document")
+            materialized = VibeCADGui._dispatch_to_document_thread(
+                lambda: materialize_solver_execution_snapshot(
+                    document,
+                    captured,
+                    workspace,
+                )
+            )
+            progress(5, "Authenticating exact FEM document snapshot")
+            frozen = freeze_solver_execution_snapshot(materialized)
+            return execute_frozen_solver_execution(
+                frozen,
+                cancelled=cancelled,
+                progress=progress,
+            )
 
         def validate() -> None:
             if not _document_is_live(document):
@@ -109,6 +137,7 @@ class _SolverRunUi:
                     "The FEM document closed while the solver was running.",
                     error_code="NATIVE_ANALYZE_DOCUMENT_UNAVAILABLE",
                 )
+            validate_captured_solver_execution(document, captured)
 
         snapshot = self.manager.submit(
             document_uid=str(document.Uid),
@@ -118,7 +147,7 @@ class _SolverRunUi:
             commit=lambda prepared: _commit_human_result(document, prepared),
             dispatch_to_document_thread=VibeCADGui._dispatch_to_document_thread,
             finalize_message=f"Importing verified {self.backend} results",
-            cleanup=lambda _prepared: discard_solver_execution_request(request),
+            cleanup=lambda _prepared: workspace.cleanup(),
         )
         self.job_id = str(snapshot.job_id)
         _ACTIVE_RUNS[self.job_id] = self
@@ -140,6 +169,9 @@ class _SolverRunUi:
             return
         self.dialog.setValue(int(snapshot.progress_percent))
         self.dialog.setLabelText(str(snapshot.progress_message))
+        Gui.getMainWindow().statusBar().showMessage(
+            f"{self.backend}: {snapshot.progress_message}"
+        )
         if not snapshot.terminal:
             return
         error = dict(snapshot.error or {})
@@ -169,8 +201,16 @@ class _SolverRunUi:
                 Gui.Selection.clearSelection()
                 Gui.Selection.addSelection(result_object)
             App.Console.PrintMessage(f"{self.backend} analysis completed.\n")
+            Gui.getMainWindow().statusBar().showMessage(
+                f"{self.backend} analysis completed",
+                10000,
+            )
         elif phase == "cancelled":
             App.Console.PrintMessage(f"{self.backend} analysis cancelled.\n")
+            Gui.getMainWindow().statusBar().showMessage(
+                f"{self.backend} analysis cancelled",
+                10000,
+            )
         else:
             clean = str(message or f"{self.backend} analysis failed.")
             App.Console.PrintError(clean + "\n")
@@ -178,6 +218,10 @@ class _SolverRunUi:
                 Gui.getMainWindow(),
                 f"{self.backend} failed",
                 clean,
+            )
+            Gui.getMainWindow().statusBar().showMessage(
+                f"{self.backend} analysis failed",
+                10000,
             )
         self.dialog.deleteLater()
 
@@ -190,7 +234,7 @@ def run_solver_detached(solver: Any) -> str:
         raise TypeError("run_solver_detached requires a supported FEM solver")
     document = solver.Document
     VibeCADGui._ensure_document_thread_invoker()
-    request = prepare_solver_execution_request(
+    captured = capture_solver_execution_request(
         document,
         str(document.Uid),
         target={
@@ -199,18 +243,20 @@ def run_solver_detached(solver: Any) -> str:
         },
         timeout_seconds=86400,
     )
+    workspace = create_solver_execution_workspace()
     runner = _SolverRunUi(
         document,
-        request,
+        captured,
+        workspace,
         get_service().native_background_manager(),
     )
     try:
         return runner.start()
     except NativeBackgroundError:
-        discard_solver_execution_request(request)
+        workspace.cleanup()
         raise
     except Exception:
-        discard_solver_execution_request(request)
+        workspace.cleanup()
         raise
 
 

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecution.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecution.py
@@ -24,9 +24,31 @@ from VibeCADNativeAnalyzeState import is_live
 from VibeCADNativeMutation import NativeMutationDraft
 from VibeCADNativeTargets import object_identity
 
-
 MAX_INPUT_FILES = 4096
 MAX_INPUT_BYTES = 4 * 1024 * 1024 * 1024
+_FEM_PREFERENCES = "User parameter:BaseApp/Preferences/Mod/Fem"
+_SOLVER_RUNTIME_PREFERENCE_SPECS = (
+    (_FEM_PREFERENCES + "/General", "KeepResultsOnReRun", "bool", False, None),
+    (_FEM_PREFERENCES + "/Ccx", "ccxBinaryPath", "string", "", "calculix"),
+    (_FEM_PREFERENCES + "/Ccx", "AnalysisNumCPUs", "int", 1, "calculix"),
+    (_FEM_PREFERENCES + "/Ccx", "BinaryOutput", "bool", False, "calculix"),
+    (_FEM_PREFERENCES + "/Elmer", "gridBinaryPath", "string", "", "elmer"),
+    (_FEM_PREFERENCES + "/Elmer", "elmerBinaryPath", "string", "", "elmer"),
+    (_FEM_PREFERENCES + "/Elmer", "mpiBinaryPath", "string", "", "elmer"),
+    (_FEM_PREFERENCES + "/Elmer", "NumberOfTasks", "int", 1, "elmer"),
+    (_FEM_PREFERENCES + "/Elmer", "ThreadsPerTask", "int", 1, "elmer"),
+    (_FEM_PREFERENCES + "/Elmer", "MaxOutputLevel", "int", 10, "elmer"),
+    (_FEM_PREFERENCES + "/Mystran", "mystranBinaryPath", "string", "", "mystran"),
+    (_FEM_PREFERENCES + "/Z88", "z88BinaryPath", "string", "", "z88"),
+    (
+        _FEM_PREFERENCES + "/OpenFOAM",
+        "EnvironmentFile",
+        "string",
+        "",
+        "openfoam",
+    ),
+    ("User parameter:BaseApp/Preferences/Units", "UserSchema", "int", None, None),
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -42,6 +64,18 @@ class SolverExecutionRequest:
     input_file_count: int
     keep_results: bool
     importer_state: Mapping[str, Any]
+    runtime_preferences: tuple[tuple[str, str, str, Any], ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class CapturedSolverExecutionRequest:
+    """Exact live-document guards captured before detached case generation."""
+
+    target: PreparedSolverTarget
+    history_operations: tuple[Any, ...]
+    timeout_seconds: int
+    keep_results: bool
+    runtime_preferences: tuple[tuple[str, str, str, Any], ...]
 
 
 @dataclass(frozen=True, slots=True)
@@ -212,7 +246,9 @@ def _require_no_ignored_elmer_constraints(tool: Any) -> None:
     ignored = tuple(getattr(tool, "ignored_constraints", ()) or ())
     if not ignored:
         return
-    labels = ", ".join(str(getattr(value, "Label", "") or value.Name) for value in ignored)
+    labels = ", ".join(
+        str(getattr(value, "Label", "") or value.Name) for value in ignored
+    )
     raise NativeAnalyzeError(
         "Elmer has no active equation for these study conditions: " + labels + ".",
         error_code="NATIVE_ANALYZE_SOLVER_NOT_READY",
@@ -272,20 +308,103 @@ def _openfoam_request(solver: Any, root: Path) -> tuple[Any, tuple, dict, dict]:
     return prepare_openfoam_request(solver, root)
 
 
+def capture_solver_execution_request(
+    document: Any,
+    document_uid: str,
+    *,
+    target: Any,
+    timeout_seconds: Any,
+) -> CapturedSolverExecutionRequest:
+    """Capture exact solver guards without generating files or running tools."""
+
+    prepared = prepare_solver_target(document, document_uid, target)
+    state = solver_state(prepared.solver)
+    if state["suppressed"]:
+        raise NativeAnalyzeError("A suppressed FEM solver cannot be run.")
+    history = _require_history_root(document, prepared.solver)
+    runtime_preferences = _current_solver_runtime_preferences(prepared.kind)
+    return CapturedSolverExecutionRequest(
+        prepared,
+        history,
+        _timeout(timeout_seconds),
+        _keep_results_from_runtime_preferences(runtime_preferences),
+        runtime_preferences,
+    )
+
+
+def validate_captured_solver_execution(
+    document: Any,
+    captured: CapturedSolverExecutionRequest,
+) -> None:
+    """Reject a captured request when its exact live commit guards changed."""
+
+    if not isinstance(captured, CapturedSolverExecutionRequest):
+        raise TypeError("captured must be CapturedSolverExecutionRequest")
+    solver = captured.target.solver
+    if getattr(solver, "Document", None) is not document or not solver_still_exact(
+        solver,
+        captured.target.expected_state_sha256,
+    ):
+        raise NativeAnalyzeError(
+            "The exact FEM solver changed while execution was being prepared.",
+            error_code="NATIVE_ANALYZE_STATE_STALE",
+        )
+    if _require_history_root(document, solver) != captured.history_operations:
+        raise NativeAnalyzeError(
+            "Document History changed while FEM execution was being prepared.",
+            error_code="NATIVE_ANALYZE_STATE_STALE",
+        )
+    current_preferences = _current_solver_runtime_preferences(captured.target.kind)
+    if (
+        _keep_results_from_runtime_preferences(current_preferences)
+        is not captured.keep_results
+    ):
+        raise NativeAnalyzeError(
+            "The FEM result-retention preference changed while execution was being prepared.",
+            error_code="NATIVE_ANALYZE_STATE_STALE",
+        )
+    if current_preferences != captured.runtime_preferences:
+        raise NativeAnalyzeError(
+            "The FEM solver runtime preferences changed while execution was being prepared.",
+            error_code="NATIVE_ANALYZE_STATE_STALE",
+        )
+
+
 def prepare_solver_execution_request(
     document: Any,
     document_uid: str,
     *,
     target: Any,
     timeout_seconds: Any,
+    working_directory: str | Path | None = None,
 ) -> SolverExecutionRequest:
-    prepared = prepare_solver_target(document, document_uid, target)
+    """Generate one solver case synchronously for compatibility callers.
+
+    GUI and provider entry points capture exact guards first and generate this
+    case in an isolated child process. The optional working directory lets that
+    child keep every artifact inside its parent-owned private workspace.
+    """
+
+    captured = capture_solver_execution_request(
+        document,
+        document_uid,
+        target=target,
+        timeout_seconds=timeout_seconds,
+    )
+    prepared = captured.target
     state = solver_state(prepared.solver)
-    if state["suppressed"]:
-        raise NativeAnalyzeError("A suppressed FEM solver cannot be run.")
     implementation = str(state["implementation"])
-    history = _require_history_root(document, prepared.solver)
-    root = Path(tempfile.mkdtemp(prefix=f"vibecad-native-fem-{prepared.kind}-"))
+    if working_directory is None:
+        root = Path(tempfile.mkdtemp(prefix=f"vibecad-native-fem-{prepared.kind}-"))
+    else:
+        root = Path(working_directory).resolve()
+        try:
+            root.mkdir(mode=0o700, parents=False, exist_ok=False)
+        except OSError as exc:
+            raise NativeAnalyzeError(
+                "The private FEM case directory could not be created.",
+                error_code="NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            ) from exc
     try:
         maker = {
             "calculix": (
@@ -300,23 +419,19 @@ def prepare_solver_execution_request(
         }[prepared.kind]
         _tool, commands, environment, importer_state = maker(prepared.solver, root)
         digest, count = _input_digest(root)
-        keep_results = bool(
-            __import__("FreeCAD")
-            .ParamGet("User parameter:BaseApp/Preferences/Mod/Fem/General")
-            .GetBool("KeepResultsOnReRun", False)
-        )
         return SolverExecutionRequest(
             prepared,
             implementation,
-            history,
+            captured.history_operations,
             str(root),
             tuple(commands),
             environment,
-            _timeout(timeout_seconds),
+            captured.timeout_seconds,
             digest,
             count,
-            keep_results,
+            captured.keep_results,
             importer_state,
+            captured.runtime_preferences,
         )
     except Exception:
         shutil.rmtree(root, ignore_errors=True)
@@ -358,6 +473,51 @@ def _current_keep_results() -> bool:
             "KeepResultsOnReRun", False
         )
     )
+
+
+def _current_solver_runtime_preferences(
+    solver_kind: str,
+) -> tuple[tuple[str, str, str, Any], ...]:
+    """Capture only preferences that affect detached input, execution, or import."""
+
+    import FreeCAD as App
+
+    kind = str(solver_kind)
+    if kind not in {"calculix", "elmer", "mystran", "openfoam", "z88"}:
+        raise ValueError(f"Unsupported FEM solver kind: {kind!r}")
+    values = []
+    for path, name, value_kind, default, backend in _SOLVER_RUNTIME_PREFERENCE_SPECS:
+        if backend is not None and backend != kind:
+            continue
+        if default is None:
+            default = int(App.Units.Scheme.Internal)
+        group = App.ParamGet(path)
+        if value_kind == "bool":
+            value = bool(group.GetBool(name, default))
+        elif value_kind == "int":
+            value = int(group.GetInt(name, default))
+        else:
+            value = str(group.GetString(name, default))
+        values.append((path, name, value_kind, value))
+    return tuple(values)
+
+
+def _keep_results_from_runtime_preferences(
+    preferences: tuple[tuple[str, str, str, Any], ...],
+) -> bool:
+    matches = [
+        value
+        for path, name, value_kind, value in preferences
+        if path == _FEM_PREFERENCES + "/General"
+        and name == "KeepResultsOnReRun"
+        and value_kind == "bool"
+    ]
+    if len(matches) != 1 or type(matches[0]) is not bool:
+        raise NativeAnalyzeError(
+            "The FEM result-retention preference could not be captured exactly.",
+            error_code="NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+        )
+    return matches[0]
 
 
 def _import_tool(request: SolverExecutionRequest) -> Any:

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionChild.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionChild.py
@@ -1,0 +1,577 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Isolated FreeCADCmd child for FEM case generation and solver execution."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import stat
+from typing import Any, Mapping
+
+_PROTOCOL = "vibecad-native-analyze-solver-execution-v1"
+_MAX_REQUEST_BYTES = 256 * 1024
+_MAX_RESULT_BYTES = 16 * 1024 * 1024
+_MAX_PROGRESS_BYTES = 8 * 1024
+_MAX_SNAPSHOT_BYTES = 16 * 1024 * 1024 * 1024
+_MAX_INPUT_FILES = 4096
+_ALLOWED_PREFERENCES = {
+    (
+        "User parameter:BaseApp/Preferences/Mod/Fem/General",
+        "KeepResultsOnReRun",
+        "bool",
+    ),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Ccx", "ccxBinaryPath", "string"),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Ccx", "AnalysisNumCPUs", "int"),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Ccx", "BinaryOutput", "bool"),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Elmer", "gridBinaryPath", "string"),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Elmer", "elmerBinaryPath", "string"),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Elmer", "mpiBinaryPath", "string"),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Elmer", "NumberOfTasks", "int"),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Elmer", "ThreadsPerTask", "int"),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Elmer", "MaxOutputLevel", "int"),
+    (
+        "User parameter:BaseApp/Preferences/Mod/Fem/Mystran",
+        "mystranBinaryPath",
+        "string",
+    ),
+    ("User parameter:BaseApp/Preferences/Mod/Fem/Z88", "z88BinaryPath", "string"),
+    (
+        "User parameter:BaseApp/Preferences/Mod/Fem/OpenFOAM",
+        "EnvironmentFile",
+        "string",
+    ),
+    ("User parameter:BaseApp/Preferences/Units", "UserSchema", "int"),
+}
+_COMMON_PREFERENCES = {
+    (
+        "User parameter:BaseApp/Preferences/Mod/Fem/General",
+        "KeepResultsOnReRun",
+        "bool",
+    ),
+    ("User parameter:BaseApp/Preferences/Units", "UserSchema", "int"),
+}
+_BACKEND_PREFERENCE_PATHS = {
+    "calculix": "User parameter:BaseApp/Preferences/Mod/Fem/Ccx",
+    "elmer": "User parameter:BaseApp/Preferences/Mod/Fem/Elmer",
+    "mystran": "User parameter:BaseApp/Preferences/Mod/Fem/Mystran",
+    "openfoam": "User parameter:BaseApp/Preferences/Mod/Fem/OpenFOAM",
+    "z88": "User parameter:BaseApp/Preferences/Mod/Fem/Z88",
+}
+
+
+class _ChildFailure(RuntimeError):
+    def __init__(self, code: str, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _fail(code: str, message: str) -> None:
+    raise _ChildFailure(code, message)
+
+
+def _read_regular(path: Path, *, root: Path, maximum: int) -> bytes:
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "A detached FEM artifact escaped its private workspace.",
+        )
+    try:
+        value = path.lstat()
+    except OSError as exc:
+        raise _ChildFailure(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "A detached FEM artifact is unavailable.",
+        ) from exc
+    if not stat.S_ISREG(value.st_mode):
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "A detached FEM artifact is not a regular file.",
+        )
+    descriptor = -1
+    data = bytearray()
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or int(opened.st_dev) != int(value.st_dev)
+            or int(opened.st_ino) != int(value.st_ino)
+        ):
+            _fail(
+                "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+                "A detached FEM artifact changed while opening.",
+            )
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            data.extend(chunk)
+            if len(data) > maximum:
+                _fail(
+                    "NATIVE_ANALYZE_SOLVER_INPUT_LIMIT",
+                    "A detached FEM artifact exceeds its safety bound.",
+                )
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if not data:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "A detached FEM artifact is empty.",
+        )
+    return bytes(data)
+
+
+def _hash_regular(path: Path, *, root: Path, maximum: int) -> tuple[int, str]:
+    """Authenticate a potentially large artifact without retaining it in memory."""
+
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "A detached FEM artifact escaped its private workspace.",
+        )
+    try:
+        value = path.lstat()
+    except OSError as exc:
+        raise _ChildFailure(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "A detached FEM artifact is unavailable.",
+        ) from exc
+    if not stat.S_ISREG(value.st_mode):
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "A detached FEM artifact is not a regular file.",
+        )
+    descriptor = -1
+    digest = hashlib.sha256()
+    size = 0
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or int(opened.st_dev) != int(value.st_dev)
+            or int(opened.st_ino) != int(value.st_ino)
+        ):
+            _fail(
+                "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+                "A detached FEM artifact changed while opening.",
+            )
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            size += len(chunk)
+            if size > maximum:
+                _fail(
+                    "NATIVE_ANALYZE_SOLVER_INPUT_LIMIT",
+                    "A detached FEM artifact exceeds its safety bound.",
+                )
+            digest.update(chunk)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if size < 1:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "A detached FEM artifact is empty.",
+        )
+    return size, digest.hexdigest()
+
+
+def _write_private(path: Path, data: bytes, maximum: int) -> None:
+    if not data or len(data) > maximum:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_LIMIT",
+            "A detached FEM metadata artifact exceeds its safety bound.",
+        )
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        offset = 0
+        while offset < len(data):
+            offset += os.write(descriptor, data[offset:])
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _replace_private(path: Path, data: bytes) -> None:
+    if not data or len(data) > _MAX_PROGRESS_BYTES:
+        return
+    temporary = path.with_suffix(".tmp")
+    try:
+        if temporary.exists():
+            temporary.unlink()
+        _write_private(temporary, data, _MAX_PROGRESS_BYTES)
+        os.replace(temporary, path)
+    except OSError:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _request() -> tuple[dict[str, Any], Path, Path, str]:
+    raw_path = os.environ.get("VIBECAD_NATIVE_ANALYZE_SOLVER_EXECUTION_REQUEST", "")
+    if not raw_path:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM request path is unavailable.",
+        )
+    path = Path(raw_path).resolve()
+    root = path.parent
+    if path.name != "request.json":
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM request has an unexpected identity.",
+        )
+    data = _read_regular(path, root=root, maximum=_MAX_REQUEST_BYTES)
+    request_sha256 = hashlib.sha256(data).hexdigest()
+    try:
+        value = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise _ChildFailure(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM request is unreadable.",
+        ) from exc
+    required = {
+        "protocol",
+        "workspace",
+        "snapshot",
+        "snapshot_bytes",
+        "snapshot_sha256",
+        "solver",
+        "timeout_seconds",
+        "keep_results",
+        "runtime_preferences",
+        "case",
+        "result",
+    }
+    if (
+        not isinstance(value, dict)
+        or set(value) != required
+        or value.get("protocol") != _PROTOCOL
+        or Path(str(value.get("workspace") or "")).resolve() != root
+        or value.get("snapshot") != "document.FCStd"
+        or value.get("case") != "case"
+        or value.get("result") != "result.json"
+    ):
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM request failed protocol validation.",
+        )
+    return value, root, root / "result.json", request_sha256
+
+
+def _solver_descriptor(value: Any) -> dict[str, Any]:
+    required = {"object_name", "object_id", "type_id", "kind", "state_sha256"}
+    if not isinstance(value, Mapping) or set(value) != required:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM solver descriptor is malformed.",
+        )
+    result = dict(value)
+    if (
+        not str(result["object_name"] or "")
+        or type(result["object_id"]) is not int
+        or result["object_id"] < 1
+        or not str(result["type_id"] or "")
+        or str(result["kind"])
+        not in {"calculix", "elmer", "mystran", "openfoam", "z88"}
+        or len(str(result["state_sha256"] or "")) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in str(result["state_sha256"])
+        )
+    ):
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM solver descriptor is invalid.",
+        )
+    return result
+
+
+def _preferences(
+    value: Any,
+    solver_kind: str,
+) -> tuple[tuple[str, str, str, Any], ...]:
+    expected = _COMMON_PREFERENCES | {
+        identity
+        for identity in _ALLOWED_PREFERENCES
+        if identity[0] == _BACKEND_PREFERENCE_PATHS[solver_kind]
+    }
+    if not isinstance(value, list) or len(value) != len(expected):
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM runtime preferences are malformed.",
+        )
+    result = []
+    identities = set()
+    for item in value:
+        if not isinstance(item, list) or len(item) != 4:
+            _fail(
+                "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+                "A detached FEM runtime preference is malformed.",
+            )
+        path, name, kind, setting = item
+        identity = (str(path), str(name), str(kind))
+        if identity not in expected or identity in identities:
+            _fail(
+                "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+                "A detached FEM runtime preference is unsupported.",
+            )
+        if (
+            (kind == "bool" and type(setting) is not bool)
+            or (kind == "int" and type(setting) is not int)
+            or (
+                kind == "string"
+                and (not isinstance(setting, str) or len(setting) > 4096)
+            )
+        ):
+            _fail(
+                "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+                "A detached FEM runtime preference has an invalid value.",
+            )
+        identities.add(identity)
+        result.append((identity[0], identity[1], identity[2], setting))
+    if identities != expected:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM runtime preference set is incomplete.",
+        )
+    return tuple(result)
+
+
+def _apply_preferences(preferences: tuple[tuple[str, str, str, Any], ...]) -> None:
+    import FreeCAD as App
+
+    for path, name, kind, value in preferences:
+        group = App.ParamGet(path)
+        if kind == "bool":
+            group.SetBool(name, value)
+        elif kind == "int":
+            group.SetInt(name, value)
+        else:
+            group.SetString(name, value)
+
+
+def _progress_writer(root: Path, request_sha256: str):
+    progress_path = root / "progress.json"
+
+    def report(percent: int, message: str) -> None:
+        mapped = max(20, min(82, 20 + int(int(percent) * 62 / 90)))
+        value = {
+            "protocol": _PROTOCOL,
+            "request_sha256": request_sha256,
+            "progress_percent": mapped,
+            "progress_message": str(message or "")[:160],
+        }
+        _replace_private(
+            progress_path,
+            json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8"),
+        )
+
+    return report
+
+
+def _execute(
+    request: Mapping[str, Any], root: Path, request_sha256: str
+) -> dict[str, Any]:
+    import FreeCAD as App
+
+    solver_spec = _solver_descriptor(request["solver"])
+    timeout = request["timeout_seconds"]
+    keep_results = request["keep_results"]
+    snapshot_size = request["snapshot_bytes"]
+    snapshot_sha256 = str(request["snapshot_sha256"] or "")
+    if (
+        type(timeout) is not int
+        or not 1 <= timeout <= 86400
+        or type(keep_results) is not bool
+        or type(snapshot_size) is not int
+        or not 1 <= snapshot_size <= _MAX_SNAPSHOT_BYTES
+        or len(snapshot_sha256) != 64
+    ):
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM execution bounds are invalid.",
+        )
+    preferences = _preferences(
+        request["runtime_preferences"],
+        str(solver_spec["kind"]),
+    )
+    captured_keep_results = next(
+        value
+        for path, name, kind, value in preferences
+        if path.endswith("/General") and name == "KeepResultsOnReRun" and kind == "bool"
+    )
+    if captured_keep_results is not keep_results:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM result-retention guards disagree.",
+        )
+    _apply_preferences(preferences)
+    snapshot_path = root / "document.FCStd"
+    observed_snapshot_size, observed_snapshot_sha256 = _hash_regular(
+        snapshot_path,
+        root=root,
+        maximum=_MAX_SNAPSHOT_BYTES,
+    )
+    if (
+        observed_snapshot_size != snapshot_size
+        or observed_snapshot_sha256 != snapshot_sha256
+    ):
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_SNAPSHOT_CHANGED",
+            "The detached FEM document snapshot changed before execution.",
+        )
+    report = _progress_writer(root, request_sha256)
+    report(1, "Generating exact FEM solver input outside the UI process")
+    document = App.openDocument(str(snapshot_path))
+    try:
+        solver = document.getObject(str(solver_spec["object_name"]))
+        if (
+            solver is None
+            or int(solver.ID) != solver_spec["object_id"]
+            or str(solver.TypeId) != solver_spec["type_id"]
+        ):
+            _fail(
+                "NATIVE_ANALYZE_STATE_STALE",
+                "The exact FEM solver is unavailable in its frozen snapshot.",
+            )
+        from VibeCADNativeAnalyzeSolverState import solver_state
+
+        state = solver_state(solver)
+        if (
+            state["solver_kind"] != solver_spec["kind"]
+            or state["state_sha256"] != solver_spec["state_sha256"]
+        ):
+            _fail(
+                "NATIVE_ANALYZE_STATE_STALE",
+                "The exact FEM solver changed in its frozen snapshot.",
+            )
+        from VibeCADNativeAnalyzeSolverExecution import (
+            prepare_solver_execution_request,
+            run_solver_execution,
+        )
+
+        execution_request = prepare_solver_execution_request(
+            document,
+            str(document.Uid),
+            target={
+                "object_name": str(solver.Name),
+                "expected_state_sha256": str(solver_spec["state_sha256"]),
+            },
+            timeout_seconds=timeout,
+            working_directory=root / "case",
+        )
+        if execution_request.runtime_preferences != preferences:
+            _fail(
+                "NATIVE_ANALYZE_STATE_STALE",
+                "The isolated FEM runtime preferences changed before execution.",
+            )
+        report(7, f"Prepared exact {solver_spec['kind'].title()} solver case")
+        prepared = run_solver_execution(
+            execution_request,
+            cancelled=lambda: False,
+            progress=report,
+        )
+        importer_state = dict(execution_request.importer_state)
+        encoded_importer = json.dumps(
+            importer_state,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        if len(encoded_importer.encode("utf-8")) > _MAX_REQUEST_BYTES:
+            _fail(
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_LIMIT",
+                "The detached FEM importer metadata exceeds its safety bound.",
+            )
+        return {
+            "ok": True,
+            "protocol": _PROTOCOL,
+            "request_sha256": request_sha256,
+            "solver_name": str(solver.Name),
+            "solver_kind": str(execution_request.target.kind),
+            "solver_state_sha256": str(execution_request.target.expected_state_sha256),
+            "implementation": str(execution_request.implementation),
+            "case": "case",
+            "input_sha256": str(execution_request.input_sha256),
+            "input_file_count": int(execution_request.input_file_count),
+            "keep_results": bool(execution_request.keep_results),
+            "importer_state": importer_state,
+            "stages": list(prepared.stages),
+        }
+    finally:
+        App.closeDocument(document.Name)
+
+
+def _main() -> int:
+    result_path: Path | None = None
+    request_sha256 = ""
+    try:
+        request, root, result_path, request_sha256 = _request()
+        result = _execute(request, root, request_sha256)
+        _write_private(
+            result_path,
+            json.dumps(
+                result,
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8"),
+            _MAX_RESULT_BYTES,
+        )
+        return 0
+    except _ChildFailure as exc:
+        failure = {
+            "ok": False,
+            "protocol": _PROTOCOL,
+            "request_sha256": request_sha256,
+            "error_code": exc.code,
+            "message": str(exc)[:320],
+        }
+    except Exception as exc:
+        code = str(getattr(exc, "error_code", "") or "")
+        message = str(exc).strip()
+        failure = {
+            "ok": False,
+            "protocol": _PROTOCOL,
+            "request_sha256": request_sha256,
+            "error_code": (
+                code
+                if code.startswith("NATIVE_ANALYZE_")
+                else "NATIVE_ANALYZE_SOLVER_EXECUTION_FAILED"
+            ),
+            "message": (
+                message[:320]
+                if code.startswith("NATIVE_ANALYZE_") and message
+                else "The isolated FEM solver process failed."
+            ),
+        }
+    if result_path is not None and not result_path.exists():
+        try:
+            _write_private(
+                result_path,
+                json.dumps(failure, sort_keys=True, separators=(",", ":")).encode(
+                    "utf-8"
+                ),
+                _MAX_RESULT_BYTES,
+            )
+        except Exception:
+            pass
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionInput.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionInput.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Private exact-document input for isolated FEM solver execution."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import hashlib
+import json
+import os
+from pathlib import Path
+import tempfile
+from typing import Any
+
+from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeSolverExecution import (
+    CapturedSolverExecutionRequest,
+    validate_captured_solver_execution,
+)
+from VibeCADNativeDrawingProjectionInput import (
+    FrozenFile,
+    freeze_regular_file,
+    resolve_freecadcmd,
+)
+
+ANALYZE_SOLVER_EXECUTION_PROTOCOL = "vibecad-native-analyze-solver-execution-v1"
+MAX_SOLVER_SNAPSHOT_BYTES = 16 * 1024 * 1024 * 1024
+MAX_SOLVER_REQUEST_BYTES = 256 * 1024
+MAX_SOLVER_CHILD_BYTES = 1024 * 1024
+
+
+@dataclass(slots=True)
+class SolverExecutionWorkspace:
+    temporary: tempfile.TemporaryDirectory[str] = field(repr=False)
+    path: Path = field(repr=False)
+    freecadcmd: FrozenFile = field(repr=False)
+    child: FrozenFile = field(repr=False)
+
+    def cleanup(self) -> None:
+        self.temporary.cleanup()
+
+
+@dataclass(frozen=True, slots=True)
+class MaterializedSolverExecutionSnapshot:
+    workspace: SolverExecutionWorkspace = field(repr=False, compare=False)
+    captured: CapturedSolverExecutionRequest = field(repr=False, compare=False)
+    snapshot_path: Path = field(repr=False, compare=False)
+    solver_name: str
+    solver_id: int
+    solver_type_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class FrozenSolverExecution:
+    workspace: SolverExecutionWorkspace = field(repr=False, compare=False)
+    captured: CapturedSolverExecutionRequest = field(repr=False, compare=False)
+    snapshot: FrozenFile = field(repr=False, compare=False)
+    request: FrozenFile = field(repr=False, compare=False)
+    request_sha256: str
+    solver_name: str
+
+
+def _error(message: str, code: str) -> None:
+    raise NativeAnalyzeError(message, error_code=code)
+
+
+def _write_private(path: Path, data: bytes) -> None:
+    descriptor = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        offset = 0
+        while offset < len(data):
+            offset += os.write(descriptor, data[offset:])
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def create_solver_execution_workspace() -> SolverExecutionWorkspace:
+    """Own every snapshot, case, log, and result for one solver job."""
+
+    temporary = tempfile.TemporaryDirectory(
+        prefix="vibecad-native-analyze-solver-execution-"
+    )
+    root = Path(temporary.name).resolve()
+    try:
+        os.chmod(root, 0o700)
+        child = freeze_regular_file(
+            Path(__file__)
+            .with_name("VibeCADNativeAnalyzeSolverExecutionChild.py")
+            .resolve(),
+            maximum=MAX_SOLVER_CHILD_BYTES,
+        )
+        return SolverExecutionWorkspace(
+            temporary=temporary,
+            path=root,
+            freecadcmd=resolve_freecadcmd(),
+            child=child,
+        )
+    except Exception as exc:
+        temporary.cleanup()
+        if isinstance(exc, NativeAnalyzeError):
+            raise
+        raise NativeAnalyzeError(
+            "The fixed windowless FEM worker runtime is unavailable.",
+            error_code="NATIVE_ANALYZE_SOLVER_BACKGROUND_UNAVAILABLE",
+        ) from exc
+
+
+def materialize_solver_execution_snapshot(
+    document: Any,
+    captured: CapturedSolverExecutionRequest,
+    workspace: SolverExecutionWorkspace,
+) -> MaterializedSolverExecutionSnapshot:
+    """Copy exact live state on the document thread, without case generation."""
+
+    if not isinstance(workspace, SolverExecutionWorkspace):
+        raise TypeError("workspace must be a SolverExecutionWorkspace")
+    validate_captured_solver_execution(document, captured)
+    snapshot_path = workspace.path / "document.FCStd"
+    try:
+        result = document.saveCopy(str(snapshot_path))
+    except Exception as exc:
+        raise NativeAnalyzeError(
+            "The exact FEM document could not be copied for detached execution.",
+            error_code="NATIVE_ANALYZE_SOLVER_SNAPSHOT_FAILED",
+        ) from exc
+    if result is False or not snapshot_path.is_file():
+        _error(
+            "The exact FEM document snapshot was not created.",
+            "NATIVE_ANALYZE_SOLVER_SNAPSHOT_FAILED",
+        )
+    os.chmod(snapshot_path, 0o600)
+    validate_captured_solver_execution(document, captured)
+    solver = captured.target.solver
+    return MaterializedSolverExecutionSnapshot(
+        workspace=workspace,
+        captured=captured,
+        snapshot_path=snapshot_path,
+        solver_name=str(solver.Name),
+        solver_id=int(solver.ID),
+        solver_type_id=str(solver.TypeId),
+    )
+
+
+def freeze_solver_execution_snapshot(
+    materialized: MaterializedSolverExecutionSnapshot,
+) -> FrozenSolverExecution:
+    """Authenticate the snapshot and write bounded child metadata off-thread."""
+
+    if not isinstance(materialized, MaterializedSolverExecutionSnapshot):
+        raise TypeError("materialized must be a MaterializedSolverExecutionSnapshot")
+    workspace = materialized.workspace
+    captured = materialized.captured
+    try:
+        snapshot = freeze_regular_file(
+            materialized.snapshot_path,
+            maximum=MAX_SOLVER_SNAPSHOT_BYTES,
+        )
+    except Exception as exc:
+        raise NativeAnalyzeError(
+            "The exact FEM document snapshot could not be authenticated.",
+            error_code="NATIVE_ANALYZE_SOLVER_SNAPSHOT_FAILED",
+        ) from exc
+    preferences = [list(value) for value in captured.runtime_preferences]
+    request_value = {
+        "protocol": ANALYZE_SOLVER_EXECUTION_PROTOCOL,
+        "workspace": str(workspace.path),
+        "snapshot": "document.FCStd",
+        "snapshot_bytes": snapshot.size_bytes,
+        "snapshot_sha256": snapshot.sha256,
+        "solver": {
+            "object_name": materialized.solver_name,
+            "object_id": materialized.solver_id,
+            "type_id": materialized.solver_type_id,
+            "kind": str(captured.target.kind),
+            "state_sha256": str(captured.target.expected_state_sha256),
+        },
+        "timeout_seconds": int(captured.timeout_seconds),
+        "keep_results": bool(captured.keep_results),
+        "runtime_preferences": preferences,
+        "case": "case",
+        "result": "result.json",
+    }
+    encoded = json.dumps(
+        request_value,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    if len(encoded) > MAX_SOLVER_REQUEST_BYTES:
+        _error(
+            "The exact FEM solver request exceeds its metadata bound.",
+            "NATIVE_ANALYZE_SOLVER_INPUT_LIMIT",
+        )
+    request_path = workspace.path / "request.json"
+    _write_private(request_path, encoded)
+    try:
+        request = freeze_regular_file(
+            request_path,
+            maximum=MAX_SOLVER_REQUEST_BYTES,
+        )
+    except Exception as exc:
+        raise NativeAnalyzeError(
+            "The exact FEM solver request could not be authenticated.",
+            error_code="NATIVE_ANALYZE_SOLVER_SNAPSHOT_FAILED",
+        ) from exc
+    if request.sha256 != hashlib.sha256(encoded).hexdigest():
+        _error(
+            "The exact FEM solver request changed while it was written.",
+            "NATIVE_ANALYZE_SOLVER_SNAPSHOT_FAILED",
+        )
+    return FrozenSolverExecution(
+        workspace=workspace,
+        captured=captured,
+        snapshot=snapshot,
+        request=request,
+        request_sha256=request.sha256,
+        solver_name=materialized.solver_name,
+    )
+
+
+__all__ = [
+    "ANALYZE_SOLVER_EXECUTION_PROTOCOL",
+    "FrozenSolverExecution",
+    "MaterializedSolverExecutionSnapshot",
+    "SolverExecutionWorkspace",
+    "create_solver_execution_workspace",
+    "freeze_solver_execution_snapshot",
+    "materialize_solver_execution_snapshot",
+]

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionProcess.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionProcess.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 
 from pathlib import Path
 import subprocess
+import sys
 import time
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
-from VibeCADNativeAnalyzeMeshGenerationProcess import stop_process
 from VibeCADNativeBackground import NativeBackgroundCancelled
-
+from VibeCADScriptedProcess import terminate_process_tree
 
 MAX_SOLVER_LOG_BYTES = 16 * 1024 * 1024
 
@@ -60,6 +60,8 @@ def run_solver_processes(
         log_path = root / f"solver-{index + 1}.log"
         base_progress = 12 + int(65 * index / len(commands))
         progress(base_progress, f"Running {backend} stage {index + 1}/{len(commands)}")
+        stage_started = time.monotonic()
+        next_status = stage_started + 5.0
         try:
             with log_path.open("wb") as log:
                 process = subprocess.Popen(
@@ -70,23 +72,40 @@ def run_solver_processes(
                     stdout=log,
                     stderr=subprocess.STDOUT,
                     shell=False,
+                    start_new_session=sys.platform != "win32",
+                    creationflags=(
+                        int(getattr(subprocess, "CREATE_NO_WINDOW", 0))
+                        if sys.platform == "win32"
+                        else 0
+                    ),
                 )
                 while process.poll() is None:
                     if cancelled():
-                        stop_process(process)
+                        terminate_process_tree(process)
                         raise NativeBackgroundCancelled()
                     if time.monotonic() - started > timeout_seconds:
-                        stop_process(process)
+                        terminate_process_tree(process)
                         raise NativeAnalyzeError(
                             f"{backend} exceeded timeout_seconds before producing results.",
                             error_code="NATIVE_ANALYZE_SOLVER_TIMEOUT",
                         )
                     if log_path.stat().st_size > MAX_SOLVER_LOG_BYTES:
-                        stop_process(process)
+                        terminate_process_tree(process)
                         raise NativeAnalyzeError(
                             f"{backend} exceeded the 16 MiB diagnostic-output bound.",
                             error_code="NATIVE_ANALYZE_SOLVER_OUTPUT_LIMIT",
                         )
+                    now = time.monotonic()
+                    if now >= next_status:
+                        elapsed = int(now - stage_started)
+                        progress(
+                            base_progress,
+                            (
+                                f"Running {backend} stage {index + 1}/{len(commands)} "
+                                f"({elapsed}s elapsed)"
+                            ),
+                        )
+                        next_status = now + 5.0
                     time.sleep(0.1)
                 exit_code = int(process.returncode or 0)
         except (NativeBackgroundCancelled, NativeAnalyzeError):

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionRuntime.py
@@ -8,11 +8,18 @@ from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
 from VibeCADNativeAnalyzeSolverExecution import (
+    capture_solver_execution_request,
     commit_solver_execution,
-    discard_solver_execution_request,
-    prepare_solver_execution_request,
-    run_solver_execution,
+    validate_captured_solver_execution,
     verify_solver_execution,
+)
+from VibeCADNativeAnalyzeSolverExecutionInput import (
+    create_solver_execution_workspace,
+    freeze_solver_execution_snapshot,
+    materialize_solver_execution_snapshot,
+)
+from VibeCADNativeAnalyzeSolverExecutionWorker import (
+    execute_frozen_solver_execution,
 )
 from VibeCADNativeArguments import strict_variant_arguments
 from VibeCADNativeBackground import NativeBackgroundError
@@ -46,26 +53,45 @@ class NativeAnalyzeSolverExecutionRuntime:
                 "Background FEM solver execution is unavailable in this session.",
                 error_code="NATIVE_ANALYZE_SOLVER_BACKGROUND_UNAVAILABLE",
             )
-        request = prepare_solver_execution_request(
+        captured = capture_solver_execution_request(
             context.document,
             context.document_uid,
             **values,
         )
+        workspace = create_solver_execution_workspace()
 
         def prepare(cancelled: Any, progress: Any) -> Any:
-            return run_solver_execution(request, cancelled=cancelled, progress=progress)
+            progress(3, "Capturing exact FEM document")
+            materialized = dispatcher(
+                lambda: materialize_solver_execution_snapshot(
+                    context.document,
+                    captured,
+                    workspace,
+                )
+            )
+            progress(5, "Authenticating exact FEM document snapshot")
+            frozen = freeze_solver_execution_snapshot(materialized)
+            return execute_frozen_solver_execution(
+                frozen,
+                cancelled=cancelled,
+                progress=progress,
+            )
+
+        def validate() -> None:
+            context.guard()
+            validate_captured_solver_execution(context.document, captured)
 
         def commit(prepared: Any) -> Mapping[str, Any]:
             return run_immediate_mutation(
                 context,
                 ticket=ticket,
-                transaction_name=f"Import {request.target.kind.title()} FEM Results",
+                transaction_name=(f"Import {captured.target.kind.title()} FEM Results"),
                 mutate=lambda document: commit_solver_execution(document, prepared),
                 verify=verify_solver_execution,
             )
 
         def cleanup(_prepared: Any) -> None:
-            discard_solver_execution_request(request)
+            workspace.cleanup()
             context.state.cancel_mutation(ticket)
 
         try:
@@ -73,7 +99,7 @@ class NativeAnalyzeSolverExecutionRuntime:
                 document_uid=context.document_uid,
                 capability_name="analyze.solver_execution.run",
                 prepare=prepare,
-                validate_before_commit=context.guard,
+                validate_before_commit=validate,
                 commit=commit,
                 dispatch_to_document_thread=dispatcher,
                 finalize_message="Importing verified FEM results",
@@ -81,13 +107,13 @@ class NativeAnalyzeSolverExecutionRuntime:
                 changes_document=True,
             )
         except NativeBackgroundError as exc:
-            discard_solver_execution_request(request)
+            workspace.cleanup()
             raise NativeAnalyzeError(
                 str(exc),
                 error_code="NATIVE_ANALYZE_SOLVER_QUEUE_FAILED",
             ) from exc
         except Exception:
-            discard_solver_execution_request(request)
+            workspace.cleanup()
             raise
         return {
             "job": {

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionWorker.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionWorker.py
@@ -1,0 +1,495 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Cancellable isolated FEM worker and authenticated result adoption."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import stat
+import sys
+from typing import Any, Callable, Mapping
+
+from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeSolverExecution import (
+    PreparedSolverExecution,
+    SolverExecutionRequest,
+)
+from VibeCADNativeAnalyzeSolverExecutionInput import (
+    ANALYZE_SOLVER_EXECUTION_PROTOCOL,
+    MAX_SOLVER_CHILD_BYTES,
+    MAX_SOLVER_REQUEST_BYTES,
+    MAX_SOLVER_SNAPSHOT_BYTES,
+    FrozenSolverExecution,
+)
+from VibeCADNativeBackground import NativeBackgroundCancelled
+from VibeCADNativeDrawingProjectionInput import validate_frozen_file
+from VibeCADScriptedProcess import run_process
+
+MAX_SOLVER_RESULT_BYTES = 16 * 1024 * 1024
+MAX_SOLVER_PROGRESS_BYTES = 8 * 1024
+MAX_SOLVER_PREPARATION_SECONDS = 3600.0
+
+
+class _ArtifactChangedWhileOpening(NativeAnalyzeError):
+    """An atomic metadata replacement raced with one parent-side sample."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            "A detached FEM artifact changed while opening.",
+            error_code="NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+
+
+def _error(message: str, code: str) -> None:
+    raise NativeAnalyzeError(message, error_code=code)
+
+
+def _read_regular(path: Path, *, root: Path, maximum: int) -> bytes:
+    resolved = path.resolve()
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        _error(
+            "A detached FEM artifact escaped its private workspace.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    try:
+        value = path.lstat()
+    except OSError as exc:
+        raise NativeAnalyzeError(
+            "A detached FEM artifact is unavailable.",
+            error_code="NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        ) from exc
+    if not stat.S_ISREG(value.st_mode):
+        _error(
+            "A detached FEM artifact is not a regular file.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    descriptor = -1
+    data = bytearray()
+    try:
+        descriptor = os.open(path, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+        opened = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(opened.st_mode)
+            or int(opened.st_dev) != int(value.st_dev)
+            or int(opened.st_ino) != int(value.st_ino)
+        ):
+            raise _ArtifactChangedWhileOpening()
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            data.extend(chunk)
+            if len(data) > maximum:
+                _error(
+                    "A detached FEM artifact exceeds its safety bound.",
+                    "NATIVE_ANALYZE_SOLVER_OUTPUT_LIMIT",
+                )
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    if not data:
+        _error(
+            "A detached FEM artifact is empty.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    return bytes(data)
+
+
+def _environment(frozen: FrozenSolverExecution) -> dict[str, str]:
+    root = str(frozen.workspace.path)
+    environment = dict(os.environ)
+    environment.update(
+        {
+            "PYTHONNOUSERSITE": "1",
+            "TEMP": root,
+            "TMP": root,
+            "TMPDIR": root,
+            "VIBECAD_NATIVE_ANALYZE_SOLVER_EXECUTION_REQUEST": str(frozen.request.path),
+            "VIBECAD_NATIVE_ANALYZE_SOLVER_EXECUTION_CHILD": str(
+                frozen.workspace.child.path
+            ),
+        }
+    )
+    return environment
+
+
+def _validate_inputs(frozen: FrozenSolverExecution) -> None:
+    try:
+        validate_frozen_file(
+            frozen.workspace.freecadcmd,
+            maximum=None,
+            executable=True,
+        )
+        validate_frozen_file(
+            frozen.workspace.child,
+            maximum=MAX_SOLVER_CHILD_BYTES,
+        )
+        validate_frozen_file(frozen.request, maximum=MAX_SOLVER_REQUEST_BYTES)
+        validate_frozen_file(frozen.snapshot, maximum=MAX_SOLVER_SNAPSHOT_BYTES)
+    except Exception as exc:
+        if isinstance(exc, NativeAnalyzeError):
+            raise
+        raise NativeAnalyzeError(
+            "A frozen FEM worker input changed after preflight.",
+            error_code="NATIVE_ANALYZE_SOLVER_INPUT_CHANGED",
+        ) from exc
+
+
+def _read_progress(
+    frozen: FrozenSolverExecution,
+    progress: Callable[[int, str], None],
+    state: dict[str, Any],
+) -> None:
+    path = frozen.workspace.path / "progress.json"
+    if not path.exists():
+        return
+    try:
+        data = _read_regular(
+            path,
+            root=frozen.workspace.path,
+            maximum=MAX_SOLVER_PROGRESS_BYTES,
+        )
+    except _ArtifactChangedWhileOpening:
+        # progress.json is an atomic, replace-in-place status channel. Missing
+        # one racing sample is harmless; the next process poll reads the new
+        # complete file. Final result artifacts remain strict and fatal.
+        return
+    try:
+        value = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise NativeAnalyzeError(
+            "The isolated FEM progress report is unreadable.",
+            error_code="NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        ) from exc
+    required = {
+        "protocol",
+        "request_sha256",
+        "progress_percent",
+        "progress_message",
+    }
+    percent = value.get("progress_percent") if isinstance(value, Mapping) else None
+    message = value.get("progress_message") if isinstance(value, Mapping) else None
+    if (
+        not isinstance(value, Mapping)
+        or set(value) != required
+        or value.get("protocol") != ANALYZE_SOLVER_EXECUTION_PROTOCOL
+        or value.get("request_sha256") != frozen.request_sha256
+        or type(percent) is not int
+        or not 10 <= percent <= 89
+        or not isinstance(message, str)
+        or not message.strip()
+        or len(message) > 160
+    ):
+        _error(
+            "The isolated FEM progress report failed protocol validation.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    if percent > state["percent"] or message != state["message"]:
+        progress(percent, message)
+        state["percent"] = percent
+        state["message"] = message
+
+
+def _simple_name(value: Any, field: str) -> str:
+    name = str(value or "")
+    if not name or len(name) > 260 or Path(name).name != name or name in {".", ".."}:
+        _error(
+            f"The detached FEM {field} is invalid.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    return name
+
+
+def _sha256(value: Any, field: str) -> str:
+    digest = str(value or "")
+    if len(digest) != 64 or any(
+        character not in "0123456789abcdef" for character in digest
+    ):
+        _error(
+            f"The detached FEM {field} is invalid.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    return digest
+
+
+def _importer_state(
+    value: Any,
+    *,
+    frozen: FrozenSolverExecution,
+    implementation: str,
+) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        _error(
+            "The detached FEM importer metadata is malformed.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    result = dict(value)
+    kind = frozen.captured.target.kind
+    case = frozen.workspace.path / "case"
+    if kind == "calculix" and implementation == "ccx_tools":
+        if set(result) != {"input_file"}:
+            _error(
+                "The detached CalculiX importer metadata is malformed.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+        path = Path(str(result["input_file"] or "")).resolve()
+        try:
+            path.relative_to(case)
+        except ValueError:
+            _error(
+                "The detached CalculiX input path escaped its private case.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+        if not path.is_file():
+            _error(
+                "The detached CalculiX input file is unavailable.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+        result["input_file"] = str(path)
+    elif kind == "calculix":
+        if set(result) != {"input_deck"}:
+            _error(
+                "The detached CalculiX importer metadata is malformed.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+        result["input_deck"] = _simple_name(result["input_deck"], "input deck")
+    elif kind == "elmer":
+        if set(result) != {"result_format"} or result["result_format"] not in {
+            ".vtu",
+            ".pvtu",
+            ".pvd",
+        }:
+            _error(
+                "The detached Elmer importer metadata is malformed.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+    elif kind == "mystran":
+        if set(result) != {"input_deck"}:
+            _error(
+                "The detached Mystran importer metadata is malformed.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+        result["input_deck"] = _simple_name(result["input_deck"], "input deck")
+    elif kind == "openfoam":
+        if set(result) != {"result_glob", "solver_log", "summary_context"}:
+            _error(
+                "The detached OpenFOAM importer metadata is malformed.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+        if result["result_glob"] != "VTK/*.vtk":
+            _error(
+                "The detached OpenFOAM result path is invalid.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+        _simple_name(result["solver_log"], "solver log")
+        if not isinstance(result["summary_context"], Mapping):
+            _error(
+                "The detached OpenFOAM summary context is malformed.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+    elif kind == "z88":
+        if result:
+            _error(
+                "The detached Z88 importer metadata is malformed.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+    else:
+        _error(
+            "The detached FEM backend is unsupported.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    return result
+
+
+def _stages(value: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, list) or not 1 <= len(value) <= 16:
+        _error(
+            "The detached FEM stage summary is malformed.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    result = []
+    for index, item in enumerate(value, 1):
+        if (
+            not isinstance(item, Mapping)
+            or set(item) != {"stage", "program", "exit_code"}
+            or item.get("stage") != index
+            or item.get("exit_code") != 0
+        ):
+            _error(
+                "The detached FEM stage summary is invalid.",
+                "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+            )
+        result.append(
+            {
+                "stage": index,
+                "program": _simple_name(item.get("program"), "stage program"),
+                "exit_code": 0,
+            }
+        )
+    return tuple(result)
+
+
+def _read_result(frozen: FrozenSolverExecution) -> PreparedSolverExecution:
+    data = _read_regular(
+        frozen.workspace.path / "result.json",
+        root=frozen.workspace.path,
+        maximum=MAX_SOLVER_RESULT_BYTES,
+    )
+    try:
+        value = json.loads(data.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise NativeAnalyzeError(
+            "The detached FEM result is unreadable.",
+            error_code="NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        ) from exc
+    if not isinstance(value, Mapping):
+        _error(
+            "The detached FEM result is malformed.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    if value.get("ok") is False:
+        code = str(value.get("error_code") or "")
+        message = str(value.get("message") or "")[:320]
+        if (
+            value.get("protocol") != ANALYZE_SOLVER_EXECUTION_PROTOCOL
+            or value.get("request_sha256") != frozen.request_sha256
+            or not code.startswith("NATIVE_ANALYZE_")
+            or not message
+        ):
+            _error(
+                "The detached FEM solver process failed.",
+                "NATIVE_ANALYZE_SOLVER_EXECUTION_FAILED",
+            )
+        raise NativeAnalyzeError(message, error_code=code)
+    required = {
+        "ok",
+        "protocol",
+        "request_sha256",
+        "solver_name",
+        "solver_kind",
+        "solver_state_sha256",
+        "implementation",
+        "case",
+        "input_sha256",
+        "input_file_count",
+        "keep_results",
+        "importer_state",
+        "stages",
+    }
+    implementation = str(value.get("implementation") or "")
+    input_count = value.get("input_file_count")
+    kind = frozen.captured.target.kind
+    allowed_implementations = (
+        {"pipeline", "ccx_tools"} if kind == "calculix" else {kind}
+    )
+    if (
+        set(value) != required
+        or value.get("ok") is not True
+        or value.get("protocol") != ANALYZE_SOLVER_EXECUTION_PROTOCOL
+        or value.get("request_sha256") != frozen.request_sha256
+        or value.get("solver_name") != frozen.solver_name
+        or value.get("solver_kind") != frozen.captured.target.kind
+        or value.get("solver_state_sha256")
+        != frozen.captured.target.expected_state_sha256
+        or value.get("case") != "case"
+        or implementation not in allowed_implementations
+        or type(input_count) is not int
+        or not 1 <= input_count <= 4096
+        or value.get("keep_results") is not frozen.captured.keep_results
+    ):
+        _error(
+            "The detached FEM result failed protocol validation.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    input_sha256 = _sha256(value["input_sha256"], "input digest")
+    case = frozen.workspace.path / "case"
+    if case.is_symlink() or not case.is_dir():
+        _error(
+            "The detached FEM case directory is unavailable.",
+            "NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+        )
+    request = SolverExecutionRequest(
+        target=frozen.captured.target,
+        implementation=implementation,
+        history_operations=frozen.captured.history_operations,
+        working_directory=str(case),
+        commands=(),
+        environment={},
+        timeout_seconds=frozen.captured.timeout_seconds,
+        input_sha256=input_sha256,
+        input_file_count=input_count,
+        keep_results=frozen.captured.keep_results,
+        importer_state=_importer_state(
+            value["importer_state"],
+            frozen=frozen,
+            implementation=implementation,
+        ),
+        runtime_preferences=frozen.captured.runtime_preferences,
+    )
+    return PreparedSolverExecution(request=request, stages=_stages(value["stages"]))
+
+
+def execute_frozen_solver_execution(
+    frozen: FrozenSolverExecution,
+    *,
+    cancelled: Callable[[], bool],
+    progress: Callable[[int, str], None],
+) -> PreparedSolverExecution:
+    """Generate and run one exact solver case outside the VibeCAD GUI process."""
+
+    if not isinstance(frozen, FrozenSolverExecution):
+        raise TypeError("frozen must be a FrozenSolverExecution")
+    if cancelled():
+        raise NativeBackgroundCancelled()
+    progress(8, "Authenticating exact FEM solver inputs")
+    _validate_inputs(frozen)
+    if cancelled():
+        raise NativeBackgroundCancelled()
+    progress(10, "Starting isolated FEM solver worker")
+    state = {"percent": 10, "message": "Starting isolated FEM solver worker"}
+    code = (
+        "import os,runpy;"
+        "runpy.run_path(os.environ['VIBECAD_NATIVE_ANALYZE_SOLVER_EXECUTION_CHILD'],"
+        "run_name='__main__')"
+    )
+    process = run_process(
+        [str(frozen.workspace.freecadcmd.path), "--safe-mode", "-c", code],
+        cwd=frozen.workspace.path,
+        environment=_environment(frozen),
+        cancellation_check=cancelled,
+        timeout_seconds=(
+            float(frozen.captured.timeout_seconds) + MAX_SOLVER_PREPARATION_SECONDS
+        ),
+        memory_limit_bytes=0,
+        poll_callback=lambda: _read_progress(frozen, progress, state),
+    )
+    if bool(process.get("cancelled")):
+        raise NativeBackgroundCancelled()
+    if not bool(process.get("started")):
+        _error(
+            "The isolated FEM solver process could not start.",
+            "NATIVE_ANALYZE_SOLVER_START_FAILED",
+        )
+    if bool(process.get("timed_out")):
+        _error(
+            "FEM case generation or execution exceeded its safety timeout.",
+            "NATIVE_ANALYZE_SOLVER_TIMEOUT",
+        )
+    if cancelled():
+        raise NativeBackgroundCancelled()
+    progress(max(84, state["percent"]), "Authenticating FEM solver results")
+    prepared = _read_result(frozen)
+    if int(process.get("returncode", 1)) != 0:
+        _error(
+            "The isolated FEM solver process exited unsuccessfully.",
+            "NATIVE_ANALYZE_SOLVER_EXECUTION_FAILED",
+        )
+    progress(89, "Prepared exact FEM solver results for import")
+    return prepared
+
+
+__all__ = ["execute_frozen_solver_execution"]

--- a/src/Mod/VibeCAD/VibeCADScriptedProcess.py
+++ b/src/Mod/VibeCAD/VibeCADScriptedProcess.py
@@ -92,18 +92,37 @@ def _windows_process_memory_bytes(pid: int) -> int | None:
         kernel32.CloseHandle(handle)
 
 
-def _terminate(process: subprocess.Popen[str]) -> None:
+def terminate_process_tree(process: subprocess.Popen[Any]) -> None:
+    """Terminate a worker and every subprocess it owns."""
+
     if process.poll() is not None:
         return
     try:
         if sys.platform == "win32":
-            process.terminate()
+            system_root = Path(os.environ.get("SystemRoot", r"C:\Windows"))
+            taskkill = system_root / "System32" / "taskkill.exe"
+            subprocess.run(
+                [str(taskkill), "/PID", str(process.pid), "/T", "/F"],
+                stdin=subprocess.DEVNULL,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                shell=False,
+                creationflags=int(getattr(subprocess, "CREATE_NO_WINDOW", 0)),
+                timeout=3.0,
+                check=False,
+            )
         else:
             os.killpg(process.pid, signal.SIGTERM)
         process.wait(timeout=3.0)
     except Exception:
         process.kill()
         process.wait(timeout=3.0)
+
+
+def _terminate(process: subprocess.Popen[Any]) -> None:
+    """Compatibility wrapper for existing internal callers and tests."""
+
+    terminate_process_tree(process)
 
 
 def _read_output_tail(stream: Any, *, max_bytes: int = 64_000) -> str:
@@ -122,6 +141,7 @@ def run_process(
     cancellation_check: Callable[[], bool] | None,
     timeout_seconds: float,
     memory_limit_bytes: int,
+    poll_callback: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     """Run one child process without a console window and enforce hard bounds."""
     creation_flags = (
@@ -160,6 +180,12 @@ def run_process(
             if cancellation_check is not None and cancellation_check():
                 cancelled = True
                 break
+            if poll_callback is not None:
+                try:
+                    poll_callback()
+                except Exception:
+                    terminate_process_tree(process)
+                    raise
             now = time.monotonic()
             if now - started > timeout_seconds:
                 timed_out = True
@@ -172,7 +198,7 @@ def run_process(
                     break
             time.sleep(0.05)
         if cancelled or timed_out or memory_exceeded:
-            _terminate(process)
+            terminate_process_tree(process)
         process.wait()
         cpu_exceeded = bool(
             sys.platform != "win32"
@@ -182,13 +208,15 @@ def run_process(
         termination_reason = (
             "host_cancellation_request"
             if cancelled
-            else "wall_time_limit"
-            if timed_out
-            else "memory_limit"
-            if memory_exceeded
-            else "cpu_time_limit"
-            if cpu_exceeded
-            else "process_exit"
+            else (
+                "wall_time_limit"
+                if timed_out
+                else (
+                    "memory_limit"
+                    if memory_exceeded
+                    else "cpu_time_limit" if cpu_exceeded else "process_exit"
+                )
+            )
         )
         return {
             "started": True,
@@ -203,11 +231,11 @@ def run_process(
             "limit_reached": (
                 "wall_time_seconds"
                 if timed_out
-                else "memory_bytes"
-                if memory_exceeded
-                else "cpu_seconds"
-                if cpu_exceeded
-                else None
+                else (
+                    "memory_bytes"
+                    if memory_exceeded
+                    else "cpu_seconds" if cpu_exceeded else None
+                )
             ),
             "termination_reason": termination_reason,
             "timeout_seconds": float(timeout_seconds),

--- a/src/Mod/VibeCAD/vibecad_tests/native_analyze_solver_execution_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_analyze_solver_execution_gui_integration.py
@@ -44,7 +44,9 @@ def _surface(main_window):
     controller = main_window.findChild(QtCore.QObject, "VibeCADRibbonController")
     tabs = main_window.findChild(QtWidgets.QTabBar, "VibeCADRibbonTabs")
     assert controller is not None and tabs is not None
-    index = next(i for i in range(tabs.count()) if str(tabs.tabData(i)) == "FemWorkbench")
+    index = next(
+        i for i in range(tabs.count()) if str(tabs.tabData(i)) == "FemWorkbench"
+    )
     tabs.setCurrentIndex(index)
     _events(24)
     surface = read_active_ribbon_surface(controller)
@@ -201,6 +203,7 @@ def _run() -> None:
     active_status_seen = False
     original_require_binary = None
     original_import_tool = execution_module._import_tool
+    original_ccx_binary_path = None
 
     def finish(code: int) -> None:
         nonlocal exit_code
@@ -211,6 +214,10 @@ def _run() -> None:
             from femsolver import settings
 
             settings.require_binary = original_require_binary
+        if original_ccx_binary_path is not None:
+            App.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem/Ccx").SetString(
+                "ccxBinaryPath", original_ccx_binary_path
+            )
         execution_module._import_tool = original_import_tool
         if document is not None and document.Name in App.listDocuments():
             App.closeDocument(document.Name)
@@ -224,12 +231,19 @@ def _run() -> None:
             prefix="vibecad-native-analyze-solver-execution-"
         )
         temporary_path = Path(temporary.name)
-        fake_solver = temporary_path / "fake-ccx"
-        fake_solver.write_text(
-            "#!/bin/sh\nsleep 0.25\nprintf 'solver completed'\n",
-            encoding="utf-8",
-        )
-        fake_solver.chmod(0o700)
+        if sys.platform == "win32":
+            fake_solver = temporary_path / "fake-ccx.cmd"
+            fake_solver.write_text(
+                "@echo off\r\nping -n 2 127.0.0.1 >nul\r\necho solver completed\r\n",
+                encoding="utf-8",
+            )
+        else:
+            fake_solver = temporary_path / "fake-ccx"
+            fake_solver.write_text(
+                "#!/bin/sh\nsleep 0.25\nprintf 'solver completed'\n",
+                encoding="utf-8",
+            )
+            fake_solver.chmod(0o700)
         output = temporary_path / "native-analyze-solver-execution.FCStd"
         document = App.newDocument("NativeAnalyzeSolverExecutionGate")
         document.UndoMode = 1
@@ -244,6 +258,12 @@ def _run() -> None:
         from femsolver import settings
 
         original_require_binary = settings.require_binary
+        ccx_preferences = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Fem/Ccx")
+        original_ccx_binary_path = ccx_preferences.GetString(
+            "ccxBinaryPath",
+            "",
+        )
+        ccx_preferences.SetString("ccxBinaryPath", str(fake_solver))
         settings.require_binary = lambda name: (
             str(fake_solver) if name == "Calculix" else original_require_binary(name)
         )
@@ -335,9 +355,7 @@ def _run() -> None:
                     domain = service.native_active_snapshot()["domain"]
                     run_status = domain["run_status"]
                     assert run_status["job_id"] == job_id
-                    assert run_status["capability"] == (
-                        "analyze.solver_execution.run"
-                    )
+                    assert run_status["capability"] == ("analyze.solver_execution.run")
                     assert domain["analysis_workflow_count"] == 1
                     workflow = domain["analysis_workflows"][0]
                     assert workflow["readiness"]["ready"] is True
@@ -376,9 +394,7 @@ def _run() -> None:
                 assert "NodeNumbers" not in encoded_domain
                 result_resources = result["result"]["resources"]
                 assert len(result_resources) == 1
-                output_object = document.getObject(
-                    result_resources[0]["object_name"]
-                )
+                output_object = document.getObject(result_resources[0]["object_name"])
                 assert output_object is not None
                 output_name = str(output_object.Name)
                 assert result_object.VibeCADTimelineRole == "resource"
@@ -411,9 +427,7 @@ def _run() -> None:
                         live_root,
                     )
 
-                old_solver_name, old_root_name, old_output_name = (
-                    completed_results[0]
-                )
+                old_solver_name, old_root_name, old_output_name = completed_results[0]
                 replacement_solver = document.getObject(old_solver_name)
                 document.openTransaction("Replace exact FEM result graph")
                 try:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_solver_execution.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_solver_execution.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import os
+import runpy
 import sys
 import threading
 import time
 from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 import pytest
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
@@ -108,7 +110,74 @@ def test_process_failure_returns_only_bounded_tail(tmp_path: Path) -> None:
         )
 
 
-def test_openfoam_failure_reports_the_fatal_reason_not_the_stack(tmp_path: Path) -> None:
+def test_atomic_progress_replacement_is_a_transient_sample(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import VibeCADNativeAnalyzeSolverExecutionWorker as worker
+
+    (tmp_path / "progress.json").write_text("{}", encoding="utf-8")
+    frozen = SimpleNamespace(
+        workspace=SimpleNamespace(path=tmp_path),
+        request_sha256="a" * 64,
+    )
+    monkeypatch.setattr(
+        worker,
+        "_read_regular",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            worker._ArtifactChangedWhileOpening()
+        ),
+    )
+    progress = []
+    state = {"percent": 10, "message": "Starting isolated FEM solver worker"}
+
+    worker._read_progress(
+        frozen,
+        lambda percent, message: progress.append((percent, message)),
+        state,
+    )
+
+    assert progress == []
+    assert state == {
+        "percent": 10,
+        "message": "Starting isolated FEM solver worker",
+    }
+
+
+def test_non_transient_progress_validation_failure_remains_fatal(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import VibeCADNativeAnalyzeSolverExecutionWorker as worker
+
+    (tmp_path / "progress.json").write_text("{}", encoding="utf-8")
+    frozen = SimpleNamespace(
+        workspace=SimpleNamespace(path=tmp_path),
+        request_sha256="a" * 64,
+    )
+    malformed = NativeAnalyzeError(
+        "The isolated FEM progress report is malformed.",
+        error_code="NATIVE_ANALYZE_SOLVER_OUTPUT_INVALID",
+    )
+    monkeypatch.setattr(
+        worker,
+        "_read_regular",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(malformed),
+    )
+
+    with pytest.raises(NativeAnalyzeError) as raised:
+        worker._read_progress(
+            frozen,
+            lambda _percent, _message: None,
+            {"percent": 10, "message": "Starting isolated FEM solver worker"},
+        )
+
+    assert raised.value is malformed
+
+
+def test_openfoam_failure_reports_the_fatal_reason_not_the_stack(
+    tmp_path: Path,
+) -> None:
     program = _program(
         tmp_path / "foam-fail",
         'print("banner")\n'
@@ -170,6 +239,497 @@ def test_solver_execution_rejects_empty_result_data() -> None:
             {"result_kind": "pipeline", "field_count": 0, "data_available": False}
         )
 
-    _require_meaningful_result_state(
-        {"result_kind": "result", "field_count": 2}
+    _require_meaningful_result_state({"result_kind": "result", "field_count": 2})
+
+
+def test_solver_capture_does_not_generate_case_files(monkeypatch) -> None:
+    import VibeCADNativeAnalyzeSolverExecution as execution
+
+    solver = SimpleNamespace(Name="Solver", Document=object())
+    target = SimpleNamespace(
+        solver=solver,
+        kind="openfoam",
+        expected_state_sha256="a" * 64,
     )
+    history = (solver,)
+    monkeypatch.setattr(execution, "prepare_solver_target", lambda *_args: target)
+    monkeypatch.setattr(
+        execution,
+        "solver_state",
+        lambda *_args: {"suppressed": False},
+    )
+    monkeypatch.setattr(execution, "_require_history_root", lambda *_args: history)
+    monkeypatch.setattr(execution, "_current_keep_results", lambda: True)
+    monkeypatch.setattr(
+        execution,
+        "_current_solver_runtime_preferences",
+        lambda _kind: (
+            (
+                "User parameter:BaseApp/Preferences/Mod/Fem/General",
+                "KeepResultsOnReRun",
+                "bool",
+                True,
+            ),
+            ("preferences", "threads", "int", 6),
+        ),
+    )
+    monkeypatch.setattr(
+        execution,
+        "_openfoam_request",
+        lambda *_args: pytest.fail("capture must not generate solver input"),
+    )
+
+    captured = execution.capture_solver_execution_request(
+        solver.Document,
+        "document-a",
+        target={
+            "object_name": "Solver",
+            "expected_state_sha256": "a" * 64,
+        },
+        timeout_seconds=7200,
+    )
+
+    assert captured.target is target
+    assert captured.history_operations == history
+    assert captured.timeout_seconds == 7200
+    assert captured.keep_results is True
+    assert captured.runtime_preferences == (
+        (
+            "User parameter:BaseApp/Preferences/Mod/Fem/General",
+            "KeepResultsOnReRun",
+            "bool",
+            True,
+        ),
+        ("preferences", "threads", "int", 6),
+    )
+
+
+def test_solver_capture_validation_rejects_runtime_preference_changes(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSolverExecution as execution
+
+    document = object()
+    solver = SimpleNamespace(Document=document)
+    captured = execution.CapturedSolverExecutionRequest(
+        SimpleNamespace(
+            solver=solver,
+            kind="calculix",
+            expected_state_sha256="c" * 64,
+        ),
+        (solver,),
+        3600,
+        False,
+        (
+            (
+                "User parameter:BaseApp/Preferences/Mod/Fem/General",
+                "KeepResultsOnReRun",
+                "bool",
+                False,
+            ),
+            ("preferences", "threads", "int", 6),
+        ),
+    )
+    monkeypatch.setattr(execution, "solver_still_exact", lambda *_args: True)
+    monkeypatch.setattr(execution, "_require_history_root", lambda *_args: (solver,))
+    monkeypatch.setattr(execution, "_current_keep_results", lambda: False)
+    monkeypatch.setattr(
+        execution,
+        "_current_solver_runtime_preferences",
+        lambda _kind: (
+            (
+                "User parameter:BaseApp/Preferences/Mod/Fem/General",
+                "KeepResultsOnReRun",
+                "bool",
+                False,
+            ),
+            ("preferences", "threads", "int", 8),
+        ),
+    )
+
+    with pytest.raises(NativeAnalyzeError, match="runtime preferences changed"):
+        execution.validate_captured_solver_execution(document, captured)
+
+
+def test_solver_runtime_preferences_are_scoped_to_selected_backend(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSolverExecution as execution
+
+    class Group:
+        def GetBool(self, _name, default):
+            return default
+
+        def GetInt(self, _name, default):
+            return default
+
+        def GetString(self, name, default):
+            return f"configured-{name}" if name.endswith("BinaryPath") else default
+
+    freecad = SimpleNamespace(
+        ParamGet=lambda _path: Group(),
+        Units=SimpleNamespace(Scheme=SimpleNamespace(Internal=7)),
+    )
+    monkeypatch.setitem(sys.modules, "FreeCAD", freecad)
+
+    preferences = execution._current_solver_runtime_preferences("calculix")
+    paths = {path for path, _name, _kind, _value in preferences}
+
+    assert "User parameter:BaseApp/Preferences/Mod/Fem/Ccx" in paths
+    assert "User parameter:BaseApp/Preferences/Mod/Fem/Elmer" not in paths
+    assert "User parameter:BaseApp/Preferences/Mod/Fem/OpenFOAM" not in paths
+    assert (
+        "User parameter:BaseApp/Preferences/Units",
+        "UserSchema",
+        "int",
+        7,
+    ) in preferences
+
+
+def test_solver_snapshot_is_materialized_only_inside_owned_workspace(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    import VibeCADNativeAnalyzeSolverExecutionInput as execution_input
+
+    snapshot_calls = []
+
+    class Document:
+        def saveCopy(self, path: str) -> bool:
+            snapshot_calls.append(path)
+            Path(path).write_bytes(b"FCStd snapshot")
+            return True
+
+    captured = SimpleNamespace(
+        target=SimpleNamespace(
+            solver=SimpleNamespace(Name="Solver", ID=17, TypeId="Fem::FemSolverObject"),
+            kind="calculix",
+            expected_state_sha256="b" * 64,
+        ),
+        history_operations=(),
+        timeout_seconds=3600,
+        keep_results=False,
+        runtime_preferences=(),
+    )
+    workspace = execution_input.SolverExecutionWorkspace(
+        temporary=SimpleNamespace(cleanup=lambda: None),
+        path=tmp_path,
+        freecadcmd=SimpleNamespace(path=tmp_path / "FreeCADCmd.exe"),
+        child=SimpleNamespace(path=tmp_path / "solver-child.py"),
+    )
+    workspace.freecadcmd.path.write_bytes(b"exe")
+    workspace.child.path.write_bytes(b"child")
+    monkeypatch.setattr(
+        execution_input,
+        "validate_captured_solver_execution",
+        lambda *_args: None,
+    )
+
+    materialized = execution_input.materialize_solver_execution_snapshot(
+        Document(),
+        captured,
+        workspace,
+    )
+    frozen = execution_input.freeze_solver_execution_snapshot(materialized)
+
+    assert snapshot_calls == [str(tmp_path / "document.FCStd")]
+    assert materialized.snapshot_path == tmp_path / "document.FCStd"
+    assert frozen.snapshot.path == tmp_path / "document.FCStd"
+    assert frozen.request.path == tmp_path / "request.json"
+    assert frozen.solver_name == "Solver"
+
+
+def test_human_and_ai_solver_entrypoints_do_not_call_synchronous_case_builder() -> None:
+    root = Path(__file__).resolve().parents[1]
+    human = (root / "VibeCADAnalyzeSolverGui.py").read_text(encoding="utf-8")
+    ai = (root / "VibeCADNativeAnalyzeSolverExecutionRuntime.py").read_text(
+        encoding="utf-8"
+    )
+
+    for source in (human, ai):
+        assert "capture_solver_execution_request" in source
+        assert "prepare_solver_execution_request" not in source
+        assert "execute_frozen_solver_execution" in source
+
+
+def test_human_solver_progress_is_mirrored_to_the_status_bar(monkeypatch) -> None:
+    import types
+
+    from PySide6 import QtCore, QtWidgets
+
+    pyside = types.ModuleType("PySide")
+    pyside.QtCore = QtCore
+    pyside.QtWidgets = QtWidgets
+    monkeypatch.setitem(sys.modules, "PySide", pyside)
+    import VibeCADAnalyzeSolverGui as solver_gui
+
+    dialog_updates: list[tuple[str, object]] = []
+    status_updates: list[str] = []
+    runner = object.__new__(solver_gui._SolverRunUi)
+    runner.job_id = "solver-job"
+    runner.backend = "CalculiX"
+    runner.manager = SimpleNamespace(
+        snapshot=lambda _job_id: SimpleNamespace(
+            progress_percent=37,
+            progress_message="Running CalculiX stage 1/1 (65s elapsed)",
+            terminal=False,
+        )
+    )
+    runner.dialog = SimpleNamespace(
+        setValue=lambda value: dialog_updates.append(("percent", value)),
+        setLabelText=lambda value: dialog_updates.append(("message", value)),
+    )
+    monkeypatch.setattr(
+        solver_gui.Gui,
+        "getMainWindow",
+        lambda: SimpleNamespace(
+            statusBar=lambda: SimpleNamespace(
+                showMessage=lambda value, *_args: status_updates.append(value)
+            )
+        ),
+        raising=False,
+    )
+
+    runner.poll()
+
+    assert dialog_updates == [
+        ("percent", 37),
+        ("message", "Running CalculiX stage 1/1 (65s elapsed)"),
+    ]
+    assert status_updates == [
+        "CalculiX: Running CalculiX stage 1/1 (65s elapsed)"
+    ]
+
+
+def test_analyze_preferences_expose_the_openfoam_environment_contract() -> None:
+    repository = Path(__file__).resolve().parents[4]
+    gui = repository / "src" / "Mod" / "Fem" / "Gui"
+    app_source = (gui / "AppFemGui.cpp").read_text(encoding="utf-8")
+    cmake_source = (gui / "CMakeLists.txt").read_text(encoding="utf-8")
+    init_gui_source = (
+        repository / "src" / "Mod" / "Fem" / "InitGui.py"
+    ).read_text(encoding="utf-8")
+    runtime_source = (
+        repository / "src" / "Mod" / "Fem" / "femsolver" / "runtime.py"
+    ).read_text(encoding="utf-8")
+    openfoam_ui = (gui / "DlgSettingsFemOpenFOAM.ui").read_text(encoding="utf-8")
+
+    assert '#include "DlgSettingsFemOpenFOAMImp.h"' in app_source
+    assert "PrefPageProducer<FemGui::DlgSettingsFemOpenFOAMImp>" in app_source
+    assert (
+        'setGroupData(\n        "Analyze", "fem"' in app_source
+    )
+    assert app_source.count('QT_TRANSLATE_NOOP("QObject", "Analyze")') == 7
+    assert 'QT_TRANSLATE_NOOP("QObject", "FEM")' not in app_source
+    assert (
+        'addPreferencePage(fempreferencepages.DlgSettingsNetgen, "Analyze")'
+        in init_gui_source
+    )
+    assert (
+        'addPreferencePage(fempreferencepages.DlgSettingsNetgen, "FEM")'
+        not in init_gui_source
+    )
+    for name in (
+        "DlgSettingsFemOpenFOAM.ui",
+        "DlgSettingsFemOpenFOAMImp.cpp",
+        "DlgSettingsFemOpenFOAMImp.h",
+    ):
+        assert name in cmake_source
+    assert "<cstring>EnvironmentFile</cstring>" in openfoam_ui
+    assert "<cstring>Mod/Fem/OpenFOAM</cstring>" in openfoam_ui
+    assert (
+        '_OPENFOAM_PARAMETER_PATH = "User parameter:BaseApp/Preferences/Mod/Fem/OpenFOAM"'
+        in runtime_source
+    )
+    assert '_OPENFOAM_ENVIRONMENT_KEY = "EnvironmentFile"' in runtime_source
+
+
+def test_analyze_preferences_register_before_workbench_activation(monkeypatch) -> None:
+    repository = Path(__file__).resolve().parents[4]
+    preference_pages: list[tuple[object, str]] = []
+    workbenches: list[object] = []
+
+    class Workbench:
+        pass
+
+    freecad = ModuleType("FreeCAD")
+    freecad.__cmake__ = ""
+    freecad.__unit_test__ = []
+    freecad.getResourceDir = lambda: "resources/"
+
+    freecad_gui = ModuleType("FreeCADGui")
+    freecad_gui.Workbench = Workbench
+    freecad_gui.addWorkbench = workbenches.append
+    freecad_gui.addPreferencePage = lambda page, group: preference_pages.append(
+        (page, group)
+    )
+
+    migrate_gui = ModuleType("femguiutils.migrate_gui")
+
+    class FemMigrateGui:
+        pass
+
+    migrate_gui.FemMigrateGui = FemMigrateGui
+    femguiutils = ModuleType("femguiutils")
+    femguiutils.__path__ = []
+    fem = ModuleType("Fem")
+    fem_gui = ModuleType("FemGui")
+    fem_commands = ModuleType("femcommands")
+    fem_commands.__path__ = []
+    command_module = ModuleType("femcommands.commands")
+    fem_commands.commands = command_module
+    preferences = ModuleType("fempreferencepages")
+    preferences.DlgSettingsNetgen = type("DlgSettingsNetgen", (), {})
+
+    for name, module in (
+        ("FreeCAD", freecad),
+        ("FreeCADGui", freecad_gui),
+        ("Fem", fem),
+        ("FemGui", fem_gui),
+        ("femcommands", fem_commands),
+        ("femcommands.commands", command_module),
+        ("fempreferencepages", preferences),
+        ("femguiutils", femguiutils),
+        ("femguiutils.migrate_gui", migrate_gui),
+    ):
+        monkeypatch.setitem(sys.modules, name, module)
+
+    old_meta_path = list(sys.meta_path)
+    try:
+        runpy.run_path(str(repository / "src" / "Mod" / "Fem" / "InitGui.py"))
+        assert preference_pages == [(preferences.DlgSettingsNetgen, "Analyze")]
+        assert len(workbenches) == 1
+
+        workbenches[0].Initialize()
+        assert preference_pages == [(preferences.DlgSettingsNetgen, "Analyze")]
+    finally:
+        sys.meta_path[:] = old_meta_path
+
+
+def test_authenticated_worker_result_reuses_only_parent_commit_guards(
+    tmp_path: Path,
+) -> None:
+    import json
+
+    import VibeCADNativeAnalyzeSolverExecutionWorker as worker
+    from VibeCADNativeAnalyzeSolverExecution import CapturedSolverExecutionRequest
+    from VibeCADNativeAnalyzeSolverExecutionInput import (
+        ANALYZE_SOLVER_EXECUTION_PROTOCOL,
+        FrozenSolverExecution,
+        SolverExecutionWorkspace,
+    )
+
+    case = tmp_path / "case"
+    case.mkdir()
+    target = SimpleNamespace(
+        solver=SimpleNamespace(Name="Solver"),
+        kind="calculix",
+        expected_state_sha256="d" * 64,
+    )
+    history = (object(), object())
+    runtime_preferences = (
+        (
+            "User parameter:BaseApp/Preferences/Mod/Fem/General",
+            "KeepResultsOnReRun",
+            "bool",
+            False,
+        ),
+    )
+    captured = CapturedSolverExecutionRequest(
+        target,
+        history,
+        7200,
+        False,
+        runtime_preferences,
+    )
+    request_sha256 = "e" * 64
+    workspace = SolverExecutionWorkspace(
+        temporary=SimpleNamespace(cleanup=lambda: None),
+        path=tmp_path,
+        freecadcmd=SimpleNamespace(),
+        child=SimpleNamespace(),
+    )
+    frozen = FrozenSolverExecution(
+        workspace=workspace,
+        captured=captured,
+        snapshot=SimpleNamespace(),
+        request=SimpleNamespace(),
+        request_sha256=request_sha256,
+        solver_name="Solver",
+    )
+    result = {
+        "ok": True,
+        "protocol": ANALYZE_SOLVER_EXECUTION_PROTOCOL,
+        "request_sha256": request_sha256,
+        "solver_name": "Solver",
+        "solver_kind": "calculix",
+        "solver_state_sha256": "d" * 64,
+        "implementation": "pipeline",
+        "case": "case",
+        "input_sha256": "f" * 64,
+        "input_file_count": 3,
+        "keep_results": False,
+        "importer_state": {"input_deck": "model"},
+        "stages": [{"stage": 1, "program": "ccx.exe", "exit_code": 0}],
+    }
+    (tmp_path / "result.json").write_text(json.dumps(result), encoding="utf-8")
+
+    prepared = worker._read_result(frozen)
+
+    assert prepared.request.target is target
+    assert prepared.request.history_operations == history
+    assert prepared.request.commands == ()
+    assert prepared.request.environment == {}
+    assert prepared.request.runtime_preferences == runtime_preferences
+    assert prepared.stages == ({"stage": 1, "program": "ccx.exe", "exit_code": 0},)
+
+
+def test_worker_rejects_backend_implementation_substitution(tmp_path: Path) -> None:
+    import json
+
+    import VibeCADNativeAnalyzeSolverExecutionWorker as worker
+    from VibeCADNativeAnalyzeSolverExecution import CapturedSolverExecutionRequest
+    from VibeCADNativeAnalyzeSolverExecutionInput import (
+        ANALYZE_SOLVER_EXECUTION_PROTOCOL,
+        FrozenSolverExecution,
+        SolverExecutionWorkspace,
+    )
+
+    (tmp_path / "case").mkdir()
+    target = SimpleNamespace(
+        solver=SimpleNamespace(Name="Solver"),
+        kind="elmer",
+        expected_state_sha256="1" * 64,
+    )
+    frozen = FrozenSolverExecution(
+        workspace=SolverExecutionWorkspace(
+            temporary=SimpleNamespace(cleanup=lambda: None),
+            path=tmp_path,
+            freecadcmd=SimpleNamespace(),
+            child=SimpleNamespace(),
+        ),
+        captured=CapturedSolverExecutionRequest(target, (), 60, False, ()),
+        snapshot=SimpleNamespace(),
+        request=SimpleNamespace(),
+        request_sha256="2" * 64,
+        solver_name="Solver",
+    )
+    result = {
+        "ok": True,
+        "protocol": ANALYZE_SOLVER_EXECUTION_PROTOCOL,
+        "request_sha256": "2" * 64,
+        "solver_name": "Solver",
+        "solver_kind": "elmer",
+        "solver_state_sha256": "1" * 64,
+        "implementation": "openfoam",
+        "case": "case",
+        "input_sha256": "3" * 64,
+        "input_file_count": 1,
+        "keep_results": False,
+        "importer_state": {"result_format": ".vtu"},
+        "stages": [{"stage": 1, "program": "ElmerSolver", "exit_code": 0}],
+    }
+    (tmp_path / "result.json").write_text(json.dumps(result), encoding="utf-8")
+
+    with pytest.raises(NativeAnalyzeError, match="protocol validation"):
+        worker._read_result(frozen)

--- a/src/Mod/VibeCAD/vibecad_tests/test_scripted_process.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_scripted_process.py
@@ -8,8 +8,55 @@ import os
 from pathlib import Path
 import signal
 import sys
+from types import SimpleNamespace
+
+import pytest
 
 from VibeCADScriptedProcess import run_process
+
+
+def test_windows_termination_targets_the_entire_worker_tree(monkeypatch) -> None:
+    import VibeCADScriptedProcess as scripted
+
+    calls = []
+
+    class Process:
+        pid = 4321
+        returncode = None
+
+        def poll(self):
+            return None if self.returncode is None else self.returncode
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                self.returncode = -1
+            return self.returncode
+
+        def terminate(self):
+            pytest.fail("a Windows worker cancellation must terminate its process tree")
+
+        def kill(self):
+            self.returncode = -9
+
+    monkeypatch.setattr(scripted.sys, "platform", "win32")
+    monkeypatch.setenv("SystemRoot", r"C:\Windows")
+    monkeypatch.setattr(
+        scripted.subprocess,
+        "run",
+        lambda command, **kwargs: calls.append((command, kwargs))
+        or SimpleNamespace(returncode=0),
+    )
+
+    scripted.terminate_process_tree(Process())
+
+    assert calls[0][0] == [
+        r"C:\Windows\System32\taskkill.exe",
+        "/PID",
+        "4321",
+        "/T",
+        "/F",
+    ]
+    assert calls[0][1]["shell"] is False
 
 
 def test_large_worker_output_cannot_fill_a_parent_pipe(tmp_path: Path) -> None:


### PR DESCRIPTION
﻿## Outcome

VibeCAD now runs supported human and AI Analyze solver workflows through one isolated background pipeline, keeping Qt responsive during case preparation, solving, and result processing. This PR also restores the Windows McMaster catalog after the shared Linux launcher adopted `--key=value` arguments.

Closes #102
Closes #99

## What changed

- Capture solver state on the document thread, then prepare, execute, and process results in an isolated FreeCAD worker process.
- Revalidate document identity, revision, solver state, preferences, and authenticated artifacts before a bounded document-thread commit.
- Share the scheduler, cancellation, progress, and result path between human commands and AI tools.
- Terminate worker/solver process trees and reject stale late commits.
- Mirror human progress to the non-modal surface and VibeCAD status bar.
- Add OpenFOAM configuration under the renamed **Analyze** preference category.
- Register Analyze preferences at GUI startup, before the Analyze workbench is first visited.
- Accept both `--name value` and `--name=value` in the Windows McMaster WebView2 helper.
- Add a Windows packaging smoke test for the exact McMaster launch-path contract.

## TDD and verification

Red phase for the startup-preference and McMaster parser regressions:

```powershell
$env:PYTHONPATH='src/Mod/VibeCAD;src/Mod/TechDraw;src/Mod/Fem;src/Mod/McMasterInsert'
& '.pixi/envs/default/python.exe' -m pytest src/Mod/McMasterInsert/tests/test_catalog.py src/Mod/VibeCAD/vibecad_tests/test_native_analyze_solver_execution.py -k 'windows_build_defines_and_installs_webview2_helper or analyze_preferences_register_before_workbench_activation' -q
```

Result before implementation: `2 failed, 49 deselected`.

Green focused regressions: same command after implementation: `2 passed, 49 deselected in 0.80s`.

Solver/process suite:

```powershell
$env:PYTHONPATH='src/Mod/VibeCAD;src/Mod/TechDraw;src/Mod/Fem'
& '.pixi/envs/default/python.exe' -m pytest src/Mod/VibeCAD/vibecad_tests/test_native_analyze_solver_execution.py src/Mod/VibeCAD/vibecad_tests/test_scripted_process.py -q
```

Result: `24 passed in 3.39s`.

McMaster suite in the real FreeCAD runtime:

```powershell
& 'package/rattler-build/.pixi/envs/default/Library/bin/FreeCADCmd.exe' --safe-mode -c "import sys, unittest; sys.path.insert(0, r'C:\Users\robit\vibecad\src\Mod\McMasterInsert'); suite=unittest.defaultTestLoader.discover(r'C:\Users\robit\vibecad\src\Mod\McMasterInsert\tests'); result=unittest.TextTestRunner(verbosity=1).run(suite); raise SystemExit(0 if result.wasSuccessful() else 1)"
```

Result: `Ran 35 tests ... OK`.

Runner-equivalent full Windows package build:

```powershell
& "$env:USERPROFILE\.pixi\bin\pixi.exe" reinstall -e default vibecad
```

Result: exit `0`; fresh `VibeCAD 26.3.1-RC5 (Build 4)` package built in `1030.1s`.

Compiled McMaster helper smoke checks:

```powershell
McMasterCatalogWebView2.exe --argument-parser-smoke-test --inbox=equals-inbox --profile split-profile
McMasterCatalogWebView2.exe --argument-parser-smoke-test --inbox split-inbox --profile=equals-profile
```

Result: exit `0` for both formats.

Packaged GUI integration gate:

```text
VIBECAD_NATIVE_ANALYZE_SOLVER_EXECUTION_GUI_OK action=1 implementations=2 background=true ui_responsive=true exact_input=true job_status=true workflow_readiness=true concise_snapshot=true exact_commit=true history=true undo_redo=true reopen=true
```

Manual acceptance on the fresh package confirmed Analyze preferences are available before visiting the tab and the McMaster catalog opens on Windows.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing defaults are preserved.
- [x] The McMaster helper accepts both old and new argument forms.
- [x] No breaking changes.

## Risk and non-goals

The main risk is solver lifecycle behavior across backend-specific result importers; the isolated-worker integration gate covers capture, responsiveness, progress, exact commit, history, undo/redo, and reopen. This PR does not remove legacy public entry points or change solver/tool schemas.
