### PR TITLE
Redesign the VibeCAD Start page

### DIFF
--- a/src/Gui/Stylesheets/VibeDark.qss
+++ b/src/Gui/Stylesheets/VibeDark.qss
@@ -92,11 +92,62 @@ Start page
   background-color: transparent;
   border: none; }
 
+QWidget#VibeCADStartContent {
+  background-color: transparent; }
+
+QFrame#VibeCADStartHero {
+  color: #e8edf2;
+  background-color: #1b2938;
+  border: 1px solid #2e4b66;
+  border-radius: 14px; }
+
+QLabel#VibeCADStartBrandTitle,
+QLabel#VibeCADFirstStartTitle {
+  color: #f3f7fb;
+  font-size: 26px;
+  font-weight: 700; }
+
+QLabel#VibeCADStartBrandDescription,
+QLabel#VibeCADFirstStartDescription,
+QLabel#VibeCADAISetupDescription {
+  color: #aab7c4;
+  font-size: 14px; }
+
+QLabel#VibeCADStartSectionTitle,
+QLabel#VibeCADFirstStartSectionTitle,
+QLabel#VibeCADAISetupTitle {
+  color: #edf3f8;
+  font-size: 18px;
+  font-weight: 650; }
+
+QFrame#VibeCADAISetupCard {
+  background-color: #202b37;
+  border: 1px solid #334252;
+  border-radius: 12px; }
+
+#StartView QPushButton[vibeStartPrimary="true"] {
+  color: #08111b;
+  background-color: #74c0fc;
+  border: 1px solid #4dabf7;
+  border-radius: 7px;
+  padding: 7px 14px; }
+  #StartView QPushButton[vibeStartPrimary="true"]:hover {
+    background-color: #91cdfd;
+    border-color: #74c0fc; }
+  #StartView QPushButton[vibeStartPrimary="true"]:pressed {
+    background-color: #4dabf7; }
+
+#StartView QListView {
+  background-color: transparent;
+  border: none;
+  outline: none; }
+
 QWidget#CreateNewRow {
   background-color: transparent;
   padding: 2px; }
 
-QPushButton#newFileButton {
+QPushButton#newFileButton,
+StartGui--NewFileButton {
   min-width: 180px;
   max-width: 180px;
   min-height: 76px;
@@ -104,16 +155,20 @@ QPushButton#newFileButton {
   background-color: #1d242d;
   border: 1px solid #29313c;
   border-radius: 8px; }
-  QPushButton#newFileButton:hover {
+  QPushButton#newFileButton:hover,
+  StartGui--NewFileButton:hover {
     background-color: #232b35;
     border-color: #39434f; }
-  QPushButton#newFileButton:pressed {
+  QPushButton#newFileButton:pressed,
+  StartGui--NewFileButton:pressed {
     color: #ffffff;
     background-color: #283140;
     border-color: #4dabf7; }
-  QPushButton#newFileButton:focus {
+  QPushButton#newFileButton:focus,
+  StartGui--NewFileButton:focus {
     border-color: #4dabf7; }
-  QPushButton#newFileButton QLabel {
+  QPushButton#newFileButton QLabel,
+  StartGui--NewFileButton QLabel {
     color: #e8edf2;
     background-color: transparent; }
 

--- a/src/Gui/Stylesheets/VibeLight.qss
+++ b/src/Gui/Stylesheets/VibeLight.qss
@@ -95,11 +95,62 @@ Start page
   background-color: transparent;
   border: none; }
 
+QWidget#VibeCADStartContent {
+  background-color: transparent; }
+
+QFrame#VibeCADStartHero {
+  color: #1d2733;
+  background-color: #eef6ff;
+  border: 1px solid #c7def3;
+  border-radius: 14px; }
+
+QLabel#VibeCADStartBrandTitle,
+QLabel#VibeCADFirstStartTitle {
+  color: #132337;
+  font-size: 26px;
+  font-weight: 700; }
+
+QLabel#VibeCADStartBrandDescription,
+QLabel#VibeCADFirstStartDescription,
+QLabel#VibeCADAISetupDescription {
+  color: #536273;
+  font-size: 14px; }
+
+QLabel#VibeCADStartSectionTitle,
+QLabel#VibeCADFirstStartSectionTitle,
+QLabel#VibeCADAISetupTitle {
+  color: #172536;
+  font-size: 18px;
+  font-weight: 650; }
+
+QFrame#VibeCADAISetupCard {
+  background-color: #f5f9fe;
+  border: 1px solid #cbdceb;
+  border-radius: 12px; }
+
+#StartView QPushButton[vibeStartPrimary="true"] {
+  color: #ffffff;
+  background-color: #1971c2;
+  border: 1px solid #1864ab;
+  border-radius: 7px;
+  padding: 7px 14px; }
+  #StartView QPushButton[vibeStartPrimary="true"]:hover {
+    background-color: #1864ab;
+    border-color: #14558f; }
+  #StartView QPushButton[vibeStartPrimary="true"]:pressed {
+    background-color: #14558f; }
+
+#StartView QListView {
+  background-color: transparent;
+  border: none;
+  outline: none; }
+
 QWidget#CreateNewRow {
   background-color: transparent;
   padding: 2px; }
 
-QPushButton#newFileButton {
+QPushButton#newFileButton,
+StartGui--NewFileButton {
   min-width: 180px;
   max-width: 180px;
   min-height: 76px;
@@ -107,16 +158,20 @@ QPushButton#newFileButton {
   background-color: #fbfcfe;
   border: 1px solid #d6dce4;
   border-radius: 8px; }
-  QPushButton#newFileButton:hover {
+  QPushButton#newFileButton:hover,
+  StartGui--NewFileButton:hover {
     background-color: #dfe5ec;
     border-color: #bcc6d1; }
-  QPushButton#newFileButton:pressed {
+  QPushButton#newFileButton:pressed,
+  StartGui--NewFileButton:pressed {
     color: #0b1521;
     background-color: #d4dce5;
     border-color: #1971c2; }
-  QPushButton#newFileButton:focus {
+  QPushButton#newFileButton:focus,
+  StartGui--NewFileButton:focus {
     border-color: #1971c2; }
-  QPushButton#newFileButton QLabel {
+  QPushButton#newFileButton QLabel,
+  StartGui--NewFileButton QLabel {
     color: #1d2733;
     background-color: transparent; }
 

--- a/src/Mod/Start/Gui/FileCardView.cpp
+++ b/src/Mod/Start/Gui/FileCardView.cpp
@@ -33,16 +33,20 @@ namespace StartGui
 FileCardView::FileCardView(QWidget* parent)
     : QListView(parent)
 {
-    QSizePolicy sizePolicy(QSizePolicy::Policy::MinimumExpanding, QSizePolicy::Policy::MinimumExpanding);
+    QSizePolicy sizePolicy(QSizePolicy::Policy::Expanding, QSizePolicy::Policy::Preferred);
     sizePolicy.setHeightForWidth(true);
     setSizePolicy(sizePolicy);
     setHorizontalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);
-    setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAsNeeded);
+    setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);
+    setFrameShape(QFrame::NoFrame);
+    setEditTriggers(QAbstractItemView::NoEditTriggers);
+    setSelectionMode(QAbstractItemView::SingleSelection);
     setViewMode(QListView::ViewMode::IconMode);
     setFlow(QListView::Flow::LeftToRight);
     setResizeMode(QListView::ResizeMode::Adjust);
     setUniformItemSizes(true);
     setMouseTracking(true);
+    setCursor(Qt::PointingHandCursor);
 
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start"

--- a/src/Mod/Start/Gui/FirstStartWidget.cpp
+++ b/src/Mod/Start/Gui/FirstStartWidget.cpp
@@ -23,7 +23,9 @@
 
 
 #include <QGuiApplication>
+#include <QFrame>
 #include <QHBoxLayout>
+#include <QIcon>
 #include <QLabel>
 #include <QPushButton>
 #include <QResizeEvent>
@@ -46,9 +48,15 @@ FirstStartWidget::FirstStartWidget(QWidget* parent)
     , _generalSettingsWidget {nullptr}
     , _welcomeLabel {nullptr}
     , _descriptionLabel {nullptr}
+    , _aiTitleLabel {nullptr}
+    , _aiDescriptionLabel {nullptr}
+    , _personalizeLabel {nullptr}
+    , _configureAIButton {nullptr}
+    , _openAssistantButton {nullptr}
     , _doneButton {nullptr}
 {
     setObjectName(QLatin1String("FirstStartWidget"));
+    setMaximumWidth(1180);
     setupUi();
     qApp->installEventFilter(this);
 }
@@ -56,11 +64,77 @@ FirstStartWidget::FirstStartWidget(QWidget* parent)
 void FirstStartWidget::setupUi()
 {
     auto outerLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout(this));
-    outerLayout->setAlignment(Qt::AlignCenter);
+    outerLayout->setContentsMargins(32, 28, 32, 28);
+    outerLayout->setSpacing(18);
+
+    auto headerLayout = gsl::owner<QHBoxLayout*>(new QHBoxLayout);
+    headerLayout->setSpacing(18);
+
+    auto mark = gsl::owner<QLabel*>(new QLabel);
+    mark->setObjectName(QLatin1String("VibeCADFirstStartMark"));
+    mark->setPixmap(QIcon(QLatin1String(":/icons/vibecad.svg")).pixmap(72, 72));
+    mark->setFixedSize(72, 72);
+    headerLayout->addWidget(mark, 0, Qt::AlignTop);
+
+    auto welcomeLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout);
+    welcomeLayout->setSpacing(4);
     _welcomeLabel = gsl::owner<QLabel*>(new QLabel);
-    outerLayout->addWidget(_welcomeLabel);
+    _welcomeLabel->setObjectName(QLatin1String("VibeCADFirstStartTitle"));
+    welcomeLayout->addWidget(_welcomeLabel);
     _descriptionLabel = gsl::owner<QLabel*>(new QLabel);
-    outerLayout->addWidget(_descriptionLabel);
+    _descriptionLabel->setObjectName(QLatin1String("VibeCADFirstStartDescription"));
+    _descriptionLabel->setWordWrap(true);
+    welcomeLayout->addWidget(_descriptionLabel);
+    headerLayout->addLayout(welcomeLayout, 1);
+    outerLayout->addLayout(headerLayout);
+
+    auto aiCard = gsl::owner<QFrame*>(new QFrame);
+    aiCard->setObjectName(QLatin1String("VibeCADAISetupCard"));
+    auto aiCardLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout(aiCard));
+    aiCardLayout->setContentsMargins(20, 18, 20, 18);
+    aiCardLayout->setSpacing(18);
+
+    auto aiTextLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout);
+    aiTextLayout->setSpacing(4);
+    _aiTitleLabel = gsl::owner<QLabel*>(new QLabel);
+    _aiTitleLabel->setObjectName(QLatin1String("VibeCADAISetupTitle"));
+    aiTextLayout->addWidget(_aiTitleLabel);
+    _aiDescriptionLabel = gsl::owner<QLabel*>(new QLabel);
+    _aiDescriptionLabel->setObjectName(QLatin1String("VibeCADAISetupDescription"));
+    _aiDescriptionLabel->setWordWrap(true);
+    aiTextLayout->addWidget(_aiDescriptionLabel);
+    aiCardLayout->addLayout(aiTextLayout, 1);
+
+    auto aiButtonLayout = gsl::owner<QHBoxLayout*>(new QHBoxLayout);
+    aiButtonLayout->addStretch();
+    _configureAIButton = gsl::owner<QPushButton*>(new QPushButton);
+    _configureAIButton->setObjectName(QLatin1String("VibeCADFirstStartConfigureAI"));
+    _configureAIButton->setProperty("vibeStartPrimary", true);
+    _configureAIButton->setIcon(QIcon(QLatin1String(":/icons/preferences-general.svg")));
+    connect(
+        _configureAIButton,
+        &QPushButton::clicked,
+        this,
+        &FirstStartWidget::configureAIRequested
+    );
+    aiButtonLayout->addWidget(_configureAIButton);
+
+    _openAssistantButton = gsl::owner<QPushButton*>(new QPushButton);
+    _openAssistantButton->setObjectName(QLatin1String("VibeCADFirstStartOpenAssistant"));
+    _openAssistantButton->setIcon(QIcon(QLatin1String(":/icons/vibecad.svg")));
+    connect(
+        _openAssistantButton,
+        &QPushButton::clicked,
+        this,
+        &FirstStartWidget::openAssistantRequested
+    );
+    aiButtonLayout->addWidget(_openAssistantButton);
+    aiCardLayout->addLayout(aiButtonLayout);
+    outerLayout->addWidget(aiCard);
+
+    _personalizeLabel = gsl::owner<QLabel*>(new QLabel);
+    _personalizeLabel->setObjectName(QLatin1String("VibeCADFirstStartSectionTitle"));
+    outerLayout->addWidget(_personalizeLabel);
 
     _themeSelectorWidget = gsl::owner<ThemeSelectorWidget*>(new ThemeSelectorWidget(this));
     _generalSettingsWidget = gsl::owner<GeneralSettingsWidget*>(new GeneralSettingsWidget(this));
@@ -69,6 +143,7 @@ void FirstStartWidget::setupUi()
     outerLayout->addWidget(_themeSelectorWidget);
 
     _doneButton = gsl::owner<QPushButton*>(new QPushButton);
+    _doneButton->setObjectName(QLatin1String("VibeCADFirstStartContinue"));
     connect(_doneButton, &QPushButton::clicked, this, &FirstStartWidget::dismissed);
     auto buttonBar = gsl::owner<QHBoxLayout*>(new QHBoxLayout);
     buttonBar->setAlignment(Qt::AlignRight);
@@ -88,13 +163,18 @@ bool FirstStartWidget::eventFilter(QObject* object, QEvent* event)
 
 void FirstStartWidget::retranslateUi()
 {
-    _doneButton->setText(tr("Done"));
-    QString application = QString::fromStdString(App::Application::getExecutableName());
-    _welcomeLabel->setText(
-        QLatin1String("<h1>") + tr("Welcome to %1").arg(application) + QLatin1String("</h1>")
-    );
+    _doneButton->setText(tr("Continue to Start"));
+    _welcomeLabel->setText(tr("Welcome to VibeCAD"));
     _descriptionLabel->setText(
-        tr("Set your basic configuration options below.") + QLatin1String(" ")
-        + tr("These options (and many more) can be changed later in the preferences.")
+        tr("Set up your AI collaborator and make the workspace yours. You can change every "
+           "option later in Preferences.")
     );
+    _aiTitleLabel->setText(tr("1. Connect your AI"));
+    _aiDescriptionLabel->setText(
+        tr("Use a ChatGPT subscription, OpenAI or Anthropic API key, or an X / Grok account. "
+           "VibeCAD keeps sign-in and provider settings in its existing secure setup flow.")
+    );
+    _configureAIButton->setText(tr("Set up AI"));
+    _openAssistantButton->setText(tr("Open Assistant"));
+    _personalizeLabel->setText(tr("2. Personalize your workspace"));
 }

--- a/src/Mod/Start/Gui/FirstStartWidget.h
+++ b/src/Mod/Start/Gui/FirstStartWidget.h
@@ -42,6 +42,8 @@ public:
     explicit FirstStartWidget(QWidget* parent = nullptr);
     bool eventFilter(QObject* object, QEvent* event) override;
     Q_SIGNAL void dismissed();
+    Q_SIGNAL void configureAIRequested();
+    Q_SIGNAL void openAssistantRequested();
 
 private:
     void retranslateUi();
@@ -52,6 +54,11 @@ private:
 
     QLabel* _welcomeLabel;
     QLabel* _descriptionLabel;
+    QLabel* _aiTitleLabel;
+    QLabel* _aiDescriptionLabel;
+    QLabel* _personalizeLabel;
+    QPushButton* _configureAIButton;
+    QPushButton* _openAssistantButton;
     QPushButton* _doneButton;
 };
 

--- a/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
+++ b/src/Mod/Start/Gui/GeneralSettingsWidget.cpp
@@ -68,22 +68,22 @@ void GeneralSettingsWidget::setupUi()
     createLanguageComboBox();
     createUnitSystemComboBox();
     createNavigationStyleComboBox();
-    createHorizontalUi();
+    createResponsiveUi();
     retranslateUi();
 }
 
-void GeneralSettingsWidget::createHorizontalUi()
+void GeneralSettingsWidget::createResponsiveUi()
 {
-    auto mainLayout = gsl::owner<QHBoxLayout*>(new QHBoxLayout(this));
-    const int extraSpace {36};
-    mainLayout->addWidget(_languageLabel);
-    mainLayout->addWidget(_languageComboBox);
-    mainLayout->addSpacing(extraSpace);
-    mainLayout->addWidget(_unitSystemLabel);
-    mainLayout->addWidget(_unitSystemComboBox);
-    mainLayout->addSpacing(extraSpace);
-    mainLayout->addWidget(_navigationStyleLabel);
-    mainLayout->addWidget(_navigationStyleComboBox);
+    auto mainLayout = gsl::owner<QGridLayout*>(new QGridLayout(this));
+    mainLayout->setHorizontalSpacing(24);
+    mainLayout->setVerticalSpacing(8);
+    mainLayout->addWidget(_languageLabel, 0, 0);
+    mainLayout->addWidget(_languageComboBox, 0, 1);
+    mainLayout->addWidget(_unitSystemLabel, 1, 0);
+    mainLayout->addWidget(_unitSystemComboBox, 1, 1);
+    mainLayout->addWidget(_navigationStyleLabel, 2, 0);
+    mainLayout->addWidget(_navigationStyleComboBox, 2, 1);
+    mainLayout->setColumnStretch(1, 1);
 }
 
 

--- a/src/Mod/Start/Gui/GeneralSettingsWidget.h
+++ b/src/Mod/Start/Gui/GeneralSettingsWidget.h
@@ -44,7 +44,7 @@ private:
     void retranslateUi();
 
     void setupUi();
-    void createHorizontalUi();
+    void createResponsiveUi();
 
     QString createLabelText(const QString& translatedText) const;
     gsl::owner<QComboBox*> createLanguageComboBox();

--- a/src/Mod/Start/Gui/NewFileButton.cpp
+++ b/src/Mod/Start/Gui/NewFileButton.cpp
@@ -52,6 +52,7 @@ NewFileButton::NewFileButton(const NewButton& newButton)
     iconSize = int(hGrp->GetInt("NewFileIconSize", defaultSize));
 
     auto iconLabel = new QLabel(this);
+    iconLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
     QIcon baseIcon(newButton.iconPath);
     iconLabel->setPixmap(baseIcon.pixmap(iconSize, iconSize));
 
@@ -61,11 +62,13 @@ NewFileButton::NewFileButton(const NewButton& newButton)
     textLayout->setContentsMargins(0, 0, 0, 0);
 
     headingLabel->setText(newButton.heading);
+    headingLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
     QFont font = headingLabel->font();
     font.setWeight(QFont::Bold);
     headingLabel->setFont(font);
 
     descriptionLabel->setText(newButton.description);
+    descriptionLabel->setAttribute(Qt::WA_TransparentForMouseEvents);
     descriptionLabel->setWordWrap(true);
     descriptionLabel->setFixedWidth(labelWidth);
     descriptionLabel->setAlignment(Qt::AlignTop);
@@ -80,6 +83,7 @@ NewFileButton::NewFileButton(const NewButton& newButton)
     mainLayout->setContentsMargins(margin, margin, 2 * margin, margin);
     setLayout(mainLayout);
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    setCursor(Qt::PointingHandCursor);
 }
 
 QSize NewFileButton::minimumSizeHint() const

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -26,6 +26,8 @@
 #include <QCheckBox>
 #include <QFrame>
 #include <QGridLayout>
+#include <QHBoxLayout>
+#include <QIcon>
 #include <QLabel>
 #include <QListView>
 #include <QMdiSubWindow>
@@ -65,14 +67,22 @@ TYPESYSTEM_SOURCE_ABSTRACT(StartGui::StartView, Gui::MDIView)  // NOLINT
 
 StartView::StartView(QWidget* parent)
     : Gui::MDIView(nullptr, parent)
-    , _contents(new QStackedWidget(parent))
+    , _contents(new QStackedWidget(this))
     , _newFileLabel {nullptr}
+    , _heroTitleLabel {nullptr}
+    , _heroDescriptionLabel {nullptr}
     , _examplesLabel {nullptr}
     , _recentFilesLabel {nullptr}
     , _customFolderLabel {nullptr}
+    , _configureAI {nullptr}
+    , _openAssistant {nullptr}
     , _showOnStartupCheckBox {nullptr}
 {
     setObjectName(QLatin1String("StartView"));
+    // Start is a full-width document surface. The permanent model browser is
+    // useful for CAD views, but would otherwise sit invisibly above the left
+    // side of this page and intercept its first card in every section.
+    setProperty("vibecadUsesModelBrowser", false);
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start"
     );
@@ -94,15 +104,29 @@ StartView::StartView(QWidget* parent)
 
     auto firstStartRegion = gsl::owner<QHBoxLayout*>(new QHBoxLayout(firstStartScrollWidget));
     firstStartRegion->setAlignment(Qt::AlignCenter);
-    auto firstStartWidget = gsl::owner<FirstStartWidget*>(new FirstStartWidget(this));
+    auto firstStartWidget = gsl::owner<FirstStartWidget*>(new FirstStartWidget(firstStartScrollWidget));
     connect(firstStartWidget, &FirstStartWidget::dismissed, this, &StartView::firstStartWidgetDismissed);
+    connect(
+        firstStartWidget,
+        &FirstStartWidget::configureAIRequested,
+        this,
+        &StartView::openVibeCADPreferences
+    );
+    connect(
+        firstStartWidget,
+        &FirstStartWidget::openAssistantRequested,
+        this,
+        &StartView::openVibeCADAssistant
+    );
     firstStartRegion->addWidget(firstStartWidget);
     _contents->addWidget(firstStartScrollArea);
 
     // Documents page
     auto documentsWidget = gsl::owner<QWidget*>(new QWidget());
+    documentsWidget->setObjectName(QLatin1String("VibeCADStartDocuments"));
     _contents->addWidget(documentsWidget);
     auto documentsMainLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout());
+    documentsMainLayout->setContentsMargins(0, 0, 0, 0);
     documentsWidget->setLayout(documentsMainLayout);
     auto documentsScrollArea = gsl::owner<QScrollArea*>(new QScrollArea());
     documentsScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAsNeeded);
@@ -110,13 +134,70 @@ StartView::StartView(QWidget* parent)
     auto documentsScrollWidget = gsl::owner<QWidget*>(new QWidget(documentsScrollArea));
     documentsScrollArea->setWidget(documentsScrollWidget);
     documentsScrollArea->setWidgetResizable(true);
-    auto documentsContentLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout(documentsScrollWidget));
+
+    auto documentsViewportLayout = gsl::owner<QHBoxLayout*>(new QHBoxLayout(documentsScrollWidget));
+    documentsViewportLayout->setContentsMargins(28, 24, 28, 24);
+    auto documentsContentWidget = gsl::owner<QWidget*>(new QWidget(documentsScrollWidget));
+    documentsContentWidget->setObjectName(QLatin1String("VibeCADStartContent"));
+    documentsContentWidget->setMaximumWidth(1440);
+    documentsContentWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    documentsViewportLayout->addStretch();
+    documentsViewportLayout->addWidget(documentsContentWidget, 1);
+    documentsViewportLayout->addStretch();
+
+    auto documentsContentLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout(documentsContentWidget));
+    documentsContentLayout->setContentsMargins(0, 0, 0, 0);
     documentsContentLayout->setSizeConstraint(QLayout::SizeConstraint::SetMinAndMaxSize);
 
+    auto hero = gsl::owner<QFrame*>(new QFrame(documentsContentWidget));
+    hero->setObjectName(QLatin1String("VibeCADStartHero"));
+    auto heroLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout(hero));
+    heroLayout->setContentsMargins(24, 22, 24, 22);
+    heroLayout->setSpacing(18);
+
+    auto heroTopLayout = gsl::owner<QHBoxLayout*>(new QHBoxLayout);
+    heroTopLayout->setSpacing(18);
+
+    auto heroMark = gsl::owner<QLabel*>(new QLabel(hero));
+    heroMark->setObjectName(QLatin1String("VibeCADStartHeroMark"));
+    heroMark->setPixmap(QIcon(QLatin1String(":/icons/vibecad.svg")).pixmap(68, 68));
+    heroMark->setFixedSize(68, 68);
+    heroTopLayout->addWidget(heroMark, 0, Qt::AlignTop);
+
+    auto heroTextLayout = gsl::owner<QVBoxLayout*>(new QVBoxLayout);
+    heroTextLayout->setSpacing(4);
+    _heroTitleLabel = gsl::owner<QLabel*>(new QLabel(hero));
+    _heroTitleLabel->setObjectName(QLatin1String("VibeCADStartBrandTitle"));
+    heroTextLayout->addWidget(_heroTitleLabel);
+    _heroDescriptionLabel = gsl::owner<QLabel*>(new QLabel(hero));
+    _heroDescriptionLabel->setObjectName(QLatin1String("VibeCADStartBrandDescription"));
+    _heroDescriptionLabel->setWordWrap(true);
+    heroTextLayout->addWidget(_heroDescriptionLabel);
+    heroTopLayout->addLayout(heroTextLayout, 1);
+    heroLayout->addLayout(heroTopLayout);
+
+    auto heroActions = gsl::owner<QHBoxLayout*>(new QHBoxLayout);
+    heroActions->addStretch();
+    _configureAI = gsl::owner<QPushButton*>(new QPushButton(hero));
+    _configureAI->setObjectName(QLatin1String("VibeCADStartConfigureAI"));
+    _configureAI->setIcon(QIcon(QLatin1String(":/icons/preferences-general.svg")));
+    connect(_configureAI, &QPushButton::clicked, this, &StartView::openVibeCADPreferences);
+    heroActions->addWidget(_configureAI);
+
+    _openAssistant = gsl::owner<QPushButton*>(new QPushButton(hero));
+    _openAssistant->setObjectName(QLatin1String("VibeCADStartOpenAssistant"));
+    _openAssistant->setProperty("vibeStartPrimary", true);
+    _openAssistant->setIcon(QIcon(QLatin1String(":/icons/vibecad.svg")));
+    connect(_openAssistant, &QPushButton::clicked, this, &StartView::openVibeCADAssistant);
+    heroActions->addWidget(_openAssistant);
+    heroLayout->addLayout(heroActions);
+    documentsContentLayout->addWidget(hero);
+
     _newFileLabel = gsl::owner<QLabel*>(new QLabel());
+    _newFileLabel->setObjectName(QLatin1String("VibeCADStartSectionTitle"));
     documentsContentLayout->addWidget(_newFileLabel);
 
-    auto createNewRow = gsl::owner<QWidget*>(new QWidget);
+    auto createNewRow = gsl::owner<QWidget*>(new QWidget(documentsContentWidget));
     auto flowLayout = gsl::owner<FlowLayout*>(new FlowLayout);
 
     // Reset margins of layout to provide consistent spacing
@@ -130,15 +211,19 @@ StartView::StartView(QWidget* parent)
     configureNewFileButtons(flowLayout);
 
     _recentFilesLabel = gsl::owner<QLabel*>(new QLabel());
+    _recentFilesLabel->setObjectName(QLatin1String("VibeCADStartSectionTitle"));
     documentsContentLayout->addWidget(_recentFilesLabel);
-    auto recentFilesListWidget = gsl::owner<FileCardView*>(new FileCardView(_contents));
+    auto recentFilesListWidget = gsl::owner<FileCardView*>(new FileCardView(documentsContentWidget));
+    recentFilesListWidget->setObjectName(QLatin1String("RecentFilesList"));
     connect(recentFilesListWidget, &QListView::clicked, this, &StartView::fileCardSelected);
     documentsContentLayout->addWidget(recentFilesListWidget);
 
     FileCardView* customFolderListWidget {};
     if (showCustomFolder) {
-        customFolderListWidget = gsl::owner<FileCardView*>(new FileCardView(_contents));
+        customFolderListWidget = gsl::owner<FileCardView*>(new FileCardView(documentsContentWidget));
+        customFolderListWidget->setObjectName(QLatin1String("CustomFolderList"));
         _customFolderLabel = gsl::owner<QLabel*>(new QLabel());
+        _customFolderLabel->setObjectName(QLatin1String("VibeCADStartSectionTitle"));
         documentsContentLayout->addWidget(_customFolderLabel);
 
         connect(customFolderListWidget, &QListView::clicked, this, &StartView::fileCardSelected);
@@ -147,8 +232,10 @@ StartView::StartView(QWidget* parent)
 
     FileCardView* examplesListWidget {};
     if (showExamples) {
-        examplesListWidget = gsl::owner<FileCardView*>(new FileCardView(_contents));
+        examplesListWidget = gsl::owner<FileCardView*>(new FileCardView(documentsContentWidget));
+        examplesListWidget->setObjectName(QLatin1String("ExamplesList"));
         _examplesLabel = gsl::owner<QLabel*>(new QLabel());
+        _examplesLabel->setObjectName(QLatin1String("VibeCADStartSectionTitle"));
         documentsContentLayout->addWidget(_examplesLabel);
 
         connect(examplesListWidget, &QListView::clicked, this, &StartView::fileCardSelected);
@@ -161,6 +248,7 @@ StartView::StartView(QWidget* parent)
 
     // Documents page footer
     auto footerLayout = gsl::owner<QHBoxLayout*>(new QHBoxLayout());
+    footerLayout->setContentsMargins(24, 8, 24, 10);
     documentsMainLayout->addLayout(footerLayout);
 
     _openFirstStart = gsl::owner<QPushButton*>(new QPushButton());
@@ -191,7 +279,7 @@ StartView::StartView(QWidget* parent)
     }
     configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel);
 
-    QTimer::singleShot(2000, [this, recentFilesListWidget]() {
+    QTimer::singleShot(2000, this, [this, recentFilesListWidget]() {
         auto updateFun = [this, recentFilesListWidget]() {
             configureRecentFilesListWidget(recentFilesListWidget, _recentFilesLabel);
         };
@@ -210,27 +298,32 @@ void StartView::configureNewFileButtons(QLayout* layout) const
 {
     auto newEmptyFile = gsl::owner<NewFileButton*>(new NewFileButton(
         {tr("Empty File"),
-         tr("Creates a new empty FreeCAD file"),
+         tr("Creates a new empty VibeCAD document"),
          QLatin1String(":/icons/document-new.svg")}
     ));
+    newEmptyFile->setObjectName(QLatin1String("VibeCADNewFile"));
     auto openFile = gsl::owner<NewFileButton*>(new NewFileButton(
         {tr("Open File"),
          tr("Opens an existing CAD file or 3D model"),
          QLatin1String(":/icons/document-open.svg")}
     ));
+    openFile->setObjectName(QLatin1String("VibeCADOpenFile"));
     auto partDesign = gsl::owner<NewFileButton*>(new NewFileButton(
         {tr("Parametric Body"),
          tr("Creates a body with the Part Design workbench"),
          QLatin1String(":/icons/PartDesignWorkbench.svg")}
     ));
+    partDesign->setObjectName(QLatin1String("VibeCADParametricBody"));
     auto assembly = gsl::owner<NewFileButton*>(new NewFileButton(
         {tr("Assembly"),
          tr("Creates an assembly project"),
          QLatin1String(":/icons/AssemblyWorkbench.svg")}
     ));
+    assembly->setObjectName(QLatin1String("VibeCADAssembly"));
     auto draft = gsl::owner<NewFileButton*>(new NewFileButton(
         {tr("2D Draft"), tr("Creates a 2D Draft document"), QLatin1String(":/icons/DraftWorkbench.svg")}
     ));
+    draft->setObjectName(QLatin1String("VibeCADDraft"));
     // TODO: Ensure all of the required WBs are actually available
     layout->addWidget(partDesign);
     layout->addWidget(assembly);
@@ -249,11 +342,7 @@ void StartView::configureFileCardWidget(QListView* fileCardWidget)
 {
     auto delegate = gsl::owner<FileCardDelegate*>(new FileCardDelegate(fileCardWidget));
     fileCardWidget->setItemDelegate(delegate);
-
-    fileCardWidget->setMinimumWidth(fileCardWidget->parentWidget()->width());
-    //    fileCardWidget->setGridSize(
-    //        fileCardWidget->itemDelegate()->sizeHint(QStyleOptionViewItem(),
-    //                                                 fileCardWidget->model()->index(0, 0)));
+    fileCardWidget->setMinimumWidth(0);
 }
 
 
@@ -418,6 +507,53 @@ void StartView::firstStartWidgetDismissed()
     _contents->setCurrentIndex(1);
 }
 
+void StartView::openVibeCADPreferences()
+{
+    try {
+        // Preferences are an onboarding action, not a document command. Invoke the
+        // dedicated entry point directly so global command-busy state cannot silently
+        // discard the click.
+        Base::Interpreter().runString(
+            "import VibeCADGui; VibeCADGui.open_preferences(\"VibeCAD\")"
+        );
+        return;
+    }
+    catch (Base::PyException& error) {
+        Base::Console().warning(
+            "Could not open VibeCAD Preferences from the Start page: %s\n",
+            error.getMessage().c_str()
+        );
+    }
+
+    QMessageBox::warning(
+        this,
+        tr("VibeCAD setup unavailable"),
+        tr("VibeCAD Preferences could not be opened. The VibeCAD module may not be available in "
+           "this installation.")
+    );
+}
+
+void StartView::openVibeCADAssistant()
+{
+    try {
+        Base::Interpreter().runString("import VibeCADGui; VibeCADGui.open_assistant()");
+        return;
+    }
+    catch (Base::PyException& error) {
+        Base::Console().warning(
+            "Could not open the VibeCAD Assistant from the Start page: %s\n",
+            error.getMessage().c_str()
+        );
+    }
+
+    QMessageBox::warning(
+        this,
+        tr("VibeCAD Assistant unavailable"),
+        tr("The VibeCAD Assistant could not be opened. The VibeCAD module may not be available "
+           "in this installation.")
+    );
+}
+
 void StartView::changeEvent(QEvent* event)
 {
     if (!isInitialized) {
@@ -491,11 +627,19 @@ void StartView::retranslateUi()
     const QLatin1String h1Start("<h1>");
     const QLatin1String h1End("</h1>");
 
-    _newFileLabel->setText(h1Start + tr("New File") + h1End);
+    _heroTitleLabel->setText(tr("Welcome to VibeCAD"));
+    _heroDescriptionLabel->setText(
+        tr("Create, inspect, analyze, manufacture, and document real CAD with an AI collaborator "
+           "at your side.")
+    );
+    _configureAI->setText(tr("AI Settings"));
+    _openAssistant->setText(tr("Open Assistant"));
+
+    _newFileLabel->setText(h1Start + tr("Start a design") + h1End);
     if (_examplesLabel) {
-        _examplesLabel->setText(h1Start + tr("Examples") + h1End);
+        _examplesLabel->setText(h1Start + tr("Explore examples") + h1End);
     }
-    _recentFilesLabel->setText(h1Start + tr("Recent Files") + h1End);
+    _recentFilesLabel->setText(h1Start + tr("Continue working") + h1End);
 
     auto hGrp = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Mod/Start"
@@ -509,7 +653,6 @@ void StartView::retranslateUi()
         _customFolderLabel->setText(h1Start + QString::fromUtf8(customFolder.c_str()) + h1End);
     }
 
-    QString application = QString::fromUtf8(App::Application::Config()["ExeName"].c_str());
-    _openFirstStart->setText(tr("Open First Start Setup"));
+    _openFirstStart->setText(tr("Setup & appearance"));
     _showOnStartupCheckBox->setText(tr("Do not show this Start page again (start with blank screen)"));
 }

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -96,6 +96,8 @@ protected:
     void showOnStartupChanged(bool checked);
     void openFirstStartClicked();
     void firstStartWidgetDismissed();
+    void openVibeCADPreferences();
+    void openVibeCADAssistant();
 
     QString fileCardStyle() const;
 
@@ -111,9 +113,13 @@ private:
     Start::ExamplesModel _examplesModel;
     Start::CustomFolderModel _customFolderModel;
     QLabel* _newFileLabel;
+    QLabel* _heroTitleLabel;
+    QLabel* _heroDescriptionLabel;
     QLabel* _examplesLabel;
     QLabel* _recentFilesLabel;
     QLabel* _customFolderLabel;
+    QPushButton* _configureAI;
+    QPushButton* _openAssistant;
     QPushButton* _openFirstStart;
     QCheckBox* _showOnStartupCheckBox;
 

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -5221,7 +5221,7 @@ class OpenAssistantCommand(_BaseCommand):
     pixmap = ICON_OPEN_ASSISTANT
 
     def Activated(self) -> None:
-        _show_panel()
+        open_assistant()
 
 
 class OpenPreferencesCommand(_BaseCommand):
@@ -5230,9 +5230,8 @@ class OpenPreferencesCommand(_BaseCommand):
     pixmap = ICON_MARK
 
     def Activated(self) -> None:
-        ensure_preferences_registered()
         try:
-            Gui.showPreferencesByName("VibeCAD", "VibeCAD")
+            open_preferences()
         except Exception as exc:
             _show_panel(f"VibeCAD preferences could not be opened: {exc}")
 
@@ -5410,6 +5409,19 @@ def ensure_preferences_registered() -> None:
     )
     Gui.addPreferencePage(VibeCADPreferences.VibeCADDebugPreferencesPage, "VibeCAD")
     _preferences_registered = True
+
+
+def open_preferences(page_name: str = "VibeCAD") -> None:
+    """Open VibeCAD Preferences without depending on command dispatch state."""
+
+    ensure_preferences_registered()
+    Gui.showPreferencesByName("VibeCAD", str(page_name or "VibeCAD"))
+
+
+def open_assistant() -> None:
+    """Open the assistant without depending on command dispatch state."""
+
+    _show_panel()
 
 
 def ensure_commands_registered() -> None:

--- a/tests/test_vibecad_start_page.py
+++ b/tests/test_vibecad_start_page.py
@@ -1,0 +1,91 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Source contracts for VibeCAD's branded, backwards-compatible Start page."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+START_GUI = ROOT / "src" / "Mod" / "Start" / "Gui"
+START_VIEW_CPP = START_GUI / "StartView.cpp"
+FIRST_START_CPP = START_GUI / "FirstStartWidget.cpp"
+NEW_FILE_BUTTON_CPP = START_GUI / "NewFileButton.cpp"
+FILE_CARD_VIEW_CPP = START_GUI / "FileCardView.cpp"
+GENERAL_SETTINGS_CPP = START_GUI / "GeneralSettingsWidget.cpp"
+VIBECAD_GUI_PY = ROOT / "src" / "Mod" / "VibeCAD" / "VibeCADGui.py"
+
+
+def test_vibecad_start_page_keeps_the_existing_freecad_capabilities() -> None:
+    source = START_VIEW_CPP.read_text(encoding="utf-8")
+
+    for capability in (
+        "newEmptyFile",
+        "newPartDesignFile",
+        "openExistingFile",
+        "newAssemblyFile",
+        "newDraftFile",
+        "configureRecentFilesListWidget",
+        "configureExamplesListWidget",
+        "configureCustomFolderListWidget",
+        'GetBool("ShowExamples", true)',
+        'GetASCII("CustomFolder", "")',
+        'GetBool("ShowOnStartup", true)',
+        'GetBool("FirstStart2024", true)',
+    ):
+        assert capability in source
+
+
+def test_start_page_guides_users_into_the_real_vibecad_ai_flows() -> None:
+    start_source = START_VIEW_CPP.read_text(encoding="utf-8")
+    first_start_source = FIRST_START_CPP.read_text(encoding="utf-8")
+    vibecad_gui_source = VIBECAD_GUI_PY.read_text(encoding="utf-8")
+
+    assert 'setObjectName(QLatin1String("VibeCADStartHero"))' in start_source
+    assert 'Gui.addCommand("VibeCAD_OpenPreferences", OpenPreferencesCommand())' in vibecad_gui_source
+    assert 'Gui.addCommand("VibeCAD_OpenAssistant", OpenAssistantCommand())' in vibecad_gui_source
+    assert "def open_preferences(page_name: str = \"VibeCAD\") -> None:" in vibecad_gui_source
+    assert "def open_assistant() -> None:" in vibecad_gui_source
+    assert 'VibeCADGui.open_preferences(\\"VibeCAD\\")' in start_source
+    assert "VibeCADGui.open_assistant()" in start_source
+    assert "GeneralSettingsWidget" in first_start_source
+    assert "ThemeSelectorWidget" in first_start_source
+
+
+def test_start_page_hit_targets_are_explicit_and_mouse_safe() -> None:
+    start_source = START_VIEW_CPP.read_text(encoding="utf-8")
+    button_source = NEW_FILE_BUTTON_CPP.read_text(encoding="utf-8")
+
+    assert 'setProperty("vibecadUsesModelBrowser", false)' in start_source
+
+    for object_name in (
+        "VibeCADNewFile",
+        "VibeCADOpenFile",
+        "VibeCADParametricBody",
+        "VibeCADAssembly",
+        "VibeCADDraft",
+        "RecentFilesList",
+        "ExamplesList",
+        "CustomFolderList",
+    ):
+        assert object_name in start_source
+
+    assert "Qt::WA_TransparentForMouseEvents" in button_source
+
+
+def test_start_page_layouts_shrink_without_losing_existing_controls() -> None:
+    start_source = START_VIEW_CPP.read_text(encoding="utf-8")
+    first_start_source = FIRST_START_CPP.read_text(encoding="utf-8")
+    file_card_source = FILE_CARD_VIEW_CPP.read_text(encoding="utf-8")
+    general_source = GENERAL_SETTINGS_CPP.read_text(encoding="utf-8")
+
+    assert "QSizePolicy::Policy::Expanding, QSizePolicy::Policy::Preferred" in file_card_source
+    assert "new QVBoxLayout(hero)" in start_source
+    assert "new QVBoxLayout(aiCard)" in first_start_source
+    assert "new QGridLayout(this)" in general_source
+    for control in (
+        "_languageComboBox",
+        "_unitSystemComboBox",
+        "_navigationStyleComboBox",
+    ):
+        assert control in general_source


### PR DESCRIPTION
## Outcome

Replaces the obsolete FreeCAD-oriented Start experience with a responsive VibeCAD Start page and a useful first-run flow while retaining the existing New, Recent, Examples, Custom, Show on startup, language, units, navigation, and theme capabilities.

The AI setup actions now work directly from both first-run onboarding and the normal Start page. This also fixes #111: the permanent model-browser host was invisibly covering the left 288 px of the Start page and intercepting clicks.

Closes #111

## What changed

- Added branded first-run onboarding with working **Set up AI** and **Open Assistant** actions.
- Added a responsive normal Start page with AI Settings, Open Assistant, new-document templates, recent files, examples, and custom folders.
- Marked the Start view as not using the permanent model browser so its invisible host cannot steal pointer events.
- Made card child labels transparent to mouse input and gave primary controls stable object names.
- Added direct, additive `VibeCADGui.open_preferences()` and `VibeCADGui.open_assistant()` helpers; existing commands remain compatible wrappers.
- Added dark and light styling for the new controls and responsive layouts for compact windows.

## TDD and verification

Red test command (failed before implementation on the missing branded actions, unobstructed hit targets, direct setup helpers, and responsive contract):

```powershell
$env:PYTHONPATH=(Resolve-Path 'build/pytest-runner').Path
py -m pytest tests/test_vibecad_start_page.py -q
```

Green result using the same command:

```text
4 passed in 0.05s
```

Relevant compatibility suite:

```powershell
$env:PYTHONPATH=(Resolve-Path 'build/pytest-runner').Path
py -m pytest tests/test_vibecad_start_page.py src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py::test_mcp_settings_have_a_dedicated_vibecad_preference_page src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py::test_overlaid_dock_visibility_has_one_requested_state_owner src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py::test_assistant_panel_uses_vibecad_product_name src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py::test_vibecad_ships_exactly_two_constrained_appearance_profiles src/Mod/VibeCAD/vibecad_tests/test_native_application_manifest.py -q
```

```text
13 passed in 0.91s
```

Incremental C++ build against the existing Windows rattler work tree:

```powershell
cmake --build package/rattler-build/.pixi/bld/vibecad/O5m01f1YiFA/work/build --target StartGui -j 12
```

Result: Automoc/UIC, changed Start sources, and `StartGui.pyd` compiled and linked successfully (exit 0).

Live Windows GUI verification against the built module:

- First-run **Set up AI** and normal **AI Settings** both opened `DlgPreferencesImp` on the visible VibeCAD preferences page.
- **Open Assistant** opened the assistant dock.
- A real OS click on **Parametric Body** created one document and one `PartDesign::Body`.
- Real OS clicks opened the expected Custom and Examples files.
- Primary actions and first-card hit targets were unobstructed.
- First-run and normal pages fit at 1100x760 without horizontal overflow or clipped controls.
- Both VibeDark and VibeLight variants were rendered and visually inspected.

## Risk and non-goals

Risk is limited to the Start workbench UI and the two additive VibeCAD GUI helpers. This does not alter release packaging, versions, AI preferences, tool schemas, or document formats.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing Start-page capabilities and defaults remain available.
- [x] Existing VibeCAD commands remain registered and callable through compatibility wrappers.
- [x] No breaking changes or deprecations.