### PR TITLE
Bump VibeCAD RC5 to build 6

### DIFF
--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 5
+  number: 6
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC5",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 5,
+  "build_version": 6,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
﻿## Summary

Bump the canonical VibeCAD release identity from RC5 build 5 to RC5 build 6 so the newly merged Fusion/JT, Drawing, and native lifecycle work can be released without reusing an immutable build tag.

## Changes

- Set `version.json` build number to 6.
- Set the rattler recipe build number to 6.
- Release metadata resolves to `VibeCAD 26.3.1-RC5 (Build 6)` and tag `v26.3.1-RC5-build6`.

## Validation

```powershell
& .pixi/envs/default/python.exe src/Tools/sync_version.py --check
```

Result: all canonical version files are in sync.

```powershell
& .pixi/envs/default/python.exe -m pytest -q src/Tools/tests/test_sync_version.py src/Tools/tests/test_release_artifact_name.py
```

Result: `56 passed in 0.44s`.

TDD does not apply: this is a metadata-only release build-number increment with no runtime behavior change.

A broader existing branding suite currently has three unrelated `InitGui.py` bootstrap expectation failures; this two-line metadata change neither causes nor modifies them.

## Compatibility

- [x] Existing public functions/APIs remain unchanged.
- [x] No preference keys, tool names, or schema fields are changed.
- [x] Runtime defaults and behavior are unchanged.
- [x] No breaking changes.
