### PR TITLE
Make Analyze workflows non-blocking and reusable

### DIFF
--- a/package/rattler-build/pixi.lock
+++ b/package/rattler-build/pixi.lock
@@ -971,7 +971,7 @@ environments:
       - conda: https://prefix.dev/conda-forge/osx-64/zlib-1.3.2-hbb4bfdb_2.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zlib-ng-2.3.2-h8bce59a_1.conda
       - conda: https://prefix.dev/conda-forge/osx-64/zstd-1.5.7-h3eecb57_6.conda
-      - conda_source: vibecad[e1a9344c] @ .
+      - conda_source: vibecad[dcd689d9] @ .
       osx-arm64:
       - conda: https://prefix.dev/conda-forge/noarch/adwaita-icon-theme-49.0-unix_0.conda
       - conda: https://prefix.dev/conda-forge/noarch/aiohappyeyeballs-2.6.1-pyhd8ed1ab_0.conda
@@ -31669,7 +31669,7 @@ packages:
   - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-1.3.2-h8088a28_2.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/zlib-ng-2.3.3-hed4e4f5_1.conda
   - conda: https://prefix.dev/conda-forge/osx-arm64/zstd-1.5.7-hbf9d68e_6.conda
-- conda_source: vibecad[e1a9344c] @ .
+- conda_source: vibecad[dcd689d9] @ .
   variants:
     build_platform: osx-64
     target_platform: osx-64

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 4
+  number: 5
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -47,6 +47,7 @@
 #include <Base/Reader.h>
 #include <Base/Sequencer.h>
 #include <Base/Tools.h>
+#include <Base/Type.h>
 #include <Base/Writer.h>
 
 #include <Base/Color.h>
@@ -5859,6 +5860,10 @@ void DocumentItem::rebuildModelBrowser()
     std::unordered_map<RoleContextKey, EntryBucket, RoleContextKeyHash> entriesByComponentRole;
     // All Component entries, for root placement of unowned components.
     EntryBucket componentEntries;
+    // Analysis containers and loose FEM objects keyed by their owning
+    // component. Members of an analysis are rendered from native Group
+    // membership instead of being flattened into type categories.
+    std::unordered_map<const App::DocumentObject*, EntryBucket> analyzeEntriesByComponent;
 
     for (const auto& entry : entries) {
         if (entry.role == Role::Origin || entry.role == Role::OriginFeature) {
@@ -5873,6 +5878,38 @@ void DocumentItem::rebuildModelBrowser()
         entriesByComponentRole[{entry.component, entry.role}].push_back(&entry);
         if (entry.role == Role::Component) {
             componentEntries.push_back(&entry);
+        }
+    }
+
+    const Base::Type analysisType = Base::Type::fromName("Fem::FemAnalysis");
+    auto isAnalysis = [analysisType](const App::DocumentObject* object) {
+        if (!object) {
+            return false;
+        }
+        return !analysisType.isBad() && object->getTypeId().isDerivedFrom(analysisType);
+    };
+    auto isFemObject = [](const App::DocumentObject* object) {
+        return object
+            && std::string_view(object->getTypeId().getName()).starts_with("Fem::");
+    };
+    auto analysisOwner = [&](const Entry& entry) {
+        App::DocumentObject* group = entry.group;
+        // Native document groups reject containment cycles. Keep an explicit
+        // bound as damage protection without allocating a visited set for
+        // every FEM entry during each browser rebuild.
+        for (std::size_t depth = 0; group && depth <= entries.size(); ++depth) {
+            if (isAnalysis(group)) {
+                return group;
+            }
+            const Entry* groupEntry = projection.find(group);
+            group = groupEntry ? groupEntry->group : nullptr;
+        }
+        return static_cast<App::DocumentObject*>(nullptr);
+    };
+    for (const auto& entry : entries) {
+        if (isAnalysis(entry.object)
+            || (isFemObject(entry.object) && !analysisOwner(entry))) {
+            analyzeEntriesByComponent[entry.component].push_back(&entry);
         }
     }
 
@@ -5914,6 +5951,7 @@ void DocumentItem::rebuildModelBrowser()
     std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderBody;
     std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderComponent;
     std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderGroup;
+    std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderAnalyzeObject;
 
     // FreeCAD resolves duplicate default labels by appending a zero-padded
     // numeric suffix of at least three digits ("Origin001", "X-axis002"; see
@@ -6107,6 +6145,59 @@ void DocumentItem::rebuildModelBrowser()
         );
     };
 
+    renderAnalyzeObject = [&](const Entry& entry,
+                              QTreeWidgetItem* parent,
+                              DocumentObjectItem* logicalParent) {
+        if (entry.publishedImplementation || entry.bodyRepresentation) {
+            return;
+        }
+        auto* item = renderObject(entry, parent, logicalParent);
+        if (!item) {
+            return;
+        }
+
+        // FemAnalysis is the document's authoritative study container. Show
+        // every native member below it, including timeline resources such as
+        // materials, meshes, constraints, and solvers that are deliberately
+        // hidden from the generic model categories. Recurse through any plain
+        // organizational groups nested inside a study as well.
+        const auto members = takeBucket(findBucket(entriesByGroup, entry.object));
+        for (const auto* member : members) {
+            renderAnalyzeObject(*member, item, item);
+        }
+        item->setChildIndicatorPolicy(
+            item->childCount() > 0 ? QTreeWidgetItem::ShowIndicator
+                                   : QTreeWidgetItem::DontShowIndicator
+        );
+    };
+
+    auto renderAnalyze = [&](QTreeWidgetItem* parent,
+                             DocumentObjectItem* contextItem,
+                             App::DocumentObject* contextObject) {
+        const auto entries = takeBucket(findBucket(
+            analyzeEntriesByComponent,
+            static_cast<const App::DocumentObject*>(contextObject)
+        ));
+        if (entries.empty()) {
+            return;
+        }
+        auto* folder = makeFolder(
+            parent,
+            contextItem,
+            contextKey(contextObject),
+            "analyze",
+            TreeWidget::tr("Analyze"),
+            "FemWorkbench"
+        );
+        for (const auto* entry : entries) {
+            renderAnalyzeObject(
+                *entry,
+                folder,
+                logicalItem(entry->logicalParent, contextItem)
+            );
+        }
+    };
+
     auto renderReferences = [&](
                                 QTreeWidgetItem* parent,
                                 DocumentObjectItem* contextItem,
@@ -6253,6 +6344,8 @@ void DocumentItem::rebuildModelBrowser()
             "Sketcher_NewSketch",
             sketches
         );
+
+        renderAnalyze(componentItem, componentItem, componentEntry.object);
 
         const auto operations = filterBucket(
             findBucket(
@@ -6428,6 +6521,8 @@ void DocumentItem::rebuildModelBrowser()
         "Sketcher_NewSketch",
         rootSketches
     );
+
+    renderAnalyze(this, nullptr, nullptr);
 
     const auto rootOperations = filterBucket(
         findBucket(entriesByComponentRole, RoleContextKey {nullptr, Role::History}),

--- a/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
@@ -16,6 +16,11 @@ import Sketcher  # noqa: F401 - registers Sketcher document types
 from PySide import QtCore, QtGui
 from pivy import coin
 
+try:
+    import Fem  # noqa: F401 - registers optional FEM document types
+except ImportError:
+    Fem = None
+
 
 BROWSER_FOLDER_TYPE = 1002
 BROWSER_DETAIL_TYPE = 1003
@@ -697,6 +702,74 @@ class TestModelTreeBrowser(unittest.TestCase):
         for item in _visible_walk(document_item):
             if item.type() == BROWSER_FOLDER_TYPE:
                 self.assertFalse(item.icon(0).isNull(), item.text(0))
+
+    @unittest.skipIf(Fem is None, "Requires FEM")
+    def test_analyze_folder_preserves_study_membership_without_duplicates(self):
+        analysis = self.document.addObject(
+            "Fem::FemAnalysis",
+            "StructuralAnalysis",
+        )
+        analysis.Label = "Structural Analysis"
+        _tag_timeline_role(analysis, "operation")
+
+        material = self.document.addObject(
+            "App::MaterialObjectPython",
+            "StructuralMaterial",
+        )
+        material.Label = "PETG Material"
+        _tag_timeline_role(material, "resource")
+        analysis.addObject(material)
+
+        constraint = self.document.addObject(
+            "Fem::ConstraintFixed",
+            "FixedSupport",
+        )
+        constraint.Label = "Fixed Support"
+        _tag_timeline_role(constraint, "resource")
+        analysis.addObject(constraint)
+
+        solver = self.document.addObject(
+            "Fem::FemSolverObjectPython",
+            "CalculiXSolver",
+        )
+        solver.Label = "CalculiX Solver"
+        _tag_timeline_role(solver, "resource")
+        analysis.addObject(solver)
+
+        loose_solver = self.document.addObject(
+            "Fem::FemSolverObjectPython",
+            "UnassignedSolver",
+        )
+        loose_solver.Label = "Unassigned Solver"
+        self.document.recompute()
+
+        def analyze_items():
+            _tree, document_item = self._tree_and_document_item()
+            analyze = _child(document_item, "Analyze", BROWSER_FOLDER_TYPE)
+            study = _child(analyze, analysis.Label)
+            values = (document_item, analyze, study)
+            return values if all(value is not None for value in values) else None
+
+        observed = _wait_until(analyze_items)
+        self.assertIsNotNone(observed, self._snapshot())
+        document_item, analyze, study = observed
+        self.assertEqual(
+            [item.text(0) for item in _visible_children(study)],
+            [material.Label, constraint.Label, solver.Label],
+        )
+        self.assertIsNotNone(_child(analyze, loose_solver.Label))
+
+        operations = _child(document_item, "Operations", BROWSER_FOLDER_TYPE)
+        other = _child(document_item, "Other", BROWSER_FOLDER_TYPE)
+        for label in (
+            analysis.Label,
+            material.Label,
+            constraint.Label,
+            solver.Label,
+            loose_solver.Label,
+        ):
+            self.assertFalse(_snapshot_has_label(_snapshot(operations), label))
+            self.assertFalse(_snapshot_has_label(_snapshot(other), label))
 
     def test_vibecad_outputs_are_badged_and_not_classified_as_references(self):
         model_id = "browser-target-backed-publication"

--- a/src/Mod/VibeCAD/VibeCADAnalyzeSolverGui.py
+++ b/src/Mod/VibeCAD/VibeCADAnalyzeSolverGui.py
@@ -32,6 +32,7 @@ from VibeCADNativeMutation import NativeMutationDraft
 import VibeCADGui
 
 _ACTIVE_RUNS: dict[str, "_SolverRunUi"] = {}
+_STATUS_RUNS: dict[str, "_SolverJobStatusUi"] = {}
 _BACKEND_LABELS = {
     "calculix": "CalculiX",
     "elmer": "Elmer",
@@ -224,6 +225,55 @@ class _SolverRunUi:
                 10000,
             )
         self.dialog.deleteLater()
+
+
+class _SolverJobStatusUi:
+    """Mirror provider-started solver progress into VibeCAD's status bar."""
+
+    def __init__(self, manager: Any, job_id: str, solver_kind: str) -> None:
+        self.manager = manager
+        self.job_id = str(job_id)
+        self.backend = _BACKEND_LABELS.get(str(solver_kind), str(solver_kind).title())
+        self.timer = QtCore.QTimer(Gui.getMainWindow())
+        self.timer.setInterval(500)
+        self.timer.timeout.connect(self.poll)
+
+    def start(self) -> None:
+        _STATUS_RUNS[self.job_id] = self
+        self.poll()
+        if self.job_id in _STATUS_RUNS:
+            self.timer.start()
+
+    def poll(self) -> None:
+        try:
+            snapshot = self.manager.snapshot(self.job_id)
+        except Exception:
+            self._finish("failed")
+            return
+        Gui.getMainWindow().statusBar().showMessage(
+            f"{self.backend}: {snapshot.progress_message}"
+        )
+        if snapshot.terminal:
+            self._finish(str(snapshot.phase))
+
+    def _finish(self, phase: str) -> None:
+        self.timer.stop()
+        _STATUS_RUNS.pop(self.job_id, None)
+        message = {
+            "completed": f"{self.backend} analysis completed",
+            "cancelled": f"{self.backend} analysis cancelled",
+        }.get(phase, f"{self.backend} analysis failed")
+        Gui.getMainWindow().statusBar().showMessage(message, 10000)
+        self.timer.deleteLater()
+
+
+def watch_solver_job(manager: Any, job_id: str, solver_kind: str) -> None:
+    """Start one non-modal status watcher for an AI-started solver job."""
+
+    clean = str(job_id or "")
+    if not clean or clean in _STATUS_RUNS:
+        return
+    _SolverJobStatusUi(manager, clean, solver_kind).start()
 
 
 def run_solver_detached(solver: Any) -> str:

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -821,7 +821,7 @@ class VibeCADService:
         details = begin_analyze_snapshot_capture(
             document,
             background_job=background_job,
-            defer_brep_validation=True,
+            validate_brep=False,
         )
         return {
             **details,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeAssignments.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeAssignments.py
@@ -213,6 +213,93 @@ def assignment_records(analysis: Any) -> tuple[dict[str, Any], ...]:
     return tuple(records)
 
 
+def _mesh_validation_record(obj: Any) -> dict[str, Any] | None:
+    """Read only mesh facts needed for validation, without serializing FemMesh."""
+
+    from VibeCADNativeAnalyzeMeshState import fem_mesher_kind
+
+    try:
+        kind = fem_mesher_kind(obj)
+    except NativeAnalyzeError as exc:
+        if exc.error_code == _TARGET_INVALID:
+            return None
+        return _invalid_record(obj, "mesh", exc)
+    try:
+        source = obj.Shape
+        source_name = str(source.Name)
+        fem_mesh = obj.FemMesh
+        topology = {
+            "nodes": int(fem_mesh.NodeCount),
+            "edges": int(fem_mesh.EdgeCount),
+            "faces": int(fem_mesh.FaceCount),
+            "volumes": int(fem_mesh.VolumeCount),
+        }
+        if not source_name:
+            raise NativeAnalyzeError("The FEM mesh definition has no geometry source.")
+        return {
+            "object_name": str(obj.Name),
+            "label": str(obj.Label),
+            "type_id": str(obj.TypeId),
+            "category": "mesh",
+            "kind": "netgen" if kind == "netgen_legacy" else kind,
+            "references": [{"object_name": source_name, "subelements": []}],
+            "definition": {
+                "generated": topology["nodes"] > 0,
+                "topology": topology,
+            },
+        }
+    except Exception as exc:
+        return _invalid_record(obj, "mesh", exc)
+
+
+def assignment_validation_records(analysis: Any) -> tuple[dict[str, Any], ...]:
+    """Return assignment facts needed for validation without hashing mesh payloads."""
+
+    from VibeCADNativeAnalyzeMeshRefinementState import mesh_refinement_state
+
+    records: list[dict[str, Any]] = []
+    mesh_objects = []
+    seen: set[tuple[str, int]] = set()
+    for member in tuple(getattr(analysis, "Group", ()) or ()):
+        identity = (
+            str(getattr(member, "Name", "") or ""),
+            int(getattr(member, "ID", -1)),
+        )
+        if identity in seen:
+            continue
+        seen.add(identity)
+        mesh_record = _mesh_validation_record(member)
+        if mesh_record is not None:
+            records.append(mesh_record)
+            if mesh_record.get("valid") is not False:
+                mesh_objects.append(member)
+            continue
+        record, invalid = _read_assignment(member)
+        if record is not None:
+            records.append(record)
+        elif invalid is not None:
+            records.append(invalid)
+    for mesh in mesh_objects:
+        resources = (
+            *tuple(getattr(mesh, "MeshRefinementList", ()) or ()),
+            *tuple(getattr(mesh, "MeshGroupList", ()) or ()),
+        )
+        for resource in resources:
+            identity = (
+                str(getattr(resource, "Name", "") or ""),
+                int(getattr(resource, "ID", -1)),
+            )
+            if identity in seen:
+                continue
+            seen.add(identity)
+            try:
+                state = mesh_refinement_state(resource)
+                records.append(compact_assignment_state("mesh_refinement", state))
+            except NativeAnalyzeError as exc:
+                records.append(_invalid_record(resource, "mesh_refinement", exc))
+    return tuple(records)
+
+
 def page_assignment_records(
     records: Iterable[Mapping[str, Any]],
     *,
@@ -279,9 +366,161 @@ def _reference_issue(
     return None
 
 
+def validate_assignment_coverage(
+    records: Iterable[Mapping[str, Any]],
+    *,
+    mesh_domains: Mapping[str, set[str]],
+    solid_units: Mapping[str, set[tuple[str, str]]],
+    solid_reference_units: (
+        Mapping[tuple[str, str], set[tuple[str, str]]] | None
+    ) = None,
+) -> dict[str, Any]:
+    """Validate assignment and material coverage for generated mesh domains.
+
+    ``mesh_domains`` expands each mesh source into every original geometry object
+    represented by that source. ``solid_units`` records the exact solid units that
+    require material within the same generated source. The optional alias map lets
+    derived multipart domains translate their ``SolidN`` names back to source
+    solids without weakening direct-object validation.
+    """
+
+    values = tuple(dict(record) for record in records)
+    generated_sources: list[str] = []
+    for record in values:
+        if record.get("category") != "mesh":
+            continue
+        definition = record.get("definition")
+        if not isinstance(definition, Mapping) or definition.get("generated") is not True:
+            continue
+        for reference in tuple(record.get("references") or ()):
+            if not isinstance(reference, Mapping):
+                continue
+            name = str(reference.get("object_name") or "")
+            if name and name not in generated_sources:
+                generated_sources.append(name)
+    if not generated_sources:
+        return {"valid": True, "issue_count": 0, "issues": []}
+
+    covered_objects = set()
+    required_solids: set[tuple[str, str]] = set()
+    for source_name in generated_sources:
+        covered_objects.update(mesh_domains.get(source_name, {source_name}))
+        required_solids.update(solid_units.get(source_name, set()))
+
+    issues: list[dict[str, str]] = []
+    for record in values:
+        if record.get("category") in {"mesh", "mesh_refinement"}:
+            continue
+        assignment = str(record.get("object_name") or "<unnamed>")
+        for reference in tuple(record.get("references") or ()):
+            if not isinstance(reference, Mapping):
+                continue
+            object_name = str(reference.get("object_name") or "")
+            if object_name and object_name not in covered_objects:
+                issues.append(
+                    {
+                        "object_name": assignment,
+                        "message": (
+                            f"{assignment} references {object_name}, which is outside "
+                            "every generated mesh domain in this analysis."
+                        ),
+                    }
+                )
+
+    if required_solids:
+        material_records = tuple(
+            record
+            for record in values
+            if record.get("category") == "material"
+            and record.get("kind") in {"solid", "reinforced"}
+        )
+        covered_solids: set[tuple[str, str]] = set()
+        aliases = solid_reference_units or {}
+        for material in material_records:
+            references = tuple(material.get("references") or ())
+            if not references:
+                covered_solids.update(required_solids)
+                continue
+            for reference in references:
+                if not isinstance(reference, Mapping):
+                    continue
+                object_name = str(reference.get("object_name") or "")
+                subelements = tuple(reference.get("subelements") or ())
+                if not subelements:
+                    covered_solids.update(
+                        unit for unit in required_solids if unit[0] == object_name
+                    )
+                    continue
+                for raw in subelements:
+                    subelement = str(raw)
+                    if "." in subelement:
+                        prefix, subelement = subelement.split(".", 1)
+                        if prefix != object_name:
+                            continue
+                    if not subelement.startswith("Solid"):
+                        continue
+                    token = (object_name, subelement)
+                    covered_solids.update(aliases.get(token, {token}))
+        for object_name, subelement in sorted(required_solids - covered_solids):
+            identity = f"{object_name}.{subelement}"
+            issues.append(
+                {
+                    "object_name": identity,
+                    "message": f"{identity} has no solid material in its generated mesh domain.",
+                }
+            )
+
+    return {
+        "valid": not issues,
+        "issue_count": len(issues),
+        "issues": issues[:64],
+    }
+
+
+def _mesh_domain_coverage(
+    source: Any,
+) -> tuple[set[str], set[tuple[str, str]], dict[tuple[str, str], set[tuple[str, str]]]]:
+    source_name = str(getattr(source, "Name", "") or "")
+    covered = {source_name}
+    units: set[tuple[str, str]] = set()
+    aliases: dict[tuple[str, str], set[tuple[str, str]]] = {}
+    is_domain = bool(getattr(source, "VibeCADAnalysisDomain", False))
+    members = tuple(getattr(source, "AnalysisSources", ()) or ()) if is_domain else ()
+    mode = str(getattr(source, "AnalysisInterfaceMode", "") or "")
+    if not members:
+        solid_count = len(tuple(getattr(getattr(source, "Shape", None), "Solids", ()) or ()))
+        for index in range(1, solid_count + 1):
+            token = (source_name, f"Solid{index}")
+            units.add(token)
+            aliases[token] = {token}
+        return covered, units, aliases
+
+    covered.update(str(getattr(member, "Name", "") or "") for member in members)
+    if mode == "separate":
+        domain_index = 1
+        for member in members:
+            member_name = str(getattr(member, "Name", "") or "")
+            solid_count = len(
+                tuple(getattr(getattr(member, "Shape", None), "Solids", ()) or ())
+            )
+            for member_index in range(1, solid_count + 1):
+                token = (member_name, f"Solid{member_index}")
+                units.add(token)
+                aliases[token] = {token}
+                aliases[(source_name, f"Solid{domain_index}")] = {token}
+                domain_index += 1
+    else:
+        solid_count = len(tuple(getattr(getattr(source, "Shape", None), "Solids", ()) or ()))
+        for index in range(1, solid_count + 1):
+            token = (source_name, f"Solid{index}")
+            units.add(token)
+            aliases[token] = {token}
+    return covered, units, aliases
+
+
 def validate_assignments(analysis: Any) -> dict[str, Any]:
     document = analysis.Document
-    records = assignment_records(analysis)
+    records = assignment_validation_records(analysis)
     issues = []
     for record in records:
         name = str(record.get("object_name") or "<unnamed>")
@@ -296,13 +535,39 @@ def validate_assignments(analysis: Any) -> dict[str, Any]:
             issue = _reference_issue(document, name, reference)
             if issue:
                 issues.append({"object_name": name, "message": issue})
+    mesh_domains: dict[str, set[str]] = {}
+    solid_units: dict[str, set[tuple[str, str]]] = {}
+    solid_aliases: dict[tuple[str, str], set[tuple[str, str]]] = {}
+    for record in records:
+        if record.get("category") != "mesh":
+            continue
+        references = tuple(record.get("references") or ())
+        if len(references) != 1 or not isinstance(references[0], Mapping):
+            continue
+        source_name = str(references[0].get("object_name") or "")
+        source = document.getObject(source_name) if source_name else None
+        if source is None:
+            continue
+        covered, units, aliases = _mesh_domain_coverage(source)
+        mesh_domains[source_name] = covered
+        solid_units[source_name] = units
+        solid_aliases.update(aliases)
+    coverage = validate_assignment_coverage(
+        records,
+        mesh_domains=mesh_domains,
+        solid_units=solid_units,
+        solid_reference_units=solid_aliases,
+    )
+    total_issue_count = len(issues) + int(coverage.get("issue_count", 0) or 0)
+    issues.extend(coverage["issues"])
     visible = issues[:64]
     return {
-        "valid": not issues,
+        "valid": total_issue_count == 0,
         "assignment_count": len(records),
-        "issue_count": len(issues),
+        "issue_count": total_issue_count,
         "issues": visible,
-        "issues_truncated": len(issues) > len(visible),
+        "issues_truncated": total_issue_count > len(visible),
+        "mesh_coverage": coverage,
     }
 
 

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshLifecycleBindings.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshLifecycleBindings.py
@@ -46,6 +46,12 @@ def _edit_values(
         "expected_state_sha256": state["state_sha256"],
     }
     request = {"operation": "update_gmsh", "target": target}
+    if "source_name" in values:
+        request["source"] = current_target(
+            runtime,
+            values.pop("source_name"),
+            mesh_object_state,
+        )
     setting_names = ("maximum_size_mm", "minimum_size_mm", "element_order")
     if any(name in values for name in setting_names):
         settings = dict(state["settings"])
@@ -56,6 +62,8 @@ def _edit_values(
         request["settings"] = settings
     if "label" in values:
         request["label"] = values.pop("label")
+    if values:
+        raise NativeAnalyzeError("The Gmsh mesh edit contains unsupported values.")
     if len(request) == 2:
         raise NativeAnalyzeError("Edit the mesh size or label.")
     result = dict(runtime.execute(request, ticket=ticket))

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshLifecycleSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshLifecycleSchema.py
@@ -181,12 +181,19 @@ def analyze_mesh_lifecycle_capability_definitions() -> tuple[NativeCapabilityDef
                         "type": "object",
                         "properties": {
                             "mesh_name": _OBJECT_NAME,
+                            "source_name": {
+                                **_SOURCE_NAME,
+                                "description": (
+                                    "Replacement geometry object name; changing it "
+                                    "invalidates the generated mesh."
+                                ),
+                            },
                             "maximum_size_mm": _CFD_MAXIMUM_SIZE,
                             "minimum_size_mm": _SIZE,
                             "label": _LABEL,
                         },
                         "required": ["mesh_name"],
-                        "minProperties": 3,
+                        "minProperties": 2,
                         "additionalProperties": False,
                     },
                     provider_supplemental=True,
@@ -208,6 +215,13 @@ def analyze_mesh_lifecycle_capability_definitions() -> tuple[NativeCapabilityDef
                     "maximum_size_mm": _CFD_MAXIMUM_SIZE,
                     "minimum_size_mm": _SIZE,
                     "element_order": _ELEMENT_ORDER,
+                    "source_name": {
+                        **_SOURCE_NAME,
+                        "description": (
+                            "Replacement geometry object name; changing it invalidates "
+                            "the generated mesh."
+                        ),
+                    },
                 },
                 "required": ["mesh_name"],
                 "minProperties": 2,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshState.py
@@ -151,15 +151,114 @@ def _mesh_content_sha256(fem_mesh: Any) -> str | None:
         return None
     try:
         payload = bytes(fem_mesh.dumpContent())
-        archive = zipfile.ZipFile(BytesIO(payload), "r")
         digest = hashlib.sha256()
-        for name in sorted(archive.namelist()):
-            digest.update(name.encode("utf-8"))
-            digest.update(b"\0")
-            digest.update(archive.read(name))
+        canonical_groups = []
+        with zipfile.ZipFile(BytesIO(payload), "r") as archive:
+            for name in sorted(archive.namelist()):
+                content = archive.read(name)
+                if name.lower().endswith(".unv"):
+                    canonical_groups.extend(_canonical_unv_groups(content))
+                    content = _unv_without_group_datasets(content)
+                digest.update(name.encode("utf-8"))
+                digest.update(b"\0")
+                digest.update(content)
+        digest.update(b"\0canonical-groups\0")
+        digest.update(
+            json.dumps(
+                _sorted_group_records(canonical_groups),
+                ensure_ascii=True,
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
         return digest.hexdigest()
     except Exception as exc:
         raise NativeAnalyzeError("The generated FEM mesh could not be hashed exactly.") from exc
+
+
+def _unv_without_group_datasets(payload: bytes) -> bytes:
+    """Remove volatile UNV group records while retaining exact mesh records.
+
+    FreeCAD may renumber and reorder UNV 2467/2477 group records after a file
+    round trip. Group semantics are hashed separately as canonical UNV records.
+    """
+
+    lines = payload.splitlines(keepends=True)
+    stable = []
+    index = 0
+    while index < len(lines):
+        if (
+            lines[index].strip() == b"-1"
+            and index + 1 < len(lines)
+            and lines[index + 1].strip() in {b"2467", b"2477"}
+        ):
+            index += 2
+            while index < len(lines) and lines[index].strip() != b"-1":
+                index += 1
+            if index < len(lines):
+                index += 1
+            continue
+        stable.append(lines[index])
+        index += 1
+    return b"".join(stable)
+
+
+def _canonical_unv_groups(payload: bytes) -> list[dict[str, Any]]:
+    lines = payload.splitlines()
+    groups = []
+    index = 0
+    while index + 1 < len(lines):
+        if (
+            lines[index].strip() != b"-1"
+            or lines[index + 1].strip() not in {b"2467", b"2477"}
+        ):
+            index += 1
+            continue
+        dataset = lines[index + 1].strip().decode("ascii")
+        index += 2
+        while index < len(lines) and lines[index].strip() != b"-1":
+            header = [int(value) for value in lines[index].split()]
+            if len(header) != 8 or header[-1] < 0 or index + 1 >= len(lines):
+                raise ValueError("The UNV mesh contains an invalid group header.")
+            count = header[-1]
+            name = lines[index + 1].decode("utf-8", errors="replace")
+            index += 2
+            members = []
+            while len(members) < count:
+                if index >= len(lines) or lines[index].strip() == b"-1":
+                    raise ValueError("The UNV mesh group has incomplete membership.")
+                values = [int(value) for value in lines[index].split()]
+                if len(values) % 4 != 0:
+                    raise ValueError("The UNV mesh group membership is malformed.")
+                members.extend(
+                    tuple(values[offset : offset + 4])
+                    for offset in range(0, len(values), 4)
+                )
+                index += 1
+            if len(members) != count:
+                raise ValueError("The UNV mesh group contains excess membership.")
+            groups.append(
+                {
+                    "dataset": dataset,
+                    "name": name,
+                    "attributes": header[1:7],
+                    "members": sorted(members),
+                }
+            )
+        index += 1
+    return groups
+
+
+def _sorted_group_records(groups: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return sorted(
+        groups,
+        key=lambda value: json.dumps(
+            value,
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
 
 
 def _topology(fem_mesh: Any) -> dict[str, int]:

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeProviderScope.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeProviderScope.py
@@ -659,8 +659,6 @@ def analyze_provider_tool_names(
         )
         if "gmsh" not in mesh_kinds and not mesh_kinds_truncated:
             allowed.discard(ANALYZE_EDIT_GMSH_MESH)
-        if generated_mesh_count >= mesh_count:
-            allowed.discard(ANALYZE_GENERATE_GMSH)
     if generated_mesh_count:
         allowed.add("analyze.mesh_output")
     if solver_count:
@@ -798,9 +796,7 @@ def _model_operations(
     available: Sequence[str],
 ) -> tuple[str, ...]:
     state = _physics_state(domain)
-    wanted = set()
-    if state is None or state[1] == 0:
-        wanted.add("create_analysis")
+    wanted = {"create_analysis"}
     if state is not None and state[1] > 0:
         physics = state[0]
         wanted.add("update_study")

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSnapshot.py
@@ -350,6 +350,12 @@ def _geometry_sources(
     ):
         try:
             state = mesh_object_state(obj)
+            topology = state.get("topology")
+            if not isinstance(topology, Mapping) or not any(
+                isinstance(value, int) and value > 0
+                for value in topology.values()
+            ):
+                continue
             if include_clipping_face_targets:
                 state["clipping_face_target"] = clipping_face_source_state(
                     obj,
@@ -696,11 +702,18 @@ def begin_analyze_snapshot_capture(
     *,
     background_job: Any | None = None,
     defer_brep_validation: bool = False,
+    validate_brep: bool = True,
 ) -> dict[str, Any]:
     """Capture only detached identity needed to schedule bounded reads."""
 
     if type(defer_brep_validation) is not bool:
         raise TypeError("defer_brep_validation must be a boolean")
+    if type(validate_brep) is not bool:
+        raise TypeError("validate_brep must be a boolean")
+    if defer_brep_validation and not validate_brep:
+        raise ValueError(
+            "defer_brep_validation cannot be enabled when validate_brep is false"
+        )
     document_uid = str(getattr(document, "Uid", "") or "").strip()
     if not document_uid:
         raise RuntimeError("Analyze context requires an exact document UID.")
@@ -720,7 +733,7 @@ def begin_analyze_snapshot_capture(
             Path(tempfile.gettempdir())
             / f"vibecad-analyze-validation-{uuid.uuid4().hex}"
         )
-        if defer_brep_validation
+        if validate_brep and defer_brep_validation
         else ""
     )
     return {
@@ -731,6 +744,7 @@ def begin_analyze_snapshot_capture(
             str(getattr(active, "Name", "") or "") if active is not None else ""
         ),
         "background_job": _background_job_payload(document_uid, background_job),
+        "validate_brep": validate_brep,
         "defer_brep_validation": defer_brep_validation,
         "geometry_validation_artifact_root": validation_root,
     }
@@ -817,12 +831,15 @@ def capture_analyze_snapshot_batch(
         )
 
     material_count, materials = _materials(batch)
-    defer_brep_validation = bool(request.get("defer_brep_validation", False))
+    validate_brep = bool(request.get("validate_brep", True))
+    defer_brep_validation = validate_brep and bool(
+        request.get("defer_brep_validation", False)
+    )
     geometry_count, geometry, geometry_validation_artifacts = _geometry_sources(
         batch,
         filter_analysis_sources=False,
-        validate_brep=not defer_brep_validation,
-        include_clipping_face_targets=not defer_brep_validation,
+        validate_brep=validate_brep and not defer_brep_validation,
+        include_clipping_face_targets=validate_brep and not defer_brep_validation,
         validation_artifact_root=(
             str(request.get("geometry_validation_artifact_root") or "")
             if defer_brep_validation

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecution.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecution.py
@@ -10,8 +10,11 @@ import os
 from pathlib import Path
 import shutil
 import tempfile
-from typing import Any, Mapping
+import threading
+import time
+from typing import Any, Callable, Mapping, TypeVar
 
+from VibeCADNativeAnalyzeAssignments import validate_assignments
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
 from VibeCADNativeAnalyzeSolverExecutionProcess import run_solver_processes
 from VibeCADNativeAnalyzeSolverState import (
@@ -26,6 +29,7 @@ from VibeCADNativeTargets import object_identity
 
 MAX_INPUT_FILES = 4096
 MAX_INPUT_BYTES = 4 * 1024 * 1024 * 1024
+_T = TypeVar("_T")
 _FEM_PREFERENCES = "User parameter:BaseApp/Preferences/Mod/Fem"
 _SOLVER_RUNTIME_PREFERENCE_SPECS = (
     (_FEM_PREFERENCES + "/General", "KeepResultsOnReRun", "bool", False, None),
@@ -161,12 +165,58 @@ def _prepare_calculix(tool: Any) -> None:
         ) from exc
 
 
-def _calculix_request(solver: Any, root: Path) -> tuple[Any, tuple, dict, dict]:
+def _run_with_progress_heartbeat(
+    work: Callable[[], _T],
+    *,
+    progress: Callable[[int, str], None] | None,
+    percent: int,
+    message: str,
+    interval_seconds: float = 5.0,
+) -> _T:
+    """Run one opaque library call while publishing honest elapsed-time liveness."""
+
+    if progress is None:
+        return work()
+    progress(percent, message)
+    stopped = threading.Event()
+    started = time.monotonic()
+
+    def heartbeat() -> None:
+        while not stopped.wait(interval_seconds):
+            elapsed = max(1, int(time.monotonic() - started))
+            progress(percent, f"{message} ({elapsed}s elapsed)")
+
+    thread = threading.Thread(
+        target=heartbeat,
+        name="VibeCAD-CalculiX-input-progress",
+        daemon=True,
+    )
+    thread.start()
+    try:
+        return work()
+    finally:
+        stopped.set()
+        thread.join(timeout=max(0.1, min(interval_seconds, 1.0)))
+
+
+def _calculix_request(
+    solver: Any,
+    root: Path,
+    *,
+    progress: Callable[[int, str], None] | None = None,
+) -> tuple[Any, tuple, dict, dict]:
     from femsolver import settings
     from femsolver.calculix.calculixtools import CalculiXTools
 
     tool = CalculiXTools(solver, detached=True, working_directory=str(root))
-    _prepare_calculix(tool)
+    _run_with_progress_heartbeat(
+        lambda: _prepare_calculix(tool),
+        progress=progress,
+        percent=4,
+        message="Generating CalculiX input deck",
+    )
+    if progress is not None:
+        progress(6, "CalculiX input deck generated")
     program = _executable(settings.require_binary("Calculix"), "CalculiX")
     arguments = ("-i", str(root / tool.input_deck))
     environment = dict(os.environ)
@@ -176,7 +226,12 @@ def _calculix_request(solver: Any, root: Path) -> tuple[Any, tuple, dict, dict]:
     return tool, ((program, arguments),), environment, {"input_deck": tool.input_deck}
 
 
-def _ccx_tools_request(solver: Any, root: Path) -> tuple[Any, tuple, dict, dict]:
+def _ccx_tools_request(
+    solver: Any,
+    root: Path,
+    *,
+    progress: Callable[[int, str], None] | None = None,
+) -> tuple[Any, tuple, dict, dict]:
     import FreeCAD
 
     from femsolver import settings
@@ -191,7 +246,14 @@ def _ccx_tools_request(solver: Any, root: Path) -> tuple[Any, tuple, dict, dict]
             "CalculiX input prerequisites are incomplete: " + readiness,
             error_code="NATIVE_ANALYZE_SOLVER_NOT_READY",
         )
-    tool.write_inp_file()
+    _run_with_progress_heartbeat(
+        tool.write_inp_file,
+        progress=progress,
+        percent=4,
+        message="Generating CalculiX input deck",
+    )
+    if progress is not None:
+        progress(6, "CalculiX input deck generated")
     input_path = Path(str(tool.inp_file_name)).resolve()
     if input_path.parent != root.resolve() or not input_path.is_file():
         raise NativeAnalyzeError(
@@ -321,6 +383,25 @@ def capture_solver_execution_request(
     state = solver_state(prepared.solver)
     if state["suppressed"]:
         raise NativeAnalyzeError("A suppressed FEM solver cannot be run.")
+    analysis_name = str(state.get("analysis") or "")
+    analysis = document.getObject(analysis_name) if analysis_name else None
+    validation = validate_assignments(analysis) if analysis is not None else None
+    if analysis_name and (
+        not isinstance(validation, Mapping) or validation.get("valid") is not True
+    ):
+        issues = list(validation.get("issues") or ()) if isinstance(validation, Mapping) else []
+        first = str(issues[0].get("message") or "") if issues else ""
+        raise NativeAnalyzeError(
+            "The FEM study has invalid assignment or mesh coverage"
+            + (": " + first if first else "."),
+            error_code="NATIVE_ANALYZE_SOLVER_NOT_READY",
+            repair={
+                "analysis": analysis_name,
+                "issue_count": int(validation.get("issue_count", 0) or 0)
+                if isinstance(validation, Mapping)
+                else 0,
+            },
+        )
     history = _require_history_root(document, prepared.solver)
     runtime_preferences = _current_solver_runtime_preferences(prepared.kind)
     return CapturedSolverExecutionRequest(
@@ -377,6 +458,7 @@ def prepare_solver_execution_request(
     target: Any,
     timeout_seconds: Any,
     working_directory: str | Path | None = None,
+    progress: Callable[[int, str], None] | None = None,
 ) -> SolverExecutionRequest:
     """Generate one solver case synchronously for compatibility callers.
 
@@ -417,7 +499,14 @@ def prepare_solver_execution_request(
             "openfoam": _openfoam_request,
             "z88": _z88_request,
         }[prepared.kind]
-        _tool, commands, environment, importer_state = maker(prepared.solver, root)
+        if prepared.kind == "calculix":
+            _tool, commands, environment, importer_state = maker(
+                prepared.solver,
+                root,
+                progress=progress,
+            )
+        else:
+            _tool, commands, environment, importer_state = maker(prepared.solver, root)
         digest, count = _input_digest(root)
         return SolverExecutionRequest(
             prepared,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionChild.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionChild.py
@@ -473,6 +473,7 @@ def _execute(
             },
             timeout_seconds=timeout,
             working_directory=root / "case",
+            progress=report,
         )
         if execution_request.runtime_preferences != preferences:
             _fail(
@@ -544,6 +545,7 @@ def _main() -> int:
     except Exception as exc:
         code = str(getattr(exc, "error_code", "") or "")
         message = str(exc).strip()
+        repair = getattr(exc, "repair", None)
         failure = {
             "ok": False,
             "protocol": _PROTOCOL,
@@ -559,6 +561,18 @@ def _main() -> int:
                 else "The isolated FEM solver process failed."
             ),
         }
+        if isinstance(repair, Mapping):
+            try:
+                encoded_repair = json.dumps(
+                    dict(repair),
+                    ensure_ascii=True,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+            except (TypeError, ValueError):
+                encoded_repair = ""
+            if encoded_repair and len(encoded_repair.encode("utf-8")) <= 2048:
+                failure["repair"] = json.loads(encoded_repair)
     if result_path is not None and not result_path.exists():
         try:
             _write_private(

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionProcess.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionProcess.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+import re
 import subprocess
 import sys
 import time
@@ -15,6 +16,14 @@ from VibeCADNativeBackground import NativeBackgroundCancelled
 from VibeCADScriptedProcess import terminate_process_tree
 
 MAX_SOLVER_LOG_BYTES = 16 * 1024 * 1024
+MAX_DIAGNOSTIC_ARTIFACT_BYTES = 128 * 1024
+MAX_DIAGNOSTIC_EXCERPT_CHARS = 480
+MAX_DIAGNOSTIC_ARTIFACTS = 3
+_DIAGNOSTIC_SUFFIXES = (".sta", ".cvg", ".dat")
+_DIAGNOSTIC_MARKER = re.compile(
+    r"(?:\*+\s*error|fatal|singular|zero pivot|not connected|failed)",
+    re.IGNORECASE,
+)
 
 
 def _tail(path: Path) -> str:
@@ -37,6 +46,56 @@ def _failure_detail(path: Path, backend: str) -> str:
     if "From function" in reason:
         reason = reason.split("From function", 1)[0]
     return reason.strip()
+
+
+def _bounded_artifact_text(path: Path) -> str:
+    """Read bounded head/tail text without retaining a failed private workspace."""
+
+    try:
+        size = path.stat().st_size
+        with path.open("rb") as stream:
+            if size <= MAX_DIAGNOSTIC_ARTIFACT_BYTES:
+                data = stream.read(MAX_DIAGNOSTIC_ARTIFACT_BYTES)
+            else:
+                half = MAX_DIAGNOSTIC_ARTIFACT_BYTES // 2
+                head = stream.read(half)
+                stream.seek(max(0, size - half))
+                data = head + b"\n...\n" + stream.read(half)
+    except Exception:
+        return ""
+    return data.decode("utf-8", errors="replace")
+
+
+def _diagnostic_excerpt(path: Path) -> str:
+    lines = [" ".join(line.split()) for line in _bounded_artifact_text(path).splitlines()]
+    lines = [line for line in lines if line]
+    if not lines:
+        return ""
+    marked = [line for line in lines if _DIAGNOSTIC_MARKER.search(line)]
+    selected = marked[-4:] if marked else lines[-6:]
+    return " | ".join(selected)[-MAX_DIAGNOSTIC_EXCERPT_CHARS:]
+
+
+def _failure_diagnostics(root: Path, log_path: Path, backend: str) -> list[dict[str, str]]:
+    candidates: list[Path] = []
+    if str(backend).casefold() == "calculix":
+        for suffix in _DIAGNOSTIC_SUFFIXES:
+            candidates.extend(sorted(root.glob(f"*{suffix}"), key=lambda path: path.name))
+    candidates.append(log_path)
+    diagnostics = []
+    seen = set()
+    for path in candidates:
+        resolved = path.resolve()
+        if resolved in seen or not path.is_file():
+            continue
+        seen.add(resolved)
+        excerpt = _diagnostic_excerpt(path)
+        if not excerpt:
+            continue
+        diagnostics.append({"artifact": path.name, "excerpt": excerpt})
+        if len(diagnostics) >= MAX_DIAGNOSTIC_ARTIFACTS:
+            break
+    return diagnostics
 
 
 def run_solver_processes(
@@ -116,11 +175,24 @@ def run_solver_processes(
                 error_code="NATIVE_ANALYZE_SOLVER_START_FAILED",
             ) from exc
         if exit_code != 0:
-            detail = _failure_detail(log_path, backend)
+            diagnostics = _failure_diagnostics(root, log_path, backend)
+            detail = (
+                diagnostics[0]["excerpt"]
+                if diagnostics
+                else _failure_detail(log_path, backend)
+            )
+            if str(backend).casefold() == "openfoam":
+                detail = _failure_detail(log_path, backend) or detail
             suffix = f": {detail}" if detail else ""
             raise NativeAnalyzeError(
                 f"{backend} stage {index + 1} exited with code {exit_code}{suffix}",
                 error_code="NATIVE_ANALYZE_SOLVER_BACKEND_FAILED",
+                repair={
+                    "backend": str(backend),
+                    "stage": index + 1,
+                    "exit_code": exit_code,
+                    "diagnostics": diagnostics,
+                },
             )
         summaries.append(
             {

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionRuntime.py
@@ -115,6 +115,24 @@ class NativeAnalyzeSolverExecutionRuntime:
         except Exception:
             workspace.cleanup()
             raise
+        try:
+            def watch_status() -> None:
+                import FreeCAD as App
+
+                if not bool(getattr(App, "GuiUp", False)):
+                    return
+                from VibeCADAnalyzeSolverGui import watch_solver_job
+
+                watch_solver_job(
+                    manager,
+                    str(snapshot.job_id),
+                    str(captured.target.kind),
+                )
+
+            dispatcher(watch_status)
+        except Exception:
+            # Status presentation must never invalidate an already accepted job.
+            pass
         return {
             "job": {
                 "job_id": str(snapshot.job_id),
@@ -128,5 +146,10 @@ class NativeAnalyzeSolverExecutionRuntime:
                 "tool": "native.job",
                 "operation": "status",
                 "job_id": snapshot.job_id,
+                "poll_after_seconds": 30,
+                "guidance": (
+                    "Continue polling until terminal. Do not cancel solely because "
+                    "progress is slow or unchanged."
+                ),
             },
         }

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionWorker.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionWorker.py
@@ -354,17 +354,37 @@ def _read_result(frozen: FrozenSolverExecution) -> PreparedSolverExecution:
     if value.get("ok") is False:
         code = str(value.get("error_code") or "")
         message = str(value.get("message") or "")[:320]
+        repair = value.get("repair")
+        try:
+            encoded_repair = (
+                json.dumps(
+                    dict(repair),
+                    ensure_ascii=True,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                )
+                if isinstance(repair, Mapping)
+                else ""
+            )
+        except (TypeError, ValueError):
+            encoded_repair = ""
         if (
             value.get("protocol") != ANALYZE_SOLVER_EXECUTION_PROTOCOL
             or value.get("request_sha256") != frozen.request_sha256
             or not code.startswith("NATIVE_ANALYZE_")
             or not message
+            or (repair is not None and not encoded_repair)
+            or len(encoded_repair.encode("utf-8")) > 2048
         ):
             _error(
                 "The detached FEM solver process failed.",
                 "NATIVE_ANALYZE_SOLVER_EXECUTION_FAILED",
             )
-        raise NativeAnalyzeError(message, error_code=code)
+        raise NativeAnalyzeError(
+            message,
+            error_code=code,
+            repair=(json.loads(encoded_repair) if encoded_repair else None),
+        )
     required = {
         "ok",
         "protocol",
@@ -481,7 +501,7 @@ def execute_frozen_solver_execution(
         )
     if cancelled():
         raise NativeBackgroundCancelled()
-    progress(max(84, state["percent"]), "Authenticating FEM solver results")
+    progress(max(84, state["percent"]), "Reading isolated FEM solver outcome")
     prepared = _read_result(frozen)
     if int(process.get("returncode", 1)) != 0:
         _error(

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudy.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudy.py
@@ -246,6 +246,11 @@ def evaluate_study_readiness(
         if int(inventory.get("electromagnetic_constraint_count", 0) or 0) < 1:
             blockers.append("missing_electromagnetic_constraint")
 
+    if int(inventory.get("assignment_validation_issue_count", 0) or 0) > 0:
+        blockers.append("invalid_assignments")
+    if int(inventory.get("mesh_coverage_issue_count", 0) or 0) > 0:
+        blockers.append("invalid_mesh_coverage")
+
     mesh_blockers = []
     if int(inventory.get("mesh_definition_count", 0) or 0) < 1:
         mesh_blockers.append("missing_mesh_definition")

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudyState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudyState.py
@@ -40,6 +40,7 @@ def _read_member(
 
 
 def study_inventory(analysis: Any) -> dict[str, Any]:
+    from VibeCADNativeAnalyzeAssignments import validate_assignments
     from VibeCADNativeAnalyzeConnectionState import connection_state
     from VibeCADNativeAnalyzeConstraintState import electromagnetic_constraint_state
     from VibeCADNativeAnalyzeElementState import element_definition_state
@@ -129,6 +130,8 @@ def study_inventory(analysis: Any) -> dict[str, Any]:
     configuration_blockers = solver_configuration_blockers(
         study_intent_state(analysis), active_solver_states
     )
+    assignment_validation = validate_assignments(analysis)
+    mesh_coverage = assignment_validation.get("mesh_coverage")
     return {
         "geometry_source_count": len(geometry_sources),
         "geometry_sources": sorted(geometry_sources),
@@ -160,6 +163,14 @@ def study_inventory(analysis: Any) -> dict[str, Any]:
         "solver_count": len(states["solver"]),
         "solver_kinds": [str(state["solver_kind"]) for state in active_solver_states],
         "solver_configuration_blockers": configuration_blockers,
+        "assignment_validation_issue_count": int(
+            assignment_validation.get("issue_count", 0) or 0
+        ),
+        "mesh_coverage_issue_count": int(
+            mesh_coverage.get("issue_count", 0) or 0
+        )
+        if isinstance(mesh_coverage, dict)
+        else 0,
         "result_count": sum(
             int(state.get("result_count", 0) or 0) for state in states["solver"]
         ),

--- a/src/Mod/VibeCAD/VibeCADNativeBackground.py
+++ b/src/Mod/VibeCAD/VibeCADNativeBackground.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass, field
 import json
 import secrets
 import threading
+import time
 from typing import Any, Callable, Mapping
 
 
@@ -39,6 +40,9 @@ class NativeBackgroundSnapshot:
     error: dict[str, Any] | None
     cancel_requested: bool
     changes_document: bool = False
+    elapsed_seconds: int = 0
+    seconds_since_progress: int = 0
+    worker_active: bool = False
 
     @property
     def terminal(self) -> bool:
@@ -62,6 +66,8 @@ class _Job:
     changes_document: bool = False
     cancellation: threading.Event = field(default_factory=threading.Event)
     completed: threading.Event = field(default_factory=threading.Event)
+    submitted_at: float = field(default_factory=time.monotonic)
+    progress_at: float = field(default_factory=time.monotonic)
 
 
 ProgressReporter = Callable[[int, str], None]
@@ -345,6 +351,7 @@ class NativeBackgroundManager:
             job.phase = phase
             job.progress_percent = int(percent)
             job.progress_message = clean_message
+            job.progress_at = time.monotonic()
 
     def cancel(self, job_id: str) -> bool:
         with self._lock:
@@ -394,6 +401,7 @@ class NativeBackgroundManager:
 
     @staticmethod
     def _snapshot_locked(job: _Job) -> NativeBackgroundSnapshot:
+        now = time.monotonic()
         result = json.loads(job.result_json) if job.result_json is not None else None
         return NativeBackgroundSnapshot(
             job_id=job.job_id,
@@ -406,6 +414,9 @@ class NativeBackgroundManager:
             error=dict(job.error) if job.error is not None else None,
             cancel_requested=job.cancellation.is_set(),
             changes_document=job.changes_document,
+            elapsed_seconds=max(0, int(now - job.submitted_at)),
+            seconds_since_progress=max(0, int(now - job.progress_at)),
+            worker_active=not job.completed.is_set(),
         )
 
     def wait(self, job_id: str, timeout: float | None = None) -> NativeBackgroundSnapshot:

--- a/src/Mod/VibeCAD/VibeCADNativeBackgroundRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeBackgroundRuntime.py
@@ -20,6 +20,7 @@ class NativeBackgroundRuntimeError(RuntimeError):
 
 
 def _summary(snapshot: NativeBackgroundSnapshot) -> dict[str, Any]:
+    active = bool(snapshot.worker_active and not snapshot.terminal)
     result: dict[str, Any] = {
         "job_id": snapshot.job_id,
         "capability": snapshot.capability_name,
@@ -28,6 +29,16 @@ def _summary(snapshot: NativeBackgroundSnapshot) -> dict[str, Any]:
         "progress_message": snapshot.progress_message,
         "terminal": snapshot.terminal,
         "cancel_requested": snapshot.cancel_requested,
+        "worker_state": "active" if active else "terminal",
+        "elapsed_seconds": int(snapshot.elapsed_seconds),
+        "seconds_since_progress": int(snapshot.seconds_since_progress),
+        "recommended_poll_seconds": 30 if active else 0,
+        "guidance": (
+            "Continue waiting. Do not cancel an active job solely because its percent "
+            "is unchanged."
+            if active
+            else "The job is terminal; read its result or failure."
+        ),
     }
     if snapshot.result is not None:
         result["result"] = dict(snapshot.result)

--- a/src/Mod/VibeCAD/VibeCADNativeBackgroundSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeBackgroundSchema.py
@@ -39,13 +39,25 @@ def native_background_capability_definition() -> NativeCapabilityDefinition:
             },
         )
         for operation, description in (
-            ("status", "Read bounded progress or the verified terminal result."),
-            ("cancel", "Request cancellation before document commit begins."),
+            (
+                "status",
+                "Read bounded progress, liveness, polling guidance, or the verified "
+                "terminal result. Unchanged percent alone is not evidence of a hang.",
+            ),
+            (
+                "cancel",
+                "Request cancellation before document commit begins only when the user "
+                "asked to cancel or the job reported failure; never cancel merely because "
+                "progress is slow or unchanged.",
+            ),
         )
     )
     return NativeCapabilityDefinition(
         name=NATIVE_BACKGROUND_CAPABILITY_NAME,
-        description="Inspect or cancel one exact long-running document job.",
+        description=(
+            "Inspect one exact long-running document job and follow its polling guidance; "
+            "cancel only on explicit user intent or reported failure."
+        ),
         primary_classification="read",
         variants=variants,
     )

--- a/src/Mod/VibeCAD/VibeCADNativeSessionFactory.py
+++ b/src/Mod/VibeCAD/VibeCADNativeSessionFactory.py
@@ -11,7 +11,10 @@ import secrets
 from typing import Any, Callable, Mapping
 
 from VibeCADNativeDispatch import NativeDispatchError, NativeTurnDispatcher
-from VibeCADNativeCapabilityRegistry import provider_visible_native_schema
+from VibeCADNativeCapabilityRegistry import (
+    _provider_schema_operations,
+    provider_visible_native_schema,
+)
 from VibeCADNativeInput import NativeInputAuthorizer
 from VibeCADNativeOutput import NativeOutputAuthorizer
 from VibeCADNativeRegistry import build_native_capability_registry
@@ -68,6 +71,7 @@ def _validate_expected_turn(
     expected_surface: Mapping[str, Any],
     expected_schemas: list[dict[str, Any]],
     turn: NativeTurnSnapshot,
+    expected_authorization: Mapping[str, Any] | None = None,
 ) -> None:
     if (
         expected_surface.get("kind") != "turn_start_snapshot"
@@ -127,6 +131,27 @@ def _validate_expected_turn(
             "registry schema digest"
             + (f" ({', '.join(mismatched)})" if mismatched else "")
         )
+    if expected_authorization is not None:
+        if (
+            str(expected_authorization.get("schema_sha256") or "")
+            != turn.schema_sha256
+        ):
+            changed.append("operation authorization digest")
+        expected_operations = expected_authorization.get("operations_by_tool")
+        if not isinstance(expected_operations, Mapping):
+            changed.append("operation authorization map")
+        else:
+            frozen_operations = {
+                str(schema.get("name") or ""): list(operations)
+                for schema in turn.provider_schemas
+                if (operations := _provider_schema_operations(schema))
+            }
+            if {
+                str(name): [str(operation) for operation in operations]
+                for name, operations in expected_operations.items()
+                if isinstance(operations, (list, tuple))
+            } != frozen_operations:
+                changed.append("operation authorization scope")
     if str(expected_surface.get("domain") or "") != turn.surface.surface_id:
         changed.append("ribbon domain")
     if (
@@ -148,6 +173,7 @@ def create_native_session_execution(
     service: Any,
     expected_surface: Mapping[str, Any],
     expected_schemas: list[dict[str, Any]],
+    expected_authorization: Mapping[str, Any] | None = None,
     debug_sink: Callable[[Mapping[str, Any]], None] | None = None,
     registry: Any | None = None,
     controller: Any | None = None,
@@ -175,13 +201,29 @@ def create_native_session_execution(
     expected_names = tuple(
         str(value) for value in expected_surface.get("tool_names") or ()
     )
+    authorized_operations = None
+    if expected_authorization is not None:
+        if not isinstance(expected_authorization, Mapping) or not isinstance(
+            expected_authorization.get("operations_by_tool"), Mapping
+        ):
+            raise NativeDispatchError(
+                "NATIVE_TURN_INVALID",
+                "The captured turn has invalid Native operation authorization.",
+            )
+        authorized_operations = expected_authorization["operations_by_tool"]
     turn = freeze_native_turn(
         controller=controller,
         registry=selected_registry,
         tool_names=expected_names,
         provider_schemas=tuple(expected_schemas),
+        authorized_operations=authorized_operations,
     )
-    _validate_expected_turn(expected_surface, expected_schemas, turn)
+    _validate_expected_turn(
+        expected_surface,
+        expected_schemas,
+        turn,
+        expected_authorization,
+    )
     state = service.native_document_state_store()
     uid = document_uid(document)
     state.ensure_document(uid)

--- a/src/Mod/VibeCAD/VibeCADNativeTurn.py
+++ b/src/Mod/VibeCAD/VibeCADNativeTurn.py
@@ -8,6 +8,7 @@ tool execution, workbench activation, ribbon switching, or domain behavior.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 import hashlib
 import json
@@ -162,6 +163,7 @@ def freeze_native_turn(
     tool_names: tuple[str, ...] | None = None,
     active_state: dict[str, Any] | None = None,
     provider_schemas: tuple[dict[str, Any], ...] | None = None,
+    authorized_operations: Mapping[str, Sequence[str]] | None = None,
 ) -> NativeTurnSnapshot:
     """Freeze an exact validated Native surface without changing UI state."""
 
@@ -183,7 +185,48 @@ def freeze_native_turn(
             )
         except NativeCapabilityRegistryError as exc:
             raise NativeTurnUnavailable(str(exc)) from exc
-    if provider_schemas is not None:
+    if authorized_operations is not None:
+        if registry is None:
+            raise NativeTurnUnavailable(
+                "Freezing exact Native operations requires a capability registry."
+            )
+        if not isinstance(authorized_operations, Mapping):
+            raise NativeTurnUnavailable(
+                "Captured Native operation authorization must be a mapping."
+            )
+        operations_by_tool = {
+            str(name or "").strip(): tuple(
+                dict.fromkeys(
+                    str(operation or "").strip() for operation in operations
+                )
+            )
+            for name, operations in authorized_operations.items()
+            if str(name or "").strip()
+            and isinstance(operations, Sequence)
+            and not isinstance(operations, (str, bytes))
+        }
+        if len(operations_by_tool) != len(authorized_operations) or any(
+            not operations or any(not operation for operation in operations)
+            for operations in operations_by_tool.values()
+        ):
+            raise NativeTurnUnavailable(
+                "Captured Native operation authorization is malformed."
+            )
+        unknown = set(operations_by_tool) - set(provider_surface.tool_names)
+        if unknown:
+            raise NativeTurnUnavailable(
+                "Captured Native operation authorization contains tools outside "
+                "the complete Native surface."
+            )
+        try:
+            provider_surface = project_native_provider_operations(
+                provider_surface,
+                registry,
+                operations_by_tool,
+            )
+        except NativeCapabilityRegistryError as exc:
+            raise NativeTurnUnavailable(str(exc)) from exc
+    elif provider_schemas is not None:
         if registry is None:
             raise NativeTurnUnavailable(
                 "Freezing exact Native operations requires a capability registry."

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -1227,7 +1227,19 @@ def _capture_context_for_provider(
         from VibeCADNativeProviderContext import (
             schemas_for_native_provider_surface,
         )
+        from VibeCADNativeCapabilityRegistry import _provider_schema_operations
 
+        exact_native_schemas = [
+            dict(schema) for schema in native_provider_surface.schemas
+        ]
+        native_turn_authorization = {
+            "schema_sha256": provider_tool_schema_digest(exact_native_schemas),
+            "operations_by_tool": {
+                str(schema.get("name") or ""): list(operations)
+                for schema in exact_native_schemas
+                if (operations := _provider_schema_operations(schema))
+            },
+        }
         schemas = schemas_for_native_provider_surface(native_provider_surface)
     elif not native_engine:
         schemas = provider_tool_schemas(
@@ -1243,6 +1255,8 @@ def _capture_context_for_provider(
         schemas,
         resolution=resolution,
     )
+    if native_provider_surface is not None:
+        context["_native_turn_authorization"] = native_turn_authorization
     if session_trigger:
         context["session_trigger"] = dict(session_trigger)
     return context
@@ -4615,6 +4629,7 @@ def make_provider_tool_runner(
     document_thread_dispatch: DocumentThreadDispatch | None = None,
     turn_surface: dict[str, Any] | None = None,
     turn_schemas: list[dict[str, Any]] | None = None,
+    turn_authorization: Mapping[str, Any] | None = None,
     turn_modeling_surface: dict[str, Any] | None = None,
     turn_component_catalog: Mapping[str, Any] | None = None,
     turn_editable_sources: Mapping[str, Any] | None = None,
@@ -4637,6 +4652,11 @@ def make_provider_tool_runner(
                 service=service,
                 expected_surface=dict(turn_surface),
                 expected_schemas=[dict(value) for value in (turn_schemas or [])],
+                expected_authorization=(
+                    dict(turn_authorization)
+                    if isinstance(turn_authorization, Mapping)
+                    else None
+                ),
                 output_authorizer=output_authorization_callback,
                 input_authorizer=input_authorization_callback,
                 document_thread_dispatch=document_thread_dispatch,
@@ -5516,6 +5536,10 @@ def make_provider_tool_runner(
         )
         completed["provider_tool_surface"] = dict(turn_surface)
         completed["provider_tool_schemas"] = json.loads(json.dumps(frozen_schemas))
+        if isinstance(turn_authorization, Mapping):
+            completed["_native_turn_authorization"] = json.loads(
+                json.dumps(dict(turn_authorization))
+            )
         completed["workbench"] = str(turn_surface.get("workbench") or "") or None
         if frozen_modeling_surface:
             completed["modeling_surface"] = json.loads(
@@ -5700,6 +5724,11 @@ def _run_session_turn(
             for schema in list(context.get("provider_tool_schemas") or [])
             if isinstance(schema, dict)
         ],
+        turn_authorization=(
+            dict(context["_native_turn_authorization"])
+            if isinstance(context.get("_native_turn_authorization"), Mapping)
+            else None
+        ),
         turn_modeling_surface=(
             dict(context["modeling_surface"])
             if isinstance(context.get("modeling_surface"), dict)

--- a/src/Mod/VibeCAD/vibecad_tests/native_analyze_mesh_generation_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_analyze_mesh_generation_gui_integration.py
@@ -4,12 +4,16 @@
 
 from __future__ import annotations
 
+from io import BytesIO
+import hashlib
 import json
 from pathlib import Path
+import shutil
 import sys
 import tempfile
 import time
 import traceback
+import zipfile
 
 import FreeCAD as App
 import FreeCADGui as Gui
@@ -125,8 +129,9 @@ def _source(document, name: str, x: float):
     return source
 
 
-def _write_fake_gmsh(path: Path, fixture: Path) -> None:
-    path.write_text(
+def _write_fake_gmsh(path: Path, fixture: Path) -> Path:
+    script_path = path.with_suffix(".py") if sys.platform == "win32" else path
+    script_path.write_text(
         "#!/usr/bin/python3\n"
         "import pathlib, re, shutil, sys, time\n"
         "time.sleep(0.35)\n"
@@ -138,11 +143,22 @@ def _write_fake_gmsh(path: Path, fixture: Path) -> None:
         f"shutil.copyfile({str(fixture)!r}, output)\n",
         encoding="utf-8",
     )
-    path.chmod(0o700)
+    script_path.chmod(0o700)
+    if sys.platform != "win32":
+        return script_path
+    python = shutil.which("python.exe")
+    assert python is not None
+    wrapper = path.with_suffix(".cmd")
+    wrapper.write_text(
+        f'@echo off\n"{python}" "{script_path}" %*\n',
+        encoding="utf-8",
+    )
+    return wrapper
 
 
-def _write_fake_netgen(path: Path) -> None:
-    path.write_text(
+def _write_fake_netgen(path: Path) -> Path:
+    script_path = path.with_suffix(".py") if sys.platform == "win32" else path
+    script_path.write_text(
         "#!/usr/bin/python3\n"
         "import pathlib, re, sys, time\n"
         "import numpy as np\n"
@@ -157,7 +173,49 @@ def _write_fake_netgen(path: Path) -> None:
         "np.save(match.group(1), np.array([result, groups], dtype=object))\n",
         encoding="utf-8",
     )
-    path.chmod(0o700)
+    script_path.chmod(0o700)
+    if sys.platform != "win32":
+        return script_path
+    python = shutil.which("python.exe")
+    assert python is not None
+    wrapper = path.with_suffix(".cmd")
+    wrapper.write_text(
+        f'@echo off\n"{python}" "{script_path}" %*\n',
+        encoding="utf-8",
+    )
+    return wrapper
+
+
+def _archive_payloads(fem_mesh) -> dict[str, bytes]:
+    archive = zipfile.ZipFile(BytesIO(bytes(fem_mesh.dumpContent())), "r")
+    return {name: archive.read(name) for name in sorted(archive.namelist())}
+
+
+def _archive_difference(before: dict[str, bytes], after: dict[str, bytes]) -> dict:
+    result = {}
+    for name in sorted(set(before) | set(after)):
+        old = before.get(name, b"")
+        new = after.get(name, b"")
+        old_lines = old.decode("utf-8", errors="replace").splitlines()
+        new_lines = new.decode("utf-8", errors="replace").splitlines()
+        differences = []
+        for index, values in enumerate(zip(old_lines, new_lines), start=1):
+            if values[0] != values[1]:
+                differences.append((index, values[0], values[1]))
+                if len(differences) == 8:
+                    break
+        result[name] = {
+            "before": (len(old), hashlib.sha256(old).hexdigest()),
+            "after": (len(new), hashlib.sha256(new).hexdigest()),
+            "before_context": old_lines[max(0, differences[0][0] - 7) : differences[0][0]]
+            if differences
+            else [],
+            "after_context": new_lines[max(0, differences[0][0] - 7) : differences[0][0]]
+            if differences
+            else [],
+            "first_differences": differences,
+        }
+    return result
 
 
 def _run() -> None:
@@ -176,10 +234,8 @@ def _run() -> None:
         path = root / "native-fem-generation.FCStd"
         fixture = Path(App.getHomePath()) / "Mod/Fem/femtest/data/gmsh/Cube_Volume.vtk"
         assert fixture.is_file(), fixture
-        fake_gmsh = root / "fake-gmsh"
-        fake_netgen = root / "fake-netgen"
-        _write_fake_gmsh(fake_gmsh, fixture)
-        _write_fake_netgen(fake_netgen)
+        fake_gmsh = _write_fake_gmsh(root / "fake-gmsh", fixture)
+        fake_netgen = _write_fake_netgen(root / "fake-netgen")
         gmsh_preferences.SetString("gmshBinaryPath", str(fake_gmsh))
         netgen_preferences.SetString("NetgenPythonPath", str(fake_netgen))
 
@@ -363,8 +419,14 @@ def _run() -> None:
         ]
 
         expected = {
-            gmsh_mesh.Name: fem_mesh_definition_state(gmsh_mesh),
-            netgen_mesh.Name: fem_mesh_definition_state(netgen_mesh),
+            gmsh_mesh.Name: (
+                fem_mesh_definition_state(gmsh_mesh),
+                _archive_payloads(gmsh_mesh.FemMesh),
+            ),
+            netgen_mesh.Name: (
+                fem_mesh_definition_state(netgen_mesh),
+                _archive_payloads(netgen_mesh.FemMesh),
+            ),
             gmsh_region.Name: mesh_refinement_state(gmsh_region),
             netgen_region.Name: mesh_refinement_state(netgen_region),
         }
@@ -376,12 +438,22 @@ def _run() -> None:
         _events(12)
         for name, old in expected.items():
             obj = document.getObject(name)
-            current = (
-                fem_mesh_definition_state(obj)
-                if name in mesh_names
-                else mesh_refinement_state(obj)
-            )
-            assert current["state_sha256"] == old["state_sha256"]
+            if name in mesh_names:
+                old_state, old_archive = old
+                current = fem_mesh_definition_state(obj)
+                assert current["state_sha256"] == old_state["state_sha256"], (
+                    name,
+                    old_state,
+                    current,
+                    _archive_difference(old_archive, _archive_payloads(obj.FemMesh)),
+                )
+            else:
+                current = mesh_refinement_state(obj)
+                assert current["state_sha256"] == old["state_sha256"], (
+                    name,
+                    old,
+                    current,
+                )
 
         timer.stop()
         print(

--- a/src/Mod/VibeCAD/vibecad_tests/native_analyze_multipart_structural_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_analyze_multipart_structural_gui_integration.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+import shutil
 import sys
 import tempfile
 import time
@@ -58,8 +59,12 @@ def _run() -> None:
     old_gmsh = gmsh_preferences.GetString("gmshBinaryPath", "")
     old_ccx = ccx_preferences.GetString("ccxBinaryPath", "")
     try:
-        gmsh_preferences.SetString("gmshBinaryPath", "/usr/bin/gmsh")
-        ccx_preferences.SetString("ccxBinaryPath", "/usr/bin/ccx")
+        gmsh_binary = shutil.which("gmsh")
+        ccx_binary = shutil.which("ccx")
+        assert gmsh_binary is not None, "Gmsh executable is unavailable"
+        assert ccx_binary is not None, "CalculiX executable is unavailable"
+        gmsh_preferences.SetString("gmshBinaryPath", gmsh_binary)
+        ccx_preferences.SetString("ccxBinaryPath", ccx_binary)
         Gui.activateWorkbench("FemWorkbench")
         temporary = tempfile.TemporaryDirectory(
             prefix="vibecad-native-multipart-structural-"

--- a/src/Mod/VibeCAD/vibecad_tests/native_analyze_provider_surface_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_analyze_provider_surface_gui_integration.py
@@ -747,7 +747,7 @@ def _run() -> None:
             schema["name"] for schema in generated_context["provider_tool_schemas"]
         }
         assert generated_domain["provider_scope"]["generated_mesh_count"] == 1
-        assert "analyze.generate_gmsh" not in generated_names
+        assert "analyze.generate_gmsh" in generated_names
         assert "analyze.mesh_output" in generated_names
 
         completed_after_capture = create_native_session_execution(

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_assignments.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_assignments.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
+import VibeCADNativeAnalyzeAssignments as assignments
 from VibeCADNativeAnalyzeAssignments import (
     ASSIGNMENT_CATEGORIES,
+    assignment_validation_records,
     compact_assignment_state,
     page_assignment_records,
+    validate_assignment_coverage,
 )
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
 
@@ -78,6 +83,50 @@ def test_connection_and_mesh_sources_are_normalized_as_references() -> None:
     assert mesh["definition"]["generated"] is False
 
 
+def test_assignment_validation_records_do_not_serialize_generated_mesh_content() -> None:
+    source = SimpleNamespace(Name="Body")
+    mesh = SimpleNamespace(
+        Name="Mesh",
+        Label="Volume mesh",
+        TypeId="Fem::FemMeshObjectPython",
+        Proxy=SimpleNamespace(Type="Fem::FemMeshGmsh"),
+        Shape=source,
+        FemMesh=SimpleNamespace(
+            NodeCount=140228,
+            EdgeCount=0,
+            FaceCount=0,
+            VolumeCount=78832,
+            dumpContent=lambda: pytest.fail(
+                "assignment validation must not serialize generated mesh content"
+            ),
+        ),
+        MeshRefinementList=(),
+        MeshGroupList=(),
+    )
+
+    records = assignment_validation_records(SimpleNamespace(Group=(mesh,)))
+
+    assert records == (
+        {
+            "object_name": "Mesh",
+            "label": "Volume mesh",
+            "type_id": "Fem::FemMeshObjectPython",
+            "category": "mesh",
+            "kind": "gmsh",
+            "references": [{"object_name": "Body", "subelements": []}],
+            "definition": {
+                "generated": True,
+                "topology": {
+                    "nodes": 140228,
+                    "edges": 0,
+                    "faces": 0,
+                    "volumes": 78832,
+                },
+            },
+        },
+    )
+
+
 def test_assignment_pages_are_bounded_and_category_exact() -> None:
     records = tuple(
         {
@@ -102,3 +151,211 @@ def test_assignment_pages_are_bounded_and_category_exact() -> None:
         page_assignment_records(records, category="solver", offset=0, page_size=10)
     with pytest.raises(NativeAnalyzeError, match="page_size"):
         page_assignment_records(records, category="all", offset=0, page_size=65)
+
+
+def test_assignment_coverage_rejects_references_outside_generated_mesh_domain() -> None:
+    records = (
+        {
+            "object_name": "Mesh",
+            "category": "mesh",
+            "kind": "gmsh",
+            "references": [{"object_name": "Body042", "subelements": []}],
+            "definition": {"generated": True},
+        },
+        {
+            "object_name": "PETG",
+            "category": "material",
+            "kind": "solid",
+            "references": [
+                {"object_name": "Body042", "subelements": ["Solid1"]}
+            ],
+        },
+        {
+            "object_name": "Contact",
+            "category": "connection",
+            "kind": "contact",
+            "references": [
+                {"object_name": "Body042", "subelements": ["Face1"]},
+                {"object_name": "Body043", "subelements": ["Face2"]},
+            ],
+        },
+    )
+
+    result = validate_assignment_coverage(
+        records,
+        mesh_domains={"Body042": {"Body042"}},
+        solid_units={"Body042": {("Body042", "Solid1")}},
+    )
+
+    assert result["valid"] is False
+    assert result["issue_count"] == 1
+    assert result["issues"][0]["object_name"] == "Contact"
+    assert "Body043" in result["issues"][0]["message"]
+
+
+def test_assignment_coverage_requires_material_for_every_meshed_solid() -> None:
+    records = (
+        {
+            "object_name": "Mesh",
+            "category": "mesh",
+            "kind": "gmsh",
+            "references": [{"object_name": "Domain", "subelements": []}],
+            "definition": {"generated": True},
+        },
+        {
+            "object_name": "PETG",
+            "category": "material",
+            "kind": "solid",
+            "references": [
+                {"object_name": "Body042", "subelements": ["Solid1"]}
+            ],
+        },
+    )
+
+    result = validate_assignment_coverage(
+        records,
+        mesh_domains={"Domain": {"Domain", "Body042", "Body043"}},
+        solid_units={
+            "Domain": {
+                ("Body042", "Solid1"),
+                ("Body043", "Solid1"),
+            }
+        },
+    )
+
+    assert result["valid"] is False
+    assert result["issue_count"] == 1
+    assert result["issues"][0]["object_name"] == "Body043.Solid1"
+    assert "no solid material" in result["issues"][0]["message"]
+
+
+def test_global_material_covers_every_generated_mesh_solid() -> None:
+    records = (
+        {
+            "object_name": "Mesh",
+            "category": "mesh",
+            "kind": "gmsh",
+            "references": [{"object_name": "Domain", "subelements": []}],
+            "definition": {"generated": True},
+        },
+        {
+            "object_name": "PETG",
+            "category": "material",
+            "kind": "solid",
+            "references": [],
+        },
+    )
+
+    result = validate_assignment_coverage(
+        records,
+        mesh_domains={"Domain": {"Domain", "Body042", "Body043"}},
+        solid_units={
+            "Domain": {
+                ("Body042", "Solid1"),
+                ("Body043", "Solid1"),
+            }
+        },
+    )
+
+    assert result == {"valid": True, "issue_count": 0, "issues": []}
+
+
+def test_whole_object_material_covers_all_of_that_objects_solids() -> None:
+    records = (
+        {
+            "object_name": "Mesh",
+            "category": "mesh",
+            "kind": "gmsh",
+            "references": [{"object_name": "Domain", "subelements": []}],
+            "definition": {"generated": True},
+        },
+        {
+            "object_name": "PETG",
+            "category": "material",
+            "kind": "solid",
+            "references": [{"object_name": "Body042", "subelements": []}],
+        },
+    )
+
+    result = validate_assignment_coverage(
+        records,
+        mesh_domains={"Domain": {"Domain", "Body042"}},
+        solid_units={
+            "Domain": {
+                ("Body042", "Solid1"),
+                ("Body042", "Solid2"),
+            }
+        },
+    )
+
+    assert result == {"valid": True, "issue_count": 0, "issues": []}
+
+
+def test_assignment_validation_bounds_details_without_capping_total_count(
+    monkeypatch,
+) -> None:
+    source = SimpleNamespace(
+        Name="Domain",
+        Shape=SimpleNamespace(Solids=[object()]),
+        VibeCADAnalysisDomain=False,
+    )
+    outside = {
+        f"Outside{index}": SimpleNamespace(
+            Name=f"Outside{index}",
+            Shape=SimpleNamespace(),
+        )
+        for index in range(70)
+    }
+    live_assignments = {
+        "Mesh": SimpleNamespace(isValid=lambda: True),
+        "Steel": SimpleNamespace(isValid=lambda: True),
+        **{
+            f"Load{index}": SimpleNamespace(isValid=lambda: True)
+            for index in range(70)
+        },
+    }
+    document = SimpleNamespace(
+        getObject=lambda name: (
+            source
+            if name == "Domain"
+            else outside.get(name) or live_assignments.get(name)
+        )
+    )
+    records = (
+        {
+            "object_name": "Mesh",
+            "category": "mesh",
+            "kind": "gmsh",
+            "references": [{"object_name": "Domain", "subelements": []}],
+            "definition": {"generated": True},
+        },
+        {
+            "object_name": "Steel",
+            "category": "material",
+            "kind": "solid",
+            "references": [],
+        },
+        *(
+            {
+                "object_name": f"Load{index}",
+                "category": "load",
+                "kind": "force",
+                "references": [
+                    {"object_name": f"Outside{index}", "subelements": []}
+                ],
+            }
+            for index in range(70)
+        ),
+    )
+    monkeypatch.setattr(
+        assignments,
+        "assignment_validation_records",
+        lambda _analysis: records,
+    )
+
+    result = assignments.validate_assignments(SimpleNamespace(Document=document))
+
+    assert result["valid"] is False
+    assert result["issue_count"] == 70
+    assert len(result["issues"]) == 64
+    assert result["issues_truncated"] is True

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_context.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_context.py
@@ -345,6 +345,7 @@ def test_session_capture_uses_document_dispatches_then_reuses_cache(
 class _Shape:
     def __init__(self) -> None:
         self.validity_checks = 0
+        self.export_calls = 0
         self.Solids = [object()]
         self.Faces = []
         self.Edges = []
@@ -355,6 +356,10 @@ class _Shape:
     def isValid(self) -> bool:
         self.validity_checks += 1
         return True
+
+    def exportBrep(self, _path: str) -> None:
+        self.export_calls += 1
+        raise AssertionError("turn-start Analyze context must not export BREP")
 
 
 class _GeometryObject:
@@ -430,6 +435,59 @@ def test_responsive_context_request_marks_geometry_validation_as_deferred() -> N
 
     assert request["defer_brep_validation"] is True
     assert request["geometry_validation_artifact_root"]
+
+
+def test_turn_start_context_captures_geometry_without_brep_validation(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSnapshot as analyze_snapshot_module
+
+    document = SimpleNamespace(Uid="document-a", Objects=[])
+    obj = _GeometryObject(document)
+    document.Objects = [obj]
+    document.getObject = lambda name: obj if name == obj.Name else None
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+    monkeypatch.setattr(
+        analyze_snapshot_module,
+        "mesh_object_state",
+        lambda current: {
+            "object_name": current.Name,
+            "topology": {"solids": 1, "faces": 0, "edges": 0},
+            "state_sha256": "a" * 64,
+        },
+    )
+    monkeypatch.setattr(
+        analyze_snapshot_module,
+        "clipping_face_source_state",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError(
+                "turn-start Analyze context must not validate clipping faces"
+            )
+        ),
+    )
+
+    request = analyze_snapshot_module.begin_analyze_snapshot_capture(
+        document,
+        validate_brep=False,
+    )
+    part = analyze_snapshot_module.capture_analyze_snapshot_batch(
+        document,
+        request,
+        [obj.Name],
+    )
+
+    assert request["validate_brep"] is False
+    assert request["defer_brep_validation"] is False
+    assert request["geometry_validation_artifact_root"] == ""
+    assert part["geometry_source_count"] == 1
+    assert part["geometry_sources"][0]["object_name"] == obj.Name
+    assert part["geometry_validation_artifacts"] == []
+    assert obj.Shape.validity_checks == 0
+    assert obj.Shape.export_calls == 0
 
 
 def test_analyze_geometry_postprocess_keeps_only_isolated_valid_results(

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_mesh_lifecycle_bindings.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_mesh_lifecycle_bindings.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import VibeCADNativeAnalyzeMeshLifecycleBindings as bindings
+from VibeCADNativeAnalyzeMeshRuntime import NativeAnalyzeMeshRuntime
+
+
+def test_focused_gmsh_edit_retargets_an_existing_mesh_definition(monkeypatch) -> None:
+    runtime = object.__new__(NativeAnalyzeMeshRuntime)
+    requests: list[dict] = []
+    runtime.execute = lambda request, *, ticket: requests.append(request) or {
+        "updated": True
+    }
+    mesh_state = {
+        "object_name": "Mesh",
+        "state_sha256": "a" * 64,
+        "mesher": "gmsh",
+        "settings": {
+            "maximum_size_mm": 12.0,
+            "minimum_size_mm": 2.0,
+            "element_order": "second",
+        },
+    }
+    monkeypatch.setattr(
+        bindings,
+        "current_state",
+        lambda _runtime, name, _reader: (SimpleNamespace(Name=name), mesh_state),
+    )
+    monkeypatch.setattr(
+        bindings,
+        "current_target",
+        lambda _runtime, name, _reader: {
+            "object_name": name,
+            "expected_state_sha256": "b" * 64,
+        },
+    )
+
+    result = bindings._edit_values(
+        runtime,
+        {"mesh_name": "Mesh", "source_name": "TwoBodyDomain"},
+        ticket=SimpleNamespace(),
+    )
+
+    assert requests == [
+        {
+            "operation": "update_gmsh",
+            "target": {
+                "object_name": "Mesh",
+                "expected_state_sha256": "a" * 64,
+            },
+            "source": {
+                "object_name": "TwoBodyDomain",
+                "expected_state_sha256": "b" * 64,
+            },
+        }
+    ]
+    assert result == {"updated": True, "mesh_name": "Mesh"}

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_mesh_state.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_mesh_state.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Regression coverage for stable exact FEM mesh content hashes."""
+
+from __future__ import annotations
+
+from io import BytesIO
+import zipfile
+
+from VibeCADNativeAnalyzeMeshState import _mesh_content_sha256
+
+
+def _archive(unv: str) -> bytes:
+    stream = BytesIO()
+    with zipfile.ZipFile(stream, "w") as archive:
+        archive.writestr("FemMesh.unv", unv)
+        archive.writestr("Persistence.xml", "<Persistence version='1'/>")
+    return stream.getvalue()
+
+
+class _FemMesh:
+    NodeCount = 4
+
+    def __init__(self, unv: str, groups: dict[int, tuple[str, str, tuple[int, ...]]]):
+        self._payload = _archive(unv)
+        self._groups = groups
+        self.Groups = tuple(groups)
+
+    def dumpContent(self) -> bytes:
+        return self._payload
+
+    def getGroupName(self, group_id: int) -> str:
+        return self._groups[group_id][0]
+
+    def getGroupElementType(self, group_id: int) -> str:
+        return self._groups[group_id][1]
+
+    def getGroupElements(self, group_id: int) -> tuple[int, ...]:
+        return self._groups[group_id][2]
+
+
+_PREFIX = """    -1
+  2411
+node records stay exact
+    -1
+    -1
+  2467
+"""
+
+
+def test_mesh_content_hash_ignores_serialized_group_order_and_ids() -> None:
+    before = _FemMesh(
+        _PREFIX
+        + "         1         0         0         0         0         0         0         1\n"
+        + "Edge1\n         8         1         0         0\n"
+        + "         2         0         0         0         0         0         0         1\n"
+        + "Face1\n         8        10         0         0\n    -1\n",
+        {
+            1: ("Edge1", "Edge", (1,)),
+            2: ("Face1", "Face", (10,)),
+        },
+    )
+    reopened = _FemMesh(
+        _PREFIX
+        + "         7         0         0         0         0         0         0         1\n"
+        + "Face1\n         8        10         0         0\n"
+        + "         9         0         0         0         0         0         0         1\n"
+        + "Edge1\n         8         1         0         0\n    -1\n",
+        {
+            7: ("Face1", "Face", (110,)),
+            9: ("Edge1", "Edge", (101,)),
+        },
+    )
+
+    assert _mesh_content_sha256(before) == _mesh_content_sha256(reopened)
+
+
+def test_mesh_content_hash_retains_exact_group_membership() -> None:
+    first = _FemMesh(
+        _PREFIX
+        + "         1         0         0         0         0         0         0         1\n"
+        + "Face1\n         8        10         0         0\n    -1\n",
+        {1: ("Face1", "Face", (10,))},
+    )
+    changed = _FemMesh(
+        _PREFIX
+        + "         8         0         0         0         0         0         0         1\n"
+        + "Face1\n         8        11         0         0\n    -1\n",
+        {8: ("Face1", "Face", (11,))},
+    )
+
+    assert _mesh_content_sha256(first) != _mesh_content_sha256(changed)

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_provider_scope.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_provider_scope.py
@@ -991,6 +991,9 @@ def test_focused_cfd_mesh_uses_the_supported_first_order_elements() -> None:
         "second",
         "first",
     ]
+    assert editable.parameters["properties"]["source_name"]["description"] == (
+        "Replacement geometry object name; changing it invalidates the generated mesh."
+    )
     assert editable.operation == "edit"
     assert editable.parameters["minProperties"] == 2
 
@@ -1136,7 +1139,7 @@ def test_fluid_singleton_creation_tools_disappear_after_creation() -> None:
     assert "analyze.gmsh_mesh" not in meshed
     assert "analyze.edit_gmsh_mesh" in meshed
     assert "analyze.generate_gmsh" in meshed
-    assert "analyze.generate_gmsh" not in generated
+    assert "analyze.generate_gmsh" in generated
     assert "analyze.mesh" not in meshed
     assert "analyze.openfoam_solver" not in solved
 
@@ -1480,6 +1483,7 @@ def test_operation_scope_publishes_only_calls_that_match_current_study_state() -
         ANALYZE_MATERIAL_CATALOG: {"search"},
     }
     assert fluid_operations["analyze.model"] == {
+        "create_analysis",
         "update_study",
     }
     assert fluid_operations[ANALYZE_MATERIAL_CATALOG] == {"search"}

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_solver_execution.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_solver_execution.py
@@ -16,6 +16,7 @@ from VibeCADNativeAnalyzeSolverExecution import (
     _prepare_calculix,
     _require_meaningful_result_state,
     _require_no_ignored_elmer_constraints,
+    _run_with_progress_heartbeat,
 )
 from VibeCADNativeAnalyzeSolverExecutionProcess import run_solver_processes
 from VibeCADNativeAnalyzeSolverExecutionSchema import (
@@ -60,7 +61,7 @@ def test_process_sequence_is_exact_bounded_and_shell_free(tmp_path: Path) -> Non
         (first, second),
         working_directory=str(tmp_path),
         environment={**os.environ, "SAFE_VALUE": "exact"},
-        timeout_seconds=5,
+        timeout_seconds=15,
         cancelled=lambda: False,
         progress=lambda percent, message: progress.append((percent, message)),
         backend="Test",
@@ -92,6 +93,33 @@ def test_process_sequence_cooperatively_terminates_on_cancel(tmp_path: Path) -> 
         )
 
 
+def test_long_input_generation_emits_elapsed_heartbeat_messages() -> None:
+    release = threading.Event()
+    progress: list[tuple[int, str]] = []
+
+    def work() -> str:
+        assert release.wait(1.0)
+        return "deck"
+
+    timer = threading.Timer(0.04, release.set)
+    timer.start()
+    try:
+        result = _run_with_progress_heartbeat(
+            work,
+            progress=lambda percent, message: progress.append((percent, message)),
+            percent=4,
+            message="Generating CalculiX input deck",
+            interval_seconds=0.01,
+        )
+    finally:
+        timer.cancel()
+
+    assert result == "deck"
+    assert progress[0] == (4, "Generating CalculiX input deck")
+    assert any("elapsed" in message for _percent, message in progress[1:])
+    assert all(percent == 4 for percent, _message in progress)
+
+
 def test_process_failure_returns_only_bounded_tail(tmp_path: Path) -> None:
     program = _program(
         tmp_path / "fail",
@@ -108,6 +136,49 @@ def test_process_failure_returns_only_bounded_tail(tmp_path: Path) -> None:
             progress=lambda _percent, _message: None,
             backend="Test",
         )
+
+
+def test_calculix_failure_returns_structured_artifact_diagnostics(
+    tmp_path: Path,
+) -> None:
+    program = _program(
+        tmp_path / "ccx-fail",
+        "from pathlib import Path\n"
+        'print("Determining the structure of the matrix")\n'
+        'Path("model.sta").write_text('
+        '"*ERROR: a stiffness matrix coefficient is singular\\n"'
+        ', encoding="utf-8")\n'
+        "raise SystemExit(201)\n",
+    )
+
+    with pytest.raises(NativeAnalyzeError) as raised:
+        run_solver_processes(
+            (program,),
+            working_directory=str(tmp_path),
+            environment=os.environ,
+            timeout_seconds=5,
+            cancelled=lambda: False,
+            progress=lambda _percent, _message: None,
+            backend="CalculiX",
+        )
+
+    assert raised.value.error_code == "NATIVE_ANALYZE_SOLVER_BACKEND_FAILED"
+    assert "stiffness matrix coefficient is singular" in str(raised.value)
+    assert raised.value.repair == {
+        "backend": "CalculiX",
+        "stage": 1,
+        "exit_code": 201,
+        "diagnostics": [
+            {
+                "artifact": "model.sta",
+                "excerpt": "*ERROR: a stiffness matrix coefficient is singular",
+            },
+            {
+                "artifact": "solver-1.log",
+                "excerpt": "Determining the structure of the matrix",
+            },
+        ],
+    }
 
 
 def test_atomic_progress_replacement_is_a_transient_sample(
@@ -302,6 +373,59 @@ def test_solver_capture_does_not_generate_case_files(monkeypatch) -> None:
         ),
         ("preferences", "threads", "int", 6),
     )
+
+
+def test_solver_capture_rejects_assignments_outside_the_generated_mesh(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSolverExecution as execution
+
+    analysis = SimpleNamespace(Name="Analysis")
+    document = SimpleNamespace(
+        getObject=lambda name: analysis if name == "Analysis" else None
+    )
+    target = SimpleNamespace(
+        solver=SimpleNamespace(Name="Solver", Document=document),
+        kind="calculix",
+        expected_state_sha256="a" * 64,
+    )
+    monkeypatch.setattr(execution, "prepare_solver_target", lambda *_args: target)
+    monkeypatch.setattr(
+        execution,
+        "solver_state",
+        lambda *_args: {"suppressed": False, "analysis": "Analysis"},
+    )
+    monkeypatch.setattr(
+        execution,
+        "validate_assignments",
+        lambda _analysis: {
+            "valid": False,
+            "issue_count": 1,
+            "issues": [
+                {
+                    "message": (
+                        "Contact references Body043, which is outside every "
+                        "generated mesh domain in this analysis."
+                    )
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(NativeAnalyzeError) as raised:
+        execution.capture_solver_execution_request(
+            document,
+            "document-a",
+            target={
+                "object_name": "Solver",
+                "expected_state_sha256": "a" * 64,
+            },
+            timeout_seconds=7200,
+        )
+
+    assert raised.value.error_code == "NATIVE_ANALYZE_SOLVER_NOT_READY"
+    assert "Body043" in str(raised.value)
+    assert raised.value.repair == {"analysis": "Analysis", "issue_count": 1}
 
 
 def test_solver_capture_validation_rejects_runtime_preference_changes(
@@ -501,6 +625,46 @@ def test_human_solver_progress_is_mirrored_to_the_status_bar(monkeypatch) -> Non
     ]
 
 
+def test_ai_solver_progress_is_mirrored_to_the_status_bar(monkeypatch) -> None:
+    import types
+
+    from PySide6 import QtCore, QtWidgets
+
+    pyside = types.ModuleType("PySide")
+    pyside.QtCore = QtCore
+    pyside.QtWidgets = QtWidgets
+    monkeypatch.setitem(sys.modules, "PySide", pyside)
+    import VibeCADAnalyzeSolverGui as solver_gui
+
+    status_updates: list[str] = []
+    watcher = object.__new__(solver_gui._SolverJobStatusUi)
+    watcher.job_id = "ai-solver-job"
+    watcher.backend = "CalculiX"
+    watcher.manager = SimpleNamespace(
+        snapshot=lambda _job_id: SimpleNamespace(
+            progress_percent=23,
+            progress_message="Generating CalculiX input deck (95s elapsed)",
+            terminal=False,
+        )
+    )
+    monkeypatch.setattr(
+        solver_gui.Gui,
+        "getMainWindow",
+        lambda: SimpleNamespace(
+            statusBar=lambda: SimpleNamespace(
+                showMessage=lambda value, *_args: status_updates.append(value)
+            )
+        ),
+        raising=False,
+    )
+
+    watcher.poll()
+
+    assert status_updates == [
+        "CalculiX: Generating CalculiX input deck (95s elapsed)"
+    ]
+
+
 def test_analyze_preferences_expose_the_openfoam_environment_contract() -> None:
     repository = Path(__file__).resolve().parents[4]
     gui = repository / "src" / "Mod" / "Fem" / "Gui"
@@ -682,6 +846,43 @@ def test_authenticated_worker_result_reuses_only_parent_commit_guards(
     assert prepared.request.environment == {}
     assert prepared.request.runtime_preferences == runtime_preferences
     assert prepared.stages == ({"stage": 1, "program": "ccx.exe", "exit_code": 0},)
+
+
+def test_worker_preserves_structured_backend_failure_diagnostics(
+    tmp_path: Path,
+) -> None:
+    import json
+
+    import VibeCADNativeAnalyzeSolverExecutionWorker as worker
+    from VibeCADNativeAnalyzeSolverExecutionInput import (
+        ANALYZE_SOLVER_EXECUTION_PROTOCOL,
+    )
+
+    frozen = SimpleNamespace(
+        workspace=SimpleNamespace(path=tmp_path),
+        request_sha256="a" * 64,
+    )
+    result = {
+        "ok": False,
+        "protocol": ANALYZE_SOLVER_EXECUTION_PROTOCOL,
+        "request_sha256": "a" * 64,
+        "error_code": "NATIVE_ANALYZE_SOLVER_BACKEND_FAILED",
+        "message": "CalculiX exited with code 201.",
+        "repair": {
+            "backend": "CalculiX",
+            "stage": 1,
+            "exit_code": 201,
+            "diagnostics": [
+                {"artifact": "model.sta", "excerpt": "*ERROR: singular matrix"}
+            ],
+        },
+    }
+    (tmp_path / "result.json").write_text(json.dumps(result), encoding="utf-8")
+
+    with pytest.raises(NativeAnalyzeError) as raised:
+        worker._read_result(frozen)
+
+    assert raised.value.repair == result["repair"]
 
 
 def test_worker_rejects_backend_implementation_substitution(tmp_path: Path) -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_study.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_study.py
@@ -172,6 +172,40 @@ def test_study_readiness_uses_declared_physics_and_exact_solver_status() -> None
     assert readiness["blockers"] == ["missing_fluid_boundary"]
 
 
+def test_study_readiness_rejects_invalid_assignment_and_mesh_coverage() -> None:
+    inventory = {
+        "geometry_source_count": 1,
+        "mechanical_material_count": 1,
+        "thermal_material_count": 0,
+        "transient_thermal_material_count": 0,
+        "fluid_material_count": 0,
+        "equation_kinds": [],
+        "support_count": 1,
+        "load_count": 1,
+        "thermal_condition_count": 0,
+        "thermal_condition_families": [],
+        "fluid_constraint_count": 0,
+        "fluid_constraint_kinds": [],
+        "electromagnetic_constraint_count": 0,
+        "mesh_definition_count": 1,
+        "generated_mesh_count": 1,
+        "solver_kinds": ["calculix"],
+        "result_count": 0,
+        "assignment_validation_issue_count": 2,
+        "mesh_coverage_issue_count": 1,
+    }
+
+    readiness = evaluate_study_readiness(
+        {"declared": True, "physics": ["mechanical"], "regime": "steady"},
+        inventory,
+        {"calculix": {"solver": "calculix", "engine_ready": True, "missing": []}},
+    )
+
+    assert readiness["ready_to_solve"] is False
+    assert "invalid_assignments" in readiness["blockers"]
+    assert "invalid_mesh_coverage" in readiness["blockers"]
+
+
 def test_study_readiness_does_not_claim_solver_availability() -> None:
     readiness = evaluate_study_readiness(
         {"declared": True, "physics": ["mechanical"], "regime": "steady"},

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_background.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_background.py
@@ -12,6 +12,7 @@ from VibeCADNativeBackground import (
     NativeBackgroundError,
     NativeBackgroundManager,
 )
+from VibeCADNativeBackgroundRuntime import _summary
 
 
 def _callbacks(*, prepare, validate=lambda: None, commit=lambda value: value):
@@ -56,6 +57,33 @@ def test_submit_returns_while_detached_preparation_is_running() -> None:
     completed = manager.wait(submitted.job_id, 2.0)
     assert completed.phase == "completed"
     assert completed.result == {"mesh": "ready"}
+
+
+def test_running_job_summary_tells_provider_to_wait_without_inferring_a_hang() -> None:
+    manager = NativeBackgroundManager()
+    entered = threading.Event()
+    release = threading.Event()
+
+    def prepare(_cancelled, progress):
+        progress(20, "Generating CalculiX input deck")
+        entered.set()
+        release.wait(1.0)
+        return {"deck": "ready"}
+
+    submitted = manager.submit(**_callbacks(prepare=prepare))
+    assert entered.wait(1.0)
+    summary = _summary(manager.snapshot(submitted.job_id))
+    release.set()
+    manager.wait(submitted.job_id, 2.0)
+
+    assert summary["worker_state"] == "active"
+    assert summary["recommended_poll_seconds"] >= 10
+    assert summary["elapsed_seconds"] >= 0
+    assert summary["seconds_since_progress"] >= 0
+    assert summary["guidance"] == (
+        "Continue waiting. Do not cancel an active job solely because its percent "
+        "is unchanged."
+    )
 
 
 def test_completed_mutating_job_reports_its_document_change() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_session.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_session.py
@@ -9,7 +9,10 @@ from types import SimpleNamespace
 import pytest
 
 import VibeCADNativeSessionFactory as factory_module
-from VibeCADNativeCapabilityRegistry import NativeProviderSurface
+from VibeCADNativeCapabilityRegistry import (
+    NativeProviderSurface,
+    _provider_schema_operations,
+)
 from VibeCADNativeCommonSchema import common_capability_definitions
 from VibeCADNativeProviderRunner import NativeProviderToolRunner
 from VibeCADNativeRegistry import build_native_capability_registry
@@ -172,6 +175,42 @@ def test_session_factory_uses_captured_analyze_schema_without_rereading_lifecycl
         expected_schemas=schemas,
         registry=build_native_capability_registry(),
     )
+    execution.close()
+
+
+def test_session_factory_passes_internal_operation_authorization_to_turn_freeze(
+    monkeypatch,
+) -> None:
+    turn, schemas, frozen = _common_turn("analyze")
+    captured = {}
+
+    def freeze(*_args, **kwargs):
+        captured.update(kwargs)
+        return turn
+
+    monkeypatch.setattr(factory_module, "freeze_native_turn", freeze)
+    monkeypatch.setattr(
+        factory_module,
+        "require_frozen_native_turn",
+        lambda expected, *_args: expected,
+    )
+    authorization = {
+        "schema_sha256": turn.schema_sha256,
+        "operations_by_tool": {
+            schema["name"]: list(_provider_schema_operations(schema))
+            for schema in turn.provider_schemas
+        },
+    }
+
+    execution = create_native_session_execution(
+        service=_Service(),
+        expected_surface=frozen,
+        expected_schemas=schemas,
+        expected_authorization=authorization,
+        registry=build_native_capability_registry(),
+    )
+
+    assert captured["authorized_operations"] == authorization["operations_by_tool"]
     execution.close()
 
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_turn.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_turn.py
@@ -8,8 +8,19 @@ from VibeCADNativeCapabilityRegistry import (
     NativeCapabilityDefinition,
     NativeCapabilityImplementation,
     NativeCapabilityRegistry,
+    NativeProviderSurface,
+    _provider_schema_operations,
+    provider_visible_native_schema,
 )
-from VibeCADNativeSurface import NativeSurfaceChanged, SURFACE_CHANGED
+from VibeCADNativeAnalyzeInspectSchema import (
+    ANALYZE_INSPECT_CAPABILITY_NAME,
+    analyze_inspect_capability_definition,
+)
+from VibeCADNativeSurface import (
+    NativeSurfaceChanged,
+    NativeSurfaceSnapshot,
+    SURFACE_CHANGED,
+)
 from VibeCADNativeTurn import (
     NATIVE_TURN_UNAVAILABLE,
     NativeTurnChanged,
@@ -98,6 +109,139 @@ def test_provider_turn_can_freeze_an_exact_subset_of_a_complete_surface(
         "inspect.query",
     )
     assert require_frozen_native_turn(expected, controller, registry) == expected
+
+
+@pytest.mark.parametrize(
+    "operation",
+    ("study", "analysis", "validate_assignments"),
+)
+def test_provider_turn_keeps_exact_authorized_operation_when_visible_schema_is_compact(
+    monkeypatch,
+    operation,
+) -> None:
+    import VibeCADNativeTurn as turn_module
+
+    definition = analyze_inspect_capability_definition()
+    registry = NativeCapabilityRegistry()
+    registry.register_definition(definition)
+    exact_schema = definition.provider_schema(
+        tuple(variant.operation for variant in definition.variants)
+    )
+    surface = NativeSurfaceSnapshot(
+        "analyze",
+        9,
+        "a" * 64,
+        ("VibeCAD_AnalyzeReadStudy",),
+        ("VibeCAD_AnalyzeReadStudy",),
+        (),
+    )
+    provider_surface = NativeProviderSurface(
+        snapshot=surface,
+        available=True,
+        unavailable_reason="",
+        tool_names=(ANALYZE_INSPECT_CAPABILITY_NAME,),
+        schemas=(exact_schema,),
+        human_only_action_ids=(),
+        missing_definition_names=(),
+        missing_implementation_names=(),
+        incomplete_definition_names=(),
+    )
+    visible_schema = provider_visible_native_schema(
+        definition.provider_schema((operation,))
+    )
+    monkeypatch.setattr(
+        turn_module,
+        "read_active_ribbon_surface",
+        lambda _controller: surface,
+    )
+    monkeypatch.setattr(
+        turn_module,
+        "resolve_native_provider_surface",
+        lambda _surface, _registry: provider_surface,
+    )
+
+    frozen = freeze_native_turn(
+        object(),
+        registry,
+        tool_names=(ANALYZE_INSPECT_CAPABILITY_NAME,),
+        provider_schemas=(visible_schema,),
+        authorized_operations={ANALYZE_INSPECT_CAPABILITY_NAME: (operation,)},
+    )
+
+    assert _provider_schema_operations(frozen.provider_schemas[0]) == (operation,)
+    assert (
+        provider_visible_native_schema(frozen.provider_schemas[0])
+        == visible_schema
+    )
+
+
+def test_native_context_keeps_operation_authorization_out_of_model_visible_state(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeProviderContext as provider_context
+    import VibeCADSession as session_module
+
+    definition = analyze_inspect_capability_definition()
+    registry = NativeCapabilityRegistry()
+    registry.register_definition(definition)
+    exact_schema = definition.provider_schema(("study",))
+    snapshot = NativeSurfaceSnapshot(
+        "analyze",
+        9,
+        "a" * 64,
+        ("VibeCAD_AnalyzeReadStudy",),
+        ("VibeCAD_AnalyzeReadStudy",),
+        (),
+    )
+    provider_surface = NativeProviderSurface(
+        snapshot=snapshot,
+        available=True,
+        unavailable_reason="",
+        tool_names=(ANALYZE_INSPECT_CAPABILITY_NAME,),
+        schemas=(exact_schema,),
+        human_only_action_ids=(),
+        missing_definition_names=(),
+        missing_implementation_names=(),
+        incomplete_definition_names=(),
+    )
+    monkeypatch.setattr(
+        provider_context,
+        "resolve_production_native_surface",
+        lambda: (registry, provider_surface),
+    )
+    monkeypatch.setattr(
+        provider_context,
+        "provider_authorized_native_surface",
+        lambda surface, _state, **_kwargs: surface,
+    )
+    monkeypatch.setattr(
+        provider_context,
+        "provider_visible_native_state",
+        lambda _state: {"surface_id": "analyze"},
+    )
+
+    service = type(
+        "Service",
+        (),
+        {
+            "provider_context_summary": lambda self: {},
+            "active_workbench_name": lambda self: "FemWorkbench",
+            "modeling_engine": lambda self: "native",
+            "provider_debug_config": lambda self: {"enabled": False},
+        },
+    )()
+    context = session_module._capture_context_for_provider(
+        service,
+        prepared_native_state={"surface_id": "analyze"},
+    )
+
+    assert _provider_schema_operations(context["provider_tool_schemas"][0]) == ()
+    assert context["_native_turn_authorization"]["operations_by_tool"] == {
+        ANALYZE_INSPECT_CAPABILITY_NAME: ["study"]
+    }
+    assert "_native_turn_authorization" not in session_module._provider_state_payload(
+        context
+    )
 
 
 def test_provider_turn_rejects_a_subset_outside_the_complete_surface(

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC5",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 4,
+  "build_version": 5,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Summary

- keep Analyze turn-start lightweight while preserving exact per-tool operation authorization, including generic schemas such as `analyze.inspect`
- support reusable multi-study workflows: create additional studies, retarget/regenerate Gmsh meshes, produce stable mesh identities, and validate assignment/material coverage against the generated domain
- keep long solver preparation and execution honest and usable with status-bar progress, liveness/polling guidance, bounded CalculiX diagnostics, and explicit protection against impatient cancellation
- present FEM studies and their native members under `Analyze` in the model tree; loose FEM objects remain visible there without being falsely assigned to a study or duplicated in `Operations`/`Other`
- bump VibeCAD 26.3.1-RC5 to build 5

This preserves native `FemAnalysis.Group` membership and the chronological History. The tree change is presentation-only; it does not move document objects or alter FEM ownership.

## User-visible outcome

Users can modify a model, create or repair the appropriate study and mesh, start a fresh FEA/CFD run, understand slow preparation, inspect actionable solver failure details, and continue using VibeCAD while background work runs. Large Analyze conversations no longer begin with redundant BREP validation, and the model tree now reflects actual study structure.

## TDD and verification

### Red

The model-tree regression was added before the renderer change and run against build 4:

```powershell
$exe = 'package/rattler-build/windows/VibeCAD-26.3.1-RC5-build4-Windows-x86_64/bin/VibeCAD.exe'
Start-Process -FilePath $exe -ArgumentList @(
  '-P', (Resolve-Path 'src/Mod/PartDesign/PartDesignTests'),
  '-P', (Resolve-Path 'src/Mod/VibeCAD'),
  '-t', 'TestModelTreeBrowser.TestModelTreeBrowser.test_analyze_folder_preserves_study_membership_without_duplicates'
) -WindowStyle Hidden -Wait -PassThru
```

Result before implementation: `1 failed in 13.782s`. The study appeared flat under `Operations`, study resources were absent, and an unassigned solver appeared under `Other`.

The Python tests in this change were likewise added/updated before their implementations to cover exact operation authorization, multiple-study availability, mesh retargeting/invalidation, assignment coverage, stable UNV group hashing, solver liveness/diagnostics, and polling guidance.

### Green

Analyze/background/session/turn regression slice:

```powershell
$root=(Resolve-Path '.pixi/envs/default').Path
$env:PYTHONPATH="$(Resolve-Path 'src/Mod/VibeCAD');$(Resolve-Path 'src/Mod/Fem');$(Resolve-Path 'src/Mod/TechDraw');$(Resolve-Path 'src/Mod/TechDraw/TechDrawTools')"
$tests=@(Get-ChildItem 'src/Mod/VibeCAD/vibecad_tests' -File -Filter 'test_native_analyze*.py' | ForEach-Object FullName)
$tests += (Resolve-Path 'src/Mod/VibeCAD/vibecad_tests/test_native_background.py').Path
$tests += (Resolve-Path 'src/Mod/VibeCAD/vibecad_tests/test_native_session.py').Path
$tests += (Resolve-Path 'src/Mod/VibeCAD/vibecad_tests/test_native_turn.py').Path
& "$root/python.exe" -m pytest @tests -q
```

Result: `155 passed`.

Full Windows rattler build:

```powershell
cd package/rattler-build
pixi reinstall -e default vibecad
```

Result: exit code `0`; recipe `vibecad-26.3.1RC5-h3c70cbc_5` built and installed successfully. The resulting executable reports `VibeCAD 26.3.1-RC5 (Build 5)`.

Focused native GUI regression against build 5:

```powershell
$prefix=(Resolve-Path 'package/rattler-build/.pixi/envs/default').Path
$env:PATH="$prefix;$prefix/Library/mingw-w64/bin;$prefix/Library/usr/bin;$prefix/Library/bin;$prefix/Scripts;$prefix/bin;$env:PATH"
Start-Process -FilePath "$prefix/Library/bin/freecad.exe" -ArgumentList @(
  '-P', (Resolve-Path 'src/Mod/PartDesign/PartDesignTests'),
  '-P', (Resolve-Path 'src/Mod/VibeCAD'),
  '-t', 'TestModelTreeBrowser.TestModelTreeBrowser.test_analyze_folder_preserves_study_membership_without_duplicates'
) -WindowStyle Hidden -Wait -PassThru
```

Result: `1 passed in 3.672s`.

Portable Windows bundle:

```powershell
$env:PATH="$HOME/.pixi/bin;$env:PATH"
$env:BUILD_TAG='local-build5'
$env:MAKE_INSTALLER='false'
$env:MAKE_PORTABLE_ARCHIVE='true'
pixi run -e package create_bundle
```

Result: exit code `0`; all standard bundle dependency, Codex app-server, geometry worker, windowless subprocess, command-line launcher, and McMaster WebView2 smoke tests passed. The generated archive checksum was independently verified.

Manual Windows acceptance:

- model modification followed by creation and execution of a fresh FEA study worked
- background Analyze behavior remained usable and visibly reported progress
- build 5 displayed the new Analyze tree structure; owner response: "this is pretty great"

### Broader existing GUI-suite notes

The full `TestModelTreeBrowser` class ran 27 tests: 23 passed. Four unrelated Windows harness/environment failures remain and do not enter the FEM path: unavailable optional `Assembly::BomObject`, two automated legacy Chamfer task-dialog openings, and one pre-existing scene primitive-count assertion. The focused new FEM tree regression passes in isolation on the shipping build 5 binary.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing defaults remain compatible; new parameters and schema fields are additive and optional.
- [x] Existing chronological History and native FEM document membership are preserved.
- [x] No deprecations or breaking changes are introduced.

## Risk and non-goals

- Mesh/study validation is stricter only at solve-readiness boundaries so invalid multi-body studies fail with repair details instead of producing misleading results.
- Solver liveness is honest elapsed-time reporting; opaque backend preparation does not invent percentage progress.
- This PR does not redesign legacy Part Design promotion, Assembly BOM registration, or unrelated model-browser tests.

## Issues

Fixes #112

Related to #102 (already closed by the shared background solver pipeline; this PR completes liveness, diagnostics, and status behavior on top of it).
