### PR TITLE
Let Sketcher Symmetric accept whole lines like Fusion and SolidWorks

### DIFF
--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -5381,7 +5381,6 @@ CmdSketcherConstrainDistance::CmdSketcherConstrainDistance()
                            {SelRoot, SelEdge},
                            {SelVertexOrRoot, SelExternalEdge},
                            {SelEdge, SelEdge}};
-    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainDistance::activated(int iMsg)
@@ -6033,7 +6032,6 @@ CmdSketcherConstrainDistanceX::CmdSketcherConstrainDistanceX()
     allowedSelSequences = {{SelVertexOrRoot, SelVertexOrRoot},
                            {SelEdge},
                            {SelExternalEdge}};
-    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainDistanceX::activated(int iMsg)
@@ -6335,7 +6333,6 @@ CmdSketcherConstrainDistanceY::CmdSketcherConstrainDistanceY()
     allowedSelSequences = {{SelVertexOrRoot, SelVertexOrRoot},
                            {SelEdge},
                            {SelExternalEdge}};
-    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainDistanceY::activated(int iMsg)
@@ -9715,7 +9712,6 @@ CmdSketcherConstrainAngle::CmdSketcherConstrainAngle()
                            {SelVertexOrRoot, SelExternalEdge, SelExternalEdge},
                            {SelArc},
                            {SelExternalArc}};
-    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainAngle::activated(int iMsg)
@@ -10442,16 +10438,13 @@ bool constrainTwoWholeCurvesSymmetric(
 {
     const Part::Geometry* geom1 = Obj->getGeometry(geo1);
     const Part::Geometry* geom2 = Obj->getGeometry(geo2);
-    if (!geom1 || !geom2) {
+    const Part::Geometry* geom3 =
+        pos3 == Sketcher::PointPos::none ? Obj->getGeometry(geo3) : nullptr;
+    if (!geom1 || !geom2 || !isLineSegment(*geom1) || !isLineSegment(*geom2)
+        || (pos3 == Sketcher::PointPos::none && (!geom3 || !isLineSegment(*geom3)))) {
         return false;
     }
-    auto hasOpenEndpoints = [](const Part::Geometry& geom) {
-        return isLineSegment(geom) || isArcOfCircle(geom) || isArcOfEllipse(geom)
-            || isArcOfHyperbola(geom) || isArcOfParabola(geom)
-            || (isBSplineCurve(geom) && !isPeriodicBSplineCurve(geom));
-    };
-    if (!hasOpenEndpoints(*geom1) || !hasOpenEndpoints(*geom2) || geo1 == geo2 || geo1 == geo3
-        || geo2 == geo3) {
+    if (geo1 == geo2 || geo1 == geo3 || geo2 == geo3) {
         return false;
     }
 
@@ -11016,6 +11009,16 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair>& selS
         case 15:// {SelEdge, SelEdge, SelEdgeOrAxis}
         case 16:// {SelEdge, SelEdge, SelExternalEdge}
         {
+            if (areAllPointsOrSegmentsFixed(
+                    Obj,
+                    selSeq.at(0).GeoId,
+                    selSeq.at(1).GeoId,
+                    selSeq.at(2).GeoId
+                )) {
+                showNoConstraintBetweenFixedGeometry(Obj);
+                getSelection().clearSelection();
+                return;
+            }
             if (!constrainTwoWholeCurvesSymmetric(
                     this,
                     Obj,

--- a/src/Mod/Sketcher/Gui/CommandConstraints.cpp
+++ b/src/Mod/Sketcher/Gui/CommandConstraints.cpp
@@ -1292,6 +1292,10 @@ protected:
      */
     std::vector<std::vector<SketcherGui::SelType>> allowedSelSequences;
 
+    // Fusion/SolidWorks entity constraints select a whole curve when the
+    // click hits both that curve and one of its endpoints.
+    bool preferCurveOverEndpoint {false};
+
     virtual void applyConstraint(std::vector<SelIdPair>&, int)
     {}
     void activated(int /*iMsg*/) override;
@@ -1314,6 +1318,8 @@ public:
     static constexpr const char* PICK_SYMMETRY_POINT = "%1 pick symmetry point";
     static constexpr const char* PICK_SYMMETRY_LINE_OR_POINT = "%1 pick symmetry line or point";
     static constexpr const char* PICK_SYMMETRY_LINE = "%1 pick symmetry line";
+    static constexpr const char* PICK_SECOND_LINE_OR_SYMMETRY =
+        "%1 pick second line, symmetry line, or point";
     static constexpr const char* PICK_SECOND_LINE = "%1 pick second line";
     static constexpr const char* PICK_SECOND_POINT_OR_EDGE = "%1 pick second point or edge";
     static constexpr const char* PICK_POINT_OR_EDGE = "%1 pick point or edge";
@@ -1361,13 +1367,17 @@ public:
         int VtId = getPreselectPoint();
         int CrvId = getPreselectCurve();
         int CrsId = getPreselectCross();
+        const bool allowVertex = (allowedSelTypes & SelVertex) && VtId >= 0;
+        const bool allowEdge = (allowedSelTypes & (SelEdge | SelArc)) && CrvId >= 0;
+        const bool preferCurve = cmd->preferCurveOverEndpoint && allowEdge && allowVertex
+            && vertexBelongsToCurve(sketchgui->getSketchObject(), VtId, CrvId);
         if (allowedSelTypes & SelRoot && CrsId == 0) {
             selIdPair.GeoId = Sketcher::GeoEnum::RtPnt;
             selIdPair.PosId = Sketcher::PointPos::start;
             newSelType = SelRoot;
             ss << "RootPoint";
         }
-        else if (allowedSelTypes & SelVertex && VtId >= 0) {
+        else if (allowVertex && !preferCurve) {
             sketchgui->getSketchObject()->getGeoVertexIndex(VtId, selIdPair.GeoId, selIdPair.PosId);
             newSelType = SelVertex;
             ss << "Vertex" << VtId + 1;
@@ -1588,8 +1598,8 @@ public:
                 // Point + Edge + Point or Point + Point + Edge/Point workflow
                 return {{QObject::tr(PICK_EDGE_OR_SECOND_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
             } else {
-                // Edge + Point workflow
-                return {{QObject::tr(PICK_SYMMETRY_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
+                // Whole line first: second line + axis, or this line about an axis/point
+                return {{QObject::tr(PICK_SECOND_LINE_OR_SYMMETRY), {Gui::InputHint::UserInput::MouseLeft}}};
             }
         } else if (selectionStep == 2 && !selSeq.empty()) {
             if (isVertex(selSeq[0].GeoId, selSeq[0].PosId) && isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
@@ -1598,6 +1608,9 @@ public:
             } else if (isVertex(selSeq[0].GeoId, selSeq[0].PosId) && !isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
                 // Point + Edge + Point workflow
                 return {{QObject::tr(PICK_POINT), {Gui::InputHint::UserInput::MouseLeft}}};
+            } else if (!isVertex(selSeq[0].GeoId, selSeq[0].PosId)
+                       && !isVertex(selSeq[1].GeoId, selSeq[1].PosId)) {
+                return {{QObject::tr(PICK_SYMMETRY_LINE), {Gui::InputHint::UserInput::MouseLeft}}};
             }
         }
     }
@@ -1727,11 +1740,11 @@ private:
             // Symmetry
             {.commandName = "Sketcher_ConstrainSymmetric",
             .selectionStep = 0,
-            .hints = {{QObject::tr(PICK_POINT), {Gui::InputHint::UserInput::MouseLeft}}}},
+            .hints = {{QObject::tr(PICK_EDGE_OR_FIRST_POINT), {Gui::InputHint::UserInput::MouseLeft}}}},
 
             {.commandName = "Sketcher_ConstrainSymmetric",
             .selectionStep = 1,
-            .hints = {{QObject::tr(PICK_SECOND_POINT), {Gui::InputHint::UserInput::MouseLeft}}}},
+            .hints = {{QObject::tr(PICK_SECOND_LINE_OR_SYMMETRY), {Gui::InputHint::UserInput::MouseLeft}}}},
 
             {.commandName = "Sketcher_ConstrainSymmetric",
             .selectionStep = 2,
@@ -1845,6 +1858,17 @@ protected:
     std::set<int> ongoingSequences, _tempOnSequences;
     /// Index within the selection sequences active
     unsigned int seqIndex;
+
+    static bool vertexBelongsToCurve(Sketcher::SketchObject* obj, int vertexId, int curveId)
+    {
+        if (!obj || vertexId < 0) {
+            return false;
+        }
+        int geoId = GeoEnum::GeoUndef;
+        Sketcher::PointPos posId = Sketcher::PointPos::none;
+        obj->getGeoVertexIndex(vertexId, geoId, posId);
+        return geoId == curveId;
+    }
 
     void resetOngoingSequences()
     {
@@ -4107,6 +4131,7 @@ CmdSketcherConstrainHorVer::CmdSketcherConstrainHorVer()
     eType = ForEdit;
 
     allowedSelSequences = { {SelEdge}, {SelVertexOrRoot, SelVertexOrRoot} };
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainHorVer::activated(int iMsg)
@@ -4153,6 +4178,7 @@ CmdSketcherConstrainHorizontal::CmdSketcherConstrainHorizontal()
     eType = ForEdit;
 
     allowedSelSequences = {{SelEdge}, {SelVertexOrRoot, SelVertexOrRoot}};
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainHorizontal::activated(int iMsg)
@@ -4198,6 +4224,7 @@ CmdSketcherConstrainVertical::CmdSketcherConstrainVertical()
     eType = ForEdit;
 
     allowedSelSequences = {{SelEdge}, {SelVertexOrRoot, SelVertexOrRoot}};
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainVertical::activated(int iMsg)
@@ -5354,6 +5381,7 @@ CmdSketcherConstrainDistance::CmdSketcherConstrainDistance()
                            {SelRoot, SelEdge},
                            {SelVertexOrRoot, SelExternalEdge},
                            {SelEdge, SelEdge}};
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainDistance::activated(int iMsg)
@@ -6005,6 +6033,7 @@ CmdSketcherConstrainDistanceX::CmdSketcherConstrainDistanceX()
     allowedSelSequences = {{SelVertexOrRoot, SelVertexOrRoot},
                            {SelEdge},
                            {SelExternalEdge}};
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainDistanceX::activated(int iMsg)
@@ -6306,6 +6335,7 @@ CmdSketcherConstrainDistanceY::CmdSketcherConstrainDistanceY()
     allowedSelSequences = {{SelVertexOrRoot, SelVertexOrRoot},
                            {SelEdge},
                            {SelExternalEdge}};
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainDistanceY::activated(int iMsg)
@@ -6602,6 +6632,7 @@ CmdSketcherConstrainParallel::CmdSketcherConstrainParallel()
                            {SelEdgeOrAxis, SelEdge},
                            {SelEdge, SelExternalEdge},
                            {SelExternalEdge, SelEdge}};
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainParallel::activated(int iMsg)
@@ -6773,7 +6804,7 @@ CmdSketcherConstrainPerpendicular::CmdSketcherConstrainPerpendicular()
                            {SelEdgeOrAxis, SelVertexOrRoot, SelEdge},
                            {SelEdge, SelVertexOrRoot, SelExternalEdge},
                            {SelExternalEdge, SelVertexOrRoot, SelEdge}};
-    ;
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainPerpendicular::activated(int iMsg)
@@ -7558,6 +7589,7 @@ CmdSketcherConstrainTangent::CmdSketcherConstrainTangent()
         {SelEdge, SelVertexOrRoot, SelExternalEdge},
         {SelExternalEdge, SelVertexOrRoot, SelEdge}, /* Two Curves and a Point */
         {SelVertexOrRoot, SelVertex} /*Two Endpoints*/ /*No Place for One Endpoint and One Curve*/};
+    preferCurveOverEndpoint = true;
 }
 
 bool CmdSketcherConstrainTangent::substituteConstraintCombinations(SketchObject* Obj,
@@ -9683,6 +9715,7 @@ CmdSketcherConstrainAngle::CmdSketcherConstrainAngle()
                            {SelVertexOrRoot, SelExternalEdge, SelExternalEdge},
                            {SelArc},
                            {SelExternalArc}};
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainAngle::activated(int iMsg)
@@ -10158,6 +10191,7 @@ CmdSketcherConstrainEqual::CmdSketcherConstrainEqual()
     allowedSelSequences = {{SelEdge, SelEdge},
                            {SelEdge, SelExternalEdge},
                            {SelExternalEdge, SelEdge}};// Only option for equal constraint
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainEqual::activated(int iMsg)
@@ -10367,6 +10401,133 @@ void CmdSketcherConstrainEqual::applyConstraint(std::vector<SelIdPair>& selSeq, 
 
 // ======================================================================================
 
+namespace
+{
+
+Base::Vector3d mirrorPointAboutLine(const Base::Vector3d& point,
+                                    const Base::Vector3d& axisStart,
+                                    const Base::Vector3d& axisEnd)
+{
+    const double dx = axisEnd.x - axisStart.x;
+    const double dy = axisEnd.y - axisStart.y;
+    const double len2 = dx * dx + dy * dy;
+    const double t =
+        (len2 > 0.0)
+            ? ((point.x - axisStart.x) * dx + (point.y - axisStart.y) * dy) / len2
+            : 0.0;
+    const double qx = axisStart.x + t * dx;
+    const double qy = axisStart.y + t * dy;
+    return Base::Vector3d(2.0 * qx - point.x, 2.0 * qy - point.y, 0.0);
+}
+
+Base::Vector3d mirrorPointAboutPoint(const Base::Vector3d& point, const Base::Vector3d& center)
+{
+    return Base::Vector3d(2.0 * center.x - point.x, 2.0 * center.y - point.y, 0.0);
+}
+
+double planarDistanceSquared(const Base::Vector3d& first, const Base::Vector3d& second)
+{
+    const double dx = first.x - second.x;
+    const double dy = first.y - second.y;
+    return dx * dx + dy * dy;
+}
+
+bool constrainTwoWholeCurvesSymmetric(
+    Gui::Command* cmd,
+    Sketcher::SketchObject* Obj,
+    int geo1,
+    int geo2,
+    int geo3,
+    Sketcher::PointPos pos3)
+{
+    const Part::Geometry* geom1 = Obj->getGeometry(geo1);
+    const Part::Geometry* geom2 = Obj->getGeometry(geo2);
+    if (!geom1 || !geom2) {
+        return false;
+    }
+    auto hasOpenEndpoints = [](const Part::Geometry& geom) {
+        return isLineSegment(geom) || isArcOfCircle(geom) || isArcOfEllipse(geom)
+            || isArcOfHyperbola(geom) || isArcOfParabola(geom)
+            || (isBSplineCurve(geom) && !isPeriodicBSplineCurve(geom));
+    };
+    if (!hasOpenEndpoints(*geom1) || !hasOpenEndpoints(*geom2) || geo1 == geo2 || geo1 == geo3
+        || geo2 == geo3) {
+        return false;
+    }
+
+    const auto start1 = Obj->getPoint(geo1, Sketcher::PointPos::start);
+    const auto end1 = Obj->getPoint(geo1, Sketcher::PointPos::end);
+    const auto start2 = Obj->getPoint(geo2, Sketcher::PointPos::start);
+    const auto end2 = Obj->getPoint(geo2, Sketcher::PointPos::end);
+    auto mirrored = [&](const Base::Vector3d& point) {
+        if (pos3 == Sketcher::PointPos::none) {
+            return mirrorPointAboutLine(
+                point,
+                Obj->getPoint(geo3, Sketcher::PointPos::start),
+                Obj->getPoint(geo3, Sketcher::PointPos::end)
+            );
+        }
+        return mirrorPointAboutPoint(point, Obj->getPoint(geo3, pos3));
+    };
+    const double same = planarDistanceSquared(mirrored(start1), start2)
+        + planarDistanceSquared(mirrored(end1), end2);
+    const double crossed = planarDistanceSquared(mirrored(start1), end2)
+        + planarDistanceSquared(mirrored(end1), start2);
+    const auto secondStart =
+        (crossed < same) ? Sketcher::PointPos::end : Sketcher::PointPos::start;
+    const auto secondEnd =
+        (crossed < same) ? Sketcher::PointPos::start : Sketcher::PointPos::end;
+
+    cmd->openCommand(QT_TRANSLATE_NOOP("Command", "Add symmetric constraint"));
+    if (pos3 == Sketcher::PointPos::none) {
+        Gui::cmdAppObjectArgs(
+            Obj,
+            "addConstraint(Sketcher.Constraint('Symmetric',%d,%d,%d,%d,%d))",
+            geo1,
+            static_cast<int>(Sketcher::PointPos::start),
+            geo2,
+            static_cast<int>(secondStart),
+            geo3
+        );
+        Gui::cmdAppObjectArgs(
+            Obj,
+            "addConstraint(Sketcher.Constraint('Symmetric',%d,%d,%d,%d,%d))",
+            geo1,
+            static_cast<int>(Sketcher::PointPos::end),
+            geo2,
+            static_cast<int>(secondEnd),
+            geo3
+        );
+    }
+    else {
+        Gui::cmdAppObjectArgs(
+            Obj,
+            "addConstraint(Sketcher.Constraint('Symmetric',%d,%d,%d,%d,%d,%d))",
+            geo1,
+            static_cast<int>(Sketcher::PointPos::start),
+            geo2,
+            static_cast<int>(secondStart),
+            geo3,
+            static_cast<int>(pos3)
+        );
+        Gui::cmdAppObjectArgs(
+            Obj,
+            "addConstraint(Sketcher.Constraint('Symmetric',%d,%d,%d,%d,%d,%d))",
+            geo1,
+            static_cast<int>(Sketcher::PointPos::end),
+            geo2,
+            static_cast<int>(secondEnd),
+            geo3,
+            static_cast<int>(pos3)
+        );
+    }
+    cmd->commitCommand();
+    tryAutoRecompute(Obj);
+    return true;
+}
+
+}  // namespace
+
 class CmdSketcherConstrainSymmetric: public CmdSketcherConstraint
 {
 public:
@@ -10397,7 +10558,9 @@ CmdSketcherConstrainSymmetric::CmdSketcherConstrainSymmetric()
     sAppModule = "Sketcher";
     sGroup = "Sketcher";
     sMenuText = QT_TR_NOOP("Symmetric Constraint");
-    sToolTipText = QT_TR_NOOP("Constrains the selected elements to be symmetric");
+    sToolTipText = QT_TR_NOOP(
+        "Constrains two points or two whole lines to be symmetric about a line or point"
+    );
     sWhatsThis = "Sketcher_ConstrainSymmetric";
     sStatusTip = sToolTipText;
     sPixmap = "Constraint_Symmetric";
@@ -10413,10 +10576,15 @@ CmdSketcherConstrainSymmetric::CmdSketcherConstrainSymmetric()
                            {SelVertexOrRoot, SelVertexOrRoot, SelExternalEdge},
                            {SelVertex, SelVertex, SelEdgeOrAxis},
                            {SelVertexOrRoot, SelVertexOrRoot, SelVertexOrRoot},
-                           {SelEdge, SelEdgeOrAxis},
+                           {SelEdge, SelHAxis},
+                           {SelEdge, SelVAxis},
                            {SelEdge, SelExternalEdge},
                            {SelExternalEdge, SelEdge},
-                           {SelEdgeOrAxis, SelEdge}};
+                           {SelHAxis, SelEdge},
+                           {SelVAxis, SelEdge},
+                           {SelEdge, SelEdge, SelEdgeOrAxis},
+                           {SelEdge, SelEdge, SelExternalEdge}};
+    preferCurveOverEndpoint = true;
 }
 
 void CmdSketcherConstrainSymmetric::activated(int iMsg)
@@ -10440,7 +10608,8 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
             Gui::TranslatedUserWarning(
                 getActiveGuiDocument()->getDocument(),
                 QObject::tr("Wrong selection"),
-                QObject::tr("Select two points and a symmetry line, "
+                QObject::tr("Select two lines and a symmetry line, "
+                            "two points and a symmetry line, "
                             "two points and a symmetry point, "
                             "an element and a symmetry line "
                             "or an element and a symmetry point from the sketch."));
@@ -10548,6 +10717,24 @@ void CmdSketcherConstrainSymmetric::activated(int iMsg)
     }
 
     getIdsFromName(SubNames[2], Obj, GeoId3, PosId3);
+
+    if (isEdge(GeoId1, PosId1) && isEdge(GeoId2, PosId2)
+        && (isEdge(GeoId3, PosId3) || isVertex(GeoId3, PosId3))) {
+        if (areAllPointsOrSegmentsFixed(Obj, GeoId1, GeoId2, GeoId3)) {
+            showNoConstraintBetweenFixedGeometry(Obj);
+            return;
+        }
+        if (!constrainTwoWholeCurvesSymmetric(this, Obj, GeoId1, GeoId2, GeoId3, PosId3)) {
+            Gui::TranslatedUserWarning(
+                Obj,
+                QObject::tr("Wrong selection"),
+                QObject::tr("Cannot add a symmetry constraint between these two lines "
+                            "and a symmetry line."));
+            return;
+        }
+        getSelection().clearSelection();
+        return;
+    }
 
     if (isEdge(GeoId1, PosId1) && isVertex(GeoId3, PosId3)) {
         std::swap(GeoId1, GeoId3);
@@ -10772,10 +10959,12 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair>& selS
             getSelection().clearSelection();
             return;
         }
-        case 9:// {SelEdge, SelEdgeOrAxis}
-        case 10:// {SelEdge, SelExternalEdge}
-        case 11:// {SelExternalEdge, SelEdge}
-        case 12:// {SelEdgeOrAxis, SelEdge}
+        case 9:// {SelEdge, SelHAxis}
+        case 10:// {SelEdge, SelVAxis}
+        case 11:// {SelEdge, SelExternalEdge}
+        case 12:// {SelExternalEdge, SelEdge}
+        case 13:// {SelHAxis, SelEdge}
+        case 14:// {SelVAxis, SelEdge}
         {
             if (selSeq.at(0).GeoId == Sketcher::GeoEnum::HAxis || selSeq.at(0).GeoId == Sketcher::GeoEnum::VAxis) {
                 GeoId1 = GeoId2 = selSeq.at(1).GeoId;
@@ -10823,6 +11012,26 @@ void CmdSketcherConstrainSymmetric::applyConstraint(std::vector<SelIdPair>& selS
                 return;
             }
             break;
+        }
+        case 15:// {SelEdge, SelEdge, SelEdgeOrAxis}
+        case 16:// {SelEdge, SelEdge, SelExternalEdge}
+        {
+            if (!constrainTwoWholeCurvesSymmetric(
+                    this,
+                    Obj,
+                    selSeq.at(0).GeoId,
+                    selSeq.at(1).GeoId,
+                    selSeq.at(2).GeoId,
+                    selSeq.at(2).PosId
+                )) {
+                Gui::TranslatedUserWarning(
+                    Obj,
+                    QObject::tr("Wrong selection"),
+                    QObject::tr("Cannot add a symmetry constraint between these two lines "
+                                "and a symmetry line."));
+            }
+            getSelection().clearSelection();
+            return;
         }
         default:
             break;

--- a/src/Mod/VibeCAD/VibeCADNativeSketchConstraintSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeSketchConstraintSchema.py
@@ -737,8 +737,9 @@ def sketch_constraint_capability_definition() -> NativeCapabilityDefinition:
             NativeCapabilityVariant(
                 operation="constrain_symmetric",
                 description=(
-                    "Reflect two exact points or one open curve's endpoints about "
-                    "one exact whole straight line, Sketch axis, or exact point."
+                    "Reflect two exact points, one open curve's endpoints, or two "
+                    "whole open curves about one exact whole straight line, Sketch "
+                    "axis, or exact point."
                 ),
                 action_ids=frozenset({"Sketcher_ConstrainSymmetric"}),
                 surface_ids=frozenset({"sketch.edit"}),

--- a/src/Mod/VibeCAD/VibeCADNativeSketchConstraintSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeSketchConstraintSchema.py
@@ -738,7 +738,7 @@ def sketch_constraint_capability_definition() -> NativeCapabilityDefinition:
                 operation="constrain_symmetric",
                 description=(
                     "Reflect two exact points, one open curve's endpoints, or two "
-                    "whole open curves about one exact whole straight line, Sketch "
+                    "whole straight lines about one exact whole straight line, Sketch "
                     "axis, or exact point."
                 ),
                 action_ids=frozenset({"Sketcher_ConstrainSymmetric"}),

--- a/src/Mod/VibeCAD/vibecad_tests/test_sketcher_constraint_selection.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_sketcher_constraint_selection.py
@@ -16,6 +16,13 @@ _REPOSITORY = Path(__file__).resolve().parents[4]
 _CONSTRAINTS = (
     _REPOSITORY / "src" / "Mod" / "Sketcher" / "Gui" / "CommandConstraints.cpp"
 )
+_SCHEMA = (
+    _REPOSITORY
+    / "src"
+    / "Mod"
+    / "VibeCAD"
+    / "VibeCADNativeSketchConstraintSchema.py"
+)
 
 
 def _source() -> str:
@@ -65,14 +72,23 @@ def test_entity_constraints_prefer_whole_curves_like_fusion() -> None:
         "Sketcher_ConstrainPerpendicular",
         "Sketcher_ConstrainEqual",
         "Sketcher_ConstrainTangent",
+    )
+    for command in entity_commands:
+        constructor = _command_constructor(source, command)
+        assert "preferCurveOverEndpoint = true" in constructor, command
+
+
+def test_dimensional_constraints_keep_endpoint_selection_behavior() -> None:
+    source = _source()
+    dimensional_commands = (
         "Sketcher_ConstrainDistance",
         "Sketcher_ConstrainDistanceX",
         "Sketcher_ConstrainDistanceY",
         "Sketcher_ConstrainAngle",
     )
-    for command in entity_commands:
+    for command in dimensional_commands:
         constructor = _command_constructor(source, command)
-        assert "preferCurveOverEndpoint = true" in constructor, command
+        assert "preferCurveOverEndpoint = true" not in constructor, command
 
 
 def test_point_constraints_still_prefer_vertices() -> None:
@@ -99,6 +115,32 @@ def test_symmetric_accepts_two_whole_lines_and_a_symmetry_line() -> None:
     assert "constrainTwoWholeCurvesSymmetric" in activated
     assert "constrainTwoWholeCurvesSymmetric" in apply
     assert "two lines and a symmetry line" in activated
+
+
+def test_two_whole_curve_symmetry_is_limited_to_straight_lines() -> None:
+    source = _source()
+    helper = _function_section(source, "bool constrainTwoWholeCurvesSymmetric(")
+    assert "isLineSegment(*geom1)" in helper
+    assert "isLineSegment(*geom2)" in helper
+    assert "isLineSegment(*geom3)" in helper
+    assert "isArcOfCircle" not in helper
+    assert "isBSplineCurve" not in helper
+
+    schema = _SCHEMA.read_text(encoding="utf-8")
+    assert "whole straight lines about" in schema
+    assert "two whole open curves" not in schema
+
+
+def test_interactive_whole_line_symmetry_refuses_all_fixed_geometry() -> None:
+    source = _source()
+    apply = _function_section(
+        source, "void CmdSketcherConstrainSymmetric::applyConstraint("
+    )
+    whole_line_cases = apply.split(
+        "case 15:// {SelEdge, SelEdge, SelEdgeOrAxis}", 1
+    )[1].split("default:", 1)[0]
+    assert "areAllPointsOrSegmentsFixed" in whole_line_cases
+    assert "showNoConstraintBetweenFixedGeometry" in whole_line_cases
 
 
 def test_symmetric_hints_allow_a_second_line_instead_of_only_a_point() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_sketcher_constraint_selection.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_sketcher_constraint_selection.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Fusion/SolidWorks-style Sketcher constraint selection contracts.
+
+Symmetric must accept whole lines, not only endpoints. Horizontal, Vertical,
+and the other entity constraints that allow both a curve and a vertex must
+prefer the curve when the preselected vertex is just that curve's endpoint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_REPOSITORY = Path(__file__).resolve().parents[4]
+_CONSTRAINTS = (
+    _REPOSITORY / "src" / "Mod" / "Sketcher" / "Gui" / "CommandConstraints.cpp"
+)
+
+
+def _source() -> str:
+    return _CONSTRAINTS.read_text(encoding="utf-8")
+
+
+def _command_constructor(source: str, command: str) -> str:
+    marker = f'CmdSketcherConstraint("{command}")'
+    start = source.index(marker)
+    end = source.find("void CmdSketcher", start + len(marker))
+    if end < 0:
+        end = source.find("\nclass ", start + len(marker))
+    return source[start:end]
+
+
+def _function_section(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace = source.index("{", start)
+    depth = 0
+    for index in range(brace, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[start : index + 1]
+    raise AssertionError(f"Unterminated function {signature}")
+
+
+def test_generic_handler_prefers_a_whole_curve_over_its_own_endpoint() -> None:
+    source = _source()
+    assert "preferCurveOverEndpoint" in source
+    release = _function_section(source, "bool releaseButton(Base::Vector2d onSketchPos) override")
+    assert "preferCurveOverEndpoint" in release
+    assert "vertexBelongsToCurve" in release
+    assert "allowVertex && !preferCurve" in release
+
+
+def test_entity_constraints_prefer_whole_curves_like_fusion() -> None:
+    source = _source()
+    entity_commands = (
+        "Sketcher_ConstrainSymmetric",
+        "Sketcher_ConstrainHorizontal",
+        "Sketcher_ConstrainVertical",
+        "Sketcher_ConstrainHorVer",
+        "Sketcher_ConstrainParallel",
+        "Sketcher_ConstrainPerpendicular",
+        "Sketcher_ConstrainEqual",
+        "Sketcher_ConstrainTangent",
+        "Sketcher_ConstrainDistance",
+        "Sketcher_ConstrainDistanceX",
+        "Sketcher_ConstrainDistanceY",
+        "Sketcher_ConstrainAngle",
+    )
+    for command in entity_commands:
+        constructor = _command_constructor(source, command)
+        assert "preferCurveOverEndpoint = true" in constructor, command
+
+
+def test_point_constraints_still_prefer_vertices() -> None:
+    source = _source()
+    coincident = _function_section(
+        source,
+        "CmdSketcherConstrainCoincidentUnified::CmdSketcherConstrainCoincidentUnified(const char* initName)",
+    )
+    lock = _command_constructor(source, "Sketcher_ConstrainLock")
+    assert "preferCurveOverEndpoint = true" not in coincident
+    assert "preferCurveOverEndpoint = true" not in lock
+
+
+def test_symmetric_accepts_two_whole_lines_and_a_symmetry_line() -> None:
+    source = _source()
+    constructor = _command_constructor(source, "Sketcher_ConstrainSymmetric")
+    activated = _function_section(
+        source, "void CmdSketcherConstrainSymmetric::activated(int iMsg)"
+    )
+    apply = _function_section(
+        source, "void CmdSketcherConstrainSymmetric::applyConstraint("
+    )
+    assert "{SelEdge, SelEdge, SelEdgeOrAxis}" in constructor
+    assert "constrainTwoWholeCurvesSymmetric" in activated
+    assert "constrainTwoWholeCurvesSymmetric" in apply
+    assert "two lines and a symmetry line" in activated
+
+
+def test_symmetric_hints_allow_a_second_line_instead_of_only_a_point() -> None:
+    source = _source()
+    hints = _function_section(source, "std::list<Gui::InputHint> getToolHints() const override")
+    symmetric = hints.split('if (commandName == "Sketcher_ConstrainSymmetric")', 1)[1]
+    symmetric = symmetric.split("if (commandName ==", 1)[0]
+    first_after_edge = symmetric.split("selectionStep == 1", 1)[1].split(
+        "selectionStep == 2", 1
+    )[0]
+    assert "PICK_SECOND_LINE_OR_SYMMETRY" in first_after_edge
+    assert "PICK_SYMMETRY_POINT" not in first_after_edge
+    assert "PICK_SYMMETRY_LINE" in symmetric


### PR DESCRIPTION
Sketcher **Symmetric** required endpoint-by-endpoint selection even when the user intended to select whole line segments. This keeps the established point workflows while adding an opt-in whole-entity selection path for entity constraints.

## Fix

- Prefer a curve over its coincident endpoint only for entity constraints where the curve is the intended target: Symmetric, Horizontal, Vertical, HorVer, Parallel, Perpendicular, Equal, and Tangent.
- Preserve endpoint-first behavior for Distance, Distance X/Y, Angle, Coincident, and Lock.
- Let Symmetric accept two whole straight line segments plus a straight symmetry line or Sketch axis, pairing the endpoints automatically.
- Reject arbitrary open curves and non-line symmetry references rather than creating constraints that do not mirror the complete geometry.
- Apply the existing all-fixed-geometry guard to the new interactive path.
- Update live selection hints and keep the capability description aligned with the implemented straight-line behavior.

## Red/green TDD

Red command:

```powershell
$env:PYTHONPATH='src/Mod/VibeCAD'; & '.pixi/envs/default/python.exe' -m pytest -q --import-mode=importlib src/Mod/VibeCAD/vibecad_tests/test_sketcher_constraint_selection.py
```

Red result: **3 failed, 5 passed** for dimensional endpoint preservation, straight-line-only symmetry, and the interactive fixed-geometry guard.

Green command:

```powershell
$env:PYTHONPATH='src/Mod/VibeCAD'; & '.pixi/envs/default/python.exe' -m pytest -q --import-mode=importlib src/Mod/VibeCAD/vibecad_tests/test_sketcher_constraint_selection.py src/Mod/VibeCAD/vibecad_tests/test_native_sketch_symmetric.py
```

Green result: **48 passed in 1.09s**.

## Windows build and manual validation

From `package/rattler-build`:

```powershell
& $env:USERPROFILE\.pixi\bin\pixi.exe reinstall -e default vibecad
```

Result: **exit 0**; the upstream-equivalent Rattler package build completed the full Windows C++ compile and package reinstall in **1148.3s**.

The repository owner then tested the rebuilt package by selecting two whole line segments and a center symmetry line and confirmed the Symmetric constraint worked.

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] Existing two-point and one-curve Symmetric forms remain supported.
- [x] Dimensional and point constraints preserve endpoint selection behavior.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults preserve prior behavior unless a command explicitly opts into whole-curve preference.
- [x] No breaking changes.

No GitHub issue is linked to this PR.