### PR TITLE
Fix Install and Restart so the macOS updater applies a downloaded DMG

### DIFF
--- a/src/Mod/VibeCAD/VibeCADUpdate.py
+++ b/src/Mod/VibeCAD/VibeCADUpdate.py
@@ -16,7 +16,9 @@ import json
 import os
 import platform
 import re
+import shlex
 import shutil
+import subprocess
 import sys
 import tempfile
 import time
@@ -232,11 +234,14 @@ receipt="$5"
 pending="$6"
 
 log="$(dirname "$receipt")/install-helper.log"
+started="$(dirname "$receipt")/install-helper.started"
 health_wait="${VIBECAD_UPDATE_HEALTH_WAIT:-120}"
 open_bin="${VIBECAD_UPDATE_OPEN:-open}"
 log_msg() {
     printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" >> "$log"
 }
+printf '%s\n' "$$" > "$started"
+log_msg "helper started pid=$$ waiting for $pid package=$package app=$app"
 
 bundle_executable() {
     candidate="$1/Contents/MacOS/FreeCAD"
@@ -429,6 +434,90 @@ def macos_install_helper_command(
         str(root / "install-receipt.json"),
         str(root / "pending-install.json"),
     ]
+
+
+def macos_install_helper_started_path(update_directory: Path | None = None) -> Path:
+    """Return the handshake file written as soon as the macOS helper is alive."""
+
+    root = (update_directory or default_update_directory()).resolve()
+    return root / "install-helper.started"
+
+
+def spawn_detached_install_helper(
+    command: Sequence[str],
+    *,
+    log_path: Path,
+) -> None:
+    """Start an install helper that outlives this GUI process.
+
+    Stdio is redirected so Qt teardown cannot block on inherited pipes.  On
+    macOS the helper is backgrounded with ``nohup`` in a new session so
+    RunningBoard does not treat it as part of VibeCAD.app and kill it when
+    the application exits.
+    """
+
+    argv = [str(part) for part in command]
+    if not argv:
+        raise UpdateError("The install helper command is empty.")
+    log_path = Path(log_path)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    if sys.platform == "darwin":
+        inner = " ".join(shlex.quote(part) for part in argv)
+        log = shlex.quote(str(log_path))
+        shell = (
+            "trap '' HUP INT TERM\n"
+            f"/usr/bin/nohup {inner} </dev/null >>{log} 2>&1 &\n"
+            "exit 0\n"
+        )
+        process = subprocess.Popen(
+            ["/bin/sh", "-c", shell],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            close_fds=True,
+            start_new_session=True,
+        )
+        process.wait(timeout=5)
+        if process.returncode not in (0, None):
+            raise UpdateError(
+                f"The install helper launcher exited with status {process.returncode}."
+            )
+        return
+
+    log_handle = open(log_path, "ab")
+    try:
+        kwargs: dict[str, Any] = {
+            "stdin": subprocess.DEVNULL,
+            "stdout": log_handle,
+            "stderr": subprocess.STDOUT,
+            "close_fds": True,
+        }
+        if os.name == "nt":
+            kwargs["creationflags"] = (
+                getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+                | getattr(subprocess, "CREATE_NO_WINDOW", 0)
+                | getattr(subprocess, "DETACHED_PROCESS", 0)
+            )
+        else:
+            kwargs["start_new_session"] = True
+        subprocess.Popen(argv, **kwargs)
+    finally:
+        log_handle.close()
+
+
+def wait_for_install_helper_start(
+    started_path: Path,
+    *,
+    timeout: float = 5.0,
+) -> bool:
+    """Return True once the helper has written its startup handshake file."""
+
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if started_path.is_file():
+            return True
+        time.sleep(0.05)
+    return started_path.is_file()
 
 
 def normalize_architecture(value: str) -> str:

--- a/src/Mod/VibeCAD/VibeCADUpdateGui.py
+++ b/src/Mod/VibeCAD/VibeCADUpdateGui.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 import os
-import subprocess
 import threading
 from pathlib import Path
 from typing import Any
@@ -26,7 +25,10 @@ from VibeCADUpdate import (
     default_update_directory,
     load_update_policy,
     macos_install_helper_command,
+    macos_install_helper_started_path,
     record_pending_install,
+    spawn_detached_install_helper,
+    wait_for_install_helper_start,
     write_macos_install_helper,
 )
 
@@ -296,7 +298,7 @@ Start-Process -FilePath $Installer
         encoding="utf-8",
         newline="\n",
     )
-    subprocess.Popen(
+    spawn_detached_install_helper(
         [
             "powershell.exe",
             "-NoLogo",
@@ -309,11 +311,7 @@ Start-Process -FilePath $Installer
             str(plan.package),
             str(os.getpid()),
         ],
-        close_fds=True,
-        creationflags=(
-            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-            | getattr(subprocess, "CREATE_NO_WINDOW", 0)
-        ),
+        log_path=helper_dir / "install-helper.log",
     )
 
 
@@ -387,7 +385,7 @@ printf '{"status":"rolled-back","platform":"appimage"}\n' > "$receipt"
         newline="\n",
     )
     helper.chmod(0o700)
-    subprocess.Popen(
+    spawn_detached_install_helper(
         [
             "/bin/sh",
             str(helper),
@@ -398,8 +396,7 @@ printf '{"status":"rolled-back","platform":"appimage"}\n' > "$receipt"
             str(receipt),
             str(update_dir / "pending-install.json"),
         ],
-        close_fds=True,
-        start_new_session=True,
+        log_path=update_dir / "install-helper.log",
     )
 
 
@@ -410,16 +407,19 @@ def _launch_macos_install_helper(plan: InstallPlan) -> None:
     update_dir = default_update_directory()
     helper_dir = update_dir / "install-helper"
     helper = write_macos_install_helper(helper_dir / "install-macos-update.sh")
-    subprocess.Popen(
+    started = macos_install_helper_started_path(update_dir)
+    started.unlink(missing_ok=True)
+    spawn_detached_install_helper(
         macos_install_helper_command(
             helper,
             plan,
             process_id=os.getpid(),
             update_directory=update_dir,
         ),
-        close_fds=True,
-        start_new_session=True,
+        log_path=update_dir / "install-helper.log",
     )
+    if not wait_for_install_helper_start(started):
+        raise RuntimeError("The macOS install helper did not start.")
 
 
 class CheckForUpdatesCommand:
@@ -630,9 +630,24 @@ class UpdateCenterDialog(QtWidgets.QDialog):
     def _install_and_restart(self) -> None:
         self.controller.stage_install()
         if self.controller.pending_plan is None:
+            _warn_install_failure(self, self.status.text())
+            return
+        try:
+            self.hide()
+            _prepare_to_quit_for_update()
+        except Exception as exc:
+            self.show()
+            self.status.setText(str(exc))
+            _warn_install_failure(self, str(exc))
             return
         self.controller.launch_pending_install_now()
-        _quit_application_for_update()
+        if not self.controller._helper_launched:
+            self.show()
+            message = "VibeCAD could not start the install helper. See the Report view."
+            self.status.setText(message)
+            _warn_install_failure(self, message)
+            return
+        _exit_process_for_update()
 
 
 def _show_update_notification(result: UpdateCheckResult) -> None:
@@ -700,15 +715,35 @@ def _clear_update_center(*_args: Any) -> None:
     _update_center = None
 
 
-def _quit_application_for_update() -> None:
-    """Leave through FreeCAD's main-window close path, then stop Qt."""
+def _warn_install_failure(parent: Any, message: str) -> None:
+    text = (message or "").strip() or "The update could not be installed."
+    QtWidgets.QMessageBox.warning(parent, "Install update", text)
+
+
+def _prepare_to_quit_for_update() -> None:
+    """Save or discard open documents before the process is replaced."""
 
     main_window = Gui.getMainWindow()
-    if main_window is not None:
-        main_window.close()
-    application = QtWidgets.QApplication.instance()
-    if application is not None:
-        application.quit()
+    if main_window is None:
+        return
+    closer = getattr(main_window, "closeAllDocuments", None)
+    if callable(closer) and not closer(False):
+        raise RuntimeError(
+            "Save or discard open documents, then choose Install and restart."
+        )
+
+
+def _exit_process_for_update() -> None:
+    """Hard-exit so the detached helper can replace this application bundle."""
+
+    os._exit(0)
+
+
+def _quit_application_for_update() -> None:
+    """Compatibility wrapper used by tests and older callers."""
+
+    _prepare_to_quit_for_update()
+    _exit_process_for_update()
 
 
 def get_update_controller() -> UpdateController:

--- a/src/Tools/tests/test_vibecad_update.py
+++ b/src/Tools/tests/test_vibecad_update.py
@@ -10,6 +10,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -39,6 +40,7 @@ from VibeCADUpdate import (  # noqa: E402
     normalize_architecture,
     parse_update_manifest,
     record_pending_install,
+    spawn_detached_install_helper,
     update_policy_from_mapping,
     write_macos_install_helper,
 )
@@ -899,9 +901,27 @@ class UpdateServiceTests(unittest.TestCase):
         self.assertIn("write_macos_install_helper", launch)
         self.assertIn("macos_install_helper_command", launch)
         self.assertIn("launch_pending_install_now()", restart)
-        self.assertIn("_quit_application_for_update()", restart)
-        self.assertIn("main_window.close()", gui)
+        self.assertIn("_prepare_to_quit_for_update()", restart)
+        self.assertIn("_exit_process_for_update()", restart)
+        self.assertLess(
+            restart.index("_prepare_to_quit_for_update()"),
+            restart.index("launch_pending_install_now()"),
+        )
+        self.assertLess(
+            restart.index("launch_pending_install_now()"),
+            restart.index("_exit_process_for_update()"),
+        )
+        self.assertIn("closeAllDocuments", gui)
+        self.assertIn("os._exit(0)", gui)
+        self.assertIn("spawn_detached_install_helper", gui)
+        self.assertIn("macos_install_helper_started_path", launch)
+        self.assertIn("wait_for_install_helper_start", launch)
         self.assertIn("hdiutil attach", helper)
+        self.assertIn("install-helper.started", helper)
+        self.assertLess(
+            helper.index('printf \'%s\\n\' "$$" > "$started"'),
+            helper.index('while kill -0 "$pid"'),
+        )
         self.assertIn("ditto", helper)
         self.assertIn('new_app="$mount/VibeCAD.app"', helper)
         self.assertIn("bundle_executable", helper)
@@ -950,6 +970,87 @@ class UpdateServiceTests(unittest.TestCase):
         self.assertEqual(command[5], f"{app}.vibecad-rollback")
         self.assertEqual(Path(command[6]).resolve(), (root / "install-receipt.json").resolve())
         self.assertEqual(Path(command[7]).resolve(), (root / "pending-install.json").resolve())
+
+    def test_macos_helper_stamps_started_before_waiting_for_the_app(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            helper = write_macos_install_helper(root / "install-macos-update.sh")
+            receipt = root / "install-receipt.json"
+            pending = root / "pending-install.json"
+            pending.write_text('{"schema":1,"status":"pending"}\n', encoding="utf-8")
+            waiter = subprocess.Popen(
+                [sys.executable, "-c", "import time; time.sleep(30)"],
+            )
+            helper_proc = subprocess.Popen(
+                [
+                    "/bin/sh",
+                    str(helper),
+                    str(waiter.pid),
+                    str(root / "missing.dmg"),
+                    str(root / "VibeCAD.app"),
+                    str(root / "VibeCAD.app.vibecad-rollback"),
+                    str(receipt),
+                    str(pending),
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            stamp = root / "install-helper.started"
+            log_path = root / "install-helper.log"
+            waiter_pid = waiter.pid
+            try:
+                deadline = time.time() + 5
+                log = ""
+                while time.time() < deadline:
+                    if stamp.is_file() and log_path.is_file():
+                        log = log_path.read_text(encoding="utf-8")
+                        if "helper started" in log:
+                            break
+                    time.sleep(0.05)
+                started = stamp.is_file()
+                log = log_path.read_text(encoding="utf-8") if log_path.is_file() else ""
+            finally:
+                helper_proc.kill()
+                waiter.kill()
+                helper_proc.wait(timeout=5)
+                waiter.wait(timeout=5)
+        self.assertTrue(started, f"log={log}")
+        self.assertIn("helper started", log)
+        self.assertIn(f"waiting for {waiter_pid}", log)
+
+    def test_spawn_detached_helper_outlives_the_parent_process(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            marker = root / "alive"
+            log = root / "helper.log"
+            launcher = (
+                "from pathlib import Path\n"
+                "from VibeCADUpdate import spawn_detached_install_helper\n"
+                "spawn_detached_install_helper(\n"
+                f"    ['/bin/sh', '-c', 'sleep 0.4; printf ready > {marker}'],\n"
+                f"    log_path=Path({str(log)!r}),\n"
+                ")\n"
+            )
+            completed = subprocess.run(
+                [sys.executable, "-c", launcher],
+                check=False,
+                cwd=str(VIBECAD_MODULE_DIR),
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONPATH": str(VIBECAD_MODULE_DIR)},
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                f"stdout={completed.stdout}\nstderr={completed.stderr}",
+            )
+            deadline = time.time() + 5
+            while time.time() < deadline and not marker.is_file():
+                time.sleep(0.05)
+            self.assertTrue(
+                marker.is_file(),
+                f"stderr={completed.stderr}\nlog={log.read_text(encoding='utf-8') if log.is_file() else ''}",
+            )
 
     def test_macos_helper_replaces_the_app_and_keeps_a_live_update(self) -> None:
         if sys.platform != "darwin" or shutil.which("hdiutil") is None:

--- a/src/Tools/tests/test_vibecad_update.py
+++ b/src/Tools/tests/test_vibecad_update.py
@@ -972,6 +972,8 @@ class UpdateServiceTests(unittest.TestCase):
         self.assertEqual(Path(command[7]).resolve(), (root / "pending-install.json").resolve())
 
     def test_macos_helper_stamps_started_before_waiting_for_the_app(self) -> None:
+        if sys.platform != "darwin":
+            self.skipTest("Requires the macOS install-helper runtime")
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
             helper = write_macos_install_helper(root / "install-macos-update.sh")
@@ -1023,11 +1025,21 @@ class UpdateServiceTests(unittest.TestCase):
             root = Path(temp_dir)
             marker = root / "alive"
             log = root / "helper.log"
+            helper_command = [
+                sys.executable,
+                "-c",
+                (
+                    "import time\n"
+                    "from pathlib import Path\n"
+                    "time.sleep(0.4)\n"
+                    f"Path({str(marker)!r}).write_text('ready', encoding='utf-8')\n"
+                ),
+            ]
             launcher = (
                 "from pathlib import Path\n"
                 "from VibeCADUpdate import spawn_detached_install_helper\n"
                 "spawn_detached_install_helper(\n"
-                f"    ['/bin/sh', '-c', 'sleep 0.4; printf ready > {marker}'],\n"
+                f"    {helper_command!r},\n"
                 f"    log_path=Path({str(log)!r}),\n"
                 ")\n"
             )


### PR DESCRIPTION
macOS **Check Updates** already downloads and verifies the matching DMG, but **Install and restart** still did not apply it. The helper was spawned as a child of `VibeCAD.app`, then quit went through `main_window.close()` plus `QApplication.quit()`. macOS RunningBoard killed the helper with the app, or an open document cancelled the close, so the process never exited and the helper never mounted the DMG.

## Why

- `subprocess.Popen(..., start_new_session=True)` still leaves the helper in VibeCAD's application unit. When the `.app` exits, the helper dies before `hdiutil`/`ditto`.
- `MainWindow.close()` asks to save documents and can be cancelled; the helper was already waiting forever on a live PID.
- Helper stdio was inherited from the GUI, and it wrote no start log, so a failed launch looked like a no-op after download.

## Fix

- Launch the helper with `/usr/bin/nohup` in a new session, stdio appended to `install-helper.log`.
- Helper writes `install-helper.started` before waiting for the old PID; Install and Restart waits for that stamp and warns if it never appears.
- Save or discard open documents first. Do not launch the helper if the user cancels.
- Hard-exit with `os._exit(0)` after the helper is alive so the bundle can be replaced.
- Failures after a successful download now show a warning instead of silently returning.

Windows installer and Linux AppImage paths use the same detached spawn helper. Apply logic (`hdiutil`, `ditto`, health receipt, rollback) is unchanged.

## Tests

- Helper writes the start stamp and logs `helper started` before waiting for the old PID.
- `spawn_detached_install_helper` outlives the parent process.
- GUI Install and Restart sequence is documents → launch helper → `os._exit`.
- Existing live `hdiutil` replace/rollback tests still pass.

Exact green command:

```text
PYTHONPATH=src/Mod/VibeCAD python3.11 -m pytest --import-mode=importlib src/Tools/tests/test_vibecad_update.py -q --tb=short -k "not test_cached_windows_installer_uses_manifest_size_and_hash_without_authenticode"
```

Result: **42 passed**, 1 skipped, 1 deselected. The deselected test is the pre-existing Windows cache path assertion (`/var` vs `/private/var`), unrelated to this change.

`npm test` and `cargo test` are not part of this Python updater change.

A live replace of `/Applications/VibeCAD.app` was not executed in this environment. The installed app picks up the Python helper after a restart that includes these files.

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] `_quit_application_for_update()` remains as a compatibility wrapper.
- [x] No preference keys, tool names, or schema fields renamed/removed.
- [x] Defaults preserve previous Windows and Linux updater apply logic.
- [x] No deprecations.
- [x] No breaking changes.
