### PR TITLE
Stop treating Draft Working Plane Proxy as removed architecture

### DIFF
--- a/src/Mod/VibeCAD/VibeCADLegacyArchitecture.py
+++ b/src/Mod/VibeCAD/VibeCADLegacyArchitecture.py
@@ -7,6 +7,8 @@ from __future__ import annotations
 from typing import Any
 
 
+# Proxy.Type values from the removed BIM/Arch toolset. Draft WorkingPlaneProxy
+# remains supported and must stay off this list.
 _LEGACY_PROXY_TYPES = frozenset(
     {
         "ArchSectionView",
@@ -34,7 +36,6 @@ _LEGACY_PROXY_TYPES = frozenset(
         "Structure",
         "Wall",
         "Window",
-        "WorkingPlaneProxy",
     }
 )
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_legacy_architecture_warning.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_legacy_architecture_warning.py
@@ -27,6 +27,7 @@ def test_detector_ignores_general_draft_and_mechanical_objects():
             _object(type_id="PartDesign::Feature"),
             _object(properties=("PredefinedType",)),
             _object(proxy=SimpleNamespace(Type="Wire")),
+            _object(proxy=SimpleNamespace(Type="WorkingPlaneProxy")),
             _object(type_id="TechDraw::DrawViewDraft"),
         ]
     )


### PR DESCRIPTION
Opening the shipped Start example `draft_test_objects` no longer shows the
unsupported-architectural-document dialog. The detector was matching Draft's
still-supported WorkingPlaneProxy.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
- [x] The PR lists the exact build and test commands and their results.

```text
PYTHONPATH=src/Mod/VibeCAD uv run --with pytest python -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_legacy_architecture_warning.py
# before: 1 failed (WorkingPlaneProxy treated as legacy)
# after:  3 passed
```

## Issues

Fixes #108

## Before and After Images

**Before:** opening Start → Examples → `draft_test_objects` showed the unsupported-architectural-document dialog and Report view warning:

![Unsupported architectural document dialog](https://raw.githubusercontent.com/TheronRogers/vibecad/issue-108-screenshots/issue-108/unsupported-architectural-dialog.png)

![Report view with architectural warning](https://raw.githubusercontent.com/TheronRogers/vibecad/issue-108-screenshots/issue-108/report-view.png)

**After:** the same Start example opens with no architectural-removed dialog. Detector unit coverage now treats Draft `WorkingPlaneProxy` as ordinary Draft (same path as `Wire`), while Wall / IFC / `TechDraw::DrawViewArch` still warn.

## Compatibility

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed/removed without approval.
- [x] Defaults preserve previous behavior for users who do not opt into new features.
- [x] Deprecations (if any) are documented and dual-path supported.
- [x] Breaking changes are listed with owner approval reference.

Made with [Cursor](https://cursor.com)