### PR TITLE
Fix Drawing responsiveness, bounded state, hierarchy, and restored presentation

### DIFF
--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5864,6 +5864,22 @@ void DocumentItem::rebuildModelBrowser()
     // component. Members of an analysis are rendered from native Group
     // membership instead of being flattened into type categories.
     std::unordered_map<const App::DocumentObject*, EntryBucket> analyzeEntriesByComponent;
+    // Drawing pages keyed by their owning component, plus the native
+    // ViewProvider presentation graph below each page. TechDraw page/view
+    // ownership is not an App::Group relationship, so it needs the same
+    // explicit browser treatment as an FEM Analysis.
+    std::unordered_map<const App::DocumentObject*, EntryBucket> drawingPagesByComponent;
+    std::unordered_map<const App::DocumentObject*, EntryBucket> drawingChildren;
+
+    const Base::Type drawingPageType = Base::Type::fromName("TechDraw::DrawPage");
+    auto isDrawingPage = [drawingPageType](const App::DocumentObject* object) {
+        return object && !drawingPageType.isBad()
+            && object->getTypeId().isDerivedFrom(drawingPageType);
+    };
+    auto isDrawingObject = [](const App::DocumentObject* object) {
+        return object
+            && std::string_view(object->getTypeId().getName()).starts_with("TechDraw::");
+    };
 
     for (const auto& entry : entries) {
         if (entry.role == Role::Origin || entry.role == Role::OriginFeature) {
@@ -5878,6 +5894,21 @@ void DocumentItem::rebuildModelBrowser()
         entriesByComponentRole[{entry.component, entry.role}].push_back(&entry);
         if (entry.role == Role::Component) {
             componentEntries.push_back(&entry);
+        }
+        if (isDrawingPage(entry.object)) {
+            drawingPagesByComponent[entry.component].push_back(&entry);
+        }
+        if (isDrawingObject(entry.object)) {
+            auto* viewProvider = getViewProvider(entry.object);
+            if (!viewProvider) {
+                continue;
+            }
+            for (auto* child : viewProvider->claimChildren()) {
+                const Entry* childEntry = projection.find(child);
+                if (childEntry && isDrawingObject(childEntry->object)) {
+                    drawingChildren[entry.object].push_back(childEntry);
+                }
+            }
         }
     }
 
@@ -5952,6 +5983,7 @@ void DocumentItem::rebuildModelBrowser()
     std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderComponent;
     std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderGroup;
     std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderAnalyzeObject;
+    std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderDrawingObject;
 
     // FreeCAD resolves duplicate default labels by appending a zero-padded
     // numeric suffix of at least three digits ("Origin001", "X-axis002"; see
@@ -6198,6 +6230,58 @@ void DocumentItem::rebuildModelBrowser()
         }
     };
 
+    renderDrawingObject = [&](const Entry& entry,
+                              QTreeWidgetItem* parent,
+                              DocumentObjectItem* logicalParent) {
+        if (entry.publishedImplementation || entry.bodyRepresentation) {
+            return;
+        }
+        auto* item = renderObject(entry, parent, logicalParent);
+        if (!item) {
+            return;
+        }
+
+        // TechDraw's ViewProviders are the authoritative presentation owners:
+        // Page claims its template, views, and annotations; a projected view
+        // claims its dimensions and dependent drawing objects. Follow that
+        // graph recursively instead of flattening timeline operations.
+        const auto children = takeBucket(findBucket(drawingChildren, entry.object));
+        for (const auto* child : children) {
+            renderDrawingObject(*child, item, item);
+        }
+        item->setChildIndicatorPolicy(
+            item->childCount() > 0 ? QTreeWidgetItem::ShowIndicator
+                                   : QTreeWidgetItem::DontShowIndicator
+        );
+    };
+
+    auto renderDrawings = [&](QTreeWidgetItem* parent,
+                              DocumentObjectItem* contextItem,
+                              App::DocumentObject* contextObject) {
+        const auto pages = takeBucket(findBucket(
+            drawingPagesByComponent,
+            static_cast<const App::DocumentObject*>(contextObject)
+        ));
+        if (pages.empty()) {
+            return;
+        }
+        auto* folder = makeFolder(
+            parent,
+            contextItem,
+            contextKey(contextObject),
+            "drawings",
+            TreeWidget::tr("Drawings"),
+            "TechDrawWorkbench"
+        );
+        for (const auto* page : pages) {
+            renderDrawingObject(
+                *page,
+                folder,
+                logicalItem(page->logicalParent, contextItem)
+            );
+        }
+    };
+
     auto renderReferences = [&](
                                 QTreeWidgetItem* parent,
                                 DocumentObjectItem* contextItem,
@@ -6346,6 +6430,7 @@ void DocumentItem::rebuildModelBrowser()
         );
 
         renderAnalyze(componentItem, componentItem, componentEntry.object);
+        renderDrawings(componentItem, componentItem, componentEntry.object);
 
         const auto operations = filterBucket(
             findBucket(
@@ -6523,6 +6608,7 @@ void DocumentItem::rebuildModelBrowser()
     );
 
     renderAnalyze(this, nullptr, nullptr);
+    renderDrawings(this, nullptr, nullptr);
 
     const auto rootOperations = filterBucket(
         findBucket(entriesByComponentRole, RoleContextKey {nullptr, Role::History}),

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -6271,7 +6271,7 @@ void DocumentItem::rebuildModelBrowser()
             contextKey(contextObject),
             "drawings",
             TreeWidget::tr("Drawings"),
-            "TechDrawWorkbench"
+            "preferences-techdraw"
         );
         for (const auto* page : pages) {
             renderDrawingObject(

--- a/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
@@ -124,6 +124,17 @@ def _snapshot_labels(snapshot):
     )
 
 
+def _icon_png(icon, size=16):
+    data = QtCore.QByteArray()
+    buffer = QtCore.QBuffer(data)
+    if not buffer.open(QtCore.QIODevice.WriteOnly):
+        raise RuntimeError("Could not open the icon comparison buffer")
+    if not icon.pixmap(size, size).save(buffer, "PNG"):
+        raise RuntimeError("Could not serialize the icon for comparison")
+    buffer.close()
+    return bytes(data)
+
+
 def _event_step(milliseconds=10):
     Gui.updateGui()
     loop = QtCore.QEventLoop()
@@ -827,6 +838,35 @@ class TestModelTreeBrowser(unittest.TestCase):
         self.assertIsNotNone(observed, self._snapshot())
         document_item, drawings, page_item, view_item = observed
         self.assertFalse(drawings.icon(0).isNull())
+
+        previous_visibility_icon = self.tree_parameters.GetBool(
+            "VisibilityIcon",
+            True,
+        )
+        try:
+            self.tree_parameters.SetBool("VisibilityIcon", False)
+            _event_step()
+            _tree, current_document_item = self._tree_and_document_item()
+            current_drawings = _child(
+                current_document_item,
+                "Drawings",
+                BROWSER_FOLDER_TYPE,
+            )
+            self.assertIsNotNone(current_drawings)
+            expected_icon = Gui.getIcon("preferences-techdraw")
+            self.assertIsNotNone(expected_icon)
+            self.assertFalse(expected_icon.isNull())
+            self.assertEqual(
+                _icon_png(current_drawings.icon(0)),
+                _icon_png(expected_icon),
+            )
+        finally:
+            self.tree_parameters.SetBool(
+                "VisibilityIcon",
+                previous_visibility_icon,
+            )
+            _event_step()
+
         self.assertIsNotNone(_child(page_item, template.Label))
         self.assertIsNotNone(_child(page_item, annotation.Label))
         self.assertIsNotNone(_child(view_item, dimension.Label))

--- a/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
@@ -21,6 +21,12 @@ try:
 except ImportError:
     Fem = None
 
+try:
+    import TechDraw  # noqa: F401 - registers optional TechDraw document types
+    import TechDrawGui  # noqa: F401 - registers TechDraw view providers
+except ImportError:
+    TechDraw = None
+
 
 BROWSER_FOLDER_TYPE = 1002
 BROWSER_DETAIL_TYPE = 1003
@@ -767,6 +773,72 @@ class TestModelTreeBrowser(unittest.TestCase):
             constraint.Label,
             solver.Label,
             loose_solver.Label,
+        ):
+            self.assertFalse(_snapshot_has_label(_snapshot(operations), label))
+            self.assertFalse(_snapshot_has_label(_snapshot(other), label))
+
+    @unittest.skipIf(TechDraw is None, "Requires TechDraw")
+    def test_drawings_folder_preserves_page_view_ownership_without_duplicates(self):
+        page = self.document.addObject("TechDraw::DrawPage", "DrawingPage")
+        page.Label = "Manufacturing Drawing"
+        _tag_timeline_role(page, "operation")
+
+        template = self.document.addObject(
+            "TechDraw::DrawSVGTemplate",
+            "DrawingTemplate",
+        )
+        template.Label = "A3 Template"
+        _tag_timeline_role(template, "resource")
+        page.Template = template
+
+        view = self.document.addObject("TechDraw::DrawViewPart", "DrawingView")
+        view.Label = "Base Front"
+        view.Source = [self.root_operation]
+        _tag_timeline_role(view, "operation")
+        page.addView(view)
+
+        dimension = self.document.addObject(
+            "TechDraw::DrawViewDimension",
+            "DrawingDimension",
+        )
+        dimension.Label = "Overall Width"
+        dimension.Type = "Distance"
+        dimension.References2D = [(view, "Edge1")]
+        _tag_timeline_role(dimension, "operation")
+        page.addView(dimension)
+
+        annotation = self.document.addObject(
+            "TechDraw::DrawRichAnno",
+            "DrawingAnnotation",
+        )
+        annotation.Label = "General Notes"
+        page.addView(annotation)
+        self.document.recompute()
+
+        def drawing_items():
+            _tree, document_item = self._tree_and_document_item()
+            drawings = _child(document_item, "Drawings", BROWSER_FOLDER_TYPE)
+            page_item = _child(drawings, page.Label)
+            view_item = _child(page_item, view.Label)
+            values = (document_item, drawings, page_item, view_item)
+            return values if all(value is not None for value in values) else None
+
+        observed = _wait_until(drawing_items)
+        self.assertIsNotNone(observed, self._snapshot())
+        document_item, drawings, page_item, view_item = observed
+        self.assertFalse(drawings.icon(0).isNull())
+        self.assertIsNotNone(_child(page_item, template.Label))
+        self.assertIsNotNone(_child(page_item, annotation.Label))
+        self.assertIsNotNone(_child(view_item, dimension.Label))
+
+        operations = _child(document_item, "Operations", BROWSER_FOLDER_TYPE)
+        other = _child(document_item, "Other", BROWSER_FOLDER_TYPE)
+        for label in (
+            page.Label,
+            template.Label,
+            view.Label,
+            dimension.Label,
+            annotation.Label,
         ):
             self.assertFalse(_snapshot_has_label(_snapshot(operations), label))
             self.assertFalse(_snapshot_has_label(_snapshot(other), label))

--- a/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
+++ b/src/Mod/TechDraw/Gui/QGIViewDimension.cpp
@@ -377,14 +377,18 @@ QString QGIViewDimension::getLabelText()
 void QGIViewDimension::draw()
 {
     prepareGeometryChange();
-    if (!isVisible()) {
-        return;
-    }
-
     auto* dim = dynamic_cast<TechDraw::DrawViewDimension*>(getViewObject());
     if (!dim ||//nothing to draw, don't try
         !dim->isDerivedFrom<TechDraw::DrawViewDimension>()
         || !dim->has2DReferences()) {
+        datumLabel->hide();
+        hide();
+        return;
+    }
+
+    auto* viewProvider =
+        dynamic_cast<ViewProviderDimension*>(getViewProvider(getViewObject()));
+    if (viewProvider && !viewProvider->isShow()) {
         datumLabel->hide();
         hide();
         return;
@@ -400,7 +404,7 @@ void QGIViewDimension::draw()
         return;
     }
 
-    auto vp = static_cast<ViewProviderDimension*>(getViewProvider(getViewObject()));
+    auto* vp = viewProvider;
     if (!vp) {
         datumLabel->show();
         show();

--- a/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
+++ b/src/Mod/TechDraw/Gui/ViewProviderDrawingView.cpp
@@ -42,6 +42,7 @@
 #include <Mod/TechDraw/App/DrawUtil.h>
 #include <Mod/TechDraw/App/DrawViewBalloon.h>
 #include <Mod/TechDraw/App/DrawViewDimension.h>
+#include <Mod/TechDraw/App/DrawViewPart.h>
 #include <Mod/TechDraw/App/Preferences.h>
 
 #include "ViewProviderDrawingView.h"
@@ -54,6 +55,35 @@
 using namespace TechDrawGui;
 using namespace TechDraw;
 namespace sp = std::placeholders;
+
+namespace {
+
+void redrawViewAndDependentDimensions(QGIView* view)
+{
+    if (!view) {
+        return;
+    }
+
+    view->updateView(true);
+
+    auto* viewPart = dynamic_cast<DrawViewPart*>(view->getViewObject());
+    auto* page = dynamic_cast<QGSPage*>(view->scene());
+    if (!viewPart || !page || !viewPart->hasGeometry()) {
+        return;
+    }
+
+    // A Dimension can hide itself while its referenced view is still restoring.
+    // Once that view has geometry, redraw its active dependants so each Dimension
+    // can restore its saved visibility without waiting for user selection.
+    for (auto* dimension : viewPart->getActiveDimensions()) {
+        auto* dimensionView = page->findQViewForDocObj(dimension);
+        if (dimensionView) {
+            dimensionView->updateView(true);
+        }
+    }
+}
+
+}  // namespace
 
 PROPERTY_SOURCE(TechDrawGui::ViewProviderDrawingView, Gui::ViewProviderDocumentObject)
 
@@ -346,7 +376,7 @@ void ViewProviderDrawingView::multiParentPaint(std::vector<TechDraw::DrawPage*>&
             if (vpPage->getQGSPage()) {
                 QGIView* qView = dynamic_cast<QGIView *>(vpPage->getQGSPage()->findQViewForDocObj(v));
                 if (qView) {
-                    qView->updateView(true);
+                    redrawViewAndDependentDimensions(qView);
                 }
             }
         }
@@ -363,7 +393,7 @@ void ViewProviderDrawingView::singleParentPaint(const TechDraw::DrawView* dv)
     }
     QGIView* qgiv = getQView();
     if (qgiv) {
-        qgiv->updateView(true);
+        redrawViewAndDependentDimensions(qgiv);
     } else {       //we are not part of the Gui page yet. ask page to add us.
         ViewProviderPage* vpPage = getViewProviderPage();
         if (vpPage) {

--- a/src/Mod/TechDraw/TDTest/TechDrawGuiBehaviorContractTest.py
+++ b/src/Mod/TechDraw/TDTest/TechDrawGuiBehaviorContractTest.py
@@ -529,6 +529,37 @@ class TechDrawGuiBehaviorSourceContractTest(unittest.TestCase):
             compact,
         )
 
+    def test_dimension_redraw_uses_durable_view_visibility(self):
+        source = (self.gui / "QGIViewDimension.cpp").read_text(encoding="utf-8")
+        draw = _function_body(source, "void QGIViewDimension::draw()")
+        before_reference_geometry = draw[: draw.index("if (!refObj->hasGeometry())")]
+
+        self.assertNotIn("if (!isVisible())", before_reference_geometry)
+        self.assertIn("viewProvider->isShow()", before_reference_geometry)
+
+    def test_view_repaint_redraws_dimensions_after_reference_geometry(self):
+        source = (self.gui / "ViewProviderDrawingView.cpp").read_text(
+            encoding="utf-8"
+        )
+        redraw = _function_body(
+            source,
+            "void redrawViewAndDependentDimensions(QGIView* view)",
+        )
+        self.assertIn("view->updateView(true)", redraw)
+        self.assertIn("getActiveDimensions()", redraw)
+        self.assertIn("dimensionView->updateView(true)", redraw)
+
+        single_parent = _function_body(
+            source,
+            "void ViewProviderDrawingView::singleParentPaint",
+        )
+        multi_parent = _function_body(
+            source,
+            "void ViewProviderDrawingView::multiParentPaint",
+        )
+        self.assertIn("redrawViewAndDependentDimensions(qgiv)", single_parent)
+        self.assertIn("redrawViewAndDependentDimensions(qView)", multi_parent)
+
     def test_exact_drawing_toolbar_inventory(self):
         workbench = (self.gui / "Workbench.cpp").read_text(encoding="utf-8")
         toolbar = workbench[
@@ -2125,6 +2156,73 @@ class TechDrawGuiBehaviorRuntimeContractTest(unittest.TestCase):
                 1,
             )
             self.assertFalse(rendered_svg_items[0].boundingRect().isEmpty())
+
+    def test_visible_dimension_redraws_after_referenced_view_restores(self):
+        import TechDrawGui
+
+        from .TechDrawTestUtilities import createPageWithSVGTemplate
+
+        box = self.document.addObject("Part::Box", "DimensionSource")
+        box.Length = 20
+        box.Width = 10
+        box.Height = 5
+        page = createPageWithSVGTemplate(self.document)
+        view = self.document.addObject("TechDraw::DrawViewPart", "DimensionView")
+        view.Source = [box]
+        page.addView(view)
+        self.document.recompute()
+
+        dimension = self.document.addObject(
+            "TechDraw::DrawViewDimension",
+            "RestoredDimension",
+        )
+        dimension.Type = "Distance"
+        dimension.References2D = [(view, "Edge1")]
+        page.addView(dimension)
+        hidden_dimension = self.document.addObject(
+            "TechDraw::DrawViewDimension",
+            "HiddenRestoredDimension",
+        )
+        hidden_dimension.Type = "Distance"
+        hidden_dimension.References2D = [(view, "Edge2")]
+        page.addView(hidden_dimension)
+        self.document.recompute()
+        page.ViewObject.Visibility = True
+        view.ViewObject.Visibility = True
+        dimension.ViewObject.Visibility = True
+        hidden_dimension.ViewObject.Visibility = False
+        page_name = page.Name
+        view_name = view.Name
+        dimension_name = dimension.Name
+        hidden_dimension_name = hidden_dimension.Name
+
+        with tempfile.TemporaryDirectory() as directory:
+            filename = os.path.join(directory, "drawing-dimension-reopen.FCStd")
+            self.document.saveAs(filename)
+            App.closeDocument(self.document.Name)
+
+            self.document = App.openDocument(filename)
+            restored_page = self.document.getObject(page_name)
+            restored_dimension = self.document.getObject(dimension_name)
+            restored_hidden_dimension = self.document.getObject(
+                hidden_dimension_name
+            )
+            self.assertTrue(restored_dimension.ViewObject.Visibility)
+            self.assertFalse(restored_hidden_dimension.ViewObject.Visibility)
+            Gui.Selection.clearSelection()
+            TechDrawGui.showDrawingPage(restored_page)
+
+            def rendered_drawing_objects():
+                layout = TechDrawGui.inspectPageLayout(restored_page)
+                rendered = {
+                    item["object_name"] for item in layout.get("items", [])
+                }
+                return rendered if view_name in rendered else None
+
+            rendered = _wait_until(rendered_drawing_objects)
+            self.assertIsNotNone(rendered)
+            self.assertIn(dimension_name, rendered)
+            self.assertNotIn(hidden_dimension_name, rendered)
 
     def test_projection_group_resources_do_not_become_visible_history_steps(self):
         from .TechDrawTestUtilities import createPageWithSVGTemplate

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -428,6 +428,7 @@ set(VibeCAD_Scripts
     VibeCADNativeDrawingPresentationState.py
     VibeCADNativeDrawingInternalTargets.py
     VibeCADNativeDrawingProviderState.py
+    VibeCADNativeDrawingContext.py
     VibeCADNativeDrawingSourceCatalog.py
     VibeCADNativeDrawingHatch.py
     VibeCADNativeDrawingHatchBindings.py

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -429,6 +429,7 @@ set(VibeCAD_Scripts
     VibeCADNativeDrawingInternalTargets.py
     VibeCADNativeDrawingProviderState.py
     VibeCADNativeDrawingContext.py
+    VibeCADNativeDrawingHistory.py
     VibeCADNativeDrawingSourceCatalog.py
     VibeCADNativeDrawingHatch.py
     VibeCADNativeDrawingHatchBindings.py
@@ -1375,6 +1376,7 @@ if(BUILD_TEST AND BUILD_GUI)
     vibecad_tests/test_native_drawing_cosmetic_line.py
     vibecad_tests/test_native_drawing_special_dimension.py
     vibecad_tests/test_native_drawing_balloon.py
+    vibecad_tests/test_native_drawing_history.py
     vibecad_tests/test_native_drawing_view.py
     vibecad_tests/test_native_drawing_internal_targets.py
     vibecad_tests/test_native_drawing_provider_state.py

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -1353,6 +1353,7 @@ if(BUILD_TEST AND BUILD_GUI)
 	    vibecad_tests/native_drawing_special_dimension_gui_integration.py
 	    vibecad_tests/native_drawing_balloon_gui_integration.py
 	    vibecad_tests/native_drawing_active_view_gui_integration.py
+	    vibecad_tests/native_drawing_page_capture_gui_integration.py
     vibecad_tests/test_native_drawing_page.py
     vibecad_tests/test_native_drawing_active_view.py
     vibecad_tests/test_native_drawing_dimension.py
@@ -1381,6 +1382,7 @@ if(BUILD_TEST AND BUILD_GUI)
     vibecad_tests/test_native_drawing_internal_targets.py
     vibecad_tests/test_native_drawing_provider_state.py
     vibecad_tests/test_native_geometry_sources.py
+    vibecad_tests/test_view_drawing_page_capture.py
     vibecad_tests/native_parameters_gui_integration.py
     vibecad_tests/native_mesh_io_gui_integration.py
     vibecad_tests/native_mesh_convert_gui_integration.py

--- a/src/Mod/VibeCAD/VibeCADCodex.py
+++ b/src/Mod/VibeCAD/VibeCADCodex.py
@@ -138,7 +138,7 @@ def vibecad_thread_config(
     # a user question must never be held inside a long-running exec cell.
     config["features.code_mode"] = {
         "enabled": False,
-        "direct_only_tool_namespaces": ["core", "conversation"],
+        "direct_only_tool_namespaces": ["core", "conversation", "view"],
     }
     if openai_base_url is not None:
         config.update(codex_openai_provider_config(openai_base_url))

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -742,8 +742,10 @@ class VibeCADService:
             uid,
             property_name,
         )
-        if revision != previous_revision:
+        revision_changed = revision != previous_revision
+        if str(property_name or "") == "Visibility" or revision_changed:
             self._invalidate_native_read_contexts(uid)
+        if revision_changed:
             self._sync_native_authority_metadata_if_active(uid)
         return revision
 

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -810,13 +810,18 @@ class VibeCADService:
         )
 
     def begin_native_analyze_context_request(self) -> dict[str, Any] | None:
-        """Capture detached identity for one bounded Analyze context read."""
+        """Capture one detached, visibility-scoped Analyze context request."""
 
         document = self._active_document()
         if document is None:
             return None
         from VibeCADModelingSurface import provider_engine_for_ribbon
-        from VibeCADNativeAnalyzeSnapshot import begin_analyze_snapshot_capture
+        from VibeCADNativeAnalyzeSnapshot import (
+            begin_analyze_snapshot_capture,
+            capture_analyze_clipping,
+            capture_analyze_snapshot_batch,
+        )
+        from VibeCADNativeGeometrySources import drawing_analysis_artifact_names
         from VibeCADNativeSnapshot import capture_active_snapshot_base
         from VibeCADRibbonSurface import read_active_ribbon_surface
 
@@ -831,26 +836,48 @@ class VibeCADService:
             str(document.Uid),
             capability_prefix="analyze.",
         )
+        analysis_artifacts = drawing_analysis_artifact_names(document)
         base = capture_active_snapshot_base(
             document,
             "analyze",
             native_state,
+            analysis_artifact_names=analysis_artifacts,
         )
         details = begin_analyze_snapshot_capture(
             document,
             background_job=background_job,
             validate_brep=False,
+            analysis_artifact_names=analysis_artifacts,
         )
-        return {
+        revision = int(native_state.get("structural_revision", 0) or 0)
+        cacheable = bool(
+            background_job is None or bool(getattr(background_job, "terminal", False))
+        )
+        cache_hit = bool(
+            cacheable
+            and self._native_analyze_contexts.has_cached(
+                str(document.Uid),
+                revision,
+                variant=str(details.get("active_analysis_name") or ""),
+            )
+        )
+        detached_clipping = capture_analyze_clipping(document, details)
+        request = {
             **details,
-            "structural_revision": int(
-                native_state.get("structural_revision", 0) or 0
-            ),
+            "detached_clipping": detached_clipping,
+            "structural_revision": revision,
             "base_snapshot": base,
-            "cacheable": bool(
-                background_job is None or bool(getattr(background_job, "terminal", False))
-            ),
+            "cacheable": cacheable,
         }
+        if not cache_hit:
+            request["detached_parts"] = [
+                capture_analyze_snapshot_batch(
+                    document,
+                    details,
+                    list(details["object_names"]),
+                )
+            ]
+        return request
 
     def _validate_native_analyze_context_request(
         self,
@@ -909,13 +936,22 @@ class VibeCADService:
         return self._native_analyze_contexts
 
     def begin_native_drawing_context_request(self) -> dict[str, Any] | None:
-        """Capture detached identity for bounded Drawing source preparation."""
+        """Capture one detached, visibility-scoped Drawing context request."""
 
         document = self._active_document()
         if document is None:
             return None
         from VibeCADModelingSurface import provider_engine_for_ribbon
-        from VibeCADNativeSnapshot import capture_active_snapshot_base
+        from VibeCADNativeDrawingSnapshot import build_drawing_snapshot
+        from VibeCADNativeDrawingSourceCatalog import (
+            cached_drawing_source_catalog_state,
+            capture_drawing_source_catalog_inventory,
+        )
+        from VibeCADNativeGeometrySources import drawing_analysis_artifact_names
+        from VibeCADNativeSnapshot import (
+            capture_active_snapshot_base,
+            complete_active_snapshot,
+        )
         from VibeCADRibbonSurface import read_active_ribbon_surface
 
         surface = read_active_ribbon_surface()
@@ -925,24 +961,39 @@ class VibeCADService:
         ) != "native":
             return None
         native_state = self.native_document_state()
-        names = []
-        seen = set()
-        for obj in tuple(getattr(document, "Objects", ()) or ()):
-            name = str(getattr(obj, "Name", "") or "")
-            if name and name not in seen:
-                seen.add(name)
-                names.append(name)
+        revision = int(native_state.get("structural_revision", 0) or 0)
+        sources = cached_drawing_source_catalog_state(
+            str(document.Uid),
+            revision,
+        )
+        if sources is None:
+            inventory = capture_drawing_source_catalog_inventory(document)
+            sources = [dict(source) for source in inventory["sources"]]
+            object_names = list(inventory["object_names"])
+            analysis_artifacts = frozenset(inventory["analysis_artifact_names"])
+        else:
+            object_names = [str(source["object_name"]) for source in sources]
+            analysis_artifacts = drawing_analysis_artifact_names(document)
+        base = capture_active_snapshot_base(
+            document,
+            "drawing",
+            native_state,
+            analysis_artifact_names=analysis_artifacts,
+        )
+        selection = base.get("_selection")
+        domain = build_drawing_snapshot(
+            document,
+            selection=selection if isinstance(selection, Mapping) else None,
+            structural_revision=revision,
+            detached_sources=sources,
+        )
         return {
             "document_uid": str(document.Uid),
-            "structural_revision": int(
-                native_state.get("structural_revision", 0) or 0
-            ),
-            "object_names": names,
-            "base_snapshot": capture_active_snapshot_base(
-                document,
-                "drawing",
-                native_state,
-            ),
+            "structural_revision": revision,
+            "object_names": object_names,
+            "detached_sources": sources,
+            "base_snapshot": base,
+            "completed_snapshot": complete_active_snapshot(base, domain),
         }
 
     def _validate_native_drawing_context_request(

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -35,6 +35,7 @@ from VibeCADIntentMemory import (
 from VibeCADModelingSurface import resolve_modeling_surface
 from VibeCADNativeBackground import NativeBackgroundManager
 from VibeCADNativeAnalyzeContext import AnalyzeContextCoordinator
+from VibeCADNativeDrawingContext import DrawingSourceCatalogCoordinator
 from VibeCADNativeState import NativeDocumentStateStore
 from VibeCADNativeUndo import NativeAssistantUndoLedger
 from VibeCADNativeStatePersistence import (
@@ -226,6 +227,7 @@ class VibeCADService:
         self._native_assistant_undo = NativeAssistantUndoLedger()
         self._native_background_jobs = NativeBackgroundManager()
         self._native_analyze_contexts = AnalyzeContextCoordinator()
+        self._native_drawing_source_contexts = DrawingSourceCatalogCoordinator()
         self._native_state_restores: set[tuple[str, str]] = set()
         self._native_state_restore_errors: dict[str, str] = {}
         self._new_document_authoring_pending: set[str] = set()
@@ -700,7 +702,7 @@ class VibeCADService:
             self._native_document_states.note_structural_change(uid) if uid else None
         )
         if uid:
-            self._native_analyze_contexts.invalidate_document(uid)
+            self._invalidate_native_read_contexts(uid)
         self._sync_native_authority_metadata_if_active(uid)
         return revision
 
@@ -710,7 +712,7 @@ class VibeCADService:
             self._native_document_states.note_structural_change(uid) if uid else None
         )
         if uid:
-            self._native_analyze_contexts.invalidate_document(uid)
+            self._invalidate_native_read_contexts(uid)
         self._sync_native_authority_metadata_if_active(uid)
         return revision
 
@@ -741,9 +743,23 @@ class VibeCADService:
             property_name,
         )
         if revision != previous_revision:
-            self._native_analyze_contexts.invalidate_document(uid)
+            self._invalidate_native_read_contexts(uid)
             self._sync_native_authority_metadata_if_active(uid)
         return revision
+
+    def _invalidate_native_read_contexts(self, document_uid: str) -> None:
+        """Invalidate revision-scoped detached read state for one document."""
+
+        uid = str(document_uid or "").strip()
+        if not uid:
+            return
+        self._native_analyze_contexts.invalidate_document(uid)
+        self._native_drawing_source_contexts.invalidate_document(uid)
+        from VibeCADNativeDrawingSourceCatalog import (
+            invalidate_drawing_source_catalog_cache,
+        )
+
+        invalidate_drawing_source_catalog_cache(uid)
 
     def native_document_state(self) -> dict[str, Any]:
         uid = str(self._active_document_uid() or "")
@@ -890,10 +906,138 @@ class VibeCADService:
 
         return self._native_analyze_contexts
 
+    def begin_native_drawing_context_request(self) -> dict[str, Any] | None:
+        """Capture detached identity for bounded Drawing source preparation."""
+
+        document = self._active_document()
+        if document is None:
+            return None
+        from VibeCADModelingSurface import provider_engine_for_ribbon
+        from VibeCADNativeSnapshot import capture_active_snapshot_base
+        from VibeCADRibbonSurface import read_active_ribbon_surface
+
+        surface = read_active_ribbon_surface()
+        if surface.surface_id != "drawing" or provider_engine_for_ribbon(
+            self.modeling_engine(),
+            surface.surface_id,
+        ) != "native":
+            return None
+        native_state = self.native_document_state()
+        names = []
+        seen = set()
+        for obj in tuple(getattr(document, "Objects", ()) or ()):
+            name = str(getattr(obj, "Name", "") or "")
+            if name and name not in seen:
+                seen.add(name)
+                names.append(name)
+        return {
+            "document_uid": str(document.Uid),
+            "structural_revision": int(
+                native_state.get("structural_revision", 0) or 0
+            ),
+            "object_names": names,
+            "base_snapshot": capture_active_snapshot_base(
+                document,
+                "drawing",
+                native_state,
+            ),
+        }
+
+    def _validate_native_drawing_context_request(
+        self,
+        request: Mapping[str, Any],
+    ) -> Any:
+        from VibeCADModelingSurface import provider_engine_for_ribbon
+        from VibeCADNativeDrawingContext import DrawingContextStale
+        from VibeCADRibbonSurface import read_active_ribbon_surface
+
+        document = self._active_document()
+        uid = str(request.get("document_uid") or "")
+        revision = int(request.get("structural_revision", -1) or 0)
+        current_uid = str(getattr(document, "Uid", "") or "")
+        current_revision = int(
+            self.native_document_state().get("structural_revision", 0) or 0
+        )
+        surface = read_active_ribbon_surface()
+        if (
+            document is None
+            or current_uid != uid
+            or current_revision != revision
+            or surface.surface_id != "drawing"
+            or provider_engine_for_ribbon(
+                self.modeling_engine(),
+                surface.surface_id,
+            )
+            != "native"
+        ):
+            raise DrawingContextStale(
+                "The active Drawing document changed during source capture."
+            )
+        return document
+
+    def capture_native_drawing_context_batch(
+        self,
+        request: Mapping[str, Any],
+        object_names: Sequence[str],
+    ) -> dict[str, Any]:
+        """Capture one small, live Drawing source batch on the document thread."""
+
+        from VibeCADNativeDrawingViewState import drawing_source_catalog_identity_state
+        from VibeCADNativeGeometrySources import is_potential_design_geometry_source
+
+        document = self._validate_native_drawing_context_request(request)
+        sources = []
+        for value in object_names:
+            name = str(value or "")
+            if not name:
+                raise ValueError("Drawing context batch contains an invalid object name.")
+            obj = document.getObject(name)
+            if obj is None or not is_potential_design_geometry_source(document, obj):
+                continue
+            try:
+                sources.append(drawing_source_catalog_identity_state(obj))
+            except (AttributeError, ReferenceError, RuntimeError, TypeError, ValueError):
+                continue
+        return {"sources": sources}
+
+    def finish_native_drawing_context_request(
+        self,
+        request: Mapping[str, Any],
+    ) -> dict[str, Any]:
+        """Build the bounded Drawing snapshot after its source cache is ready."""
+
+        from VibeCADNativeDrawingSnapshot import build_drawing_snapshot
+        from VibeCADNativeSnapshot import complete_active_snapshot
+
+        document = self._validate_native_drawing_context_request(request)
+        base = request.get("base_snapshot")
+        if not isinstance(base, Mapping):
+            raise ValueError("Drawing context request has no base snapshot.")
+        selection = base.get("_selection")
+        domain = build_drawing_snapshot(
+            document,
+            selection=selection if isinstance(selection, Mapping) else None,
+            structural_revision=int(request["structural_revision"]),
+        )
+        return complete_active_snapshot(base, domain)
+
+    def native_drawing_context_coordinator(
+        self,
+    ) -> DrawingSourceCatalogCoordinator:
+        """Return the read-only Drawing source lane; never a provider tool."""
+
+        return self._native_drawing_source_contexts
+
     def close_native_document_state(self, document_uid: str) -> None:
         uid = str(document_uid or "").strip()
         self._native_background_jobs.cancel_document(uid)
         self._native_analyze_contexts.close_document(uid)
+        self._native_drawing_source_contexts.close_document(uid)
+        from VibeCADNativeDrawingSourceCatalog import (
+            invalidate_drawing_source_catalog_cache,
+        )
+
+        invalidate_drawing_source_catalog_cache(uid)
         if uid:
             self._native_assistant_undo.close_document(uid)
         self._native_document_states.close_document(uid)

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -1858,6 +1858,7 @@ class VibeCADService:
         frame: str = "auto",
         object_names: list[str] | None = None,
         sketch_annotations: str = "clean",
+        page_name: str | None = None,
     ) -> dict[str, Any]:
         arguments: dict[str, Any] = {
             "camera": {"mode": "auto"} if camera is None else camera,
@@ -1866,6 +1867,8 @@ class VibeCADService:
         }
         if object_names is not None:
             arguments["object_names"] = object_names
+        if page_name is not None:
+            arguments["page_name"] = page_name
         return self._registry.call("core.capture_view_screenshot", **arguments)
 
     def set_view(

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -35,6 +35,7 @@ from VibeCADPromptStarters import (
 from VibeCADSession import (
     _format_document_delta,
     prewarm_analyze_context,
+    prewarm_drawing_context,
     rebuild_intent_memory,
     run_native_surface_continuation,
     run_prompt,
@@ -1862,6 +1863,9 @@ _ANALYZE_CONTEXT_STATUS_EVENTS = frozenset(
         "analyze_context_cache_hit",
         "analyze_context_progress",
         "analyze_context_ready",
+        "drawing_context_cache_hit",
+        "drawing_context_progress",
+        "drawing_context_ready",
     }
 )
 
@@ -1877,7 +1881,11 @@ def _show_analyze_context_application_status(
         return
     try:
         status_bar = Gui.getMainWindow().statusBar()
-        timeout = 5000 if event_name != "analyze_context_progress" else 0
+        timeout = (
+            0
+            if event_name in {"analyze_context_progress", "drawing_context_progress"}
+            else 5000
+        )
         status_bar.showMessage(str(text or "").strip(), timeout)
     except Exception:
         # The assistant status line remains the fallback for headless tests and
@@ -1924,6 +1932,12 @@ def _format_progress_event(event: dict[str, Any]) -> str:
     if name in {"analyze_context_cache_hit", "analyze_context_ready"}:
         revision = int(event.get("structural_revision", 0) or 0)
         return f"Analyze context is ready for document revision {revision}."
+    if name == "drawing_context_progress":
+        message = str(event.get("message") or "").strip()
+        return message or "Reading Drawing sources..."
+    if name in {"drawing_context_cache_hit", "drawing_context_ready"}:
+        revision = int(event.get("structural_revision", 0) or 0)
+        return f"Drawing context is ready for document revision {revision}."
     if name == "provider_subprocess_started":
         return f"{event.get('provider', 'Provider')} process started" + (
             f" | pid {event.get('pid')}" if event.get("pid") else ""
@@ -2138,6 +2152,9 @@ _PROGRESS_STATUS_ONLY_EVENTS: set[str] = {
     "analyze_context_cache_hit",
     "analyze_context_progress",
     "analyze_context_ready",
+    "drawing_context_cache_hit",
+    "drawing_context_progress",
+    "drawing_context_ready",
     "context_build_completed",
     "context_build_started",
     "document_recompute_waiting",
@@ -4887,7 +4904,7 @@ def show_assistant_for_active_workbench() -> None:
 
 
 def _schedule_analyze_context_prewarm() -> None:
-    """Warm Analyze provider state without occupying Qt or Native CAD jobs."""
+    """Warm responsive Native provider state without occupying Qt."""
 
     global _analyze_context_prewarm_thread
     with _analyze_context_prewarm_lock:
@@ -4919,18 +4936,35 @@ def _schedule_analyze_context_prewarm() -> None:
                     _dispatch_to_document_thread,
                     progress_callback=progress,
                 )
+                prewarm_drawing_context(
+                    get_service(),
+                    _dispatch_to_document_thread,
+                    progress_callback=progress,
+                )
             except Exception as exc:
                 from VibeCADNativeAnalyzeContext import (
                     AnalyzeContextCancelled,
                     AnalyzeContextStale,
                 )
+                from VibeCADNativeDrawingContext import (
+                    DrawingContextCancelled,
+                    DrawingContextStale,
+                )
 
-                if not isinstance(exc, (AnalyzeContextCancelled, AnalyzeContextStale)):
-                    _warn(f"VibeCAD Analyze context prewarm failed: {exc}")
+                if not isinstance(
+                    exc,
+                    (
+                        AnalyzeContextCancelled,
+                        AnalyzeContextStale,
+                        DrawingContextCancelled,
+                        DrawingContextStale,
+                    ),
+                ):
+                    _warn(f"VibeCAD Native context prewarm failed: {exc}")
 
         _analyze_context_prewarm_thread = threading.Thread(
             target=run,
-            name="VibeCAD-Analyze-context-prewarm",
+            name="VibeCAD-Native-context-prewarm",
             daemon=True,
         )
         _analyze_context_prewarm_thread.start()

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -4505,6 +4505,25 @@ def _schedule_native_surface_continuation(event: dict[str, Any]) -> None:
 
 
 class _VibeCADGuiDocumentObserver:
+    def slotChangedObject(self, view_provider, property_name) -> None:
+        if str(property_name or "") != "Visibility":
+            return
+        is_restoring = getattr(App, "isRestoring", None)
+        if callable(is_restoring) and bool(is_restoring()):
+            return
+        try:
+            obj = getattr(view_provider, "Object", None)
+            document = getattr(obj, "Document", None)
+            if document is not None and bool(getattr(document, "Restoring", False)):
+                return
+            if str(getattr(document, "Uid", "") or "").strip():
+                get_service().note_native_object_property_change(
+                    obj,
+                    "Visibility",
+                )
+        except Exception as exc:
+            _warn(f"VibeCAD visibility observer failed: {exc}")
+
     def slotResetEdit(self, view_provider) -> None:
         try:
             event = _sketch_close_continuation_controller.consume_reset_edit(

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeAssignments.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeAssignments.py
@@ -354,14 +354,17 @@ def _reference_issue(
     if source is None:
         return f"{assignment} references missing object {source_name or '<empty>'}."
     shape = getattr(source, "Shape", None)
+    subelement_counts: dict[str, int | None] = {}
     for subelement in tuple(reference.get("subelements") or ()):
         match = _SUBELEMENT.fullmatch(str(subelement))
         if match is None:
             return f"{assignment} has invalid subelement {subelement}."
-        values = (
-            getattr(shape, match.group(1) + "s", None) if shape is not None else None
-        )
-        if values is None or int(match.group(2)) > len(values):
+        kind = str(match.group(1))
+        if kind not in subelement_counts:
+            values = getattr(shape, kind + "s", None) if shape is not None else None
+            subelement_counts[kind] = len(values) if values is not None else None
+        count = subelement_counts[kind]
+        if count is None or int(match.group(2)) > count:
             return f"{assignment} references missing {source_name}.{subelement}."
     return None
 

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeContext.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeContext.py
@@ -310,25 +310,40 @@ def capture_responsive_analyze_snapshot(
                 "Analyze context preparation was cancelled."
             )
 
-    parts: list[Mapping[str, Any]] = []
-    batch_count = max(1, (len(object_names) + batch_size - 1) // batch_size)
-    for index, offset in enumerate(range(0, len(object_names), batch_size)):
+    detached_parts = request.get("detached_parts")
+    if detached_parts is not None:
+        if not isinstance(detached_parts, list) or any(
+            not isinstance(part, Mapping) for part in detached_parts
+        ):
+            raise AnalyzeContextError("Detached Analyze context is malformed.")
         check_cancelled()
-        names = object_names[offset : offset + batch_size]
-        part = dispatch_to_document_thread(
-            lambda names=names: capture_batch(request, names)
-        )
-        if not isinstance(part, Mapping):
-            raise AnalyzeContextError(
-                "Analyze context batch capture returned no object."
-            )
-        parts.append(dict(part))
+        parts = [deepcopy(dict(part)) for part in detached_parts]
         if progress_callback is not None:
             progress_callback(
-                5 + int(80 * (index + 1) / batch_count),
-                f"Analyzing objects {min(offset + len(names), len(object_names))}"
-                f" of {len(object_names)}",
+                85,
+                f"Analyzing objects {len(object_names)} of {len(object_names)}",
             )
+    else:
+        parts = []
+        batch_count = max(1, (len(object_names) + batch_size - 1) // batch_size)
+        for index, offset in enumerate(range(0, len(object_names), batch_size)):
+            check_cancelled()
+            names = object_names[offset : offset + batch_size]
+            part = dispatch_to_document_thread(
+                lambda names=names: capture_batch(request, names)
+            )
+            if not isinstance(part, Mapping):
+                raise AnalyzeContextError(
+                    "Analyze context batch capture returned no object."
+                )
+            parts.append(dict(part))
+            if progress_callback is not None:
+                progress_callback(
+                    5 + int(80 * (index + 1) / batch_count),
+                    f"Analyzing objects "
+                    f"{min(offset + len(names), len(object_names))}"
+                    f" of {len(object_names)}",
+                )
 
     if postprocess_parts is not None:
         check_cancelled()
@@ -347,7 +362,12 @@ def capture_responsive_analyze_snapshot(
         parts = [dict(part) for part in processed]
 
     check_cancelled()
-    clipping = dispatch_to_document_thread(lambda: capture_clipping(request))
+    detached_clipping = request.get("detached_clipping")
+    clipping = (
+        deepcopy(dict(detached_clipping))
+        if isinstance(detached_clipping, Mapping)
+        else dispatch_to_document_thread(lambda: capture_clipping(request))
+    )
     if not isinstance(clipping, Mapping):
         raise AnalyzeContextError(
             "Analyze clipping capture returned no object."

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshOutputState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshOutputState.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
 from VibeCADNativeAnalyzeMeshState import (
+    fem_mesh_object_context_state,
     fem_mesh_object_state,
     fem_mesh_object_still_exact,
 )
@@ -111,9 +112,9 @@ def prepare_fem_mesh_object_target(
         document,
         NativeObjectRef(document_uid, str(value["object_name"])),
     )
-    state = fem_mesh_object_state(mesh)
+    state = fem_mesh_object_context_state(mesh)
     expected_sha = str(value["expected_state_sha256"] or "")
-    if state["state_sha256"] != expected_sha:
+    if not fem_mesh_object_still_exact(mesh, expected_sha):
         raise NativeAnalyzeError(
             "The exact FEM mesh changed after the provider read it.",
             error_code="NATIVE_ANALYZE_STATE_STALE",

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshState.py
@@ -270,7 +270,11 @@ def _topology(fem_mesh: Any) -> dict[str, int]:
     }
 
 
-def fem_mesh_definition_state(obj: Any) -> dict[str, Any]:
+def _fem_mesh_definition_state(
+    obj: Any,
+    *,
+    include_content_hash: bool,
+) -> dict[str, Any]:
     document = getattr(obj, "Document", None)
     if not is_live(document, obj):
         raise NativeAnalyzeError("The FEM mesh definition is no longer live.")
@@ -278,7 +282,7 @@ def fem_mesh_definition_state(obj: Any) -> dict[str, Any]:
     source, exact_source = _source(obj)
     fem_mesh = obj.FemMesh
     topology = _topology(fem_mesh)
-    content_sha = _mesh_content_sha256(fem_mesh)
+    content_sha = _mesh_content_sha256(fem_mesh) if include_content_hash else None
     settings = _settings(obj, kind)
     result = {
         **concise_object(obj),
@@ -306,15 +310,52 @@ def fem_mesh_definition_state(obj: Any) -> dict[str, Any]:
     return result
 
 
-def fem_mesh_definition_still_exact(obj: Any, expected_sha256: str) -> bool:
+def fem_mesh_definition_state(obj: Any) -> dict[str, Any]:
+    """Return the legacy exact FEM mesh-definition state.
+
+    This deliberately retains full serialized mesh hashing for callers that
+    explicitly require byte-exact generated mesh identity.
+    """
+
+    return _fem_mesh_definition_state(obj, include_content_hash=True)
+
+
+def fem_mesh_definition_context_state(obj: Any) -> dict[str, Any]:
+    """Return bounded provider context without serializing generated mesh data."""
+
+    return _fem_mesh_definition_state(obj, include_content_hash=False)
+
+
+def is_fem_mesh_definition(obj: Any) -> bool:
+    """Return whether *obj* is a supported FEM mesher definition."""
+
     try:
+        fem_mesher_kind(obj)
+        return True
+    except NativeAnalyzeError:
+        return False
+
+
+def fem_mesh_definition_still_exact(obj: Any, expected_sha256: str) -> bool:
+    """Accept current context fingerprints and legacy exact fingerprints."""
+
+    try:
+        if (
+            fem_mesh_definition_context_state(obj)["state_sha256"]
+            == expected_sha256
+        ):
+            return True
         return fem_mesh_definition_state(obj)["state_sha256"] == expected_sha256
     except NativeAnalyzeError:
         return False
 
 
-def fem_mesh_object_state(obj: Any) -> dict[str, Any]:
-    """Return exact state for any FEM mesh object accepted by the ribbon.
+def _fem_mesh_object_state(
+    obj: Any,
+    *,
+    include_content_hash: bool,
+) -> dict[str, Any]:
+    """Return bounded or exact state for any supported FEM mesh object.
 
     Mesher definitions retain their richer existing state shape.  Baked and
     filtered ``Fem::FemMeshObject`` instances use a compact mesh-only shape so
@@ -336,16 +377,22 @@ def fem_mesh_object_state(obj: Any) -> dict[str, Any]:
 
     proxy_type = str(getattr(getattr(obj, "Proxy", None), "Type", "") or "")
     if proxy_type in {"Fem::FemMeshGmsh", "Fem::FemMeshNetgen"}:
-        return fem_mesh_definition_state(obj)
+        return _fem_mesh_definition_state(
+            obj,
+            include_content_hash=include_content_hash,
+        )
     try:
         if obj.isDerivedFrom("Fem::FemMeshShapeNetgenObject"):
-            return fem_mesh_definition_state(obj)
+            return _fem_mesh_definition_state(
+                obj,
+                include_content_hash=include_content_hash,
+            )
     except Exception:
         pass
 
     fem_mesh = obj.FemMesh
     topology = _topology(fem_mesh)
-    content_sha = _mesh_content_sha256(fem_mesh)
+    content_sha = _mesh_content_sha256(fem_mesh) if include_content_hash else None
     role = str(getattr(obj, "VibeCADTimelineRole", "") or "")
     owner = getattr(obj, "VibeCADTimelineOwner", None)
     replaced = tuple(getattr(obj, "VibeCADTimelineReplacedInputs", ()) or ())
@@ -391,8 +438,22 @@ def fem_mesh_object_state(obj: Any) -> dict[str, Any]:
     return result
 
 
+def fem_mesh_object_state(obj: Any) -> dict[str, Any]:
+    """Return legacy exact state for any FEM mesh object accepted by the ribbon."""
+
+    return _fem_mesh_object_state(obj, include_content_hash=True)
+
+
+def fem_mesh_object_context_state(obj: Any) -> dict[str, Any]:
+    """Return bounded provider context without serializing FEM mesh content."""
+
+    return _fem_mesh_object_state(obj, include_content_hash=False)
+
+
 def fem_mesh_object_still_exact(obj: Any, expected_sha256: str) -> bool:
     try:
+        if fem_mesh_object_context_state(obj)["state_sha256"] == expected_sha256:
+            return True
         return fem_mesh_object_state(obj)["state_sha256"] == expected_sha256
     except NativeAnalyzeError:
         return False

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSnapshot.py
@@ -21,7 +21,11 @@ from VibeCADNativeAnalyzeSupportState import support_condition_state
 from VibeCADNativeAnalyzeConnectionState import connection_state
 from VibeCADNativeAnalyzeLoadState import load_state
 from VibeCADNativeAnalyzeThermalState import thermal_condition_state
-from VibeCADNativeAnalyzeMeshState import fem_mesh_definition_state, fem_mesh_object_state
+from VibeCADNativeAnalyzeMeshState import (
+    fem_mesh_definition_context_state,
+    fem_mesh_object_context_state,
+    is_fem_mesh_definition,
+)
 from VibeCADNativeAnalyzeMeshOutputState import mesh_filter_state
 from VibeCADNativeAnalyzeMeshRefinementState import mesh_refinement_state
 from VibeCADNativeAnalyzeSolverState import solver_state
@@ -35,7 +39,7 @@ from VibeCADNativeAnalyzeClipping import (
     clipping_state,
 )
 from VibeCADNativeAnalyzeGeometrySources import active_analyze_geometry_sources
-from VibeCADNativeMeshState import mesh_object_state
+from VibeCADNativeMeshState import mesh_object_state, mesh_object_state_cache
 from VibeCADNativeSnapshot import objects_of_type
 
 
@@ -527,7 +531,7 @@ def _mesh_definitions(
     count = 0
     for obj in list(getattr(document, "Objects", ()) or ()):
         try:
-            state = fem_mesh_definition_state(obj)
+            state = fem_mesh_definition_context_state(obj)
         except Exception:
             continue
         count += 1
@@ -555,15 +559,11 @@ def _fem_mesh_outputs(document: Any) -> tuple[int, list[dict[str, Any]]]:
     result = []
     count = 0
     for obj in list(getattr(document, "Objects", ()) or ()):
-        try:
-            state = fem_mesh_object_state(obj)
-        except Exception:
+        if is_fem_mesh_definition(obj):
             continue
         try:
-            fem_mesh_definition_state(obj)
+            state = fem_mesh_object_context_state(obj)
         except Exception:
-            pass
-        else:
             continue
         count += 1
         if len(result) < MAX_FEM_MESH_OUTPUTS:
@@ -703,6 +703,7 @@ def begin_analyze_snapshot_capture(
     background_job: Any | None = None,
     defer_brep_validation: bool = False,
     validate_brep: bool = True,
+    analysis_artifact_names: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     """Capture only detached identity needed to schedule bounded reads."""
 
@@ -717,7 +718,25 @@ def begin_analyze_snapshot_capture(
     document_uid = str(getattr(document, "Uid", "") or "").strip()
     if not document_uid:
         raise RuntimeError("Analyze context requires an exact document UID.")
-    objects = tuple(getattr(document, "Objects", ()) or ())
+    from VibeCADNativeGeometrySources import (
+        drawing_analysis_artifact_names,
+        is_analyze_context_object,
+    )
+
+    analysis_artifacts = (
+        drawing_analysis_artifact_names(document)
+        if analysis_artifact_names is None
+        else analysis_artifact_names
+    )
+    objects = tuple(
+        obj
+        for obj in tuple(getattr(document, "Objects", ()) or ())
+        if is_analyze_context_object(
+            document,
+            obj,
+            analysis_artifact_names=analysis_artifacts,
+        )
+    )
     object_names = [str(getattr(obj, "Name", "") or "") for obj in objects]
     if any(not name for name in object_names) or len(object_names) != len(
         set(object_names)
@@ -771,7 +790,10 @@ def _analysis_capture_record(
                 "graph_sha256",
             )
         }
-        state = study_state(analysis)
+        state = study_state(
+            analysis,
+            mesh_state_reader=fem_mesh_definition_context_state,
+        )
         member_names = [
             str(member.Name)
             for member in tuple(getattr(analysis, "Group", ()) or ())
@@ -780,7 +802,10 @@ def _analysis_capture_record(
         summary = None
         state = {
             "intent": study_intent_state(analysis),
-            "inventory": study_inventory(analysis),
+            "inventory": study_inventory(
+                analysis,
+                mesh_state_reader=fem_mesh_definition_context_state,
+            ),
         }
         member_names = []
     return {
@@ -792,6 +817,17 @@ def _analysis_capture_record(
 
 
 def capture_analyze_snapshot_batch(
+    document: Any,
+    request: Mapping[str, Any],
+    object_names: Sequence[str],
+) -> dict[str, Any]:
+    """Read one bounded batch while reusing immutable source topology state."""
+
+    with mesh_object_state_cache():
+        return _capture_analyze_snapshot_batch(document, request, object_names)
+
+
+def _capture_analyze_snapshot_batch(
     document: Any,
     request: Mapping[str, Any],
     object_names: Sequence[str],

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudyState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudyState.py
@@ -39,7 +39,11 @@ def _read_member(
     return None
 
 
-def study_inventory(analysis: Any) -> dict[str, Any]:
+def study_inventory(
+    analysis: Any,
+    *,
+    mesh_state_reader: Callable[[Any], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     from VibeCADNativeAnalyzeAssignments import validate_assignments
     from VibeCADNativeAnalyzeConnectionState import connection_state
     from VibeCADNativeAnalyzeConstraintState import electromagnetic_constraint_state
@@ -53,6 +57,7 @@ def study_inventory(analysis: Any) -> dict[str, Any]:
     from VibeCADNativeAnalyzeThermalState import thermal_condition_state
     from VibeCADNativeAnalyzeEquationState import equation_state
 
+    mesh_reader = mesh_state_reader or fem_mesh_definition_state
     readers = (
         ("material", material_state),
         ("element", element_definition_state),
@@ -62,7 +67,7 @@ def study_inventory(analysis: Any) -> dict[str, Any]:
         ("connection", connection_state),
         ("load", load_state),
         ("thermal", thermal_condition_state),
-        ("mesh", fem_mesh_definition_state),
+        ("mesh", mesh_reader),
         ("solver", solver_state),
     )
     states: dict[str, list[dict[str, Any]]] = {
@@ -177,9 +182,13 @@ def study_inventory(analysis: Any) -> dict[str, Any]:
     }
 
 
-def study_state(analysis: Any) -> dict[str, Any]:
+def study_state(
+    analysis: Any,
+    *,
+    mesh_state_reader: Callable[[Any], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
     intent = study_intent_state(analysis)
-    inventory = study_inventory(analysis)
+    inventory = study_inventory(analysis, mesh_state_reader=mesh_state_reader)
     solver_kinds = set(inventory["solver_kinds"])
     if solver_kinds:
         from femsolver.runtime import solver_runtime_statuses

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeTargets.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeTargets.py
@@ -46,6 +46,7 @@ from VibeCADNativeAnalyzeThermalState import (
     thermal_condition_still_exact,
 )
 from VibeCADNativeAnalyzeMeshState import (
+    fem_mesh_definition_context_state,
     fem_mesh_definition_state,
     fem_mesh_definition_still_exact,
     fem_mesher_kind,
@@ -585,9 +586,9 @@ def prepare_fem_mesh_definition_target(
             f"The exact target is {kind}; this operation requires {expected_kind}.",
             error_code="NATIVE_ANALYZE_TARGET_TYPE_INVALID",
         )
-    state = fem_mesh_definition_state(mesh)
+    state = fem_mesh_definition_context_state(mesh)
     expected_sha = str(value["expected_state_sha256"])
-    if state["state_sha256"] != expected_sha:
+    if not fem_mesh_definition_still_exact(mesh, expected_sha):
         raise NativeAnalyzeError(
             "The exact FEM mesh definition changed after the provider read its state.",
             error_code="NATIVE_ANALYZE_STATE_STALE",

--- a/src/Mod/VibeCAD/VibeCADNativeCommonRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeCommonRuntime.py
@@ -189,6 +189,7 @@ class NativeCommonRuntime:
                 "capture_all": frozenset(),
                 "capture_selection": frozenset(),
                 "capture_objects": frozenset({"targets"}),
+                "capture_drawing_page": frozenset({"page"}),
                 "capture_active_sketch": frozenset(),
             },
         )
@@ -226,6 +227,7 @@ class NativeCommonRuntime:
             "capture_all": "all",
             "capture_selection": "selection",
             "capture_objects": "objects",
+            "capture_drawing_page": "all",
             "capture_active_sketch": "active_sketch",
         }
         targets = tuple(
@@ -235,11 +237,16 @@ class NativeCommonRuntime:
             raise NativeCommonRuntimeError(
                 "Object-framed capture requires 1 to 16 exact targets."
             )
+        capture_arguments: dict[str, Any] = {
+            "frame": frames[operation],
+            "targets": targets,
+        }
+        if operation == "capture_drawing_page":
+            capture_arguments["page_name"] = str(values["page"]["object_name"])
         return capture_screenshot(
             self._service,
             self._document,
-            frame=frames[operation],
-            targets=targets,
+            **capture_arguments,
         )
 
     def inspect(self, arguments: Mapping[str, Any]) -> dict[str, Any]:

--- a/src/Mod/VibeCAD/VibeCADNativeCommonRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeCommonRuntime.py
@@ -314,10 +314,16 @@ class NativeCommonRuntime:
             {"list": frozenset({"offset"})},
         )
         self._guard(allow_owned_playback=True)
+        structural_revision = int(
+            self._state.snapshot(self._document_uid).get("structural_revision", 0)
+            or 0
+        )
         return drawing_source_catalog_page(
             self._document,
             offset=int(values["offset"]),
             page_size=MAX_DRAWING_SOURCE_PAGE_SIZE,
+            structural_revision=structural_revision,
+            require_cached=self._context.document_thread_dispatch is not None,
         )
 
     def read_projected_geometry(

--- a/src/Mod/VibeCAD/VibeCADNativeCommonSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeCommonSchema.py
@@ -261,6 +261,17 @@ def common_capability_definitions() -> tuple[NativeCapabilityDefinition, ...]:
                 exact_target_type="DocumentObject[]",
             ),
             _variant(
+                "capture_drawing_page",
+                "Capture one exact Drawing page by its internal object name.",
+                ("VibeCAD_NativeCaptureView",),
+                parameters=_parameters(
+                    {"page": _object_ref()},
+                    ("page",),
+                ),
+                exact_target_type="TechDraw::DrawPage",
+                surface_ids=frozenset({"drawing"}),
+            ),
+            _variant(
                 "capture_active_sketch",
                 "Capture a bounded image framed around the active Sketch.",
                 ("VibeCAD_NativeCaptureView",),

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingActiveView.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingActiveView.py
@@ -13,6 +13,11 @@ import tempfile
 from typing import Any, Mapping
 
 from VibeCADNativeDrawingErrors import NativeDrawingError
+from VibeCADNativeGeometrySources import (
+    drawing_analysis_artifact_names,
+    drawing_source_exclusion_reason,
+    filter_drawing_selection,
+)
 from VibeCADNativeDrawingState import drawing_page_state, is_drawing_page
 from VibeCADNativeMutation import NativeMutationDraft
 from VibeCADNativeTargets import object_identity, read_current_selection, resolve_object
@@ -234,8 +239,10 @@ def _placement(obj: Any) -> list[float] | None:
 def _geometry_record(obj: Any) -> tuple[dict[str, Any], bool]:
     shape_hash = None
     shape = getattr(obj, "Shape", None)
-    if shape is not None and not bool(shape.isNull()):
-        shape_hash = int(shape.hashCode())
+    is_null = getattr(shape, "isNull", None)
+    hash_code = getattr(shape, "hashCode", None)
+    if callable(is_null) and callable(hash_code) and not bool(is_null()):
+        shape_hash = int(hash_code())
     mesh = getattr(obj, "Mesh", None)
     mesh_record = None
     if mesh is not None:
@@ -303,7 +310,14 @@ def drawing_active_viewport_state(
         )
     records = []
     visible_geometry_count = 0
+    analysis_artifacts = drawing_analysis_artifact_names(document)
     for obj in tuple(document.Objects):
+        if drawing_source_exclusion_reason(
+            document,
+            obj,
+            analysis_artifact_names=analysis_artifacts,
+        ) is not None:
+            continue
         try:
             record, visible_geometry = _geometry_record(obj)
         except Exception as exc:
@@ -326,7 +340,11 @@ def drawing_active_viewport_state(
         "up_direction": up,
         "viewport_size_px": [width, height],
         "resolution_pixels_per_mm": resolution,
-        "selection": _current_selection(document),
+        "selection": filter_drawing_selection(
+            document,
+            _current_selection(document),
+            analysis_artifact_names=analysis_artifacts,
+        ),
         "objects": records,
     }
     encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"))

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingComplexSection.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingComplexSection.py
@@ -21,6 +21,7 @@ from VibeCADNativeDrawingViewState import (
     drawing_view_state,
     is_complex_section_drawing_view,
 )
+from VibeCADNativeGeometrySources import drawing_source_exclusion_reason
 from VibeCADNativeMutation import NativeMutationDraft
 from VibeCADNativeTargets import (
     object_identity,
@@ -109,6 +110,15 @@ def _require_usable(document: Any, obj: Any) -> None:
 
 
 def _profile_state(profile: Any, strategy: str) -> dict[str, Any]:
+    document = getattr(profile, "Document", None)
+    if (
+        document is None
+        or drawing_source_exclusion_reason(document, profile) is not None
+    ):
+        raise NativeDrawingError(
+            "A complex-section profile must be visible and outside Analyze/FEM.",
+            error_code="NATIVE_DRAWING_COMPLEX_SECTION_PROFILE_INVALID",
+        )
     try:
         state = drawing_source_state(profile)
     except (AttributeError, RuntimeError, TypeError, ValueError) as exc:

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingContext.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingContext.py
@@ -1,0 +1,302 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Responsive, revision-safe preparation of Native Drawing source context."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass, field
+import threading
+from typing import Any
+
+
+DEFAULT_DRAWING_SOURCE_BATCH_SIZE = 8
+_WAIT_POLL_SECONDS = 0.05
+
+CancellationCheck = Callable[[], bool]
+ProgressCallback = Callable[[int, str], None]
+CatalogBuilder = Callable[
+    [CancellationCheck, ProgressCallback],
+    dict[str, Any],
+]
+DocumentThreadDispatcher = Callable[[Callable[[], Any]], Any]
+
+
+class DrawingContextError(RuntimeError):
+    """Drawing provider context could not be prepared safely."""
+
+
+class DrawingContextCancelled(DrawingContextError):
+    """The caller stopped waiting for Drawing provider context."""
+
+
+class DrawingContextStale(DrawingContextError):
+    """The Drawing document changed while source context was captured."""
+
+
+def _context_key(document_uid: str, structural_revision: int) -> tuple[str, int]:
+    uid = str(document_uid or "").strip()
+    if not uid:
+        raise DrawingContextError("Drawing context requires an exact document UID.")
+    if isinstance(structural_revision, bool):
+        raise DrawingContextError("Drawing context requires an integer revision.")
+    try:
+        revision = int(structural_revision)
+    except (TypeError, ValueError) as exc:
+        raise DrawingContextError(
+            "Drawing context requires an integer revision."
+        ) from exc
+    if revision < 0:
+        raise DrawingContextError(
+            "Drawing context requires a non-negative revision."
+        )
+    return uid, revision
+
+
+@dataclass
+class _PendingCatalog:
+    document_uid: str
+    structural_revision: int
+    invalidated: threading.Event = field(default_factory=threading.Event)
+    completed: bool = False
+    result: dict[str, Any] | None = None
+    error: BaseException | None = None
+    progress_percent: int = 0
+    progress_message: str = ""
+
+
+class DrawingSourceCatalogCoordinator:
+    """Coalesce concurrent catalog capture without owning live CAD objects.
+
+    Completed data lives in ``VibeCADNativeDrawingSourceCatalog``. This class
+    only coordinates an in-flight build, so there is one source scan per exact
+    document revision even when tab prewarming and Send overlap.
+    """
+
+    def __init__(self) -> None:
+        self._condition = threading.Condition(threading.RLock())
+        self._pending: dict[tuple[str, int], _PendingCatalog] = {}
+
+    def get_or_build(
+        self,
+        document_uid: str,
+        structural_revision: int,
+        build: CatalogBuilder,
+        *,
+        cancellation_check: CancellationCheck | None = None,
+        progress_callback: ProgressCallback | None = None,
+    ) -> dict[str, Any]:
+        if not callable(build):
+            raise TypeError("build must be callable")
+        if cancellation_check is not None and not callable(cancellation_check):
+            raise TypeError("cancellation_check must be callable")
+        if progress_callback is not None and not callable(progress_callback):
+            raise TypeError("progress_callback must be callable")
+        key = _context_key(document_uid, structural_revision)
+        with self._condition:
+            pending = self._pending.get(key)
+            owner = pending is None
+            if pending is None:
+                pending = _PendingCatalog(*key)
+                self._pending[key] = pending
+
+        if not owner:
+            return self._wait_for_pending(
+                pending,
+                cancellation_check=cancellation_check,
+                progress_callback=progress_callback,
+            )
+
+        def cancelled() -> bool:
+            return pending.invalidated.is_set() or bool(
+                cancellation_check is not None and cancellation_check()
+            )
+
+        def progress(percent: int, message: str) -> None:
+            if isinstance(percent, bool) or type(percent) is not int:
+                raise DrawingContextError(
+                    "Drawing context progress must be an integer."
+                )
+            clean_percent = max(0, min(100, percent))
+            clean_message = str(message or "").strip()[:160]
+            with self._condition:
+                pending.progress_percent = max(
+                    pending.progress_percent,
+                    clean_percent,
+                )
+                pending.progress_message = clean_message
+                self._condition.notify_all()
+            if progress_callback is not None:
+                progress_callback(clean_percent, clean_message)
+
+        try:
+            result = build(cancelled, progress)
+            if not isinstance(result, dict):
+                raise DrawingContextError(
+                    "Drawing source preparation must return an object."
+                )
+            with self._condition:
+                if pending.invalidated.is_set():
+                    raise DrawingContextStale(
+                        "The Drawing document changed while sources were prepared."
+                    )
+                pending.result = deepcopy(result)
+            return deepcopy(result)
+        except BaseException as exc:
+            reported = (
+                DrawingContextStale(
+                    "The Drawing document changed while sources were prepared."
+                )
+                if pending.invalidated.is_set()
+                and isinstance(exc, DrawingContextCancelled)
+                else exc
+            )
+            with self._condition:
+                pending.error = reported
+            if reported is not exc:
+                raise reported from exc
+            raise
+        finally:
+            with self._condition:
+                pending.completed = True
+                if self._pending.get(key) is pending:
+                    self._pending.pop(key, None)
+                self._condition.notify_all()
+
+    def _wait_for_pending(
+        self,
+        pending: _PendingCatalog,
+        *,
+        cancellation_check: CancellationCheck | None,
+        progress_callback: ProgressCallback | None,
+    ) -> dict[str, Any]:
+        reported_progress = (-1, "")
+        while True:
+            with self._condition:
+                if pending.completed:
+                    if pending.error is not None:
+                        raise pending.error
+                    if pending.result is None:
+                        raise DrawingContextError(
+                            "Drawing source preparation completed without a result."
+                        )
+                    return deepcopy(pending.result)
+                current_progress = (
+                    pending.progress_percent,
+                    pending.progress_message,
+                )
+                self._condition.wait(_WAIT_POLL_SECONDS)
+            if cancellation_check is not None and cancellation_check():
+                raise DrawingContextCancelled(
+                    "Drawing source preparation was cancelled."
+                )
+            if progress_callback is not None and current_progress != reported_progress:
+                progress_callback(*current_progress)
+                reported_progress = current_progress
+
+    def invalidate_document(self, document_uid: str) -> bool:
+        uid = str(document_uid or "").strip()
+        if not uid:
+            return False
+        changed = False
+        with self._condition:
+            for key, pending in tuple(self._pending.items()):
+                if key[0] == uid:
+                    pending.invalidated.set()
+                    changed = True
+            if changed:
+                self._condition.notify_all()
+        return changed
+
+    def close_document(self, document_uid: str) -> bool:
+        return self.invalidate_document(document_uid)
+
+
+def capture_responsive_drawing_source_catalog(
+    request: Mapping[str, Any],
+    *,
+    dispatch_to_document_thread: DocumentThreadDispatcher,
+    capture_batch: Callable[
+        [Mapping[str, Any], Sequence[str]],
+        Mapping[str, Any],
+    ],
+    finalize: Callable[
+        [Mapping[str, Any], Sequence[Mapping[str, Any]]],
+        dict[str, Any],
+    ],
+    cancellation_check: CancellationCheck | None = None,
+    progress_callback: ProgressCallback | None = None,
+    batch_size: int = DEFAULT_DRAWING_SOURCE_BATCH_SIZE,
+) -> dict[str, Any]:
+    """Capture live source facts in bounded Qt dispatches, then cache detached."""
+
+    if not isinstance(request, Mapping):
+        raise TypeError("request must be a mapping")
+    for callback in (dispatch_to_document_thread, capture_batch, finalize):
+        if not callable(callback):
+            raise TypeError("Drawing context callbacks must be callable")
+    if isinstance(batch_size, bool) or type(batch_size) is not int or batch_size < 1:
+        raise ValueError("batch_size must be a positive integer")
+    raw_names = request.get("object_names")
+    if not isinstance(raw_names, list) or any(
+        not isinstance(name, str) or not name for name in raw_names
+    ):
+        raise DrawingContextError(
+            "Drawing context request requires exact object names."
+        )
+    object_names = list(raw_names)
+
+    def check_cancelled() -> None:
+        if cancellation_check is not None and cancellation_check():
+            raise DrawingContextCancelled(
+                "Drawing source preparation was cancelled."
+            )
+
+    sources: list[dict[str, Any]] = []
+    batch_count = max(1, (len(object_names) + batch_size - 1) // batch_size)
+    for index, offset in enumerate(range(0, len(object_names), batch_size)):
+        check_cancelled()
+        names = object_names[offset : offset + batch_size]
+        part = dispatch_to_document_thread(
+            lambda names=names: capture_batch(request, names)
+        )
+        if not isinstance(part, Mapping):
+            raise DrawingContextError(
+                "Drawing context batch capture returned no object."
+            )
+        batch_sources = part.get("sources")
+        if not isinstance(batch_sources, list) or any(
+            not isinstance(source, Mapping) for source in batch_sources
+        ):
+            raise DrawingContextError(
+                "Drawing context batch returned invalid source data."
+            )
+        sources.extend(dict(source) for source in batch_sources)
+        if progress_callback is not None:
+            progress_callback(
+                5 + int(80 * (index + 1) / batch_count),
+                f"Reading Drawing sources "
+                f"{min(offset + len(names), len(object_names))}"
+                f" of {len(object_names)}",
+            )
+    if not object_names and progress_callback is not None:
+        progress_callback(85, "Reading Drawing sources 0 of 0")
+
+    check_cancelled()
+    result = finalize(request, sources)
+    if not isinstance(result, dict):
+        raise DrawingContextError(
+            "Drawing context finalization returned no object."
+        )
+    return result
+
+
+__all__ = [
+    "DEFAULT_DRAWING_SOURCE_BATCH_SIZE",
+    "DrawingContextCancelled",
+    "DrawingContextError",
+    "DrawingContextStale",
+    "DrawingSourceCatalogCoordinator",
+    "capture_responsive_drawing_source_catalog",
+]

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingContext.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingContext.py
@@ -253,34 +253,54 @@ def capture_responsive_drawing_source_catalog(
                 "Drawing source preparation was cancelled."
             )
 
-    sources: list[dict[str, Any]] = []
-    batch_count = max(1, (len(object_names) + batch_size - 1) // batch_size)
-    for index, offset in enumerate(range(0, len(object_names), batch_size)):
-        check_cancelled()
-        names = object_names[offset : offset + batch_size]
-        part = dispatch_to_document_thread(
-            lambda names=names: capture_batch(request, names)
-        )
-        if not isinstance(part, Mapping):
-            raise DrawingContextError(
-                "Drawing context batch capture returned no object."
-            )
-        batch_sources = part.get("sources")
-        if not isinstance(batch_sources, list) or any(
-            not isinstance(source, Mapping) for source in batch_sources
+    detached_sources = request.get("detached_sources")
+    if detached_sources is not None:
+        if not isinstance(detached_sources, list) or any(
+            not isinstance(source, Mapping) for source in detached_sources
         ):
             raise DrawingContextError(
-                "Drawing context batch returned invalid source data."
+                "Drawing context detached sources are malformed."
             )
-        sources.extend(dict(source) for source in batch_sources)
+        check_cancelled()
+        sources = [deepcopy(dict(source)) for source in detached_sources]
         if progress_callback is not None:
             progress_callback(
-                5 + int(80 * (index + 1) / batch_count),
-                f"Reading Drawing sources "
-                f"{min(offset + len(names), len(object_names))}"
-                f" of {len(object_names)}",
+                85,
+                f"Reading Drawing sources {len(sources)} of {len(sources)}",
             )
-    if not object_names and progress_callback is not None:
+    else:
+        sources = []
+        batch_count = max(1, (len(object_names) + batch_size - 1) // batch_size)
+        for index, offset in enumerate(range(0, len(object_names), batch_size)):
+            check_cancelled()
+            names = object_names[offset : offset + batch_size]
+            part = dispatch_to_document_thread(
+                lambda names=names: capture_batch(request, names)
+            )
+            if not isinstance(part, Mapping):
+                raise DrawingContextError(
+                    "Drawing context batch capture returned no object."
+                )
+            batch_sources = part.get("sources")
+            if not isinstance(batch_sources, list) or any(
+                not isinstance(source, Mapping) for source in batch_sources
+            ):
+                raise DrawingContextError(
+                    "Drawing context batch returned invalid source data."
+                )
+            sources.extend(dict(source) for source in batch_sources)
+            if progress_callback is not None:
+                progress_callback(
+                    5 + int(80 * (index + 1) / batch_count),
+                    f"Reading Drawing sources "
+                    f"{min(offset + len(names), len(object_names))}"
+                    f" of {len(object_names)}",
+                )
+    if (
+        detached_sources is None
+        and not object_names
+        and progress_callback is not None
+    ):
         progress_callback(85, "Reading Drawing sources 0 of 0")
 
     check_cancelled()

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingDetail.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingDetail.py
@@ -9,6 +9,7 @@ import math
 from typing import Any, Mapping
 
 from VibeCADNativeDrawingErrors import NativeDrawingError
+from VibeCADNativeDrawingHistory import require_drawing_source_history_usable
 from VibeCADNativeDrawingState import drawing_page_state, is_drawing_page
 from VibeCADNativeDrawingView import standard_view_line_flags
 from VibeCADNativeDrawingViewState import (
@@ -243,7 +244,7 @@ def prepare_detail_view_create(
         )
     source_states = tuple(drawing_source_state(source) for source in sources)
     for source in sources:
-        _require_usable(document, source, "detail source")
+        require_drawing_source_history_usable(document, source, "detail source")
     line_flags = {
         name: bool(base_state["line_visibility"][name])
         for name in standard_view_line_flags("visible")

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingDraft.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingDraft.py
@@ -18,6 +18,7 @@ from VibeCADNativeDrawingDraftState import (
 from VibeCADNativeDrawingErrors import NativeDrawingError
 from VibeCADNativeDrawingState import drawing_page_state, is_drawing_page
 from VibeCADNativeDrawingViewState import DRAWING_VIEW_ORIENTATIONS
+from VibeCADNativeGeometrySources import drawing_source_exclusion_reason
 from VibeCADNativeMutation import NativeMutationDraft
 from VibeCADNativeTargets import object_identity, read_current_selection, resolve_object
 
@@ -264,6 +265,21 @@ def prepare_draft_view_create(
         document,
         {"document_uid": str(document.Uid), "object_name": source_target["object_name"]},
     )
+    exclusion = drawing_source_exclusion_reason(document, source)
+    if exclusion is not None:
+        _error(
+            (
+                "An Analyze/FEM artifact cannot be used as a Draft Drawing source."
+                if exclusion == "analysis_artifact"
+                else "The exact Draft Drawing source is hidden."
+            ),
+            "NATIVE_DRAWING_DRAFT_SOURCE_INVALID",
+            repair=(
+                {}
+                if exclusion == "analysis_artifact"
+                else {"object_name": str(source.Name), "unhide_before_retry": True}
+            ),
+        )
     try:
         fingerprint = draft_source_fingerprint(source)
     except ValueError as exc:
@@ -308,6 +324,11 @@ def validate_prepared_draft_view(document: Any, prepared: PreparedDraftView) -> 
         _error(
             "The exact Drawing graph changed while the Draft view was rendered.",
             "NATIVE_DRAWING_DRAFT_STALE",
+        )
+    if drawing_source_exclusion_reason(document, source) is not None:
+        _error(
+            "The exact Draft Drawing source left the visible Drawing scope.",
+            "NATIVE_DRAWING_DRAFT_SOURCE_STALE",
         )
     page_state = drawing_page_state(page)
     if page_state["state_sha256"] != prepared.page_state_before["state_sha256"]:

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingHistory.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingHistory.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""History-aware validation for whole-object Native Drawing sources."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from VibeCADNativeDrawingErrors import NativeDrawingError
+
+
+def _is_body(obj: Any) -> bool:
+    derived = getattr(obj, "isDerivedFrom", None)
+    if callable(derived):
+        try:
+            return bool(derived("PartDesign::Body"))
+        except Exception:
+            return False
+    return str(getattr(obj, "TypeId", "") or "") == "PartDesign::Body"
+
+
+def _is_live(document: Any, obj: Any) -> bool:
+    name = str(getattr(obj, "Name", "") or "")
+    if not name:
+        return False
+    try:
+        return document.getObject(name) is obj
+    except (AttributeError, ReferenceError, RuntimeError):
+        return False
+
+
+def is_drawing_source_history_usable(document: Any, source: Any) -> bool:
+    """Return whether *source* represents geometry at the current History position.
+
+    A PartDesign Body is a stable presentation boundary and is intentionally
+    timeline-internal.  Resolve it only for this availability check so its
+    exact active modeling state is validated while the Body itself remains the
+    whole-object TechDraw source.
+    """
+
+    if document is None or source is None or not _is_live(document, source):
+        return False
+    timeline_target = source
+    if _is_body(source):
+        try:
+            import PartGui
+
+            timeline_target = PartGui.resolveModelingObject(source)
+        except (AttributeError, ImportError, ReferenceError, RuntimeError):
+            return False
+        if timeline_target is None or not _is_live(document, timeline_target):
+            return False
+    checker = getattr(document, "isObjectUsableAtCurrentTimelinePosition", None)
+    if not callable(checker):
+        return True
+    try:
+        return bool(checker(timeline_target))
+    except (AttributeError, ReferenceError, RuntimeError):
+        return False
+
+
+def require_drawing_source_history_usable(
+    document: Any,
+    source: Any,
+    noun: str = "Drawing source",
+) -> None:
+    """Raise the shared exact Drawing error for an unavailable source."""
+
+    if not is_drawing_source_history_usable(document, source):
+        raise NativeDrawingError(
+            f"The exact {noun} is not usable at the current History position.",
+            error_code="NATIVE_DRAWING_HISTORY_TARGET_UNAVAILABLE",
+        )

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingProviderState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingProviderState.py
@@ -68,6 +68,8 @@ def compact_drawing_source(
         result["placement"] = dict(placement)
     if name in (selected_names or set()):
         result["selected"] = True
+    if source.get("geometry_details_deferred") is True:
+        result["geometry_details_deferred"] = True
     return result
 
 

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingSection.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingSection.py
@@ -9,6 +9,7 @@ import math
 from typing import Any, Mapping
 
 from VibeCADNativeDrawingErrors import NativeDrawingError
+from VibeCADNativeDrawingHistory import require_drawing_source_history_usable
 from VibeCADNativeDrawingState import drawing_page_state, is_drawing_page
 from VibeCADNativeDrawingView import standard_view_line_flags
 from VibeCADNativeDrawingViewState import (
@@ -326,7 +327,7 @@ def prepare_section_view_create(
         )
     source_states = tuple(drawing_source_state(source) for source in sources)
     for source in sources:
-        _require_usable(document, source, "section source")
+        require_drawing_source_history_usable(document, source, "section source")
     spec = _spec(values, base)
     line_flags = {
         name: bool(base_state["line_visibility"][name])

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingSnapshot.py
@@ -830,6 +830,135 @@ def _active_page_state(page: Any) -> dict[str, Any]:
     return state
 
 
+_COMPACT_VIEW_KEYS = (
+    "document_uid",
+    "object_name",
+    "type_id",
+    "label",
+    "state",
+    "state_sha256",
+    "placement",
+    "x",
+    "y",
+    "scale",
+)
+_COMPACT_PRIMARY_VIEW_DETAILS = (
+    "projection_group",
+    "surface_finish_symbol",
+    "weld_symbol",
+    "rich_annotation",
+    "leader",
+    "measurement_annotation",
+    "balloon",
+    "dimension",
+    "dimension_repair",
+    "clip_group",
+    "active_view_image",
+    # These owner/readiness states are fallbacks for drawing objects without
+    # their own primary revision block.
+    "annotation_owner",
+    "leader_owner",
+    "stack",
+    "clip_member",
+    "hatches",
+    "section_position",
+    "view_lock",
+    "hidden_edge_visibility",
+    "line_attributes",
+    "line_lengths",
+)
+_COMPACT_DETAIL_SCALARS = frozenset(
+    {
+        "kind",
+        "dimension_type",
+        "measure_type",
+        "source_view_name",
+        "page_name",
+        "object_name",
+        "view_count",
+        "member_count",
+        "line_count",
+        "hatch_count",
+        "measured_value",
+        "formatted_text",
+        "timeline_usable",
+        "valid",
+        "available",
+        "locked",
+        "repairable",
+        "error",
+    }
+)
+
+
+def _compact_view_detail(detail: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep revision and readiness facts while deferring repeated view detail."""
+
+    result = {}
+    for name, value in detail.items():
+        if name.endswith("sha256") or name in _COMPACT_DETAIL_SCALARS:
+            result[str(name)] = value
+    return result
+
+
+def compact_drawing_snapshot_for_bound(
+    domain: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Compact repeated page-view detail after an active snapshot exceeds its budget.
+
+    The complete detail remains in selected target blocks and in explicit Drawing
+    read tools. Small snapshots never call this function and retain their established
+    shape verbatim.
+    """
+
+    result = dict(domain)
+    pages = []
+    compacted = False
+    for raw_page in list(domain.get("pages") or []):
+        if not isinstance(raw_page, Mapping):
+            pages.append(raw_page)
+            continue
+        page = dict(raw_page)
+        views = []
+        page_compacted = False
+        for raw_view in list(raw_page.get("views") or []):
+            if not isinstance(raw_view, Mapping):
+                views.append(raw_view)
+                continue
+            view = {
+                name: raw_view[name]
+                for name in _COMPACT_VIEW_KEYS
+                if name in raw_view
+            }
+            # Projected views already carry their authoritative state hash at
+            # the top level. Other objects (dimensions, annotations, symbols)
+            # keep one primary revision/readiness block. Repeating every
+            # secondary inventory hash is what made one ordinary page consume
+            # almost the entire active-snapshot allowance.
+            if "state_sha256" not in view:
+                for name in _COMPACT_PRIMARY_VIEW_DETAILS:
+                    detail = raw_view.get(name)
+                    if not isinstance(detail, Mapping):
+                        continue
+                    compact_detail = _compact_view_detail(detail)
+                    if compact_detail:
+                        view[name] = compact_detail
+                        break
+            views.append(view)
+            view_compacted = view != dict(raw_view)
+            page_compacted = page_compacted or view_compacted
+            compacted = compacted or view_compacted
+        page["views"] = views
+        if views and page_compacted:
+            page["views_detail_deferred"] = True
+        pages.append(page)
+    result["pages"] = pages
+    if compacted:
+        result["snapshot_compacted"] = True
+        result["deferred_details"] = ["pages.views"]
+    return result
+
+
 def _line_inventory(
     view: Any,
     cache: dict[str, dict[str, Any] | None],

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingSnapshot.py
@@ -50,7 +50,6 @@ from VibeCADNativeDrawingLeaderState import (
     is_drawing_leader,
 )
 from VibeCADNativeDrawingDraftState import (
-    drawing_draft_source_state,
     drawing_draft_view_state,
     is_draft_drawing_view,
 )
@@ -117,16 +116,15 @@ from VibeCADNativeDrawingMeasurementAnnotationState import (
     is_drawing_measurement_annotation,
 )
 from VibeCADNativeDrawingFormatState import drawing_format_state
+from VibeCADNativeDrawingSourceCatalog import drawing_source_catalog_state_page
 from VibeCADNativeDrawingViewState import (
     MAX_DRAWING_BREAKS,
     MAX_DRAWING_VIEW_SOURCES,
-    drawing_break_state,
-    drawing_source_state,
+    drawing_source_catalog_identity_state,
     drawing_view_state,
     is_drawing_view,
     is_part_drawing_view,
 )
-from VibeCADNativeGeometrySources import active_design_geometry_sources
 from VibeCADNativeSnapshot import concise_object, objects_of_type
 
 
@@ -914,23 +912,26 @@ def _selected_sources(
         if selected is None:
             continue
         try:
-            result.append(drawing_source_state(selected))
+            result.append(drawing_source_catalog_identity_state(selected))
         except (AttributeError, RuntimeError, TypeError, ValueError):
             continue
     return result
 
 
-def _drawing_sources(document: Any) -> tuple[int, list[dict[str, Any]]]:
+def _drawing_sources(
+    document: Any,
+    *,
+    structural_revision: int | None = None,
+) -> tuple[int, list[dict[str, Any]]]:
     """Return each active design shape once at its public Body boundary."""
 
-    result = []
-    sources = active_design_geometry_sources(document)
-    for source in sources[:MAX_DRAWING_SOURCES]:
-        try:
-            result.append(drawing_source_state(source))
-        except (AttributeError, RuntimeError, TypeError, ValueError):
-            continue
-    return len(sources), result
+    page = drawing_source_catalog_state_page(
+        document,
+        offset=0,
+        page_size=MAX_DRAWING_SOURCES,
+        structural_revision=structural_revision,
+    )
+    return int(page["source_count"]), [dict(source) for source in page["sources"]]
 
 
 def _selected_break_definitions(
@@ -943,7 +944,9 @@ def _selected_break_definitions(
         if selected is None:
             continue
         try:
-            result.append(drawing_break_state(selected))
+            state = drawing_source_catalog_identity_state(selected)
+            state["break_details_deferred"] = True
+            result.append(state)
         except (AttributeError, RuntimeError, TypeError, ValueError):
             continue
     return result
@@ -959,7 +962,9 @@ def _selected_draft_sources(
         if selected is None:
             continue
         try:
-            result.append(drawing_draft_source_state(selected))
+            state = drawing_source_catalog_identity_state(selected)
+            state["draft_details_deferred"] = True
+            result.append(state)
         except (AttributeError, RuntimeError, TypeError, ValueError):
             continue
     return result
@@ -1374,9 +1379,13 @@ def build_drawing_snapshot(
     document: Any,
     *,
     selection: Mapping[str, Any] | None = None,
+    structural_revision: int | None = None,
 ) -> dict[str, Any]:
     pages = objects_of_type(document, "TechDraw::DrawPage")
-    source_count, sources = _drawing_sources(document)
+    source_count, sources = _drawing_sources(
+        document,
+        structural_revision=structural_revision,
+    )
     selected = _selected_pages(document, pages, selection)
     if len(selected) == 1:
         active = selected[0]

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingSnapshot.py
@@ -1055,9 +1055,13 @@ def _drawing_sources(
     document: Any,
     *,
     structural_revision: int | None = None,
+    detached_sources: list[Mapping[str, Any]] | None = None,
 ) -> tuple[int, list[dict[str, Any]]]:
     """Return each active design shape once at its public Body boundary."""
 
+    if detached_sources is not None:
+        sources = [dict(source) for source in detached_sources]
+        return len(sources), sources[:MAX_DRAWING_SOURCES]
     page = drawing_source_catalog_state_page(
         document,
         offset=0,
@@ -1519,11 +1523,13 @@ def build_drawing_snapshot(
     *,
     selection: Mapping[str, Any] | None = None,
     structural_revision: int | None = None,
+    detached_sources: list[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     pages = objects_of_type(document, "TechDraw::DrawPage")
     source_count, sources = _drawing_sources(
         document,
         structural_revision=structural_revision,
+        detached_sources=detached_sources,
     )
     selected = _selected_pages(document, pages, selection)
     if len(selected) == 1:

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingSnapshot.py
@@ -125,6 +125,7 @@ from VibeCADNativeDrawingViewState import (
     is_drawing_view,
     is_part_drawing_view,
 )
+from VibeCADNativeGeometrySources import is_potential_design_geometry_source
 from VibeCADNativeSnapshot import concise_object, objects_of_type
 
 
@@ -1038,7 +1039,10 @@ def _selected_sources(
     result = []
     for name in _selection_names(selection):
         selected = document.getObject(name)
-        if selected is None:
+        if selected is None or not is_potential_design_geometry_source(
+            document,
+            selected,
+        ):
             continue
         try:
             result.append(drawing_source_catalog_identity_state(selected))
@@ -1070,7 +1074,10 @@ def _selected_break_definitions(
     result = []
     for name in _selection_names(selection)[:MAX_DRAWING_BREAKS]:
         selected = document.getObject(name)
-        if selected is None:
+        if selected is None or not is_potential_design_geometry_source(
+            document,
+            selected,
+        ):
             continue
         try:
             state = drawing_source_catalog_identity_state(selected)
@@ -1088,7 +1095,10 @@ def _selected_draft_sources(
     result = []
     for name in _selection_names(selection)[:MAX_DRAWING_VIEW_SOURCES]:
         selected = document.getObject(name)
-        if selected is None:
+        if selected is None or not is_potential_design_geometry_source(
+            document,
+            selected,
+        ):
             continue
         try:
             state = drawing_source_catalog_identity_state(selected)

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingSourceCatalog.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingSourceCatalog.py
@@ -10,8 +10,15 @@ import threading
 from typing import Any
 
 from VibeCADNativeDrawingProviderState import compact_drawing_source
-from VibeCADNativeDrawingViewState import drawing_source_catalog_state
-from VibeCADNativeGeometrySources import active_design_geometry_sources
+from VibeCADNativeDrawingViewState import (
+    drawing_source_catalog_identity_state,
+    drawing_source_catalog_state,
+)
+from VibeCADNativeGeometrySources import (
+    active_design_geometry_sources,
+    drawing_analysis_artifact_names,
+    is_potential_design_geometry_source,
+)
 
 
 MAX_DRAWING_SOURCE_PAGE_SIZE = 48
@@ -33,6 +40,32 @@ _source_catalog_cache: OrderedDict[
     tuple[str, int],
     tuple[dict[str, Any], ...],
 ] = OrderedDict()
+
+
+def capture_drawing_source_catalog_inventory(document: Any) -> dict[str, Any]:
+    """Detach every effectively available Drawing source without reading BREP."""
+
+    analysis_artifacts = drawing_analysis_artifact_names(document)
+    names = []
+    sources = []
+    for obj in tuple(getattr(document, "Objects", ()) or ()):
+        if not is_potential_design_geometry_source(
+            document,
+            obj,
+            analysis_artifact_names=analysis_artifacts,
+        ):
+            continue
+        try:
+            source = drawing_source_catalog_identity_state(obj)
+        except (AttributeError, ReferenceError, RuntimeError, TypeError, ValueError):
+            continue
+        names.append(str(source["object_name"]))
+        sources.append(source)
+    return {
+        "object_names": names,
+        "sources": sources,
+        "analysis_artifact_names": sorted(analysis_artifacts),
+    }
 
 
 def invalidate_drawing_source_catalog_cache(
@@ -106,6 +139,24 @@ def drawing_source_catalog_is_cached(
             return False
         _source_catalog_cache.move_to_end(key)
         return True
+
+
+def cached_drawing_source_catalog_state(
+    document_uid: str,
+    structural_revision: int,
+) -> list[dict[str, Any]] | None:
+    """Return a detached complete catalog when its exact revision is cached."""
+
+    uid = str(document_uid or "").strip()
+    if not uid or type(structural_revision) is not int or structural_revision < 0:
+        return None
+    key = (uid, structural_revision)
+    with _source_page_cache_lock:
+        cached = _source_catalog_cache.get(key)
+        if cached is None:
+            return None
+        _source_catalog_cache.move_to_end(key)
+        return deepcopy(list(cached))
 
 
 def _validate_page_arguments(offset: int, page_size: int) -> None:
@@ -237,9 +288,11 @@ def drawing_source_catalog_page(
 
 
 __all__ = [
+    "capture_drawing_source_catalog_inventory",
     "DrawingSourceCatalogNotReady",
     "MAX_DRAWING_SOURCE_OFFSET",
     "MAX_DRAWING_SOURCE_PAGE_SIZE",
+    "cached_drawing_source_catalog_state",
     "cache_drawing_source_catalog_state",
     "drawing_source_catalog_page",
     "drawing_source_catalog_is_cached",

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingSourceCatalog.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingSourceCatalog.py
@@ -4,36 +4,130 @@
 
 from __future__ import annotations
 
+from collections import OrderedDict
+from copy import deepcopy
+import threading
 from typing import Any
 
 from VibeCADNativeDrawingProviderState import compact_drawing_source
-from VibeCADNativeDrawingViewState import drawing_source_state
+from VibeCADNativeDrawingViewState import drawing_source_catalog_state
 from VibeCADNativeGeometrySources import active_design_geometry_sources
 
 
 MAX_DRAWING_SOURCE_PAGE_SIZE = 48
 MAX_DRAWING_SOURCE_OFFSET = 1_000_000
+MAX_DRAWING_SOURCE_CACHE_PAGES = 32
+MAX_DRAWING_SOURCE_CACHE_DOCUMENTS = 4
 
 
-def drawing_source_catalog_page(
+class DrawingSourceCatalogNotReady(RuntimeError):
+    """The responsive source catalog has not completed for this revision."""
+
+
+_source_page_cache_lock = threading.RLock()
+_source_page_cache: OrderedDict[
+    tuple[str, int, int, int],
+    dict[str, Any],
+] = OrderedDict()
+_source_catalog_cache: OrderedDict[
+    tuple[str, int],
+    tuple[dict[str, Any], ...],
+] = OrderedDict()
+
+
+def invalidate_drawing_source_catalog_cache(
+    document_uid: str | None = None,
+) -> int:
+    """Discard cached detached pages for one document, or for every document."""
+
+    uid = str(document_uid or "").strip()
+    with _source_page_cache_lock:
+        page_keys = tuple(
+            key for key in _source_page_cache if not uid or key[0] == uid
+        )
+        catalog_keys = tuple(
+            key for key in _source_catalog_cache if not uid or key[0] == uid
+        )
+        for key in page_keys:
+            _source_page_cache.pop(key, None)
+        for key in catalog_keys:
+            _source_catalog_cache.pop(key, None)
+    return len(page_keys) + len(catalog_keys)
+
+
+def cache_drawing_source_catalog_state(
+    document_uid: str,
+    structural_revision: int,
+    sources: Any,
+) -> dict[str, int]:
+    """Store one complete detached source catalog for an exact revision."""
+
+    uid = str(document_uid or "").strip()
+    if not uid:
+        raise ValueError("Drawing source caching requires an exact document UID.")
+    if type(structural_revision) is not int or structural_revision < 0:
+        raise ValueError("Drawing source structural_revision must be non-negative.")
+    if not isinstance(sources, (list, tuple)) or any(
+        not isinstance(source, dict) for source in sources
+    ):
+        raise TypeError("Drawing source cache entries must be detached objects.")
+    detached = tuple(deepcopy(source) for source in sources)
+    key = (uid, structural_revision)
+    with _source_page_cache_lock:
+        for stale in tuple(_source_catalog_cache):
+            if stale[0] == uid and stale != key:
+                _source_catalog_cache.pop(stale, None)
+        for stale in tuple(_source_page_cache):
+            if stale[0] == uid and stale[1] != structural_revision:
+                _source_page_cache.pop(stale, None)
+        _source_catalog_cache[key] = detached
+        _source_catalog_cache.move_to_end(key)
+        while len(_source_catalog_cache) > MAX_DRAWING_SOURCE_CACHE_DOCUMENTS:
+            _source_catalog_cache.popitem(last=False)
+    return {
+        "structural_revision": structural_revision,
+        "source_count": len(detached),
+    }
+
+
+def drawing_source_catalog_is_cached(
+    document_uid: str,
+    structural_revision: int,
+) -> bool:
+    """Return whether a complete detached catalog exists for one revision."""
+
+    uid = str(document_uid or "").strip()
+    if not uid or type(structural_revision) is not int or structural_revision < 0:
+        return False
+    key = (uid, structural_revision)
+    with _source_page_cache_lock:
+        cached = _source_catalog_cache.get(key)
+        if cached is None:
+            return False
+        _source_catalog_cache.move_to_end(key)
+        return True
+
+
+def _validate_page_arguments(offset: int, page_size: int) -> None:
+    if type(offset) is not int or not 0 <= offset <= MAX_DRAWING_SOURCE_OFFSET:
+        raise ValueError("Drawing source offset must be 0 through 1000000.")
+    if type(page_size) is not int or not 1 <= page_size <= MAX_DRAWING_SOURCE_PAGE_SIZE:
+        raise ValueError("Drawing source page_size must be 1 through 48.")
+
+
+def _uncached_source_state_page(
     document: Any,
     *,
     offset: int,
     page_size: int,
 ) -> dict[str, Any]:
-    """Return a deterministic page of copyable exact Drawing source targets."""
-
-    if type(offset) is not int or not 0 <= offset <= MAX_DRAWING_SOURCE_OFFSET:
-        raise ValueError("Drawing source offset must be 0 through 1000000.")
-    if type(page_size) is not int or not 1 <= page_size <= MAX_DRAWING_SOURCE_PAGE_SIZE:
-        raise ValueError("Drawing source page_size must be 1 through 48.")
-    candidates = active_design_geometry_sources(document)
+    candidates = active_design_geometry_sources(document, validate_brep=False)
     count = len(candidates)
     if offset > count or (count and offset == count):
         raise ValueError("Drawing source offset exceeds the source count.")
     stop = min(offset + page_size, count)
     sources = [
-        compact_drawing_source(drawing_source_state(source))
+        drawing_source_catalog_state(source)
         for source in candidates[offset:stop]
     ]
     return {
@@ -45,8 +139,110 @@ def drawing_source_catalog_page(
     }
 
 
+def drawing_source_catalog_state_page(
+    document: Any,
+    *,
+    offset: int,
+    page_size: int,
+    structural_revision: int | None = None,
+    require_cached: bool = False,
+) -> dict[str, Any]:
+    """Return one detached raw source page, cached for an exact revision."""
+
+    _validate_page_arguments(offset, page_size)
+    if type(require_cached) is not bool:
+        raise TypeError("require_cached must be a boolean")
+    if structural_revision is None:
+        if require_cached:
+            raise DrawingSourceCatalogNotReady(
+                "A responsive Drawing source read requires an exact revision."
+            )
+        return _uncached_source_state_page(
+            document,
+            offset=offset,
+            page_size=page_size,
+        )
+    if type(structural_revision) is not int or structural_revision < 0:
+        raise ValueError("Drawing source structural_revision must be non-negative.")
+    document_uid = str(getattr(document, "Uid", "") or "").strip()
+    if not document_uid:
+        raise ValueError("Drawing source caching requires an exact document UID.")
+    key = (document_uid, structural_revision, offset, page_size)
+    with _source_page_cache_lock:
+        complete_key = (document_uid, structural_revision)
+        complete = _source_catalog_cache.get(complete_key)
+        if complete is not None:
+            _source_catalog_cache.move_to_end(complete_key)
+            count = len(complete)
+            if offset > count or (count and offset == count):
+                raise ValueError("Drawing source offset exceeds the source count.")
+            stop = min(offset + page_size, count)
+            return {
+                "source_count": count,
+                "offset": offset,
+                "returned_count": stop - offset,
+                "next_offset": stop if stop < count else None,
+                "sources": deepcopy(list(complete[offset:stop])),
+            }
+        cached = _source_page_cache.get(key)
+        if cached is not None:
+            _source_page_cache.move_to_end(key)
+            return deepcopy(cached)
+    if require_cached:
+        raise DrawingSourceCatalogNotReady(
+            "Drawing sources are still being prepared for the current document revision."
+        )
+
+    result = _uncached_source_state_page(
+        document,
+        offset=offset,
+        page_size=page_size,
+    )
+    with _source_page_cache_lock:
+        for stale in tuple(_source_page_cache):
+            if stale[0] == document_uid and stale[1] != structural_revision:
+                _source_page_cache.pop(stale, None)
+        _source_page_cache[key] = deepcopy(result)
+        _source_page_cache.move_to_end(key)
+        while len(_source_page_cache) > MAX_DRAWING_SOURCE_CACHE_PAGES:
+            _source_page_cache.popitem(last=False)
+    return deepcopy(result)
+
+
+def drawing_source_catalog_page(
+    document: Any,
+    *,
+    offset: int,
+    page_size: int,
+    structural_revision: int | None = None,
+    require_cached: bool = False,
+) -> dict[str, Any]:
+    """Return a deterministic page of copyable exact Drawing source targets."""
+
+    state = drawing_source_catalog_state_page(
+        document,
+        offset=offset,
+        page_size=page_size,
+        structural_revision=structural_revision,
+        require_cached=require_cached,
+    )
+    sources = [compact_drawing_source(source) for source in state["sources"]]
+    return {
+        "source_count": state["source_count"],
+        "offset": state["offset"],
+        "returned_count": len(sources),
+        "next_offset": state["next_offset"],
+        "sources": sources,
+    }
+
+
 __all__ = [
+    "DrawingSourceCatalogNotReady",
     "MAX_DRAWING_SOURCE_OFFSET",
     "MAX_DRAWING_SOURCE_PAGE_SIZE",
+    "cache_drawing_source_catalog_state",
     "drawing_source_catalog_page",
+    "drawing_source_catalog_is_cached",
+    "drawing_source_catalog_state_page",
+    "invalidate_drawing_source_catalog_cache",
 ]

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingView.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingView.py
@@ -9,6 +9,7 @@ import math
 from typing import Any, Mapping
 
 from VibeCADNativeDrawingErrors import NativeDrawingError
+from VibeCADNativeDrawingHistory import require_drawing_source_history_usable
 from VibeCADNativeDrawingDimensionSupport import drawing_position_within_page_bounds
 from VibeCADNativeDrawingState import drawing_page_state, is_drawing_page
 from VibeCADNativeDrawingViewState import (
@@ -237,7 +238,7 @@ def prepare_standard_view_create(
                 "object_name": target["object_name"],
             },
         )
-        _require_usable(document, source, "Drawing source")
+        require_drawing_source_history_usable(document, source)
         try:
             state = drawing_source_state(source)
         except (AttributeError, RuntimeError, TypeError, ValueError) as exc:

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingView.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingView.py
@@ -18,6 +18,7 @@ from VibeCADNativeDrawingViewState import (
     drawing_view_state,
     is_part_drawing_view,
 )
+from VibeCADNativeGeometrySources import drawing_source_exclusion_reason
 from VibeCADNativeMutation import NativeMutationDraft
 from VibeCADNativeTargets import object_identity, read_current_selection, resolve_object
 
@@ -190,6 +191,22 @@ def _require_usable(document: Any, obj: Any, noun: str) -> None:
         )
 
 
+def _require_source_in_drawing_scope(document: Any, source: Any) -> None:
+    reason = drawing_source_exclusion_reason(document, source)
+    if reason is None:
+        return
+    if reason == "analysis_artifact":
+        raise NativeDrawingError(
+            f"Analysis artifact {source.Name!r} cannot be used as Drawing geometry.",
+            error_code="NATIVE_DRAWING_VIEW_SOURCE_ANALYSIS_ARTIFACT",
+        )
+    raise NativeDrawingError(
+        f"Drawing source {source.Name!r} is hidden from the Drawing workspace.",
+        error_code="NATIVE_DRAWING_VIEW_SOURCE_HIDDEN",
+        repair={"object_name": str(source.Name), "unhide_before_retry": True},
+    )
+
+
 def prepare_standard_view_create(
     document: Any,
     *,
@@ -238,6 +255,7 @@ def prepare_standard_view_create(
                 "object_name": target["object_name"],
             },
         )
+        _require_source_in_drawing_scope(document, source)
         require_drawing_source_history_usable(document, source)
         try:
             state = drawing_source_state(source)
@@ -310,6 +328,7 @@ def validate_prepared_standard_view(
                 f"Drawing source {expected['object_name']!r} is no longer available.",
                 error_code="NATIVE_DRAWING_VIEW_SOURCE_STALE",
             )
+        _require_source_in_drawing_scope(document, current_source)
         current = drawing_source_state(current_source)
         if current["state_sha256"] != expected["state_sha256"]:
             raise NativeDrawingError(

--- a/src/Mod/VibeCAD/VibeCADNativeDrawingViewState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDrawingViewState.py
@@ -151,6 +151,57 @@ def drawing_source_state(obj: Any) -> dict[str, Any]:
     return result
 
 
+def drawing_source_catalog_state(obj: Any) -> dict[str, Any]:
+    """Return lightweight source information without exact BREP validation."""
+
+    if obj is None or is_drawing_page(obj) or is_drawing_view(obj):
+        raise ValueError("A Drawing view source must be a non-Drawing shape object.")
+    shape = getattr(obj, "Shape", None)
+    if shape is None or bool(shape.isNull()):
+        raise ValueError("A Drawing view source must have one non-empty shape.")
+    topology = {
+        "solids": len(tuple(getattr(shape, "Solids", ()) or ())),
+        "faces": len(tuple(getattr(shape, "Faces", ()) or ())),
+        "edges": len(tuple(getattr(shape, "Edges", ()) or ())),
+    }
+    if not any(topology.values()):
+        raise ValueError("A Drawing view source must have usable topology.")
+    bounds = getattr(shape, "BoundBox", None)
+    return {
+        "object_name": str(getattr(obj, "Name", "") or ""),
+        "label": str(getattr(obj, "Label", "") or ""),
+        "type_id": str(getattr(obj, "TypeId", "") or ""),
+        "shape_type": str(getattr(shape, "ShapeType", "") or ""),
+        "placement": _placement_state(obj),
+        "topology": topology,
+        "bounds_size_mm": (
+            [
+                round(float(getattr(bounds, name)), 9)
+                for name in ("XLength", "YLength", "ZLength")
+            ]
+            if bounds is not None
+            else None
+        ),
+    }
+
+
+def drawing_source_catalog_identity_state(obj: Any) -> dict[str, Any]:
+    """Return source identity without touching live BREP or placement data."""
+
+    if obj is None or is_drawing_page(obj) or is_drawing_view(obj):
+        raise ValueError("A Drawing view source must be a non-Drawing shape object.")
+    return {
+        "object_name": str(getattr(obj, "Name", "") or ""),
+        "label": str(getattr(obj, "Label", "") or ""),
+        "type_id": str(getattr(obj, "TypeId", "") or ""),
+        "shape_type": "",
+        "placement": None,
+        "topology": {},
+        "bounds_size_mm": None,
+        "geometry_details_deferred": True,
+    }
+
+
 def _straight_edge_direction(edge: Any) -> tuple[float, float, float]:
     vertices = tuple(getattr(edge, "Vertexes", ()) or ())
     if len(vertices) != 2:

--- a/src/Mod/VibeCAD/VibeCADNativeGeometrySources.py
+++ b/src/Mod/VibeCAD/VibeCADNativeGeometrySources.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from typing import Any, Mapping
 
 
@@ -63,12 +64,41 @@ def is_drawing_object_effectively_visible(obj: Any) -> bool:
         visited.add(identity)
         view = getattr(current, "ViewObject", None)
         try:
-            if view is None or not bool(view.Visibility):
+            if (
+                view is None
+                or not bool(view.Visibility)
+                or bool(getattr(current, "Suppressed", False))
+            ):
                 return False
         except (AttributeError, ReferenceError, RuntimeError):
             return False
         current = _visibility_parent(current)
     return True
+
+
+def is_provider_object_effectively_available(document: Any, obj: Any) -> bool:
+    """Return whether a live object is visible, unsuppressed, and History-usable."""
+
+    if obj is None or not is_drawing_object_effectively_visible(obj):
+        return False
+    checker = getattr(document, "isObjectUsableAtCurrentTimelinePosition", None)
+    if not callable(checker):
+        return True
+    try:
+        if bool(checker(obj)):
+            return True
+    except (AttributeError, ReferenceError, RuntimeError):
+        return False
+    if not _is_body(obj):
+        return False
+    try:
+        import PartGui
+
+        resolver = getattr(PartGui, "resolveModelingObject", None)
+        history_target = resolver(obj) if callable(resolver) else None
+        return history_target is not None and bool(checker(history_target))
+    except (AttributeError, ImportError, ReferenceError, RuntimeError):
+        return False
 
 
 def _direct_analysis_artifact(obj: Any) -> bool:
@@ -132,24 +162,16 @@ def drawing_source_exclusion_reason(
     name = str(getattr(obj, "Name", "") or "")
     if _direct_analysis_artifact(obj) or (name and name in artifact_names):
         return "analysis_artifact"
-    if not is_drawing_object_effectively_visible(obj):
+    if not is_provider_object_effectively_available(document, obj):
         return "hidden"
     return None
 
 
-def filter_drawing_selection(
+def _filter_selection(
     document: Any,
     selection: Mapping[str, Any],
-    *,
-    analysis_artifact_names: frozenset[str] | None = None,
+    include_object: Callable[[Any], bool],
 ) -> dict[str, Any]:
-    """Remove hidden and Analyze/FEM objects from one Drawing selection."""
-
-    artifact_names = (
-        drawing_analysis_artifact_names(document)
-        if analysis_artifact_names is None
-        else analysis_artifact_names
-    )
     filtered = dict(selection)
     items = []
     get_object = getattr(document, "getObject", None)
@@ -171,18 +193,61 @@ def filter_drawing_selection(
         )
         if obj is None:
             continue
-        if (
-            drawing_source_exclusion_reason(
-                document,
-                obj,
-                analysis_artifact_names=artifact_names,
-            )
-            is None
-        ):
+        if include_object(obj):
             items.append(item)
     filtered["items"] = items
     filtered["selected_count"] = len(items)
     return filtered
+
+
+def filter_analyze_selection(
+    document: Any,
+    selection: Mapping[str, Any],
+    *,
+    analysis_artifact_names: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Keep the FEM study graph plus effectively available model selections."""
+
+    artifact_names = (
+        drawing_analysis_artifact_names(document)
+        if analysis_artifact_names is None
+        else analysis_artifact_names
+    )
+
+    return _filter_selection(
+        document,
+        selection,
+        lambda obj: is_analyze_context_reference(
+            document,
+            obj,
+            analysis_artifact_names=artifact_names,
+        ),
+    )
+
+
+def filter_drawing_selection(
+    document: Any,
+    selection: Mapping[str, Any],
+    *,
+    analysis_artifact_names: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Remove unavailable and Analyze/FEM objects from one Drawing selection."""
+
+    artifact_names = (
+        drawing_analysis_artifact_names(document)
+        if analysis_artifact_names is None
+        else analysis_artifact_names
+    )
+    return _filter_selection(
+        document,
+        selection,
+        lambda obj: drawing_source_exclusion_reason(
+            document,
+            obj,
+            analysis_artifact_names=artifact_names,
+        )
+        is None,
+    )
 
 
 def _is_active_public_geometry_source(
@@ -250,14 +315,24 @@ def is_active_design_geometry_source(
     )
 
 
-def is_potential_design_geometry_source(document: Any, obj: Any) -> bool:
+def is_potential_design_geometry_source(
+    document: Any,
+    obj: Any,
+    *,
+    analysis_artifact_names: frozenset[str] | None = None,
+) -> bool:
     """Identify a Drawing candidate without reading its potentially huge Shape."""
 
     if (
         obj is None
         or _is_body_member(obj)
         or _is_internal_resource(obj)
-        or drawing_source_exclusion_reason(document, obj) is not None
+        or drawing_source_exclusion_reason(
+            document,
+            obj,
+            analysis_artifact_names=analysis_artifact_names,
+        )
+        is not None
     ):
         return False
     try:
@@ -276,6 +351,50 @@ def is_potential_design_geometry_source(document: Any, obj: Any) -> bool:
         )
     except Exception:
         return False
+
+
+def is_analyze_context_object(
+    document: Any,
+    obj: Any,
+    *,
+    analysis_artifact_names: frozenset[str] | None = None,
+) -> bool:
+    """Keep the non-rendering FEM graph plus visible public model geometry."""
+
+    artifact_names = (
+        drawing_analysis_artifact_names(document)
+        if analysis_artifact_names is None
+        else analysis_artifact_names
+    )
+    name = str(getattr(obj, "Name", "") or "")
+    if _direct_analysis_artifact(obj) or (name and name in artifact_names):
+        return True
+    return is_potential_design_geometry_source(
+        document,
+        obj,
+        analysis_artifact_names=artifact_names,
+    )
+
+
+def is_analyze_context_reference(
+    document: Any,
+    obj: Any,
+    *,
+    analysis_artifact_names: frozenset[str] | None = None,
+) -> bool:
+    """Keep required FEM definitions or one ordinarily available reference."""
+
+    artifact_names = (
+        drawing_analysis_artifact_names(document)
+        if analysis_artifact_names is None
+        else analysis_artifact_names
+    )
+    name = str(getattr(obj, "Name", "") or "")
+    return bool(
+        _direct_analysis_artifact(obj)
+        or (name and name in artifact_names)
+        or is_provider_object_effectively_available(document, obj)
+    )
 
 
 def active_public_geometry_sources(
@@ -363,9 +482,13 @@ __all__ = [
     "active_public_geometry_sources",
     "drawing_analysis_artifact_names",
     "drawing_source_exclusion_reason",
+    "filter_analyze_selection",
     "filter_drawing_selection",
     "is_active_design_geometry_source",
     "is_active_public_geometry_source",
+    "is_analyze_context_object",
+    "is_analyze_context_reference",
     "is_drawing_object_effectively_visible",
+    "is_provider_object_effectively_available",
     "is_potential_design_geometry_source",
 ]

--- a/src/Mod/VibeCAD/VibeCADNativeGeometrySources.py
+++ b/src/Mod/VibeCAD/VibeCADNativeGeometrySources.py
@@ -37,8 +37,105 @@ def _is_internal_resource(obj: Any) -> bool:
     return role in {"internal", "resource"} and not _is_body(obj)
 
 
-def active_public_geometry_sources(document: Any) -> tuple[Any, ...]:
-    """Return each active usable shape once at its public Body boundary."""
+def _is_active_public_geometry_source(
+    document: Any,
+    obj: Any,
+    *,
+    part_gui: Any,
+    validate_brep: bool,
+) -> bool:
+    shape = getattr(obj, "Shape", None)
+    if shape is None or _is_body_member(obj) or _is_internal_resource(obj):
+        return False
+    try:
+        str(document.Uid)
+        int(obj.ID)
+        return not (
+            shape.isNull()
+            or (validate_brep and not shape.isValid())
+            or not part_gui.isModelingObjectActive(obj)
+            or (
+                validate_brep
+                and not any((len(shape.Solids), len(shape.Faces), len(shape.Edges)))
+            )
+        )
+    except Exception:
+        return False
+
+
+def is_active_public_geometry_source(
+    document: Any,
+    obj: Any,
+    *,
+    validate_brep: bool = True,
+) -> bool:
+    """Return whether one object is an active public geometry boundary."""
+
+    if type(validate_brep) is not bool:
+        raise TypeError("validate_brep must be a boolean")
+    try:
+        import PartGui
+    except ImportError:
+        return False
+    return _is_active_public_geometry_source(
+        document,
+        obj,
+        part_gui=PartGui,
+        validate_brep=validate_brep,
+    )
+
+
+def is_active_design_geometry_source(
+    document: Any,
+    obj: Any,
+    *,
+    validate_brep: bool = True,
+) -> bool:
+    """Return whether one active public object is design, not analysis, geometry."""
+
+    return is_active_public_geometry_source(
+        document,
+        obj,
+        validate_brep=validate_brep,
+    ) and not bool(getattr(obj, "VibeCADAnalysisDomain", False))
+
+
+def is_potential_design_geometry_source(document: Any, obj: Any) -> bool:
+    """Identify a Drawing candidate without reading its potentially huge Shape."""
+
+    if obj is None or _is_body_member(obj) or _is_internal_resource(obj):
+        return False
+    try:
+        import PartGui
+    except ImportError:
+        return False
+    try:
+        str(document.Uid)
+        int(obj.ID)
+        properties = tuple(getattr(obj, "PropertiesList", ()) or ())
+        type_id = str(getattr(obj, "TypeId", "") or "")
+        return (
+            ("Shape" in properties or type_id in {"App::Part", "App::Link"})
+            and bool(PartGui.isModelingObjectActive(obj))
+            and not bool(getattr(obj, "VibeCADAnalysisDomain", False))
+        )
+    except Exception:
+        return False
+
+
+def active_public_geometry_sources(
+    document: Any,
+    *,
+    validate_brep: bool = True,
+) -> tuple[Any, ...]:
+    """Return each active usable shape once at its public Body boundary.
+
+    Exact callers retain BREP validation by default.  Responsive source
+    catalogs may defer that unbounded check until an exact source is used.
+    """
+
+    if type(validate_brep) is not bool:
+        raise TypeError("validate_brep must be a boolean")
 
     try:
         import PartGui
@@ -47,17 +144,14 @@ def active_public_geometry_sources(document: Any) -> tuple[Any, ...]:
     result = []
     seen: set[tuple[str, int]] = set()
     for obj in tuple(getattr(document, "Objects", ()) or ()):
-        shape = getattr(obj, "Shape", None)
-        if shape is None or _is_body_member(obj) or _is_internal_resource(obj):
+        if not _is_active_public_geometry_source(
+            document,
+            obj,
+            part_gui=PartGui,
+            validate_brep=validate_brep,
+        ):
             continue
         try:
-            if (
-                shape.isNull()
-                or not shape.isValid()
-                or not PartGui.isModelingObjectActive(obj)
-                or not any((len(shape.Solids), len(shape.Faces), len(shape.Edges)))
-            ):
-                continue
             identity = (str(document.Uid), int(obj.ID))
         except Exception:
             continue
@@ -68,14 +162,27 @@ def active_public_geometry_sources(document: Any) -> tuple[Any, ...]:
     return tuple(result)
 
 
-def active_design_geometry_sources(document: Any) -> tuple[Any, ...]:
+def active_design_geometry_sources(
+    document: Any,
+    *,
+    validate_brep: bool = True,
+) -> tuple[Any, ...]:
     """Return design geometry without downstream analysis-domain artifacts."""
 
     return tuple(
         obj
-        for obj in active_public_geometry_sources(document)
+        for obj in active_public_geometry_sources(
+            document,
+            validate_brep=validate_brep,
+        )
         if not bool(getattr(obj, "VibeCADAnalysisDomain", False))
     )
 
 
-__all__ = ["active_design_geometry_sources", "active_public_geometry_sources"]
+__all__ = [
+    "active_design_geometry_sources",
+    "active_public_geometry_sources",
+    "is_active_design_geometry_source",
+    "is_active_public_geometry_source",
+    "is_potential_design_geometry_source",
+]

--- a/src/Mod/VibeCAD/VibeCADNativeGeometrySources.py
+++ b/src/Mod/VibeCAD/VibeCADNativeGeometrySources.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Mapping
 
 
 def _is_body(obj: Any) -> bool:
@@ -35,6 +35,154 @@ def _is_body_member(obj: Any) -> bool:
 def _is_internal_resource(obj: Any) -> bool:
     role = str(getattr(obj, "VibeCADTimelineRole", "") or "").strip()
     return role in {"internal", "resource"} and not _is_body(obj)
+
+
+def _visibility_parent(obj: Any) -> Any | None:
+    for method_name in ("getParentGroup", "getParentGeoFeatureGroup"):
+        reader = getattr(obj, method_name, None)
+        if not callable(reader):
+            continue
+        try:
+            parent = reader()
+        except (AttributeError, ReferenceError, RuntimeError):
+            continue
+        if parent is not None:
+            return parent
+    return None
+
+
+def is_drawing_object_effectively_visible(obj: Any) -> bool:
+    """Return whether one object and every visual container are shown."""
+
+    visited: set[int] = set()
+    current = obj
+    while current is not None:
+        identity = id(current)
+        if identity in visited:
+            return False
+        visited.add(identity)
+        view = getattr(current, "ViewObject", None)
+        try:
+            if view is None or not bool(view.Visibility):
+                return False
+        except (AttributeError, ReferenceError, RuntimeError):
+            return False
+        current = _visibility_parent(current)
+    return True
+
+
+def _direct_analysis_artifact(obj: Any) -> bool:
+    type_id = str(getattr(obj, "TypeId", "") or "")
+    if type_id.startswith("Fem::"):
+        return True
+    try:
+        if bool(getattr(obj, "VibeCADAnalysisDomain", False)):
+            return True
+    except (AttributeError, ReferenceError, RuntimeError):
+        return True
+    properties = set(str(name) for name in tuple(getattr(obj, "PropertiesList", ()) or ()))
+    return bool(properties.intersection({"FemMesh", "FemSource", "FemResult"}))
+
+
+def drawing_analysis_artifact_names(document: Any) -> frozenset[str]:
+    """Return every FEM/Analyze artifact excluded from the Drawing surface."""
+
+    objects = tuple(getattr(document, "Objects", ()) or ())
+    names = {
+        str(getattr(obj, "Name", "") or "")
+        for obj in objects
+        if _direct_analysis_artifact(obj)
+    }
+    pending = [
+        member
+        for analysis in objects
+        if str(getattr(analysis, "TypeId", "") or "") == "Fem::FemAnalysis"
+        for member in tuple(getattr(analysis, "Group", ()) or ())
+    ]
+    visited: set[int] = set()
+    while pending:
+        member = pending.pop()
+        identity = id(member)
+        if identity in visited:
+            continue
+        visited.add(identity)
+        name = str(getattr(member, "Name", "") or "")
+        if name:
+            names.add(name)
+        pending.extend(tuple(getattr(member, "Group", ()) or ()))
+    names.discard("")
+    return frozenset(names)
+
+
+def drawing_source_exclusion_reason(
+    document: Any,
+    obj: Any,
+    *,
+    analysis_artifact_names: frozenset[str] | None = None,
+) -> str | None:
+    """Return the Drawing-only reason an object must not enter provider context."""
+
+    if obj is None:
+        return "hidden"
+    artifact_names = (
+        drawing_analysis_artifact_names(document)
+        if analysis_artifact_names is None
+        else analysis_artifact_names
+    )
+    name = str(getattr(obj, "Name", "") or "")
+    if _direct_analysis_artifact(obj) or (name and name in artifact_names):
+        return "analysis_artifact"
+    if not is_drawing_object_effectively_visible(obj):
+        return "hidden"
+    return None
+
+
+def filter_drawing_selection(
+    document: Any,
+    selection: Mapping[str, Any],
+    *,
+    analysis_artifact_names: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Remove hidden and Analyze/FEM objects from one Drawing selection."""
+
+    artifact_names = (
+        drawing_analysis_artifact_names(document)
+        if analysis_artifact_names is None
+        else analysis_artifact_names
+    )
+    filtered = dict(selection)
+    items = []
+    get_object = getattr(document, "getObject", None)
+    object_by_name = {
+        str(getattr(obj, "Name", "") or ""): obj
+        for obj in tuple(getattr(document, "Objects", ()) or ())
+    }
+    for item in list(filtered.get("items") or ()):
+        reference = item.get("object") if isinstance(item, Mapping) else None
+        name = (
+            str(reference.get("object_name") or "")
+            if isinstance(reference, Mapping)
+            else ""
+        )
+        obj = (
+            get_object(name)
+            if name and callable(get_object)
+            else object_by_name.get(name)
+        )
+        if obj is None:
+            continue
+        if (
+            drawing_source_exclusion_reason(
+                document,
+                obj,
+                analysis_artifact_names=artifact_names,
+            )
+            is None
+        ):
+            items.append(item)
+    filtered["items"] = items
+    filtered["selected_count"] = len(items)
+    return filtered
 
 
 def _is_active_public_geometry_source(
@@ -93,17 +241,24 @@ def is_active_design_geometry_source(
 ) -> bool:
     """Return whether one active public object is design, not analysis, geometry."""
 
+    if drawing_source_exclusion_reason(document, obj) is not None:
+        return False
     return is_active_public_geometry_source(
         document,
         obj,
         validate_brep=validate_brep,
-    ) and not bool(getattr(obj, "VibeCADAnalysisDomain", False))
+    )
 
 
 def is_potential_design_geometry_source(document: Any, obj: Any) -> bool:
     """Identify a Drawing candidate without reading its potentially huge Shape."""
 
-    if obj is None or _is_body_member(obj) or _is_internal_resource(obj):
+    if (
+        obj is None
+        or _is_body_member(obj)
+        or _is_internal_resource(obj)
+        or drawing_source_exclusion_reason(document, obj) is not None
+    ):
         return False
     try:
         import PartGui
@@ -169,20 +324,48 @@ def active_design_geometry_sources(
 ) -> tuple[Any, ...]:
     """Return design geometry without downstream analysis-domain artifacts."""
 
-    return tuple(
-        obj
-        for obj in active_public_geometry_sources(
+    if type(validate_brep) is not bool:
+        raise TypeError("validate_brep must be a boolean")
+    try:
+        import PartGui
+    except ImportError:
+        return ()
+    artifact_names = drawing_analysis_artifact_names(document)
+    result = []
+    seen: set[tuple[str, int]] = set()
+    for obj in tuple(getattr(document, "Objects", ()) or ()):
+        if drawing_source_exclusion_reason(
             document,
+            obj,
+            analysis_artifact_names=artifact_names,
+        ) is not None:
+            continue
+        if not _is_active_public_geometry_source(
+            document,
+            obj,
+            part_gui=PartGui,
             validate_brep=validate_brep,
-        )
-        if not bool(getattr(obj, "VibeCADAnalysisDomain", False))
-    )
+        ):
+            continue
+        try:
+            identity = (str(document.Uid), int(obj.ID))
+        except Exception:
+            continue
+        if identity in seen:
+            continue
+        seen.add(identity)
+        result.append(obj)
+    return tuple(result)
 
 
 __all__ = [
     "active_design_geometry_sources",
     "active_public_geometry_sources",
+    "drawing_analysis_artifact_names",
+    "drawing_source_exclusion_reason",
+    "filter_drawing_selection",
     "is_active_design_geometry_source",
     "is_active_public_geometry_source",
+    "is_drawing_object_effectively_visible",
     "is_potential_design_geometry_source",
 ]

--- a/src/Mod/VibeCAD/VibeCADNativeMeshState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeMeshState.py
@@ -4,6 +4,9 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
+from contextvars import ContextVar
+from copy import deepcopy
 import hashlib
 import json
 import math
@@ -15,6 +18,23 @@ from VibeCADNativeSnapshot import concise_object
 
 MAX_MESH_STATE_SOURCES = 16
 MAX_MESH_STATE_RESOURCES = 32
+
+
+_MESH_OBJECT_STATE_CACHE: ContextVar[dict[int, dict[str, Any]] | None] = ContextVar(
+    "vibecad_mesh_object_state_cache",
+    default=None,
+)
+
+
+@contextmanager
+def mesh_object_state_cache():
+    """Reuse detached mesh/object state during one immutable capture pass."""
+
+    token = _MESH_OBJECT_STATE_CACHE.set({})
+    try:
+        yield
+    finally:
+        _MESH_OBJECT_STATE_CACHE.reset(token)
 
 
 def _finite(value: Any) -> float | None:
@@ -141,6 +161,11 @@ def mesh_object_state(obj: Any) -> dict[str, Any]:
     multi-million-facet mesh.
     """
 
+    cache = _MESH_OBJECT_STATE_CACHE.get()
+    cache_key = id(obj)
+    if cache is not None and cache_key in cache:
+        return deepcopy(cache[cache_key])
+
     result = concise_object(obj)
     mesh = getattr(obj, "Mesh", None)
     points = getattr(obj, "Points", None)
@@ -210,6 +235,8 @@ def mesh_object_state(obj: Any) -> dict[str, Any]:
         if name not in {"label", "state"}
     }
     result["state_sha256"] = _state_digest(digest_source)
+    if cache is not None:
+        cache[cache_key] = deepcopy(result)
     return result
 
 

--- a/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
@@ -113,6 +113,8 @@ def live_working_set(
     document: Any,
     selection: Mapping[str, Any],
     native_state: Mapping[str, Any],
+    *,
+    include_object: Callable[[Any], bool] | None = None,
 ) -> list[dict[str, Any]]:
     get_object = getattr(document, "getObject", None)
     if not callable(get_object):
@@ -129,6 +131,8 @@ def live_working_set(
         seen.add(name)
         obj = get_object(name)
         if obj is None or getattr(obj, "Document", None) is not document:
+            continue
+        if include_object is not None and not include_object(obj):
             continue
         result.append(concise_object(obj))
         if len(result) >= MAX_WORKING_OBJECTS:
@@ -240,6 +244,38 @@ def capture_active_snapshot_base(
     selected = dict(selection) if selection is not None else read_current_selection(document)
     if str(selected.get("document_uid") or "") != uid:
         raise NativeSnapshotError("Native selection belongs to another document.")
+    include_working_object = None
+    if surface_id == "drawing":
+        from VibeCADNativeGeometrySources import (
+            drawing_analysis_artifact_names,
+            drawing_source_exclusion_reason,
+            filter_drawing_selection,
+        )
+
+        analysis_artifacts = drawing_analysis_artifact_names(document)
+
+        def include_drawing_object(obj: Any) -> bool:
+            return (
+                drawing_source_exclusion_reason(
+                    document,
+                    obj,
+                    analysis_artifact_names=analysis_artifacts,
+                )
+                is None
+            )
+
+        selected = filter_drawing_selection(
+            document,
+            selected,
+            analysis_artifact_names=analysis_artifacts,
+        )
+        include_working_object = include_drawing_object
+    working_set = live_working_set(
+        document,
+        selected,
+        native_state,
+        include_object=include_working_object,
+    )
     result: dict[str, Any] = {
         "surface_id": surface_id,
         "document": {
@@ -247,7 +283,7 @@ def capture_active_snapshot_base(
             "document_name": str(getattr(document, "Name", "") or ""),
         },
         "structural_revision": int(native_state.get("structural_revision") or 0),
-        "working_set": live_working_set(document, selected, native_state),
+        "working_set": working_set,
         "_selection": selected,
     }
     if selected.get("items"):

--- a/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
@@ -231,6 +231,7 @@ def capture_active_snapshot_base(
     native_state: Mapping[str, Any],
     *,
     selection: Mapping[str, Any] | None = None,
+    analysis_artifact_names: frozenset[str] | None = None,
 ) -> dict[str, Any]:
     """Capture detached active-surface identity before domain preparation."""
 
@@ -245,14 +246,44 @@ def capture_active_snapshot_base(
     if str(selected.get("document_uid") or "") != uid:
         raise NativeSnapshotError("Native selection belongs to another document.")
     include_working_object = None
-    if surface_id == "drawing":
+    if surface_id == "analyze":
+        from VibeCADNativeGeometrySources import (
+            drawing_analysis_artifact_names,
+            filter_analyze_selection,
+            is_analyze_context_reference,
+        )
+
+        analysis_artifacts = (
+            drawing_analysis_artifact_names(document)
+            if analysis_artifact_names is None
+            else analysis_artifact_names
+        )
+        selected = filter_analyze_selection(
+            document,
+            selected,
+            analysis_artifact_names=analysis_artifacts,
+        )
+
+        def include_available_object(obj: Any) -> bool:
+            return is_analyze_context_reference(
+                document,
+                obj,
+                analysis_artifact_names=analysis_artifacts,
+            )
+
+        include_working_object = include_available_object
+    elif surface_id == "drawing":
         from VibeCADNativeGeometrySources import (
             drawing_analysis_artifact_names,
             drawing_source_exclusion_reason,
             filter_drawing_selection,
         )
 
-        analysis_artifacts = drawing_analysis_artifact_names(document)
+        analysis_artifacts = (
+            drawing_analysis_artifact_names(document)
+            if analysis_artifact_names is None
+            else analysis_artifact_names
+        )
 
         def include_drawing_object(obj: Any) -> bool:
             return (

--- a/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
@@ -139,6 +139,7 @@ def _domain_builder(
     surface_id: str,
     background_job: Any | None = None,
     selection: Mapping[str, Any] | None = None,
+    structural_revision: int | None = None,
 ) -> Callable[[Any], Mapping[str, Any]]:
     if surface_id == "model":
         from VibeCADNativeModelSnapshot import build_model_snapshot
@@ -180,6 +181,7 @@ def _domain_builder(
         return lambda document: build_drawing_snapshot(
             document,
             selection=selection,
+            structural_revision=structural_revision,
         )
     if surface_id == "parameters":
         from VibeCADNativeParametersSnapshot import build_parameters_snapshot
@@ -212,6 +214,7 @@ def build_active_snapshot(
             surface_id,
             background_job,
             selected,
+            int(base.get("structural_revision", 0) or 0),
         )(document)
     )
     return complete_active_snapshot(base, domain)

--- a/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
@@ -13,6 +13,7 @@ from VibeCADRibbonSurface import SURFACE_IDS
 
 MAX_NATIVE_SNAPSHOT_BYTES = 64 * 1024
 MAX_WORKING_OBJECTS = 12
+MAX_DEFERRED_SECTION_SUMMARIES = 64
 
 
 class NativeSnapshotError(RuntimeError):
@@ -275,12 +276,139 @@ def complete_active_snapshot(
                 "The active Sketch did not provide an exact provider revision."
             )
         result["revision"] = revision
-    encoded = json.dumps(
-        result,
+    encoded = _encode_snapshot(result)
+    if len(encoded.encode("utf-8")) > MAX_NATIVE_SNAPSHOT_BYTES:
+        result = _compact_oversized_snapshot(result, len(encoded.encode("utf-8")))
+        encoded = _encode_snapshot(result)
+    return json.loads(encoded)
+
+
+def _encode_snapshot(snapshot: Mapping[str, Any]) -> str:
+    return json.dumps(
+        snapshot,
         ensure_ascii=True,
         sort_keys=True,
         separators=(",", ":"),
     )
-    if len(encoded.encode("utf-8")) > MAX_NATIVE_SNAPSHOT_BYTES:
-        raise NativeSnapshotError("The active Native state snapshot exceeds its bound.")
-    return json.loads(encoded)
+
+
+def _section_summary(name: str, value: Any) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "name": str(name),
+        "kind": (
+            "array"
+            if isinstance(value, list)
+            else "object"
+            if isinstance(value, Mapping)
+            else type(value).__name__
+        ),
+    }
+    if isinstance(value, (list, Mapping)):
+        result["item_count"] = len(value)
+    return result
+
+
+def _deferred_domain_manifest(
+    domain: Mapping[str, Any],
+    original_bytes: int,
+) -> dict[str, Any]:
+    sections = [
+        _section_summary(str(name), value) for name, value in domain.items()
+    ]
+    result: dict[str, Any] = {
+        "kind": str(domain.get("kind") or "unknown"),
+        "snapshot_truncated": True,
+        "detail_deferred": True,
+        "original_snapshot_bytes": int(original_bytes),
+        "section_count": len(sections),
+        "sections": sections[:MAX_DEFERRED_SECTION_SUMMARIES],
+    }
+    if len(sections) > MAX_DEFERRED_SECTION_SUMMARIES:
+        result["sections_truncated"] = True
+    return result
+
+
+def _bounded_selection(selection: Mapping[str, Any]) -> dict[str, Any]:
+    """Keep a useful exact selection even if the bounded base itself is excessive."""
+
+    items = []
+    raw_items = list(selection.get("items") or [])
+    for raw_item in raw_items[:8]:
+        if not isinstance(raw_item, Mapping):
+            continue
+        item = dict(raw_item)
+        subelements = list(item.get("subelements") or [])
+        if len(subelements) > 16:
+            item["subelements"] = subelements[:16]
+            item["subelements_truncated"] = True
+        items.append(item)
+    result = {
+        str(name): value
+        for name, value in selection.items()
+        if name != "items"
+    }
+    result["items"] = items
+    if len(raw_items) > len(items):
+        result["truncated"] = True
+    return result
+
+
+def _compact_oversized_snapshot(
+    snapshot: Mapping[str, Any],
+    original_bytes: int,
+) -> dict[str, Any]:
+    """Return bounded provider context instead of rejecting the conversation."""
+
+    result = dict(snapshot)
+    domain = result.get("domain")
+    if not isinstance(domain, Mapping):
+        domain = {}
+
+    if result.get("surface_id") == "drawing":
+        from VibeCADNativeDrawingSnapshot import compact_drawing_snapshot_for_bound
+
+        result["domain"] = compact_drawing_snapshot_for_bound(domain)
+        if len(_encode_snapshot(result).encode("utf-8")) <= MAX_NATIVE_SNAPSHOT_BYTES:
+            return result
+
+    result["domain"] = _deferred_domain_manifest(domain, original_bytes)
+    if len(_encode_snapshot(result).encode("utf-8")) <= MAX_NATIVE_SNAPSHOT_BYTES:
+        return result
+
+    # Domain detail is already deferred at this point. Remove duplicated working-set
+    # context before touching the user's exact selection.
+    if result.get("working_set"):
+        result["working_set"] = []
+        result["working_set_truncated"] = True
+    if len(_encode_snapshot(result).encode("utf-8")) <= MAX_NATIVE_SNAPSHOT_BYTES:
+        return result
+
+    selection = result.get("selection")
+    if isinstance(selection, Mapping):
+        result["selection"] = _bounded_selection(selection)
+        result["selection_truncated_for_snapshot"] = True
+    if len(_encode_snapshot(result).encode("utf-8")) <= MAX_NATIVE_SNAPSHOT_BYTES:
+        return result
+
+    # The production budget is large enough for this identity-only form. Keeping this
+    # final form deterministic makes a pathological extension safe without weakening
+    # the normal 64 KiB contract.
+    minimal = {
+        name: result[name]
+        for name in (
+            "surface_id",
+            "document",
+            "structural_revision",
+            "revision",
+        )
+        if name in result
+    }
+    minimal["domain"] = {
+        "kind": str(domain.get("kind") or "unknown"),
+        "snapshot_truncated": True,
+        "detail_deferred": True,
+        "original_snapshot_bytes": int(original_bytes),
+        "section_count": len(domain),
+        "sections": [],
+    }
+    return minimal

--- a/src/Mod/VibeCAD/VibeCADNativeView.py
+++ b/src/Mod/VibeCAD/VibeCADNativeView.py
@@ -266,6 +266,7 @@ def capture_screenshot(
     *,
     frame: str = "all",
     targets: tuple[NativeObjectRef, ...] = (),
+    page_name: str | None = None,
 ) -> dict[str, Any]:
     uid = document_uid(document)
     if str(getattr(service._active_document(), "Uid", "") or "") != uid:
@@ -282,13 +283,15 @@ def capture_screenshot(
         names = [resolve_object(document, target).Name for target in targets]
     from tool_impl.service import core_capture_view_screenshot
 
-    raw = core_capture_view_screenshot.run(
-        service,
-        camera={"mode": "auto"},
-        frame=frame_mode,
-        object_names=names,
-        sketch_annotations="clean",
-    )
+    capture_arguments: dict[str, Any] = {
+        "camera": {"mode": "auto"},
+        "frame": frame_mode,
+        "object_names": names,
+        "sketch_annotations": "clean",
+    }
+    if page_name is not None:
+        capture_arguments["page_name"] = str(page_name)
+    raw = core_capture_view_screenshot.run(service, **capture_arguments)
     if not isinstance(raw, Mapping):
         raise NativeViewError("Viewport screenshot capture failed.")
     if raw.get("ok") is not True:

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -1374,6 +1374,13 @@ def _build_context_for_provider(
         cancellation_check=cancellation_check,
         progress_callback=progress_callback,
     )
+    if prepared_native_state is None:
+        prepared_native_state = _build_responsive_drawing_native_state(
+            service,
+            document_thread_dispatch,
+            cancellation_check=cancellation_check,
+            progress_callback=progress_callback,
+        )
     captured = _on_document_thread(
         document_thread_dispatch,
         lambda: _capture_context_for_provider(
@@ -1529,6 +1536,162 @@ def prewarm_analyze_context(
     """Populate the read-only Analyze cache before the human presses Send."""
 
     return _build_responsive_analyze_native_state(
+        service,
+        document_thread_dispatch,
+        progress_callback=progress_callback,
+    )
+
+
+def _prepare_responsive_drawing_source_catalog(
+    service: VibeCADService,
+    document_thread_dispatch: DocumentThreadDispatch | None,
+    *,
+    cancellation_check: CancellationCheck | None = None,
+    progress_callback: ProgressCallback | None = None,
+) -> dict[str, Any] | None:
+    """Prepare one complete Drawing source catalog in bounded Qt batches."""
+
+    from VibeCADNativeDrawingContext import (
+        DrawingContextStale,
+        capture_responsive_drawing_source_catalog,
+    )
+    from VibeCADNativeDrawingSourceCatalog import (
+        cache_drawing_source_catalog_state,
+        drawing_source_catalog_is_cached,
+    )
+
+    begin = getattr(service, "begin_native_drawing_context_request", None)
+    coordinator_reader = getattr(service, "native_drawing_context_coordinator", None)
+    capture_batch = getattr(service, "capture_native_drawing_context_batch", None)
+    if not all(
+        callable(callback)
+        for callback in (begin, coordinator_reader, capture_batch)
+    ):
+        return None
+
+    def emit_progress(percent: int, message: str) -> None:
+        _emit(
+            progress_callback,
+            {
+                "event": "drawing_context_progress",
+                "percent": int(percent),
+                "message": str(message or ""),
+            },
+        )
+
+    for attempt in range(2):
+        request = _on_document_thread(document_thread_dispatch, begin)
+        if request is None:
+            return None
+        if not isinstance(request, Mapping):
+            raise RuntimeError("Drawing context request returned no object.")
+        uid = str(request.get("document_uid") or "")
+        revision = int(request.get("structural_revision", 0) or 0)
+        if drawing_source_catalog_is_cached(uid, revision):
+            _emit(
+                progress_callback,
+                {
+                    "event": "drawing_context_cache_hit",
+                    "structural_revision": revision,
+                },
+            )
+            return dict(request)
+        coordinator = coordinator_reader()
+
+        def build(cancelled, report):
+            if drawing_source_catalog_is_cached(uid, revision):
+                return {"structural_revision": revision, "cache_hit": True}
+            return capture_responsive_drawing_source_catalog(
+                request,
+                dispatch_to_document_thread=lambda operation: _on_document_thread(
+                    document_thread_dispatch,
+                    operation,
+                ),
+                capture_batch=capture_batch,
+                finalize=lambda current, sources: cache_drawing_source_catalog_state(
+                    str(current["document_uid"]),
+                    int(current["structural_revision"]),
+                    list(sources),
+                ),
+                cancellation_check=cancelled,
+                progress_callback=report,
+            )
+
+        try:
+            coordinator.get_or_build(
+                uid,
+                revision,
+                build,
+                cancellation_check=cancellation_check,
+                progress_callback=emit_progress,
+            )
+            if not drawing_source_catalog_is_cached(uid, revision):
+                raise RuntimeError(
+                    "Drawing source preparation completed without a cached catalog."
+                )
+            _emit(
+                progress_callback,
+                {
+                    "event": "drawing_context_ready",
+                    "structural_revision": revision,
+                },
+            )
+            return dict(request)
+        except DrawingContextStale:
+            if attempt == 0 and not (
+                cancellation_check is not None and cancellation_check()
+            ):
+                continue
+            raise
+    raise RuntimeError("Drawing context changed repeatedly during source capture.")
+
+
+def _build_responsive_drawing_native_state(
+    service: VibeCADService,
+    document_thread_dispatch: DocumentThreadDispatch | None,
+    *,
+    cancellation_check: CancellationCheck | None = None,
+    progress_callback: ProgressCallback | None = None,
+) -> dict[str, Any] | None:
+    """Build Drawing state after responsive source preparation."""
+
+    from VibeCADNativeDrawingContext import DrawingContextStale
+
+    finish = getattr(service, "finish_native_drawing_context_request", None)
+    if not callable(finish):
+        return None
+    for attempt in range(2):
+        request = _prepare_responsive_drawing_source_catalog(
+            service,
+            document_thread_dispatch,
+            cancellation_check=cancellation_check,
+            progress_callback=progress_callback,
+        )
+        if request is None:
+            return None
+        try:
+            return _on_document_thread(
+                document_thread_dispatch,
+                lambda: finish(request),
+            )
+        except DrawingContextStale:
+            if attempt == 0 and not (
+                cancellation_check is not None and cancellation_check()
+            ):
+                continue
+            raise
+    raise RuntimeError("Drawing context changed repeatedly during finalization.")
+
+
+def prewarm_drawing_context(
+    service: VibeCADService,
+    document_thread_dispatch: DocumentThreadDispatch | None,
+    *,
+    progress_callback: ProgressCallback | None = None,
+) -> dict[str, Any] | None:
+    """Populate the Drawing source cache before the human presses Send."""
+
+    return _build_responsive_drawing_native_state(
         service,
         document_thread_dispatch,
         progress_callback=progress_callback,
@@ -5442,6 +5605,13 @@ def make_provider_tool_runner(
                     cancellation_check=cancellation_check,
                     progress_callback=progress_callback,
                 )
+            )
+        if tool_name == "drawing.sources":
+            _prepare_responsive_drawing_source_catalog(
+                service,
+                document_thread_dispatch,
+                cancellation_check=cancellation_check,
+                progress_callback=progress_callback,
             )
         _emit(
             progress_callback,

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -10,6 +10,7 @@ in the live state packet. There is no workflow phase machine or prose parser.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 import json
 import threading
@@ -1496,9 +1497,14 @@ def _build_responsive_analyze_native_state(
                 progress_callback=emit_progress,
             )
             if cache_hit:
-                current_clipping = _on_document_thread(
-                    document_thread_dispatch,
-                    lambda: capture_clipping(request),
+                detached_clipping = request.get("detached_clipping")
+                current_clipping = (
+                    deepcopy(dict(detached_clipping))
+                    if isinstance(detached_clipping, Mapping)
+                    else _on_document_thread(
+                        document_thread_dispatch,
+                        lambda: capture_clipping(request),
+                    )
                 )
                 domain = dict(domain)
                 domain["clipping"] = dict(current_clipping)
@@ -1669,6 +1675,9 @@ def _build_responsive_drawing_native_state(
         )
         if request is None:
             return None
+        completed = request.get("completed_snapshot")
+        if isinstance(completed, Mapping):
+            return deepcopy(dict(completed))
         try:
             return _on_document_thread(
                 document_thread_dispatch,

--- a/src/Mod/VibeCAD/tool_impl/service/core_capture_view_screenshot.py
+++ b/src/Mod/VibeCAD/tool_impl/service/core_capture_view_screenshot.py
@@ -24,9 +24,11 @@ DUPLICATE_VISUAL_DIFFERENCE_THRESHOLD = 0.005
 
 TOOL_SPEC = {
     "description": (
-        "Capture the active Drawing page or 3D view for visual verification. auto "
-        "frames an open sketch or the full model; clean temporarily hides sketch "
-        "overlays. Omit camera for automatic orientation or pass camera='isometric'."
+        "Capture a named Drawing page, the active Drawing page, or a 3D view for "
+        "visual verification. Call again with another page_name to inspect multiple "
+        "pages in one turn. auto frames an open sketch or the full model; clean "
+        "temporarily hides sketch overlays. Omit camera for automatic orientation "
+        "or pass camera='isometric'."
     ),
     "name": "core.capture_view_screenshot",
     "parameters": {
@@ -50,6 +52,15 @@ TOOL_SPEC = {
                     "frame='objects'."
                 ),
             },
+            "page_name": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 128,
+                "description": (
+                    "Drawing page internal Name or unique Label. When supplied, "
+                    "that page is captured even when another page is active."
+                ),
+            },
             "sketch_annotations": {
                 "type": "string",
                 "enum": list(CAPTURE_ANNOTATION_MODES),
@@ -71,12 +82,14 @@ def run(
     frame: str = "auto",
     object_names: list[str] | None = None,
     sketch_annotations: str = "clean",
+    page_name: str | None = None,
 ) -> dict[str, Any]:
     requested = {
         "camera": camera,
         "frame": frame,
         "object_names": list(object_names or []),
         "sketch_annotations": sketch_annotations,
+        "page_name": page_name,
     }
     frame_mode = str(frame or "auto").strip().lower()
     annotation_mode = str(sketch_annotations or "clean").strip().lower()
@@ -120,26 +133,21 @@ def run(
             "No active document.",
             requested=requested,
         )
-    drawing_page = _active_drawing_page(document)
+    drawing_page = None
+    if page_name is not None:
+        drawing_page, page_error = _resolve_drawing_page(document, page_name)
+        if drawing_page is None:
+            return _remember_failure(
+                service,
+                "DRAWING_PAGE_TARGET_INVALID",
+                "precondition",
+                page_error,
+                requested=requested,
+                candidates=_drawing_page_candidates(document),
+            )
+    else:
+        drawing_page = _active_drawing_page(document)
     if drawing_page is not None:
-        if frame_mode not in {"auto", "all"}:
-            return _remember_failure(
-                service,
-                "DRAWING_PAGE_FRAME_UNSUPPORTED",
-                "precondition",
-                "An active Drawing page supports only an all-page capture.",
-                requested=requested,
-                allowed_values=["all"],
-            )
-        if not _automatic_camera(camera):
-            return _remember_failure(
-                service,
-                "DRAWING_PAGE_CAMERA_UNSUPPORTED",
-                "precondition",
-                "Drawing page capture has no 3D camera.",
-                requested=requested,
-                allowed_values=["auto"],
-            )
         return _capture_drawing_page(
             service,
             document,
@@ -664,6 +672,50 @@ def _active_drawing_page(document: Any) -> Any | None:
     return active[0] if len(active) == 1 else None
 
 
+def _drawing_pages(document: Any) -> list[Any]:
+    pages: list[Any] = []
+    for obj in tuple(getattr(document, "Objects", ()) or ()):
+        checker = getattr(obj, "isDerivedFrom", None)
+        try:
+            is_page = (
+                bool(checker("TechDraw::DrawPage")) if callable(checker) else False
+            )
+        except Exception:
+            is_page = False
+        if is_page or getattr(obj, "TypeId", "") == "TechDraw::DrawPage":
+            pages.append(obj)
+    return pages
+
+
+def _drawing_page_candidates(document: Any) -> list[dict[str, str]]:
+    return [
+        {
+            "object_name": str(getattr(page, "Name", "")),
+            "label": str(getattr(page, "Label", getattr(page, "Name", ""))),
+        }
+        for page in _drawing_pages(document)[:32]
+    ]
+
+
+def _resolve_drawing_page(
+    document: Any,
+    requested_name: Any,
+) -> tuple[Any | None, str]:
+    name = str(requested_name or "").strip()
+    if not name:
+        return None, "Drawing page_name must not be empty."
+    pages = _drawing_pages(document)
+    exact = [page for page in pages if str(getattr(page, "Name", "")) == name]
+    if len(exact) == 1:
+        return exact[0], ""
+    labels = [page for page in pages if str(getattr(page, "Label", "")) == name]
+    if len(labels) == 1:
+        return labels[0], ""
+    if len(labels) > 1:
+        return None, f"Drawing page label {name!r} is not unique; use object_name."
+    return None, f"No Drawing page named {name!r} exists in the active document."
+
+
 def _capture_drawing_page(
     service: Any,
     document: Any,
@@ -681,7 +733,7 @@ def _capture_drawing_page(
         width_mm = float(getattr(template, "Width", 0.0))
         height_mm = float(getattr(template, "Height", 0.0))
         if width_mm <= 0.0 or height_mm <= 0.0:
-            raise RuntimeError("The active Drawing page has no physical sheet size.")
+            raise RuntimeError("The selected Drawing page has no physical sheet size.")
         width_px = max(1, int(round(width_mm * 10.0)))
         height_px = max(1, int(round(height_mm * 10.0)))
         screenshot_dir = _screenshot_artifact_dir(service)
@@ -692,7 +744,7 @@ def _capture_drawing_page(
         )
         scene = TechDrawGui.getSceneForPage(page)
         if scene is None:
-            raise RuntimeError("The active Drawing page has no graphical scene.")
+            raise RuntimeError("The selected Drawing page has no graphical scene.")
         Gui.updateGui()
         image = QtGui.QImage(
             width_px,

--- a/src/Mod/VibeCAD/vibecad_tests/native_drawing_page_capture_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_drawing_page_capture_gui_integration.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Real GUI gate for exact, multi-page Drawing screenshot capture."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import traceback
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import Part
+from PySide import QtCore, QtWidgets
+
+from VibeCADCore import get_service
+from tool_impl.service import core_capture_view_screenshot
+
+
+def _events(rounds: int = 24) -> None:
+    for _index in range(rounds):
+        Gui.updateGui()
+        QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 25)
+
+
+def _page(document, name: str, label: str, source, direction):
+    page = document.addObject("TechDraw::DrawPage", name)
+    page.Label = label
+    template = document.addObject("TechDraw::DrawSVGTemplate", f"{name}Template")
+    template.Template = str(
+        Path(App.getResourceDir())
+        / "Mod"
+        / "TechDraw"
+        / "Templates"
+        / "ISO"
+        / "A4_Landscape_TD.svg"
+    )
+    page.Template = template
+    view = document.addObject("TechDraw::DrawViewPart", f"{name}View")
+    view.Source = [source]
+    view.Direction = direction
+    view.XDirection = (
+        App.Vector(0.0, 1.0, 0.0)
+        if abs(float(direction.x)) > 0.5
+        else App.Vector(1.0, 0.0, 0.0)
+    )
+    assert int(page.addView(view)) >= 1
+    view.X = 145.0
+    view.Y = 95.0
+    return page
+
+
+def _assert_capture(result, page) -> Path:
+    assert result.get("ok") is True, result
+    assert result.get("captured") is True, result
+    assert result["target"] == {
+        "frame": "drawing_page",
+        "object_count": 1,
+        "object_names": [page.Name],
+    }
+    path = Path(result["_vibecad_image_attachment"]["path"])
+    assert path.is_file() and path.stat().st_size > 0
+    assert result["artifact"]["path"] == str(path)
+    assert result["visual_observation"].get("mostly_blank") is False
+    return path
+
+
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    document = None
+    exit_code = 1
+    try:
+        Gui.activateWorkbench("TechDrawWorkbench")
+        document = App.newDocument("DrawingPageCaptureGate")
+        source = document.addObject("Part::Feature", "CaptureSource")
+        source.Shape = Part.makeBox(42.0, 30.0, 10.0)
+        first = _page(
+            document,
+            "FabricationPage",
+            "Fabrication",
+            source,
+            App.Vector(0.0, 0.0, 1.0),
+        )
+        second = _page(
+            document,
+            "InspectionPage",
+            "Inspection",
+            source,
+            App.Vector(1.0, 0.0, 0.0),
+        )
+        assert document.recompute() is not False
+        first.ViewObject.show()
+        _events()
+
+        service = get_service()
+        second_capture = core_capture_view_screenshot.run(
+            service,
+            page_name=second.Name,
+            frame="objects",
+            object_names=[source.Name],
+            camera={"mode": "front"},
+        )
+        second_path = _assert_capture(second_capture, second)
+
+        first_capture = core_capture_view_screenshot.run(
+            service,
+            page_name=first.Label,
+        )
+        first_path = _assert_capture(first_capture, first)
+        assert first_path != second_path
+
+        active_capture = core_capture_view_screenshot.run(
+            service,
+            frame="selection",
+            camera={"mode": "isometric"},
+        )
+        active_path = _assert_capture(active_capture, first)
+        assert active_path not in {first_path, second_path}
+
+        print(
+            "VIBECAD_NATIVE_DRAWING_PAGE_CAPTURE_GUI_OK "
+            "named_internal=true named_label=true inactive_page=true "
+            "active_fallback=true multiple_images=true",
+            flush=True,
+        )
+        exit_code = 0
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+    finally:
+        if document is not None and document.Name in App.listDocuments():
+            App.closeDocument(document.Name)
+        application.exit(exit_code)
+
+
+QtCore.QTimer.singleShot(1000, _run)

--- a/src/Mod/VibeCAD/vibecad_tests/native_drawing_standard_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_drawing_standard_view_gui_integration.py
@@ -24,7 +24,11 @@ from VibeCADNativeBackgroundSchema import NATIVE_BACKGROUND_CAPABILITY_NAME
 from VibeCADNativeCapabilityRegistry import NativeProviderSurface
 from VibeCADNativeDispatch import NativeTurnDispatcher
 from VibeCADNativeDrawingState import drawing_page_state
-from VibeCADNativeDrawingViewState import drawing_source_state, drawing_view_state
+from VibeCADNativeDrawingViewState import (
+    drawing_source_catalog_identity_state,
+    drawing_source_state,
+    drawing_view_state,
+)
 from VibeCADNativeRegistry import build_native_capability_registry
 from VibeCADNativeRuntimeContext import NativeRuntimeContext
 from VibeCADNativeRuntimeRegistry import build_native_runtime_bindings
@@ -272,7 +276,9 @@ def _run() -> None:
         )
         assert active["domain"]["active_page_resolution"] == "only_page"
         assert active["domain"]["active_page"]["state_sha256"] == page_state["state_sha256"]
-        assert active["domain"]["selected_sources"] == [source_state]
+        assert active["domain"]["selected_sources"] == [
+            drawing_source_catalog_identity_state(source)
+        ]
         assert len(json.dumps(active, separators=(",", ":")).encode()) < 64 * 1024
 
         invalid = _arguments(page_state, source_state)

--- a/src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py
@@ -555,12 +555,14 @@ def test_codex_ends_a_frozen_turn_after_an_exact_cad_transition(
     assert result.raw["cad_transition"] is True
 
 
-def test_codex_steers_tool_images_outside_replayed_tool_output(
+def test_codex_steers_multiple_tool_images_outside_replayed_tool_output(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    screenshot = tmp_path / "viewport.png"
-    screenshot.write_bytes(b"valid-local-image")
+    viewport = tmp_path / "viewport.png"
+    drawing_page = tmp_path / "drawing-page.png"
+    viewport.write_bytes(b"valid-local-image")
+    drawing_page.write_bytes(b"second-valid-local-image")
     clients = []
 
     class _Client:
@@ -616,10 +618,12 @@ def test_codex_steers_tool_images_outside_replayed_tool_output(
                 self.server_request_handler(
                     "item/tool/call",
                     {
-                        "callId": "view-call",
+                        "callId": "drawing-page-call",
                         "namespace": "core",
-                        "tool": "set_view",
-                        "arguments": {"model_id": "exact-model"},
+                        "tool": "capture_view_screenshot",
+                        "arguments": {
+                            "page_name": "Page002",
+                        },
                     },
                 )
             )
@@ -644,25 +648,33 @@ def test_codex_steers_tool_images_outside_replayed_tool_output(
             self.alive = False
 
     monkeypatch.setattr(codex, "CodexAppServerClient", _Client)
-    context = _surface_context(
-        "core.capture_view_screenshot",
-        "core.set_view",
-    )
+    context = _surface_context("core.capture_view_screenshot")
     calls = []
 
     def runner(tool_name, arguments_json, provider_call_id):
         calls.append((tool_name, provider_call_id))
-        if tool_name == "core.capture_view_screenshot":
+        arguments = json.loads(arguments_json)
+        if "page_name" not in arguments:
             return {
                 "ok": True,
                 "captured": True,
                 "new_observation": True,
                 "_vibecad_image_attachment": {
-                    "path": str(screenshot),
+                    "path": str(viewport),
                     "name": "current viewport",
                 },
             }
-        return {"ok": True}
+        assert tool_name == "core.capture_view_screenshot"
+        assert arguments["page_name"] == "Page002"
+        return {
+            "ok": True,
+            "captured": True,
+            "new_observation": True,
+            "_vibecad_image_attachment": {
+                "path": str(drawing_page),
+                "name": "Inspection Drawing page",
+            },
+        }
 
     runner.provider_update = lambda: context
     active_provider = provider.CodexProvider(
@@ -677,7 +689,7 @@ def test_codex_steers_tool_images_outside_replayed_tool_output(
     assert result.final_output == "Done."
     assert calls == [
         ("core.capture_view_screenshot", "capture-call"),
-        ("core.set_view", "view-call"),
+        ("core.capture_view_screenshot", "drawing-page-call"),
     ]
     assert clients[0].steer_requests == [
         {
@@ -687,15 +699,31 @@ def test_codex_steers_tool_images_outside_replayed_tool_output(
                 {"type": "text", "text": "V:current|current viewport"},
                 {
                     "type": "localImage",
-                    "path": str(screenshot.resolve()),
+                    "path": str(viewport.resolve()),
                     "detail": "original",
                 },
             ],
-        }
+        },
+        {
+            "threadId": "thread-visual",
+            "expectedTurnId": "turn-visual",
+            "input": [
+                {
+                    "type": "text",
+                    "text": "V:current|Inspection Drawing page",
+                },
+                {
+                    "type": "localImage",
+                    "path": str(drawing_page.resolve()),
+                    "detail": "original",
+                },
+            ],
+        },
     ]
-    capture_output = clients[0].tool_responses[0]["contentItems"]
-    assert [item["type"] for item in capture_output] == ["inputText"]
-    assert "imageUrl" not in str(capture_output)
+    for tool_response in clients[0].tool_responses:
+        content_items = tool_response["contentItems"]
+        assert [item["type"] for item in content_items] == ["inputText"]
+        assert "imageUrl" not in str(content_items)
 
 
 def test_turn_start_surface_rejects_human_mutation_commands() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py
@@ -1115,7 +1115,7 @@ def test_codex_thread_config_disables_non_vibecad_tool_surfaces() -> None:
     assert config["include_collaboration_mode_instructions"] is False
     assert config["features.code_mode"] == {
         "enabled": False,
-        "direct_only_tool_namespaces": ["core", "conversation"],
+        "direct_only_tool_namespaces": ["core", "conversation", "view"],
     }
 
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_engine_contracts.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_engine_contracts.py
@@ -194,6 +194,27 @@ class TestAnalyzeContextStatusRendering:
         )
         assert gui._progress_event_should_update_status(event) is True
 
+    def test_drawing_catalog_progress_is_visible_in_the_status_line(self) -> None:
+        gui = self._gui()
+        progress = {
+            "event": "drawing_context_progress",
+            "percent": 45,
+            "message": "Reading Drawing sources 24 of 80",
+        }
+        ready = {
+            "event": "drawing_context_ready",
+            "structural_revision": 12,
+        }
+
+        assert gui._format_progress_event(progress) == (
+            "Reading Drawing sources 24 of 80"
+        )
+        assert gui._format_progress_event(ready) == (
+            "Drawing context is ready for document revision 12."
+        )
+        assert gui._progress_event_should_update_status(progress) is True
+        assert gui._progress_event_should_update_status(ready) is True
+
     def test_analyze_progress_reaches_the_application_status_bar(
         self,
         monkeypatch,

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_context.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_context.py
@@ -18,6 +18,7 @@ from VibeCADNativeAnalyzeContext import (
     capture_responsive_analyze_snapshot,
 )
 from VibeCADNativeAnalyzeGeometrySources import active_analyze_geometry_sources
+from VibeCADNativeAnalyzeSnapshot import begin_analyze_snapshot_capture
 
 
 def _request(revision: int = 7, count: int = 10) -> dict:
@@ -36,6 +37,62 @@ def _request(revision: int = 7, count: int = 10) -> dict:
         },
         "background_job": None,
     }
+
+
+def test_analyze_capture_schedules_only_effectively_available_objects(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSnapshot as analyze_snapshot
+
+    next_id = 0
+
+    def obj(
+        name: str,
+        *,
+        type_id: str = "Part::Feature",
+        visible: bool = True,
+        suppressed: bool = False,
+    ):
+        nonlocal next_id
+        next_id += 1
+        return SimpleNamespace(
+            ID=next_id,
+            Name=name,
+            TypeId=type_id,
+            PropertiesList=("Shape",),
+            ViewObject=SimpleNamespace(Visibility=visible),
+            Suppressed=suppressed,
+            getParentGroup=lambda: None,
+            getParentGeoFeatureGroup=lambda: None,
+        )
+
+    visible = obj("VisibleBody")
+    hidden = obj("HiddenBody", visible=False)
+    suppressed = obj("SuppressedBody", suppressed=True)
+    history_inactive = obj("FutureBody")
+    analysis = obj(
+        "Analysis",
+        type_id="Fem::FemAnalysis",
+        visible=False,
+    )
+    document = SimpleNamespace(
+        Uid="document-a",
+        Objects=(visible, hidden, suppressed, history_inactive, analysis),
+        isObjectUsableAtCurrentTimelinePosition=(
+            lambda candidate: candidate is not history_inactive
+        ),
+    )
+    monkeypatch.setattr(analyze_snapshot, "_active_analysis", lambda _document: None)
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    request = begin_analyze_snapshot_capture(document, validate_brep=False)
+
+    assert request["object_names"] == ["VisibleBody", "Analysis"]
+    assert request["analysis_names"] == ["Analysis"]
 
 
 def test_context_coordinator_coalesces_callers_and_reuses_the_revision() -> None:
@@ -228,6 +285,34 @@ def test_responsive_capture_postprocesses_detached_parts_outside_dispatch() -> N
     assert all(part["validated"] is True for part in result["parts"])
 
 
+def test_pre_detached_analyze_context_never_dispatches_to_the_document_thread() -> None:
+    request = _request(count=1)
+    request["detached_parts"] = [{"captured": ["VisibleBody"]}]
+    request["detached_clipping"] = {"available": False}
+
+    result = capture_responsive_analyze_snapshot(
+        request,
+        dispatch_to_document_thread=lambda _operation: pytest.fail(
+            "detached Analyze preparation must not return to the document thread"
+        ),
+        capture_batch=lambda _request, _names: pytest.fail(
+            "detached Analyze preparation must not recapture live objects"
+        ),
+        capture_clipping=lambda _request: pytest.fail(
+            "detached Analyze preparation must not recapture clipping state"
+        ),
+        finalize=lambda _request, parts, clipping: {
+            "parts": list(parts),
+            "clipping": dict(clipping),
+        },
+    )
+
+    assert result == {
+        "parts": [{"captured": ["VisibleBody"]}],
+        "clipping": {"available": False},
+    }
+
+
 def test_responsive_capture_checks_cancellation_between_batches() -> None:
     request = _request(count=5)
     completed_batches = 0
@@ -340,6 +425,129 @@ def test_session_capture_uses_document_dispatches_then_reuses_cache(
     assert any(event["event"] == "analyze_context_progress" for event in events)
     assert any(event["event"] == "analyze_context_ready" for event in events)
     assert any(event["event"] == "analyze_context_cache_hit" for event in events)
+
+
+def test_detached_analyze_session_uses_exactly_one_document_thread_dispatch(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSnapshot as analyze_snapshot_module
+    import VibeCADSession as session_module
+
+    request = _request(count=1)
+    request["cacheable"] = False
+    request["detached_parts"] = [{"captured": ["VisibleBody"]}]
+    request["detached_clipping"] = {"available": False}
+    request["base_snapshot"]["_selection"] = {
+        "document_uid": "document-a",
+        "items": [],
+    }
+    in_dispatch = False
+    dispatch_count = 0
+
+    class _Service:
+        @staticmethod
+        def begin_native_analyze_context_request():
+            assert in_dispatch is True
+            return deepcopy(request)
+
+        @staticmethod
+        def native_analyze_context_coordinator():
+            return AnalyzeContextCoordinator()
+
+        @staticmethod
+        def capture_native_analyze_context_batch(_request, _names):
+            pytest.fail("detached Analyze context must not recapture live objects")
+
+        @staticmethod
+        def capture_native_analyze_context_clipping(_request):
+            pytest.fail("detached Analyze context must not recapture clipping state")
+
+    def dispatch(operation):
+        nonlocal in_dispatch, dispatch_count
+        assert in_dispatch is False
+        dispatch_count += 1
+        in_dispatch = True
+        try:
+            return operation()
+        finally:
+            in_dispatch = False
+
+    monkeypatch.setattr(
+        analyze_snapshot_module,
+        "finish_analyze_snapshot_capture",
+        lambda _request, parts, clipping: {
+            "kind": "analyze",
+            "parts": list(parts),
+            "clipping": dict(clipping),
+        },
+    )
+
+    result = session_module._build_responsive_analyze_native_state(
+        _Service(),
+        dispatch,
+    )
+
+    assert result["domain"]["parts"] == [{"captured": ["VisibleBody"]}]
+    assert dispatch_count == 1
+
+
+def test_cached_analyze_session_uses_initial_detached_clipping() -> None:
+    import VibeCADSession as session_module
+
+    coordinator = AnalyzeContextCoordinator()
+    coordinator.get_or_build(
+        "document-a",
+        7,
+        lambda _cancelled, _progress: {
+            "kind": "analyze",
+            "clipping": {"available": False},
+        },
+    )
+    request = _request(count=1)
+    request["cacheable"] = True
+    request["detached_clipping"] = {"available": True, "mode": "plane"}
+    request["base_snapshot"]["_selection"] = {
+        "document_uid": "document-a",
+        "items": [],
+    }
+    in_dispatch = False
+    dispatch_count = 0
+
+    class _Service:
+        @staticmethod
+        def begin_native_analyze_context_request():
+            assert in_dispatch is True
+            return deepcopy(request)
+
+        @staticmethod
+        def native_analyze_context_coordinator():
+            return coordinator
+
+        @staticmethod
+        def capture_native_analyze_context_batch(_request, _names):
+            pytest.fail("a cached Analyze context must not recapture live objects")
+
+        @staticmethod
+        def capture_native_analyze_context_clipping(_request):
+            pytest.fail("initial detached clipping must satisfy the cache refresh")
+
+    def dispatch(operation):
+        nonlocal in_dispatch, dispatch_count
+        assert in_dispatch is False
+        dispatch_count += 1
+        in_dispatch = True
+        try:
+            return operation()
+        finally:
+            in_dispatch = False
+
+    result = session_module._build_responsive_analyze_native_state(
+        _Service(),
+        dispatch,
+    )
+
+    assert result["domain"]["clipping"] == {"available": True, "mode": "plane"}
+    assert dispatch_count == 1
 
 
 class _Shape:
@@ -530,3 +738,126 @@ def test_analyze_geometry_postprocess_keeps_only_isolated_valid_results(
     assert processed[0]["geometry_source_count"] == 1
     assert processed[0]["geometry_sources"] == [{"object_name": "Valid"}]
     assert "geometry_validation_artifacts" not in processed[0]
+
+
+def test_analyze_snapshot_uses_context_mesh_state_and_skips_definitions_as_outputs(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSnapshot as snapshot
+
+    definition = object()
+    document = type("Document", (), {"Objects": [definition]})()
+    definition_calls = []
+    output_calls = []
+    monkeypatch.setattr(
+        snapshot,
+        "is_fem_mesh_definition",
+        lambda obj: obj is definition,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        snapshot,
+        "fem_mesh_definition_context_state",
+        lambda obj: definition_calls.append(obj)
+        or {"object_name": "Mesh", "state_sha256": "a" * 64},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        snapshot,
+        "fem_mesh_object_context_state",
+        lambda obj: output_calls.append(obj)
+        or {"object_name": "Output", "state_sha256": "b" * 64},
+        raising=False,
+    )
+
+    count, definitions, _states = snapshot._mesh_definitions(document)
+    output_count, outputs = snapshot._fem_mesh_outputs(document)
+
+    assert count == 1
+    assert definitions[0]["object_name"] == "Mesh"
+    assert output_count == 0
+    assert outputs == []
+    assert definition_calls == [definition]
+    assert output_calls == []
+
+
+def test_analyze_study_record_uses_bounded_mesh_context_state(monkeypatch) -> None:
+    import VibeCADNativeAnalyzeSnapshot as snapshot
+
+    analysis = SimpleNamespace(Name="Analysis", Group=[])
+    observed = []
+    monkeypatch.setattr(
+        snapshot,
+        "analysis_state",
+        lambda _analysis: {"object_name": "Analysis", "state_sha256": "a" * 64},
+    )
+    monkeypatch.setattr(
+        snapshot,
+        "result_purge_state",
+        lambda _analysis: {
+            "object_count": 0,
+            "solver_result_root_count": 0,
+            "ordinary_operation_count": 0,
+            "purge_ready": True,
+            "blockers": [],
+            "graph_sha256": "b" * 64,
+        },
+    )
+
+    def bounded_study(_analysis, *, mesh_state_reader=None):
+        observed.append(mesh_state_reader)
+        return {"intent": {}, "inventory": {}}
+
+    monkeypatch.setattr(snapshot, "study_state", bounded_study)
+
+    snapshot._analysis_capture_record(
+        analysis,
+        active_analysis_name="Analysis",
+        include_summary=True,
+    )
+
+    assert observed == [snapshot.fem_mesh_definition_context_state]
+
+
+def test_analyze_mesh_state_cache_reuses_shape_topology_within_one_capture(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeMeshState as mesh_state
+
+    class Shape:
+        def __init__(self) -> None:
+            self.face_reads = 0
+
+        @property
+        def Faces(self):
+            self.face_reads += 1
+            return [object(), object()]
+
+        Vertexes = ()
+        Edges = ()
+        Wires = ()
+        Shells = ()
+        Solids = (object(),)
+        BoundBox = None
+
+    shape = Shape()
+    obj = SimpleNamespace(
+        Name="Body",
+        Label="Body",
+        TypeId="PartDesign::Body",
+        Shape=shape,
+        PropertiesList=(),
+    )
+    monkeypatch.setattr(
+        mesh_state,
+        "concise_object",
+        lambda _obj: {"object_name": "Body", "label": "Body"},
+    )
+
+    with mesh_state.mesh_object_state_cache():
+        first = mesh_state.mesh_object_state(obj)
+        second = mesh_state.mesh_object_state(obj)
+
+    assert first == second
+    assert first is not second
+    assert shape.face_reads == 1

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_mesh_state.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_mesh_state.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from io import BytesIO
 import zipfile
 
+import VibeCADNativeAnalyzeMeshState as mesh_state
 from VibeCADNativeAnalyzeMeshState import _mesh_content_sha256
 
 
@@ -90,3 +91,124 @@ def test_mesh_content_hash_retains_exact_group_membership() -> None:
     )
 
     assert _mesh_content_sha256(first) != _mesh_content_sha256(changed)
+
+
+class _DefinitionMesh:
+    NodeCount = 140_228
+    EdgeCount = 0
+    FaceCount = 0
+    VolumeCount = 78_832
+
+    def __init__(self) -> None:
+        self.dump_count = 0
+
+    def dumpContent(self) -> bytes:
+        self.dump_count += 1
+        raise AssertionError("context capture must not serialize FEM mesh content")
+
+
+class _Definition:
+    Name = "FEMMeshGmsh"
+    Label = "Large mesh"
+    ID = 42
+
+    def __init__(self) -> None:
+        self.FemMesh = _DefinitionMesh()
+
+
+def _patch_definition_dependencies(monkeypatch) -> None:
+    monkeypatch.setattr(mesh_state, "is_live", lambda _document, _obj: True)
+    monkeypatch.setattr(mesh_state, "fem_mesher_kind", lambda _obj: "gmsh")
+    monkeypatch.setattr(
+        mesh_state,
+        "_source",
+        lambda _obj: (
+            {
+                "object_name": "Body",
+                "state_sha256": "a" * 64,
+                "shape_type": "Solid",
+                "topology": {"solids": 1},
+            },
+            {
+                "object_name": "Body",
+                "object_id": 7,
+                "state_sha256": "a" * 64,
+                "shape_type": "Solid",
+                "topology": {"solids": 1},
+            },
+        ),
+    )
+    monkeypatch.setattr(mesh_state, "_settings", lambda _obj, _kind: {"order": 2})
+    monkeypatch.setattr(mesh_state, "_native_parameters", lambda _obj: {})
+    monkeypatch.setattr(
+        mesh_state,
+        "concise_object",
+        lambda obj: {"object_name": obj.Name, "label": obj.Label},
+    )
+
+
+def test_mesh_definition_context_state_never_serializes_mesh_content(monkeypatch) -> None:
+    _patch_definition_dependencies(monkeypatch)
+    definition = _Definition()
+
+    state = mesh_state.fem_mesh_definition_context_state(definition)
+
+    assert state["generated"] is True
+    assert state["topology"] == {
+        "nodes": 140_228,
+        "edges": 0,
+        "faces": 0,
+        "volumes": 78_832,
+    }
+    assert "mesh_content_sha256" not in state
+    assert definition.FemMesh.dump_count == 0
+
+
+def test_mesh_definition_match_accepts_context_state_without_exact_hash(monkeypatch) -> None:
+    _patch_definition_dependencies(monkeypatch)
+    definition = _Definition()
+    expected = mesh_state.fem_mesh_definition_context_state(definition)["state_sha256"]
+
+    assert mesh_state.fem_mesh_definition_still_exact(definition, expected) is True
+    assert definition.FemMesh.dump_count == 0
+
+
+def test_mesh_definition_match_falls_back_to_legacy_exact_state(monkeypatch) -> None:
+    _patch_definition_dependencies(monkeypatch)
+    definition = _Definition()
+    monkeypatch.setattr(mesh_state, "_mesh_content_sha256", lambda _mesh: "b" * 64)
+    legacy = mesh_state.fem_mesh_definition_state(definition)["state_sha256"]
+
+    assert mesh_state.fem_mesh_definition_still_exact(definition, legacy) is True
+
+
+def test_baked_mesh_context_state_never_serializes_mesh_content(monkeypatch) -> None:
+    monkeypatch.setattr(mesh_state, "is_live", lambda _document, _obj: True)
+    monkeypatch.setattr(
+        mesh_state,
+        "concise_object",
+        lambda obj: {"object_name": obj.Name, "label": obj.Label},
+    )
+
+    class BakedMesh:
+        Name = "BakedMesh"
+        Label = "Baked mesh"
+        ID = 99
+
+        def __init__(self) -> None:
+            self.FemMesh = _DefinitionMesh()
+            self.Proxy = None
+            self.Document = object()
+
+        @staticmethod
+        def isDerivedFrom(type_id: str) -> bool:
+            return type_id == "Fem::FemMeshObject"
+
+    baked = BakedMesh()
+
+    state = mesh_state.fem_mesh_object_context_state(baked)
+
+    assert state["backend"] == "baked"
+    assert state["generated"] is True
+    assert "mesh_content_sha256" not in state
+    assert baked.FemMesh.dump_count == 0

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_study.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_study.py
@@ -2,6 +2,39 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+from VibeCADNativeAnalyzeAssignments import _reference_issue
+
+
+def test_assignment_reference_validation_enumerates_each_shape_kind_once() -> None:
+    class Shape:
+        def __init__(self) -> None:
+            self.face_reads = 0
+
+        @property
+        def Faces(self):
+            self.face_reads += 1
+            return [object(), object(), object()]
+
+    shape = Shape()
+    source = SimpleNamespace(Shape=shape)
+    document = SimpleNamespace(
+        getObject=lambda name: source if name == "Body" else None
+    )
+
+    issue = _reference_issue(
+        document,
+        "Constraint",
+        {
+            "object_name": "Body",
+            "subelements": ["Face1", "Face2", "Face3"],
+        },
+    )
+
+    assert issue is None
+    assert shape.face_reads == 1
+
 import pytest
 from types import SimpleNamespace
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_common_runtime.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_common_runtime.py
@@ -210,8 +210,8 @@ def test_view_runtime_uses_fixed_operations_and_exact_injected_document(
     )
     captured = []
 
-    def capture(service, target, *, frame, targets):
-        captured.append((service.name, target.Name, frame, targets))
+    def capture(service, target, *, frame, targets, page_name=None):
+        captured.append((service.name, target.Name, frame, targets, page_name))
         return {"captured": True}
 
     monkeypatch.setattr(runtime_module, "capture_screenshot", capture)
@@ -258,6 +258,13 @@ def test_view_runtime_uses_fixed_operations_and_exact_injected_document(
     ) == {"captured": True}
     target = captured[0][3][0]
     assert (target.document_uid, target.object_name) == (document.Uid, "Box")
+    assert runtime.control_view(
+        {
+            "operation": "capture_drawing_page",
+            "page": {"object_name": "Page002"},
+        }
+    ) == {"captured": True}
+    assert captured[1][2:] == ("all", (), "Page002")
 
 
 def test_inspect_runtime_maps_object_and_subelement_targets_without_labels(

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_common_runtime.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_common_runtime.py
@@ -41,6 +41,7 @@ def _runtime(**overrides):
         active_surface_id=overrides.get("active_surface_id", lambda: "model"),
         edit_or_task_active=overrides.get("edit_or_task_active", lambda: False),
         scoped_capability_prefix=overrides.get("scoped_capability_prefix"),
+        document_thread_dispatch=overrides.get("document_thread_dispatch"),
     )
     runtime = NativeCommonRuntime(context=context)
     return runtime, state, document
@@ -555,7 +556,41 @@ def test_drawing_source_catalog_defaults_to_the_first_bounded_page(
 
     assert result["source_count"] == 100
     assert result["next_offset"] == 48
-    assert observed == [(document, {"offset": 0, "page_size": 48})]
+    assert observed == [
+        (
+            document,
+            {
+                "offset": 0,
+                "page_size": 48,
+                "structural_revision": 0,
+                "require_cached": False,
+            },
+        )
+    ]
+
+
+def test_gui_drawing_source_read_requires_the_responsive_cache(monkeypatch) -> None:
+    runtime, _state, _document = _runtime(
+        active_surface_id=lambda: "drawing",
+        document_thread_dispatch=lambda operation: operation(),
+    )
+    options = []
+    monkeypatch.setattr(
+        runtime_module,
+        "drawing_source_catalog_page",
+        lambda _document, **values: options.append(values) or {"sources": []},
+    )
+
+    runtime.read_drawing_sources({"operation": "list"})
+
+    assert options == [
+        {
+            "offset": 0,
+            "page_size": 48,
+            "structural_revision": 0,
+            "require_cached": True,
+        }
+    ]
 
 
 def test_save_runtime_uses_guarded_existing_path_only(monkeypatch) -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_common_schema.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_common_schema.py
@@ -72,6 +72,7 @@ def test_common_variants_use_explicit_eligible_surfaces() -> None:
         not in {
             "drawing_projected_geometry",
             "set_object_visibility",
+            "capture_drawing_page",
             "capture_active_sketch",
         }
     )
@@ -80,6 +81,9 @@ def test_common_variants_use_explicit_eligible_surfaces() -> None:
     )
     assert variants[("view.control", "capture_active_sketch")].surface_ids == frozenset(
         {"sketch.edit"}
+    )
+    assert variants[("view.control", "capture_drawing_page")].surface_ids == frozenset(
+        {"drawing"}
     )
     drawing_sources = variants[("drawing.sources", "list")]
     assert drawing_sources.surface_ids == frozenset({"drawing"})
@@ -114,6 +118,7 @@ def test_common_variants_use_explicit_eligible_surfaces() -> None:
         "capture_all",
         "capture_selection",
         "capture_objects",
+        "capture_drawing_page",
         "capture_active_sketch",
     ]
     assert all(
@@ -205,11 +210,18 @@ def test_exact_targets_and_arrays_are_bounded_in_final_common_schemas() -> None:
     capture_branches = {
         "capture_objects": definitions["view.control"].provider_schema(
             ("capture_objects",)
-        )["parameters"]["oneOf"][0]
+        )["parameters"]["oneOf"][0],
+        "capture_drawing_page": definitions["view.control"].provider_schema(
+            ("capture_drawing_page",)
+        )["parameters"]["oneOf"][0],
     }
     assert capture_branches["capture_objects"]["properties"]["targets"][
         "maxItems"
     ] == 16
+    page = capture_branches["capture_drawing_page"]["properties"]["page"]
+    assert capture_branches["capture_drawing_page"]["required"] == ["page"]
+    assert page["required"] == ["object_name"]
+    assert set(page["properties"]) == {"object_name"}
 
 
 def test_first_projected_geometry_page_needs_no_prior_projection_hash() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_active_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_active_view.py
@@ -5,12 +5,14 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 from VibeCADNativeDrawingActiveView import (
     DEFAULT_CAPTURE_HEIGHT_PX,
     DEFAULT_CAPTURE_WIDTH_PX,
     MAX_CAPTURE_DIMENSION_PX,
     MAX_CAPTURE_PIXELS,
+    drawing_active_viewport_state,
 )
 from VibeCADNativeDrawingActiveViewSchema import (
     drawing_active_view_capability_definition,
@@ -87,3 +89,100 @@ def test_active_view_publishes_all_capture_choices_and_runtime_bounds() -> None:
     assert DEFAULT_CAPTURE_HEIGHT_PX == 1024
     assert MAX_CAPTURE_DIMENSION_PX == 4096
     assert MAX_CAPTURE_PIXELS == 16 * 1024 * 1024
+
+
+def test_active_view_state_ignores_hidden_objects_and_fem_artifacts(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeDrawingActiveView as active_view
+
+    class _Shape:
+        @staticmethod
+        def isNull() -> bool:
+            return False
+
+        @staticmethod
+        def hashCode() -> int:
+            return 42
+
+    class _Object:
+        def __init__(self, name: str, type_id: str, *, visible: bool) -> None:
+            self.ID = 1
+            self.Name = name
+            self.TypeId = type_id
+            self.ViewObject = SimpleNamespace(Visibility=visible)
+            self.Placement = None
+            self.Points = None
+
+        @staticmethod
+        def getParentGroup():
+            return None
+
+        @staticmethod
+        def getParentGeoFeatureGroup():
+            return None
+
+    class _ExcludedObject(_Object):
+        @property
+        def Shape(self):
+            raise AssertionError("excluded objects must not read Shape")
+
+    visible = _Object("VisibleBody", "PartDesign::Body", visible=True)
+    visible.Shape = _Shape()
+    hidden = _ExcludedObject("HiddenBody", "PartDesign::Body", visible=False)
+    fem = _ExcludedObject(
+        "FEMMeshGmsh",
+        "Fem::FemMeshShapeBaseObjectPython",
+        visible=True,
+    )
+    analysis = SimpleNamespace(
+        Name="Analysis",
+        TypeId="Fem::FemAnalysis",
+        Group=(fem,),
+        ViewObject=SimpleNamespace(Visibility=False),
+    )
+
+    document = SimpleNamespace(
+        Uid="document-a",
+        Objects=(visible,),
+    )
+    view = SimpleNamespace(
+        getSize=lambda: (1280, 1024),
+        getCamera=lambda: "camera",
+        getCameraType=lambda: "Perspective",
+        getViewDirection=lambda: SimpleNamespace(x=0.0, y=0.0, z=-1.0),
+        getUpDirection=lambda: SimpleNamespace(x=0.0, y=1.0, z=0.0),
+    )
+    monkeypatch.setattr(
+        active_view,
+        "_active_gui_view",
+        lambda _document, _gui=None: view,
+    )
+    monkeypatch.setattr(active_view, "_resolution_pixels_per_mm", lambda: 10.0)
+    monkeypatch.setattr(
+        active_view,
+        "_current_selection",
+        lambda current_document: (
+            {
+                "document_uid": "document-a",
+                "selected_count": 0,
+                "items": [],
+            }
+            if len(current_document.Objects) == 1
+            else {
+                "document_uid": "document-a",
+                "selected_count": 2,
+                "items": [
+                    {"object": {"object_name": hidden.Name}},
+                    {"object": {"object_name": fem.Name}},
+                ],
+            }
+        ),
+    )
+
+    baseline = drawing_active_viewport_state(document)
+    document.Objects = (visible, hidden, fem, analysis)
+    filtered = drawing_active_viewport_state(document)
+
+    assert baseline["visible_geometry_count"] == 1
+    assert filtered == baseline

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_context.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_context.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -95,6 +96,25 @@ def test_responsive_drawing_catalog_checks_cancellation_between_batches() -> Non
         )
 
     assert completed_batches == 1
+
+
+def test_visibility_change_invalidates_drawing_cache_without_structural_revision() -> None:
+    from VibeCADCore import VibeCADService
+
+    invalidated = []
+    service = VibeCADService.__new__(VibeCADService)
+    service._object_document_uid = lambda _obj: "document-a"
+    service._native_document_states = SimpleNamespace(
+        current_revision=lambda _uid: 7,
+        note_object_property_change=lambda _uid, _property: 7,
+    )
+    service._invalidate_native_read_contexts = invalidated.append
+    service._sync_native_authority_metadata_if_active = lambda _uid: None
+
+    revision = service.note_native_object_property_change(object(), "Visibility")
+
+    assert revision == 7
+    assert invalidated == ["document-a"]
 
 
 def test_drawing_catalog_coordinator_coalesces_concurrent_preparation() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_context.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_context.py
@@ -98,6 +98,33 @@ def test_responsive_drawing_catalog_checks_cancellation_between_batches() -> Non
     assert completed_batches == 1
 
 
+def test_detached_drawing_catalog_never_dispatches_to_the_document_thread() -> None:
+    request = _request(count=1)
+    request["detached_sources"] = [
+        {"object_name": "VisibleBody", "type_id": "PartDesign::Body"}
+    ]
+    progress = []
+
+    result = capture_responsive_drawing_source_catalog(
+        request,
+        dispatch_to_document_thread=lambda _operation: pytest.fail(
+            "detached Drawing preparation must not return to the document thread"
+        ),
+        capture_batch=lambda _request, _names: pytest.fail(
+            "detached Drawing preparation must not recapture live objects"
+        ),
+        finalize=lambda _request, sources: {
+            "source_names": [source["object_name"] for source in sources]
+        },
+        progress_callback=lambda percent, message: progress.append(
+            (percent, message)
+        ),
+    )
+
+    assert result == {"source_names": ["VisibleBody"]}
+    assert progress == [(85, "Reading Drawing sources 1 of 1")]
+
+
 def test_visibility_change_invalidates_drawing_cache_without_structural_revision() -> None:
     from VibeCADCore import VibeCADService
 
@@ -216,3 +243,61 @@ def test_session_build_batches_once_then_reuses_the_revision_cache() -> None:
     assert any(event["event"] == "drawing_context_progress" for event in events)
     assert any(event["event"] == "drawing_context_ready" for event in events)
     assert any(event["event"] == "drawing_context_cache_hit" for event in events)
+
+
+def test_detached_session_build_uses_exactly_one_document_thread_dispatch() -> None:
+    import VibeCADSession as session_module
+    from VibeCADNativeDrawingSourceCatalog import (
+        invalidate_drawing_source_catalog_cache,
+    )
+
+    invalidate_drawing_source_catalog_cache()
+    coordinator = DrawingSourceCatalogCoordinator()
+    expected = {
+        "surface_id": "drawing",
+        "structural_revision": 7,
+        "domain": {"kind": "drawing"},
+    }
+    request = _request(count=1)
+    request["detached_sources"] = [
+        {"object_name": "VisibleBody", "type_id": "PartDesign::Body"}
+    ]
+    request["completed_snapshot"] = expected
+    in_dispatch = False
+    dispatch_count = 0
+
+    class _Service:
+        @staticmethod
+        def begin_native_drawing_context_request():
+            assert in_dispatch is True
+            return dict(request)
+
+        @staticmethod
+        def native_drawing_context_coordinator():
+            return coordinator
+
+        @staticmethod
+        def capture_native_drawing_context_batch(_request, _names):
+            pytest.fail("detached Drawing context must not recapture live objects")
+
+        @staticmethod
+        def finish_native_drawing_context_request(_request):
+            pytest.fail("completed Drawing context must not return to the UI thread")
+
+    def dispatch(operation):
+        nonlocal in_dispatch, dispatch_count
+        assert in_dispatch is False
+        dispatch_count += 1
+        in_dispatch = True
+        try:
+            return operation()
+        finally:
+            in_dispatch = False
+
+    result = session_module._build_responsive_drawing_native_state(
+        _Service(),
+        dispatch,
+    )
+
+    assert result == expected
+    assert dispatch_count == 1

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_context.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_context.py
@@ -1,0 +1,198 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+
+from VibeCADNativeDrawingContext import (
+    DrawingContextCancelled,
+    DrawingSourceCatalogCoordinator,
+    capture_responsive_drawing_source_catalog,
+)
+
+
+def _request(*, revision: int = 7, count: int = 18) -> dict:
+    return {
+        "document_uid": "document-a",
+        "structural_revision": revision,
+        "object_names": [f"Object{index}" for index in range(count)],
+    }
+
+
+def test_responsive_drawing_catalog_dispatches_bounded_document_batches() -> None:
+    request = _request(count=18)
+    batches = []
+    in_dispatch = False
+    finalized = []
+    progress = []
+
+    def dispatch(operation):
+        nonlocal in_dispatch
+        assert in_dispatch is False
+        in_dispatch = True
+        try:
+            return operation()
+        finally:
+            in_dispatch = False
+
+    def capture_batch(current, names):
+        assert in_dispatch is True
+        assert current is request
+        batches.append(list(names))
+        return {
+            "sources": [
+                {"object_name": name, "type_id": "PartDesign::Body"}
+                for name in names
+            ]
+        }
+
+    def finalize(current, sources):
+        assert in_dispatch is False
+        finalized.append((current, list(sources)))
+        return {"source_count": len(sources)}
+
+    result = capture_responsive_drawing_source_catalog(
+        request,
+        dispatch_to_document_thread=dispatch,
+        capture_batch=capture_batch,
+        finalize=finalize,
+        progress_callback=lambda percent, message: progress.append(
+            (percent, message)
+        ),
+    )
+
+    assert batches == [
+        request["object_names"][:8],
+        request["object_names"][8:16],
+        request["object_names"][16:],
+    ]
+    assert result == {"source_count": 18}
+    assert len(finalized) == 1
+    assert [item["object_name"] for item in finalized[0][1]] == request[
+        "object_names"
+    ]
+    assert progress[-1] == (85, "Reading Drawing sources 18 of 18")
+
+
+def test_responsive_drawing_catalog_checks_cancellation_between_batches() -> None:
+    request = _request(count=9)
+    completed_batches = 0
+
+    def capture_batch(_current, names):
+        nonlocal completed_batches
+        completed_batches += 1
+        return {"sources": [{"object_name": name} for name in names]}
+
+    with pytest.raises(DrawingContextCancelled):
+        capture_responsive_drawing_source_catalog(
+            request,
+            dispatch_to_document_thread=lambda operation: operation(),
+            capture_batch=capture_batch,
+            finalize=lambda _current, _sources: {},
+            cancellation_check=lambda: completed_batches == 1,
+        )
+
+    assert completed_batches == 1
+
+
+def test_drawing_catalog_coordinator_coalesces_concurrent_preparation() -> None:
+    coordinator = DrawingSourceCatalogCoordinator()
+    entered = threading.Event()
+    release = threading.Event()
+    builds = []
+    results = []
+
+    def build(_cancelled, _progress):
+        builds.append("build")
+        entered.set()
+        assert release.wait(1.0)
+        return {"source_count": 18}
+
+    def prepare() -> None:
+        results.append(coordinator.get_or_build("document-a", 7, build))
+
+    first = threading.Thread(target=prepare)
+    second = threading.Thread(target=prepare)
+    first.start()
+    assert entered.wait(1.0)
+    second.start()
+    release.set()
+    first.join(1.0)
+    second.join(1.0)
+
+    assert builds == ["build"]
+    assert results == [{"source_count": 18}, {"source_count": 18}]
+
+
+def test_session_build_batches_once_then_reuses_the_revision_cache() -> None:
+    import VibeCADSession as session_module
+    from VibeCADNativeDrawingSourceCatalog import (
+        invalidate_drawing_source_catalog_cache,
+    )
+
+    invalidate_drawing_source_catalog_cache()
+    coordinator = DrawingSourceCatalogCoordinator()
+    request = _request(count=10)
+    capture_calls = []
+    in_dispatch = False
+
+    class _Service:
+        @staticmethod
+        def begin_native_drawing_context_request():
+            assert in_dispatch is True
+            return dict(request)
+
+        @staticmethod
+        def native_drawing_context_coordinator():
+            return coordinator
+
+        @staticmethod
+        def capture_native_drawing_context_batch(_request, names):
+            assert in_dispatch is True
+            capture_calls.append(list(names))
+            return {
+                "sources": [
+                    {"object_name": name, "type_id": "PartDesign::Body"}
+                    for name in names
+                ]
+            }
+
+        @staticmethod
+        def finish_native_drawing_context_request(current):
+            assert in_dispatch is True
+            return {
+                "surface_id": "drawing",
+                "structural_revision": current["structural_revision"],
+            }
+
+    def dispatch(operation):
+        nonlocal in_dispatch
+        assert in_dispatch is False
+        in_dispatch = True
+        try:
+            return operation()
+        finally:
+            in_dispatch = False
+
+    events = []
+    first = session_module._build_responsive_drawing_native_state(
+        _Service(),
+        dispatch,
+        progress_callback=events.append,
+    )
+    second = session_module._build_responsive_drawing_native_state(
+        _Service(),
+        dispatch,
+        progress_callback=events.append,
+    )
+
+    assert first == second == {
+        "surface_id": "drawing",
+        "structural_revision": 7,
+    }
+    assert capture_calls == [request["object_names"][:8], request["object_names"][8:]]
+    assert any(event["event"] == "drawing_context_progress" for event in events)
+    assert any(event["event"] == "drawing_context_ready" for event in events)
+    assert any(event["event"] == "drawing_context_cache_hit" for event in events)

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_history.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_history.py
@@ -29,7 +29,14 @@ class _Document:
 
 
 def _object(name: str, type_id: str) -> SimpleNamespace:
-    return SimpleNamespace(Name=name, TypeId=type_id)
+    return SimpleNamespace(
+        Name=name,
+        TypeId=type_id,
+        ViewObject=SimpleNamespace(Visibility=True),
+        PropertiesList=["Shape"],
+        getParentGroup=lambda: None,
+        getParentGeoFeatureGroup=lambda: None,
+    )
 
 
 def _install_part_gui(
@@ -144,3 +151,63 @@ def test_standard_view_keeps_the_selected_body_as_its_techdraw_source(
     )
 
     assert prepared.sources == (body,)
+
+
+def test_standard_view_rejects_a_source_hidden_after_provider_inspection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = SimpleNamespace(
+        Name="Page",
+        TypeId="TechDraw::DrawPage",
+        Views=(),
+    )
+    body = _object("Body042", "PartDesign::Body")
+    body.ViewObject.Visibility = False
+    active_state = _object("Body042_State", "PartDesign::DesignBodyState")
+    document = _Document((page, body, active_state), (page, active_state))
+    document.Uid = "drawing-hidden-source-test"
+    _install_part_gui(monkeypatch, {id(body): active_state})
+    monkeypatch.setattr(
+        drawing_view,
+        "resolve_object",
+        lambda current, target, **_kwargs: current.getObject(target["object_name"]),
+    )
+    monkeypatch.setattr(
+        drawing_view,
+        "drawing_page_state",
+        lambda _page: {"state_sha256": "page-state"},
+    )
+    monkeypatch.setattr(
+        drawing_view,
+        "drawing_source_state",
+        lambda source: {
+            "object_name": source.Name,
+            "state_sha256": "body-state",
+        },
+    )
+    monkeypatch.setattr(drawing_view, "_current_selection", lambda _document: {})
+
+    with pytest.raises(drawing_view.NativeDrawingError) as failure:
+        drawing_view.prepare_standard_view_create(
+            document,
+            values={
+                "label": "Front",
+                "page": {
+                    "object_name": page.Name,
+                    "expected_state_sha256": "page-state",
+                },
+                "sources": [
+                    {
+                        "object_name": body.Name,
+                        "expected_state_sha256": "body-state",
+                    }
+                ],
+                "orientation": "front",
+                "position": {"x_mm": 100.0, "y_mm": 100.0},
+                "scale": "page",
+                "line_style": "visible",
+            },
+            validate_position=False,
+        )
+
+    assert failure.value.error_code == "NATIVE_DRAWING_VIEW_SOURCE_HIDDEN"

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_history.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_history.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""History contracts for whole-object Native Drawing sources."""
+
+from __future__ import annotations
+
+from types import ModuleType, SimpleNamespace
+import sys
+
+import pytest
+
+import VibeCADNativeDrawingView as drawing_view
+from VibeCADNativeDrawingHistory import is_drawing_source_history_usable
+
+
+class _Document:
+    def __init__(self, objects: tuple[object, ...], usable: tuple[object, ...]) -> None:
+        self.Objects = objects
+        self._usable = usable
+
+    def getObject(self, name: str) -> object | None:
+        return next(
+            (obj for obj in self.Objects if getattr(obj, "Name", None) == name),
+            None,
+        )
+
+    def isObjectUsableAtCurrentTimelinePosition(self, obj: object) -> bool:
+        return any(obj is candidate for candidate in self._usable)
+
+
+def _object(name: str, type_id: str) -> SimpleNamespace:
+    return SimpleNamespace(Name=name, TypeId=type_id)
+
+
+def _install_part_gui(
+    monkeypatch: pytest.MonkeyPatch,
+    resolved: dict[int, object | None],
+) -> None:
+    module = ModuleType("PartGui")
+    module.resolveModelingObject = lambda obj: resolved.get(id(obj), obj)
+    monkeypatch.setitem(sys.modules, "PartGui", module)
+
+
+def test_ordinary_drawing_source_keeps_the_document_history_guard(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _object("Bracket", "Part::Feature")
+    document = _Document((source,), ())
+    _install_part_gui(monkeypatch, {})
+
+    assert not is_drawing_source_history_usable(document, source)
+
+    document._usable = (source,)
+    assert is_drawing_source_history_usable(document, source)
+
+
+def test_body_is_validated_through_its_active_modeling_state_without_replacing_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = _object("Body042", "PartDesign::Body")
+    active_state = _object("Body042_State", "PartDesign::DesignBodyState")
+    document = _Document((body, active_state), (active_state,))
+    _install_part_gui(monkeypatch, {id(body): active_state})
+
+    assert not document.isObjectUsableAtCurrentTimelinePosition(body)
+    assert is_drawing_source_history_usable(document, body)
+
+
+@pytest.mark.parametrize("resolved", [None, object()])
+def test_body_without_one_live_active_modeling_state_is_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    resolved: object | None,
+) -> None:
+    body = _object("Body043", "PartDesign::Body")
+    document = _Document((body,), ())
+    _install_part_gui(monkeypatch, {id(body): resolved})
+
+    assert not is_drawing_source_history_usable(document, body)
+
+
+def test_source_from_another_document_is_rejected_before_history_resolution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = _object("ForeignBody", "PartDesign::Body")
+    document = _Document((), (source,))
+    _install_part_gui(monkeypatch, {id(source): source})
+
+    assert not is_drawing_source_history_usable(document, source)
+
+
+def test_standard_view_keeps_the_selected_body_as_its_techdraw_source(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    page = SimpleNamespace(
+        Name="Page",
+        TypeId="TechDraw::DrawPage",
+        Views=(),
+    )
+    body = _object("Body042", "PartDesign::Body")
+    active_state = _object("Body042_State", "PartDesign::DesignBodyState")
+    document = _Document((page, body, active_state), (page, active_state))
+    document.Uid = "drawing-history-test"
+    _install_part_gui(monkeypatch, {id(body): active_state})
+    monkeypatch.setattr(
+        drawing_view,
+        "resolve_object",
+        lambda current, target, **_kwargs: current.getObject(target["object_name"]),
+    )
+    monkeypatch.setattr(
+        drawing_view,
+        "drawing_page_state",
+        lambda _page: {"state_sha256": "page-state"},
+    )
+    monkeypatch.setattr(
+        drawing_view,
+        "drawing_source_state",
+        lambda source: {
+            "object_name": source.Name,
+            "state_sha256": "body-state",
+        },
+    )
+    monkeypatch.setattr(drawing_view, "_current_selection", lambda _document: {})
+
+    prepared = drawing_view.prepare_standard_view_create(
+        document,
+        values={
+            "label": "Front",
+            "page": {
+                "object_name": page.Name,
+                "expected_state_sha256": "page-state",
+            },
+            "sources": [
+                {
+                    "object_name": body.Name,
+                    "expected_state_sha256": "body-state",
+                }
+            ],
+            "orientation": "front",
+            "position": {"x_mm": 100.0, "y_mm": 100.0},
+            "scale": "page",
+            "line_style": "visible",
+        },
+        validate_position=False,
+    )
+
+    assert prepared.sources == (body,)

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 from types import SimpleNamespace
 import sys
 
+import pytest
+
 import VibeCADNativeDrawingSourceCatalog as drawing_catalog
+import VibeCADNativeDrawingSnapshot as drawing_snapshot
 from VibeCADNativeAnalyzeGeometrySources import active_analyze_geometry_sources
 from VibeCADNativeDrawingSourceCatalog import drawing_source_catalog_page
-from VibeCADNativeGeometrySources import active_design_geometry_sources
+from VibeCADNativeDrawingViewState import drawing_source_catalog_identity_state
+from VibeCADNativeGeometrySources import (
+    active_design_geometry_sources,
+    is_potential_design_geometry_source,
+)
 
 
 class _Shape:
@@ -41,6 +48,146 @@ class _Source:
         return False
 
 
+class _CatalogShape:
+    ShapeType = "Solid"
+    Solids = (object(),)
+    Faces = tuple(object() for _index in range(6))
+    Edges = tuple(object() for _index in range(12))
+    BoundBox = SimpleNamespace(XLength=10.0, YLength=20.0, ZLength=30.0)
+
+    def __init__(self) -> None:
+        self.validity_checks = 0
+
+    @staticmethod
+    def isNull() -> bool:
+        return False
+
+    def isValid(self) -> bool:
+        self.validity_checks += 1
+        raise AssertionError("source discovery must not validate a BREP")
+
+    @staticmethod
+    def copy():
+        raise AssertionError("source discovery must not copy a BREP")
+
+
+class _CatalogSource(_Source):
+    def __init__(self, object_id: int) -> None:
+        super().__init__(object_id)
+        self.Name = "Body"
+        self.Label = "Bracket"
+        self.TypeId = "PartDesign::Body"
+        self.PropertiesList = ["Shape"]
+        self.Shape = _CatalogShape()
+        self.Placement = None
+
+
+def test_responsive_drawing_identity_capture_never_reads_live_shape(
+    monkeypatch,
+) -> None:
+    class _IdentityOnlySource:
+        Name = "HugeCompound"
+        Label = "Huge Compound"
+        TypeId = "App::Part"
+        ID = 42
+        PropertiesList = ["Shape"]
+        VibeCADAnalysisDomain = False
+        VibeCADTimelineRole = ""
+
+        @property
+        def Shape(self):
+            raise AssertionError("responsive source capture must not read Shape")
+
+        @staticmethod
+        def getParentGeoFeatureGroup():
+            return None
+
+    source = _IdentityOnlySource()
+    document = SimpleNamespace(Uid="document-a")
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    assert is_potential_design_geometry_source(document, source) is True
+    assert drawing_source_catalog_identity_state(source) == {
+        "object_name": "HugeCompound",
+        "label": "Huge Compound",
+        "type_id": "App::Part",
+        "shape_type": "",
+        "placement": None,
+        "topology": {},
+        "bounds_size_mm": None,
+        "geometry_details_deferred": True,
+    }
+
+
+@pytest.mark.parametrize("type_id", ("App::Part", "App::Link"))
+def test_responsive_drawing_keeps_container_geometry_without_shape_property(
+    monkeypatch,
+    type_id: str,
+) -> None:
+    class _ContainerSource:
+        Name = "ImportedAssembly"
+        Label = "Imported Assembly"
+        TypeId = type_id
+        ID = 43
+        PropertiesList = []
+        VibeCADAnalysisDomain = False
+
+        @property
+        def Shape(self):
+            raise AssertionError("responsive source capture must not read Shape")
+
+        @staticmethod
+        def getParentGeoFeatureGroup():
+            return None
+
+    source = _ContainerSource()
+    document = SimpleNamespace(Uid="document-a")
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    assert is_potential_design_geometry_source(document, source) is True
+    assert drawing_source_catalog_identity_state(source)["object_name"] == (
+        "ImportedAssembly"
+    )
+
+
+def test_responsive_drawing_rejects_origin_geometry_without_reading_shape(
+    monkeypatch,
+) -> None:
+    class _Origin:
+        Name = "XY_Plane"
+        Label = "XY-plane"
+        TypeId = "App::Plane"
+        ID = 44
+        PropertiesList = []
+        VibeCADAnalysisDomain = False
+
+        @property
+        def Shape(self):
+            raise AssertionError("responsive source capture must not read Shape")
+
+        @staticmethod
+        def getParentGeoFeatureGroup():
+            return None
+
+    source = _Origin()
+    document = SimpleNamespace(Uid="document-a")
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    assert is_potential_design_geometry_source(document, source) is False
+
+
 def test_drawing_keeps_design_sources_while_analyze_uses_their_domain(monkeypatch) -> None:
     source = _Source(1)
     domain = _Source(2, analysis_domain=True)
@@ -63,11 +210,11 @@ def test_drawing_source_catalog_pages_one_hundred_bodies_without_guessing(
     monkeypatch.setattr(
         drawing_catalog,
         "active_design_geometry_sources",
-        lambda _document: sources,
+        lambda _document, **_options: sources,
     )
     monkeypatch.setattr(
         drawing_catalog,
-        "drawing_source_state",
+        "drawing_source_catalog_state",
         lambda source: {
             "object_name": source.Name,
             "label": source.Name,
@@ -92,3 +239,282 @@ def test_drawing_source_catalog_pages_one_hundred_bodies_without_guessing(
     assert third["sources"][-1]["source_target"] == {
         "object_name": "Body099",
     }
+
+
+def test_drawing_source_catalog_defers_exact_brep_validation_and_hashing(
+    monkeypatch,
+) -> None:
+    source = _CatalogSource(1)
+    document = SimpleNamespace(Uid="document-a", Objects=(source,))
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    result = drawing_source_catalog_page(document, offset=0, page_size=48)
+
+    assert source.Shape.validity_checks == 0
+    assert result == {
+        "source_count": 1,
+        "offset": 0,
+        "returned_count": 1,
+        "next_offset": None,
+        "sources": [
+            {
+                "source_name": "Body",
+                "source_target": {"object_name": "Body"},
+                "type_id": "PartDesign::Body",
+                "shape_type": "Solid",
+                "topology": {"solids": 1, "faces": 6, "edges": 12},
+                "bounds_size_mm": [10.0, 20.0, 30.0],
+                "label": "Bracket",
+            }
+        ],
+    }
+
+
+def test_shared_design_source_discovery_preserves_exact_validation_by_default(
+    monkeypatch,
+) -> None:
+    source = _CatalogSource(1)
+    document = SimpleNamespace(Uid="document-a", Objects=(source,))
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    assert active_design_geometry_sources(document) == ()
+    assert source.Shape.validity_checks == 1
+    source.Shape.validity_checks = 0
+    assert active_design_geometry_sources(document, validate_brep=False) == (source,)
+    assert source.Shape.validity_checks == 0
+
+
+def test_drawing_provider_context_uses_identity_only_for_selected_sources(
+    monkeypatch,
+) -> None:
+    source = _CatalogSource(1)
+    document = SimpleNamespace(
+        getObject=lambda name: source if name == source.Name else None,
+    )
+    state = {
+        "object_name": "Body",
+        "label": "Bracket",
+        "type_id": "PartDesign::Body",
+        "shape_type": "Solid",
+        "placement": None,
+        "topology": {"solids": 1, "faces": 6, "edges": 12},
+        "bounds_size_mm": [10.0, 20.0, 30.0],
+    }
+    page_options = []
+    monkeypatch.setattr(
+        drawing_snapshot,
+        "drawing_source_catalog_state_page",
+        lambda _document, **options: page_options.append(options)
+        or {
+            "source_count": 1,
+            "offset": 0,
+            "returned_count": 1,
+            "next_offset": None,
+            "sources": [dict(state)],
+        },
+    )
+    count, sources = drawing_snapshot._drawing_sources(document)
+    selected = drawing_snapshot._selected_sources(
+        document,
+        {"items": [{"object": {"object_name": "Body"}}]},
+    )
+    selected_breaks = drawing_snapshot._selected_break_definitions(
+        document,
+        {"items": [{"object": {"object_name": "Body"}}]},
+    )
+    selected_drafts = drawing_snapshot._selected_draft_sources(
+        document,
+        {"items": [{"object": {"object_name": "Body"}}]},
+    )
+
+    assert page_options == [
+        {"offset": 0, "page_size": 48, "structural_revision": None}
+    ]
+    assert count == 1
+    assert sources == [state]
+    identity = {
+        "object_name": "Body",
+        "label": "Bracket",
+        "type_id": "PartDesign::Body",
+        "shape_type": "",
+        "placement": None,
+        "topology": {},
+        "bounds_size_mm": None,
+        "geometry_details_deferred": True,
+    }
+    assert selected == [identity]
+    assert selected_breaks == [{**identity, "break_details_deferred": True}]
+    assert selected_drafts == [{**identity, "draft_details_deferred": True}]
+    assert source.Shape.validity_checks == 0
+
+
+def test_drawing_source_catalog_cache_reuses_only_the_same_document_revision(
+    monkeypatch,
+) -> None:
+    drawing_catalog.invalidate_drawing_source_catalog_cache()
+    source = _CatalogSource(1)
+    document = SimpleNamespace(
+        Uid="document-a",
+        Objects=(source,),
+        getObject=lambda name: source if name == source.Name else None,
+    )
+    discoveries = []
+    serializations = []
+    monkeypatch.setattr(
+        drawing_catalog,
+        "active_design_geometry_sources",
+        lambda _document, **options: discoveries.append(options) or (source,),
+    )
+    monkeypatch.setattr(
+        drawing_catalog,
+        "drawing_source_catalog_state",
+        lambda candidate: serializations.append(candidate)
+        or {
+            "object_name": "Body",
+            "label": "Bracket",
+            "type_id": "PartDesign::Body",
+            "shape_type": "Solid",
+            "placement": None,
+            "topology": {"solids": 1, "faces": 6, "edges": 12},
+            "bounds_size_mm": [10.0, 20.0, 30.0],
+        },
+    )
+
+    first = drawing_source_catalog_page(
+        document,
+        offset=0,
+        page_size=48,
+        structural_revision=7,
+    )
+    first["sources"][0]["label"] = "Caller mutation"
+    repeated = drawing_source_catalog_page(
+        document,
+        offset=0,
+        page_size=48,
+        structural_revision=7,
+    )
+    changed = drawing_source_catalog_page(
+        document,
+        offset=0,
+        page_size=48,
+        structural_revision=8,
+    )
+
+    assert repeated["sources"][0]["label"] == "Bracket"
+    assert changed == repeated
+    assert discoveries == [
+        {"validate_brep": False},
+        {"validate_brep": False},
+    ]
+    assert serializations == [source, source]
+
+
+def test_drawing_provider_context_requests_revision_cached_source_page(
+    monkeypatch,
+) -> None:
+    page = {
+        "source_count": 1,
+        "offset": 0,
+        "returned_count": 1,
+        "next_offset": None,
+        "sources": [{"object_name": "Body"}],
+    }
+    observed = []
+    monkeypatch.setattr(
+        drawing_snapshot,
+        "drawing_source_catalog_state_page",
+        lambda document, **options: observed.append((document, options)) or page,
+        raising=False,
+    )
+    document = object()
+
+    assert drawing_snapshot._drawing_sources(
+        document,
+        structural_revision=12,
+    ) == (1, [{"object_name": "Body"}])
+    assert observed == [
+        (
+            document,
+            {"offset": 0, "page_size": 48, "structural_revision": 12},
+        )
+    ]
+
+
+def test_required_cached_drawing_page_never_falls_back_to_inline_discovery(
+    monkeypatch,
+) -> None:
+    drawing_catalog.invalidate_drawing_source_catalog_cache()
+    discoveries = []
+    document = SimpleNamespace(Uid="document-a", Objects=())
+    monkeypatch.setattr(
+        drawing_catalog,
+        "active_design_geometry_sources",
+        lambda *_args, **_kwargs: discoveries.append(True) or (),
+    )
+
+    with pytest.raises(drawing_catalog.DrawingSourceCatalogNotReady):
+        drawing_source_catalog_page(
+            document,
+            offset=0,
+            page_size=48,
+            structural_revision=7,
+            require_cached=True,
+        )
+
+    assert discoveries == []
+
+
+def test_completed_drawing_catalog_serves_every_page_without_rescanning(
+    monkeypatch,
+) -> None:
+    drawing_catalog.invalidate_drawing_source_catalog_cache()
+    discoveries = []
+    monkeypatch.setattr(
+        drawing_catalog,
+        "active_design_geometry_sources",
+        lambda *_args, **_kwargs: discoveries.append(True) or (),
+    )
+    sources = [
+        {
+            "object_name": f"Body{index}",
+            "label": f"Body {index}",
+            "type_id": "PartDesign::Body",
+            "shape_type": "Solid",
+            "placement": None,
+            "topology": {"solids": 1, "faces": 6, "edges": 12},
+            "bounds_size_mm": [1.0, 1.0, 1.0],
+        }
+        for index in range(100)
+    ]
+
+    drawing_catalog.cache_drawing_source_catalog_state("document-a", 7, sources)
+    document = SimpleNamespace(Uid="document-a")
+    first = drawing_source_catalog_page(
+        document,
+        offset=0,
+        page_size=48,
+        structural_revision=7,
+        require_cached=True,
+    )
+    third = drawing_source_catalog_page(
+        document,
+        offset=96,
+        page_size=48,
+        structural_revision=7,
+        require_cached=True,
+    )
+
+    assert first["source_count"] == 100
+    assert first["returned_count"] == 48
+    assert first["next_offset"] == 48
+    assert third["returned_count"] == 4
+    assert third["next_offset"] is None
+    assert discoveries == []

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py
@@ -14,6 +14,7 @@ from VibeCADNativeDrawingSourceCatalog import drawing_source_catalog_page
 from VibeCADNativeDrawingViewState import drawing_source_catalog_identity_state
 from VibeCADNativeGeometrySources import (
     active_design_geometry_sources,
+    drawing_source_exclusion_reason,
     is_potential_design_geometry_source,
 )
 
@@ -35,12 +36,21 @@ class _Shape:
 class _Source:
     def __init__(self, object_id: int, *, analysis_domain: bool = False) -> None:
         self.ID = object_id
+        self.Name = f"Source{object_id}"
+        self.Label = self.Name
+        self.TypeId = "Part::Feature"
+        self.PropertiesList = ["Shape"]
         self.Shape = _Shape()
+        self.ViewObject = SimpleNamespace(Visibility=True)
         self.VibeCADAnalysisDomain = analysis_domain
         self.AnalysisSources = ()
 
     @staticmethod
     def getParentGeoFeatureGroup():
+        return None
+
+    @staticmethod
+    def getParentGroup():
         return None
 
     @staticmethod
@@ -93,6 +103,7 @@ def test_responsive_drawing_identity_capture_never_reads_live_shape(
         PropertiesList = ["Shape"]
         VibeCADAnalysisDomain = False
         VibeCADTimelineRole = ""
+        ViewObject = SimpleNamespace(Visibility=True)
 
         @property
         def Shape(self):
@@ -100,6 +111,10 @@ def test_responsive_drawing_identity_capture_never_reads_live_shape(
 
         @staticmethod
         def getParentGeoFeatureGroup():
+            return None
+
+        @staticmethod
+        def getParentGroup():
             return None
 
     source = _IdentityOnlySource()
@@ -135,6 +150,7 @@ def test_responsive_drawing_keeps_container_geometry_without_shape_property(
         ID = 43
         PropertiesList = []
         VibeCADAnalysisDomain = False
+        ViewObject = SimpleNamespace(Visibility=True)
 
         @property
         def Shape(self):
@@ -142,6 +158,10 @@ def test_responsive_drawing_keeps_container_geometry_without_shape_property(
 
         @staticmethod
         def getParentGeoFeatureGroup():
+            return None
+
+        @staticmethod
+        def getParentGroup():
             return None
 
     source = _ContainerSource()
@@ -168,6 +188,7 @@ def test_responsive_drawing_rejects_origin_geometry_without_reading_shape(
         ID = 44
         PropertiesList = []
         VibeCADAnalysisDomain = False
+        ViewObject = SimpleNamespace(Visibility=True)
 
         @property
         def Shape(self):
@@ -175,6 +196,10 @@ def test_responsive_drawing_rejects_origin_geometry_without_reading_shape(
 
         @staticmethod
         def getParentGeoFeatureGroup():
+            return None
+
+        @staticmethod
+        def getParentGroup():
             return None
 
     source = _Origin()
@@ -201,6 +226,100 @@ def test_drawing_keeps_design_sources_while_analyze_uses_their_domain(monkeypatc
 
     assert active_design_geometry_sources(document) == (source,)
     assert active_analyze_geometry_sources(document) == (domain,)
+
+
+def test_drawing_sources_respect_effective_visibility_and_exclude_fem(
+    monkeypatch,
+) -> None:
+    visible = _Source(1)
+    hidden = _Source(2)
+    hidden.ViewObject.Visibility = False
+
+    hidden_parent = SimpleNamespace(
+        Name="HiddenAssembly",
+        ViewObject=SimpleNamespace(Visibility=False),
+        getParentGroup=lambda: None,
+        getParentGeoFeatureGroup=lambda: None,
+    )
+    nested = _Source(3)
+    nested.getParentGroup = lambda: hidden_parent
+
+    fem_mesh = _Source(4)
+    fem_mesh.TypeId = "Fem::FemMeshShapeBaseObjectPython"
+    fem_mesh.PropertiesList = ["Shape", "FemMesh"]
+
+    analysis_domain = _Source(5, analysis_domain=True)
+    analysis_member = _Source(6)
+    analysis = SimpleNamespace(
+        Name="Analysis",
+        TypeId="Fem::FemAnalysis",
+        Group=(analysis_member,),
+        ViewObject=SimpleNamespace(Visibility=False),
+    )
+    document = SimpleNamespace(
+        Uid="document-a",
+        Objects=(
+            visible,
+            hidden,
+            hidden_parent,
+            nested,
+            fem_mesh,
+            analysis_domain,
+            analysis_member,
+            analysis,
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    assert active_design_geometry_sources(document) == (visible,)
+    assert drawing_source_exclusion_reason(document, visible) is None
+    assert drawing_source_exclusion_reason(document, hidden) == "hidden"
+    assert drawing_source_exclusion_reason(document, nested) == "hidden"
+    assert drawing_source_exclusion_reason(document, fem_mesh) == "analysis_artifact"
+    assert (
+        drawing_source_exclusion_reason(document, analysis_domain)
+        == "analysis_artifact"
+    )
+    assert (
+        drawing_source_exclusion_reason(document, analysis_member)
+        == "analysis_artifact"
+    )
+
+
+def test_hidden_responsive_source_is_rejected_before_shape_access(monkeypatch) -> None:
+    class _HiddenSource:
+        Name = "HiddenBody"
+        TypeId = "PartDesign::Body"
+        ID = 7
+        PropertiesList = ["Shape"]
+        VibeCADAnalysisDomain = False
+        ViewObject = SimpleNamespace(Visibility=False)
+
+        @property
+        def Shape(self):
+            raise AssertionError("hidden Drawing sources must not read Shape")
+
+        @staticmethod
+        def getParentGeoFeatureGroup():
+            return None
+
+        @staticmethod
+        def getParentGroup():
+            return None
+
+    source = _HiddenSource()
+    document = SimpleNamespace(Uid="document-a", Objects=(source,))
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    assert is_potential_design_geometry_source(document, source) is False
 
 
 def test_drawing_source_catalog_pages_one_hundred_bodies_without_guessing(
@@ -297,7 +416,14 @@ def test_drawing_provider_context_uses_identity_only_for_selected_sources(
 ) -> None:
     source = _CatalogSource(1)
     document = SimpleNamespace(
+        Uid="document-a",
+        Objects=(source,),
         getObject=lambda name: source if name == source.Name else None,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
     )
     state = {
         "object_name": "Body",

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py
@@ -250,6 +250,10 @@ def test_drawing_sources_respect_effective_visibility_and_exclude_fem(
 
     analysis_domain = _Source(5, analysis_domain=True)
     analysis_member = _Source(6)
+    suppressed = _Source(7)
+    suppressed.Suppressed = True
+    history_inactive = _Source(8)
+    modeling_inactive = _Source(9)
     analysis = SimpleNamespace(
         Name="Analysis",
         TypeId="Fem::FemAnalysis",
@@ -267,12 +271,20 @@ def test_drawing_sources_respect_effective_visibility_and_exclude_fem(
             analysis_domain,
             analysis_member,
             analysis,
+            suppressed,
+            history_inactive,
+            modeling_inactive,
+        ),
+        isObjectUsableAtCurrentTimelinePosition=(
+            lambda obj: obj is not history_inactive
         ),
     )
     monkeypatch.setitem(
         sys.modules,
         "PartGui",
-        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+        SimpleNamespace(
+            isModelingObjectActive=lambda obj: obj is not modeling_inactive
+        ),
     )
 
     assert active_design_geometry_sources(document) == (visible,)
@@ -288,6 +300,9 @@ def test_drawing_sources_respect_effective_visibility_and_exclude_fem(
         drawing_source_exclusion_reason(document, analysis_member)
         == "analysis_artifact"
     )
+    assert drawing_source_exclusion_reason(document, suppressed) == "hidden"
+    assert drawing_source_exclusion_reason(document, history_inactive) == "hidden"
+    assert is_potential_design_geometry_source(document, modeling_inactive) is False
 
 
 def test_hidden_responsive_source_is_rejected_before_shape_access(monkeypatch) -> None:
@@ -320,6 +335,51 @@ def test_hidden_responsive_source_is_rejected_before_shape_access(monkeypatch) -
     )
 
     assert is_potential_design_geometry_source(document, source) is False
+
+
+def test_drawing_inventory_detaches_only_effectively_available_sources(
+    monkeypatch,
+) -> None:
+    visible = _CatalogSource(1)
+    hidden = _CatalogSource(2)
+    hidden.Name = "HiddenBody"
+    hidden.ViewObject.Visibility = False
+    document = SimpleNamespace(
+        Uid="document-a",
+        Objects=(visible, hidden),
+        isObjectUsableAtCurrentTimelinePosition=lambda _obj: True,
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "PartGui",
+        SimpleNamespace(isModelingObjectActive=lambda _obj: True),
+    )
+
+    inventory = drawing_catalog.capture_drawing_source_catalog_inventory(document)
+
+    assert inventory["object_names"] == ["Body"]
+    assert [source["object_name"] for source in inventory["sources"]] == ["Body"]
+    assert visible.Shape.validity_checks == 0
+    assert hidden.Shape.validity_checks == 0
+
+
+def test_complete_drawing_catalog_cache_returns_an_isolated_detached_copy() -> None:
+    drawing_catalog.invalidate_drawing_source_catalog_cache()
+    drawing_catalog.cache_drawing_source_catalog_state(
+        "document-a",
+        7,
+        [{"object_name": "Body", "label": "Body"}],
+    )
+
+    cached = drawing_catalog.cached_drawing_source_catalog_state("document-a", 7)
+    assert cached == [{"object_name": "Body", "label": "Body"}]
+    cached[0]["label"] = "mutated"
+
+    assert drawing_catalog.cached_drawing_source_catalog_state(
+        "document-a",
+        7,
+    ) == [{"object_name": "Body", "label": "Body"}]
+    drawing_catalog.invalidate_drawing_source_catalog_cache()
 
 
 def test_drawing_source_catalog_pages_one_hundred_bodies_without_guessing(

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -18,6 +19,7 @@ from VibeCADNativeSnapshot import (
     NativeSnapshotError,
     build_active_snapshot,
     concise_object,
+    complete_active_snapshot,
 )
 
 
@@ -611,7 +613,7 @@ def test_manufacture_active_job_is_human_selected_or_unambiguous() -> None:
     ) == (None, "ambiguous_selection")
 
 
-def test_snapshot_refuses_wrong_document_or_unbounded_output(monkeypatch) -> None:
+def test_snapshot_refuses_state_from_another_document() -> None:
     document = _document()
     with pytest.raises(NativeSnapshotError, match="another document"):
         build_active_snapshot(
@@ -621,11 +623,97 @@ def test_snapshot_refuses_wrong_document_or_unbounded_output(monkeypatch) -> Non
             selection={"document_uid": "document-a", "items": []},
         )
 
-    monkeypatch.setattr(snapshot_module, "MAX_NATIVE_SNAPSHOT_BYTES", 10)
-    with pytest.raises(NativeSnapshotError, match="exceeds"):
-        build_active_snapshot(
-            document,
-            "model",
-            _state(),
-            selection={"document_uid": "document-a", "items": []},
-        )
+
+def test_oversized_drawing_snapshot_defers_repeated_page_view_details(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(snapshot_module, "MAX_NATIVE_SNAPSHOT_BYTES", 8 * 1024)
+    base = {
+        "surface_id": "drawing",
+        "document": {
+            "document_uid": "document-a",
+            "document_name": "DocumentA",
+        },
+        "structural_revision": 7,
+        "working_set": [],
+    }
+    views = [
+        {
+            "document_uid": "document-a",
+            "object_name": f"View{index}",
+            "type_id": "TechDraw::DrawViewPart",
+            "label": f"Projected View {index}",
+            "state_sha256": str(index).zfill(64),
+            "placement": {
+                "position_on_page_mm": [float(index), 25.0],
+                "locked": False,
+            },
+            "line_attributes": {"detail": "x" * 1024},
+        }
+        for index in range(20)
+    ]
+    selected_dimensions = [{"object_name": "Dimension", "detail": "exact"}]
+    domain = {
+        "kind": "drawing",
+        "page_count": 1,
+        "pages": [
+            {
+                "object_name": "Page",
+                "label": "Page",
+                "type_id": "TechDraw::DrawPage",
+                "state_sha256": "a" * 64,
+                "view_count": len(views),
+                "views": views,
+            }
+        ],
+        "active_page": {"object_name": "Page", "state_sha256": "a" * 64},
+        "selected_dimensions": selected_dimensions,
+    }
+
+    result = complete_active_snapshot(base, domain)
+
+    assert len(json.dumps(result, separators=(",", ":")).encode()) <= 8 * 1024
+    assert result["domain"]["snapshot_compacted"] is True
+    assert result["domain"]["deferred_details"] == ["pages.views"]
+    assert result["domain"]["selected_dimensions"] == selected_dimensions
+    page = result["domain"]["pages"][0]
+    assert page["views_detail_deferred"] is True
+    assert [view["object_name"] for view in page["views"]] == [
+        f"View{index}" for index in range(20)
+    ]
+    assert all("line_attributes" not in view for view in page["views"])
+
+
+def test_oversized_unknown_domain_returns_a_bounded_deferred_manifest(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(snapshot_module, "MAX_NATIVE_SNAPSHOT_BYTES", 4 * 1024)
+    base = {
+        "surface_id": "model",
+        "document": {
+            "document_uid": "document-a",
+            "document_name": "DocumentA",
+        },
+        "structural_revision": 7,
+        "working_set": [],
+    }
+    domain = {
+        "kind": "model",
+        "counts": {"bodies": 200},
+        "bodies": [
+            {"object_name": f"Body{index}", "detail": "x" * 512}
+            for index in range(200)
+        ],
+    }
+
+    result = complete_active_snapshot(base, domain)
+
+    assert len(json.dumps(result, separators=(",", ":")).encode()) <= 4 * 1024
+    assert result["domain"]["kind"] == "model"
+    assert result["domain"]["snapshot_truncated"] is True
+    assert result["domain"]["detail_deferred"] is True
+    assert result["domain"]["section_count"] == 3
+    assert any(
+        section["name"] == "bodies" and section["item_count"] == 200
+        for section in result["domain"]["sections"]
+    )

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
@@ -31,6 +31,9 @@ class _Object:
         self.Label = name
         self.TypeId = type_id
         self.State = []
+        self.ViewObject = SimpleNamespace(Visibility=True)
+        self.getParentGroup = lambda: None
+        self.getParentGeoFeatureGroup = lambda: None
 
     def isDerivedFrom(self, expected: str) -> bool:
         return self.TypeId == expected
@@ -184,6 +187,87 @@ def test_drawing_base_context_omits_hidden_and_fem_working_objects() -> None:
     assert [item["object_name"] for item in result["working_set"]] == [
         "VisibleBody"
     ]
+
+
+def test_analyze_base_context_keeps_fem_graph_but_omits_hidden_geometry() -> None:
+    document = _Document()
+    visible = document.add("VisibleBody", "PartDesign::Body")
+    hidden = document.add("HiddenBody", "PartDesign::Body")
+    suppressed = document.add("SuppressedBody", "PartDesign::Body")
+    solver = document.add("Solver", "Fem::FemSolverObjectPython")
+    for obj, shown in (
+        (visible, True),
+        (hidden, False),
+        (suppressed, True),
+        (solver, False),
+    ):
+        obj.ViewObject = SimpleNamespace(Visibility=shown)
+        obj.getParentGroup = lambda: None
+        obj.getParentGeoFeatureGroup = lambda: None
+    suppressed.Suppressed = True
+    document.isObjectUsableAtCurrentTimelinePosition = lambda obj: obj is not suppressed
+    selection = {
+        "document_uid": document.Uid,
+        "selected_count": 4,
+        "items": [
+            {
+                "object": {
+                    "document_uid": document.Uid,
+                    "object_name": obj.Name,
+                    "type_id": obj.TypeId,
+                },
+                "subelements": [],
+            }
+            for obj in (visible, hidden, suppressed, solver)
+        ],
+    }
+    native_state = {
+        "document_uid": document.Uid,
+        "structural_revision": 7,
+        "recent_receipts": [
+            {
+                "created": [
+                    {
+                        "document_uid": document.Uid,
+                        "object_name": obj.Name,
+                        "type_id": obj.TypeId,
+                    }
+                    for obj in (visible, hidden, suppressed, solver)
+                ]
+            }
+        ],
+    }
+
+    result = capture_active_snapshot_base(
+        document,
+        "analyze",
+        native_state,
+        selection=selection,
+    )
+
+    assert [item["object"]["object_name"] for item in result["selection"]["items"]] == [
+        "VisibleBody",
+        "Solver",
+    ]
+    assert [item["object_name"] for item in result["working_set"]] == [
+        "VisibleBody",
+        "Solver",
+    ]
+
+
+def test_detached_drawing_sources_preserve_the_snapshot_bound() -> None:
+    sources = [
+        {"object_name": f"Body{index}", "type_id": "PartDesign::Body"}
+        for index in range(drawing_snapshot_module.MAX_DRAWING_SOURCES + 2)
+    ]
+
+    count, bounded = drawing_snapshot_module._drawing_sources(
+        None,
+        detached_sources=sources,
+    )
+
+    assert count == len(sources)
+    assert len(bounded) == drawing_snapshot_module.MAX_DRAWING_SOURCES
 
 
 def _state() -> dict:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
@@ -9,6 +9,7 @@ import pytest
 import VibeCADNativeSnapshot as snapshot_module
 import VibeCADNativeAssemblySnapshot as assembly_snapshot_module
 import VibeCADNativeAnalyzeSnapshot as analyze_snapshot_module
+import VibeCADNativeDrawingSnapshot as drawing_snapshot_module
 import VibeCADNativeModelSnapshot as model_snapshot_module
 import VibeCADNativeManufactureSnapshot as manufacture_snapshot_module
 import VibeCADNativeSketchSnapshot as sketch_snapshot_module
@@ -276,6 +277,32 @@ def test_each_surface_builds_only_its_live_domain(
         "Mesh",
     ]
     assert result["selection"] == selection
+
+
+def test_drawing_snapshot_builder_receives_the_structural_revision(monkeypatch) -> None:
+    captured = []
+    monkeypatch.setattr(
+        drawing_snapshot_module,
+        "build_drawing_snapshot",
+        lambda document, **options: captured.append((document, options))
+        or {"kind": "drawing"},
+    )
+    document = object()
+    selection = {"document_uid": "document-a", "items": []}
+
+    result = snapshot_module._domain_builder(
+        "drawing",
+        selection=selection,
+        structural_revision=12,
+    )(document)
+
+    assert result == {"kind": "drawing"}
+    assert captured == [
+        (
+            document,
+            {"selection": selection, "structural_revision": 12},
+        )
+    ]
 
 
 def test_working_set_rebuild_ignores_deleted_receipt_targets() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
@@ -18,6 +18,7 @@ from VibeCADNativeManufactureReadiness import resolve_active_job
 from VibeCADNativeSnapshot import (
     NativeSnapshotError,
     build_active_snapshot,
+    capture_active_snapshot_base,
     concise_object,
     complete_active_snapshot,
 )
@@ -126,6 +127,63 @@ def _document() -> _Document:
     sheet.getAlias = lambda cell: "width" if cell == "A1" else ""
     feature.ExpressionEngine = [("Length", "Parameters.width")]
     return document
+
+
+def test_drawing_base_context_omits_hidden_and_fem_working_objects() -> None:
+    document = _Document()
+    visible = document.add("VisibleBody", "PartDesign::Body")
+    hidden = document.add("HiddenBody", "PartDesign::Body")
+    fem = document.add("FEMMeshGmsh", "Fem::FemMeshShapeBaseObjectPython")
+    for obj, shown in ((visible, True), (hidden, False), (fem, True)):
+        obj.ViewObject = SimpleNamespace(Visibility=shown)
+        obj.getParentGroup = lambda: None
+        obj.getParentGeoFeatureGroup = lambda: None
+    selection = {
+        "document_uid": document.Uid,
+        "selected_count": 3,
+        "items": [
+            {
+                "object": {
+                    "document_uid": document.Uid,
+                    "object_name": obj.Name,
+                    "type_id": obj.TypeId,
+                },
+                "subelements": [],
+            }
+            for obj in (visible, hidden, fem)
+        ],
+    }
+    native_state = {
+        "document_uid": document.Uid,
+        "structural_revision": 7,
+        "recent_receipts": [
+            {
+                "created": [
+                    {
+                        "document_uid": document.Uid,
+                        "object_name": obj.Name,
+                        "type_id": obj.TypeId,
+                    }
+                    for obj in (visible, hidden, fem)
+                ]
+            }
+        ],
+    }
+
+    result = capture_active_snapshot_base(
+        document,
+        "drawing",
+        native_state,
+        selection=selection,
+    )
+
+    assert [item["object"]["object_name"] for item in result["selection"]["items"]] == [
+        "VisibleBody"
+    ]
+    assert result["selection"]["selected_count"] == 1
+    assert [item["object_name"] for item in result["working_set"]] == [
+        "VisibleBody"
+    ]
 
 
 def _state() -> dict:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_state.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_state.py
@@ -448,6 +448,30 @@ def test_document_observer_filters_presentation_before_revision(
     assert store.current_revision("document-a") == 1
 
 
+def test_gui_document_observer_forwards_visibility_changes(monkeypatch) -> None:
+    import VibeCADGui as gui
+
+    changed = []
+    service = SimpleNamespace(
+        note_native_object_property_change=(
+            lambda obj, property_name: changed.append((obj, property_name))
+        ),
+    )
+    monkeypatch.setattr(gui, "get_service", lambda: service)
+    monkeypatch.setattr(gui.App, "isRestoring", lambda: False, raising=False)
+    obj = SimpleNamespace(
+        Document=SimpleNamespace(Uid="document-a", Restoring=False),
+    )
+    view_provider = SimpleNamespace(Object=obj)
+
+    gui._VibeCADGuiDocumentObserver().slotChangedObject(
+        view_provider,
+        "Visibility",
+    )
+
+    assert changed == [(obj, "Visibility")]
+
+
 def test_document_observer_counts_create_and_delete(monkeypatch) -> None:
     import VibeCADGui as gui
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_view_drawing_page_capture.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_view_drawing_page_capture.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+
+
+class _Page:
+    TypeId = "TechDraw::DrawPage"
+
+    def __init__(self, name: str, label: str) -> None:
+        self.Name = name
+        self.Label = label
+
+    def isDerivedFrom(self, expected: str) -> bool:
+        return expected == self.TypeId
+
+
+class _Document:
+    Name = "DrawingDocument"
+
+    def __init__(self, *pages: _Page) -> None:
+        self.Objects = list(pages)
+
+
+def test_named_drawing_page_capture_uses_exact_name_without_being_active(
+    monkeypatch,
+) -> None:
+    from tool_impl.service import core_capture_view_screenshot as capture
+
+    first = _Page("Page", "Fabrication")
+    second = _Page("Page002", "Inspection")
+    document = _Document(first, second)
+    monkeypatch.setitem(
+        sys.modules,
+        "FreeCAD",
+        SimpleNamespace(ActiveDocument=document),
+    )
+    monkeypatch.setitem(sys.modules, "FreeCADGui", SimpleNamespace(ActiveDocument=None))
+    monkeypatch.setattr(capture, "_active_drawing_page", lambda _document: None)
+    observed = []
+    monkeypatch.setattr(
+        capture,
+        "_capture_drawing_page",
+        lambda service, target_document, page, *, requested: observed.append(
+            (service, target_document, page, requested)
+        )
+        or {"ok": True, "captured": True, "page": page.Name},
+    )
+    service = SimpleNamespace()
+
+    result = capture.run(
+        service,
+        camera={"mode": "front"},
+        frame="objects",
+        object_names=["Body"],
+        page_name="Page002",
+    )
+
+    assert result == {"ok": True, "captured": True, "page": "Page002"}
+    assert observed[0][:3] == (service, document, second)
+    assert observed[0][3]["page_name"] == "Page002"
+
+
+def test_active_drawing_page_capture_normalizes_3d_frame_requests(monkeypatch) -> None:
+    from tool_impl.service import core_capture_view_screenshot as capture
+
+    page = _Page("Page", "Fabrication")
+    document = _Document(page)
+    monkeypatch.setitem(
+        sys.modules,
+        "FreeCAD",
+        SimpleNamespace(ActiveDocument=document),
+    )
+    monkeypatch.setitem(sys.modules, "FreeCADGui", SimpleNamespace(ActiveDocument=None))
+    monkeypatch.setattr(capture, "_active_drawing_page", lambda _document: page)
+    monkeypatch.setattr(
+        capture,
+        "_capture_drawing_page",
+        lambda _service, _document, target, *, requested: {
+            "ok": True,
+            "captured": True,
+            "page": target.Name,
+            "requested": requested,
+        },
+    )
+
+    result = capture.run(
+        SimpleNamespace(),
+        frame="selection",
+        camera={"mode": "isometric"},
+    )
+
+    assert result["ok"] is True
+    assert result["page"] == "Page"
+    assert result["requested"]["frame"] == "selection"
+
+
+def test_missing_named_drawing_page_returns_bounded_candidates(monkeypatch) -> None:
+    from tool_impl.service import core_capture_view_screenshot as capture
+
+    document = _Document(_Page("Page", "Fabrication"))
+    service = SimpleNamespace(_last_view_screenshot={})
+    monkeypatch.setitem(
+        sys.modules,
+        "FreeCAD",
+        SimpleNamespace(ActiveDocument=document),
+    )
+    monkeypatch.setitem(sys.modules, "FreeCADGui", SimpleNamespace(ActiveDocument=None))
+
+    result = capture.run(service, page_name="Missing")
+
+    assert result["ok"] is False
+    assert result["failure_code"] == "DRAWING_PAGE_TARGET_INVALID"
+    assert result["candidates"] == [
+        {"object_name": "Page", "label": "Fabrication"}
+    ]


### PR DESCRIPTION
﻿﻿﻿## Summary

Fixes the Drawing assistant and `drawing.sources` UI stalls on large documents.

- Adds a dedicated read-only Drawing source-context lane that runs from the provider worker and coalesces concurrent tab-prewarm and Send requests.
- Captures only bounded source identity metadata in eight-object document-thread dispatches. The catalog path no longer reads live `Shape`, placement, topology collections, bounds, BREP validity, or geometry hashes.
- Caches the complete detached source catalog by document UID and structural revision, then serves every `drawing.sources` page from that cache.
- Invalidates Drawing read state on structural changes and document close.
- Requires the responsive cache for GUI `drawing.sources` calls so the tool cannot silently fall back to an inline full-document scan.
- Reports preparation and cache status in both the assistant status line and application status bar.
- Preserves exact BREP validation for Drawing mutations. PartDesign Body sources now validate History against their active modeling state while the selected Body remains the direct TechDraw source.

## Why

The 2,357-object CursedCase document contained an `App::Part` whose topology materialization held one Qt dispatch for about 3.07 seconds. Repeated provider-context and supplemental tool reads could repeat that work. Source listing only needs stable whole-object targets, so unbounded geometry work does not belong in that context path.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward.
- [x] Exact build and test commands and results are listed below.

### Red

```powershell
$env:PYTHONPATH='src/Mod/VibeCAD;src/Mod/TechDraw'
.\.pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py -k 'responsive_drawing'
```

Before the container-source implementation: `2 failed, 2 passed, 9 deselected`. Both failures showed that `App::Part` and `App::Link` candidates without a declared `Shape` property would be lost by an identity-only scan.

The first coordinator test also failed before production code existed because `VibeCADNativeDrawingContext` was missing.

### Green: focused

```powershell
$env:PYTHONPATH='src/Mod/VibeCAD;src/Mod/TechDraw'
.\.pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_native_drawing_context.py src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py
```

Result: `17 passed in 1.20s`.

### Green: Drawing/provider regression gate

```powershell
$env:PYTHONPATH='src/Mod/VibeCAD;src/Mod/TechDraw'
.\.pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_native_drawing_context.py src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py src/Mod/VibeCAD/vibecad_tests/test_document_save_observer.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_internal_targets.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_provider_state.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_page.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_view.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_dimension.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_dimension_repair.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_presentation.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_rich_annotation.py src/Mod/VibeCAD/vibecad_tests/test_native_common_runtime.py src/Mod/VibeCAD/vibecad_tests/test_native_common_schema.py src/Mod/VibeCAD/vibecad_tests/test_native_dispatch.py src/Mod/VibeCAD/vibecad_tests/test_native_mode_surface.py src/Mod/VibeCAD/vibecad_tests/test_native_session.py src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py src/Mod/VibeCAD/vibecad_tests/test_native_analyze_context.py src/Mod/VibeCAD/vibecad_tests/test_engine_contracts.py src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py::test_drawing_snapshot_builder_receives_the_structural_revision
```

Result: `249 passed, 1 skipped in 12.22s`.

### Syntax/package verification

```powershell
.\.pixi\envs\default\python.exe -m compileall -q src/Mod/VibeCAD/VibeCADCore.py src/Mod/VibeCAD/VibeCADGui.py src/Mod/VibeCAD/VibeCADNativeCommonRuntime.py src/Mod/VibeCAD/VibeCADNativeDrawingContext.py src/Mod/VibeCAD/VibeCADNativeDrawingProviderState.py src/Mod/VibeCAD/VibeCADNativeDrawingSnapshot.py src/Mod/VibeCAD/VibeCADNativeDrawingSourceCatalog.py src/Mod/VibeCAD/VibeCADNativeDrawingViewState.py src/Mod/VibeCAD/VibeCADNativeGeometrySources.py src/Mod/VibeCAD/VibeCADNativeSnapshot.py src/Mod/VibeCAD/VibeCADSession.py
```

Result: exit code `0`.

The modified Python modules were copied into the existing extracted Windows package and hash-compared against the source files. A packaged-runtime smoke test opened `CursedCase.FCStd` and measured:

- 2,357 document objects
- 1,838 Drawing source candidates
- 295 bounded dispatches
- 65.581 ms total identity capture
- 2.133 ms maximum dispatch
- 0.286 ms p95 dispatch
- 0.886 ms cached first-page response

The patched extracted Windows build was then launched normally and exercised interactively.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing defaults remain intact; new revision/cache parameters are optional for non-GUI callers.
- [x] Existing exact geometry validation remains available and unchanged.
- [x] No breaking changes.

## Risk and non-goals

Risk is limited to revision-scoped Drawing provider context and source discovery. Cache invalidation follows the existing Native structural-revision events, and tests cover cancellation, concurrent coalescing, stale revisions, GUI cache-only reads, status reporting, and candidate compatibility.

This PR does not change Drawing mutation behavior, tool schemas, document formats, or exact geometry algorithms.

## Issues

Closes #116

## Before and After Images

No visual layout changes. The user-visible difference is that the UI remains responsive and reports source-preparation progress instead of freezing.

## Follow-up: direct PartDesign Body sources

The saved CursedCase workflow exposed a separate exact-mutation bug after responsive discovery was fixed: `PartDesign::Body` is deliberately classified as a timeline-internal presentation boundary, so applying the generic History predicate directly to the Body rejected valid selected sources. The fix resolves the Body only for History validation, checks the exact active modeling state, and retains the original Body as `TechDraw::DrawViewPart.Source`. Standard, projection-group, broken, detail, and section flows now share that behavior.

### Red

```powershell
$env:PYTHONPATH='C:\Users\robit\vibecad\src\Mod\VibeCAD'
.\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_native_drawing_history.py -q
```

Before implementation: collection failed with `ModuleNotFoundError: No module named 'VibeCADNativeDrawingHistory'`.

### Green: focused Python gate

```powershell
$env:PYTHONPATH='C:\Users\robit\vibecad\src\Mod\VibeCAD;C:\Users\robit\vibecad\src\Mod\TechDraw'
.\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_engine_contracts.py src/Mod/VibeCAD/vibecad_tests/test_native_common_runtime.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_context.py src/Mod/VibeCAD/vibecad_tests/test_native_geometry_sources.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_history.py src/Mod/VibeCAD/vibecad_tests/test_native_drawing_view.py -q
```

Result: `84 passed in 4.83s`.

### Green: compiled Windows GUI gate

```powershell
VibeCAD.exe src/Mod/VibeCAD/vibecad_tests/native_drawing_standard_view_gui_integration.py
```

Result: `VIBECAD_NATIVE_DRAWING_STANDARD_VIEW_GUI_OK`, including exact sources, projected geometry, History, rollback, undo/redo, reopen, and responsive execution.

A packaged-runtime probe then opened the actual `CursedCase.FCStd`. The generic History predicate was false for `Body042` and `Body043`, their resolved active `DesignBodyState` objects were usable, the new Drawing predicate accepted both, and `prepare_standard_view_create` retained `['Body042', 'Body043']` as the exact sources on the existing page.


## Follow-up: bounded Drawing state and native TechDraw hierarchy

The saved CursedCase workflow exposed two additional Drawing failures in the same user path:

- The custom VibeCAD tree flattened TechDraw pages, views, dimensions, and annotations into generic categories instead of following TechDraw ownership.
- A complete Drawing provider snapshot could exceed the 64 KiB active-state budget and abort the CAD run before tool execution.

The tree now follows the authoritative `ViewProvider::claimChildren()` graph under a virtual **Drawings** folder. Snapshot completion preserves the established shape for normal-sized state, compacts repeated per-page view detail only after the budget is exceeded, and falls back to a deterministic deferred-detail manifest for pathological extension domains instead of raising a fatal size error. Explicit selected-target blocks and all drawing object identities are retained whenever the Drawing compaction fits.

### Red

```powershell
$env:PYTHONPATH='C:\Users\robit\vibecad\src\Mod\VibeCAD;C:\Users\robit\vibecad\src\Mod\TechDraw'
.\.pixi\envs\default\python.exe -m pytest -q src\Mod\VibeCAD\vibecad_tests\test_native_snapshot.py -k 'oversized or refuses_state'
```

Before implementation: `2 failed, 1 passed, 20 deselected`; both oversized-state tests raised `NativeSnapshotError: The active Native state snapshot exceeds its bound.`

The new compiled GUI regression also failed before implementation: no **Drawings** folder existed, and the page, view, dimension, and annotation were flattened into **Operations** or **Other**.

### Green: focused state tests

```powershell
$env:PYTHONPATH='C:\Users\robit\vibecad\src\Mod\VibeCAD;C:\Users\robit\vibecad\src\Mod\TechDraw'
.\.pixi\envs\default\python.exe -m pytest -q src\Mod\VibeCAD\vibecad_tests\test_native_snapshot.py -k 'oversized or refuses_state'
```

Result: `3 passed, 20 deselected in 0.98s`.

### Green: full Windows package and portable artifact

```powershell
cd package\rattler-build
& "$env:USERPROFILE\.pixi\bin\pixi.exe" reinstall -e default vibecad
$env:PATH="$env:USERPROFILE\.pixi\bin;$env:PATH"
$env:BUILD_TAG='v26.3.1-RC5-build5'
$env:MAKE_INSTALLER='false'
$env:MAKE_PORTABLE_ARCHIVE='true'
& "$env:USERPROFILE\.pixi\bin\pixi.exe" run -e package create_bundle
```

Result: clean Rattler package build succeeded; the official bundle script passed its command-line, portable-launcher, WebView2, Python dependency/keyring, provider subprocess, Codex app-server, geometry-worker, and windowless-provider smoke tests. It produced `VibeCAD-26.3.1-RC5-build5-Windows-x86_64.7z`.

```powershell
7z t package\rattler-build\windows\VibeCAD-26.3.1-RC5-build5-Windows-x86_64.7z
```

Result: `Everything is Ok` for 4,440 folders and 47,282 files. SHA-256: `ae178de03aec508e45790eb2413904655743f295a702a9d01dd3dc36ea50db8a`.

### Green: compiled GUI and real document

The focused compiled GUI test passed against the fresh bundle: `1 test, OK`.

The fresh bundle then opened `CursedCase.FCStd` (2,384 objects, 27 TechDraw objects):

- **Drawings ? Page** contains the template, projected views, and rich annotations.
- Each dimension appears below its owning view.
- **Operations** contains only the two actual non-drawing operations.
- With `Body042.Face1` selected, the raw Drawing domain measured 65,440 bytes; completed provider state measured 27,819 bytes against the 65,536-byte bound.
- All 25 page-view identities were retained; `snapshot_compacted=true` and `snapshot_truncated=false`.

The complete `TestModelTreeBrowser` GUI class was also exercised during development: the new Drawing test and 23 existing tests passed. Four failures exactly matched the pre-change package baseline (unavailable `Assembly::BomObject`, two environment-dependent chamfer task-dialog tests, and an existing publication primitive-count assertion).

### Compatibility

- Existing public functions and APIs remain present.
- No preference keys, Native tool names, or established schema fields were renamed or removed.
- Small snapshots retain the previous complete shape and behavior.
- The 64 KiB provider-state budget remains enforced; oversized detail is deferred rather than aborting the conversation.
- No document format or TechDraw ownership data is changed.


## Follow-up: restored Drawing dimensions and folder icon

Opening a saved Drawing page could leave every saved-visible dimension hidden until the user selected each one. TechDraw initially hides dimensions while their referenced view has no geometry, but the redraw path then treated that temporary QGraphics visibility as user intent. The referenced view's later paint event also refreshed only the view itself. The fix uses the durable ViewObject visibility state and redraws only the active dimensions that depend on a view after that view's geometry becomes available. Saved-hidden dimensions remain hidden.

The virtual **Drawings** folder also requested the internal workbench identifier as an icon name, producing repeated `Cannot find icon: TechDrawWorkbench` warnings. It now requests TechDraw's registered `preferences-techdraw` icon while the user-facing tab remains **Drawing**.

### Red

```powershell
$env:PYTHONPATH=(Resolve-Path 'src/Mod/TechDraw').Path
package/rattler-build/.pixi/envs/default/python.exe -m unittest TDTest.TechDrawGuiBehaviorContractTest.TechDrawGuiBehaviorSourceContractTest.test_view_repaint_redraws_dimensions_after_reference_geometry
```

Before implementation: `1 error`; the required dependent-dimension redraw path did not exist.

The unmodified portable build also ran the saved `CursedCase.FCStd` regression through its embedded Python environment: all six referenced views rendered, all six dimensions were missing, and selecting one restored only that one dimension. It also emitted repeated `Cannot find icon: TechDrawWorkbench` warnings.

### Green: focused source and build

```powershell
$env:PYTHONPATH=(Resolve-Path 'src/Mod/TechDraw').Path
package/rattler-build/.pixi/envs/default/python.exe -m unittest TDTest.TechDrawGuiBehaviorContractTest.TechDrawGuiBehaviorSourceContractTest.test_dimension_redraw_uses_durable_view_visibility TDTest.TechDrawGuiBehaviorContractTest.TechDrawGuiBehaviorSourceContractTest.test_view_repaint_redraws_dimensions_after_reference_geometry
```

Result: `2 tests, OK`.

```powershell
cmake --build package/rattler-build/.pixi/bld/vibecad/O5m01f1YiFA/work/build --target FreeCADGui TechDrawGui --parallel 12
```

Result: exit code `0`; `FreeCADGui.dll` and `TechDrawGui.pyd` linked successfully.

### Green: packaged Windows runtime

The compiled binaries were hash-matched into the existing official portable bundle and its embedded runtime executed the regressions:

- Save/reopen test: saved-visible dimension rendered automatically; saved-hidden dimension remained hidden (`1 test, OK`).
- Drawings tree test: page/view ownership remained exact and the folder resolved the registered TechDraw icon (`1 test, OK`).
- Real `CursedCase.FCStd`: all six base views and all six saved-visible dimensions rendered before selection; every dimension retained its correct parent view (`1 test, OK`, 54.014 s).
- No `Cannot find icon: TechDrawWorkbench` warning remained.

A broader pre-existing TechDraw source-contract class was also run. Nineteen tests passed and eight existing assertions failed in unrelated toolbar inventory, welding/history, print-all, chain-dimension, and axonometric-command areas. This follow-up does not touch those implementation paths or assertions.

### Compatibility

- No public API, command, preference key, schema, or document format changed.
- No geometry is recomputed redundantly; the view-ready event redraws only dependent dimension graphics.
- Existing hidden-state behavior is covered and preserved.

## Follow-up: exact multi-page Drawing capture

Drawing screenshots now work like the other visual tools. The assistant can name an exact Drawing page, capture an inactive page without changing the visible page, and request multiple pages as distinct image attachments in one turn. Existing active-page and 3D-view calls remain compatible.

The HTTP 400 had a separate transport cause: code mode wrapped `view.control` and mislabeled its JSON failure as an image URL. The `view` namespace is now direct-only, so successful captures become `localImage` inputs and failures remain text tool output.

### Red / green

```powershell
$hroot=(Resolve-Path 'package/rattler-build/.pixi/bld/vibecad/O5m01f1YiFA/host').Path
$testsite=(Resolve-Path '.pixi/envs/default/Lib/site-packages').Path
$source=(Resolve-Path 'src/Mod/VibeCAD').Path
$env:PATH="$hroot\Library\bin;$hroot\DLLs;$hroot;$env:PATH"
$env:PYTHONPATH="$source;$testsite;$hroot\Library\bin;$hroot\Library\Ext;$hroot\Library\Mod\TechDraw"
& "$hroot\python.exe" -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_native_common_schema.py src/Mod/VibeCAD/vibecad_tests/test_native_common_runtime.py::test_view_runtime_uses_fixed_operations_and_exact_injected_document src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py::test_codex_thread_config_disables_non_vibecad_tool_surfaces src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py::test_codex_steers_multiple_tool_images_outside_replayed_tool_output src/Mod/VibeCAD/vibecad_tests/test_view_drawing_page_capture.py
```

Before implementation, the focused gate reported `7 failed, 7 passed`: exact-page selection was absent, active Drawing pages rejected ordinary visual requests, and `view` was not direct-only. The final expanded gate reported `15 passed in 3.73s`. Its provider test performs two image-producing captures in one assistant turn and verifies two independent `localImage` steers with no replayed `imageUrl`.

### Packaged Windows GUI gate

The modified Python runtime modules were deployed into the existing RC5 Build 5 portable package. Its real `VibeCAD.exe` ran `native_drawing_page_capture_gui_integration.py` in the packaged Python/Qt environment.

Result: exit code `0`, empty stderr, and:

```text
VIBECAD_NATIVE_DRAWING_PAGE_CAPTURE_GUI_OK named_internal=true named_label=true inactive_page=true active_fallback=true multiple_images=true
```

The gate creates two real TechDraw pages and verifies three distinct, nonblank PNGs: an inactive page by internal name, a page by unique label, and the active-page fallback.

### Compatibility

- Existing screenshot APIs and defaults remain present.
- `page_name` is optional; no existing schema field, tool name, preference, or wire field was removed or renamed.
- The new Native operation uses an exact `TechDraw::DrawPage` reference and appears only on the Drawing surface.
- 3D framing/camera hints are normalized when a Drawing page is the actual visual target.
### Drawing visibility and FEM isolation follow-up

Hidden model objects now remain outside every Drawing provider path, including source catalogs, selected/working context, exact standard and Draft source preparation, complex-section profiles, and active-view state. Analyze/FEM objects are excluded independently by native FEM type, VibeCAD analysis-domain marker, FEM properties, and recursive membership in `Fem::FemAnalysis`; Analyze behavior is unchanged. GUI visibility changes invalidate cached Drawing context without incrementing the structural model revision.

Red/green evidence:
- RED: focused tests failed because the Drawing exclusion API and GUI visibility observer did not exist; active-view state also changed when only hidden/FEM selections were added, and a hidden standard-view source was accepted.
- GREEN: `26 passed in 1.62s` using the packaged Windows host Python across geometry-source, active-view, context invalidation, base-snapshot, standard-view history, and GUI-observer tests.
- REAL GUI: the patched RC5-build5 portable opened `CursedCase.FCStd` and passed with `objects=2394`, `sources=9`, `hidden=2309`, `analysis=20`, `visible_geometry=25`, `fem_filtered=true`, and `hidden_filtered=true`.
- COMPILE: all 15 changed Python modules/tests compiled successfully; `git diff --check` passed.

A broader touched-area run reported `92 passed, 2 failed`; both failures are pre-existing stale test doubles in `test_native_state.py` that omit the already-required `native_document_state()` service method. They are not masked or included in this change.

Compatibility:
- [x] Existing public functions/APIs remain present; the only signature extension is an optional keyword on `live_working_set`.
- [x] No preference keys, tool names, schemas, defaults, or Analyze behavior changed.
- [x] No dependency, packaging, or release changes.