### PR TITLE
Fix Bambu custom filament profile discovery

### DIFF
--- a/src/Mod/VibeCADPrint/BambuStudio.py
+++ b/src/Mod/VibeCADPrint/BambuStudio.py
@@ -373,7 +373,17 @@ def _instantiated_profiles(
 ) -> tuple[tuple[_ProfileRecord, dict[str, Any]], ...]:
     selected: dict[str, _ProfileRecord] = {}
     for record in store.records_for(profile_type):
-        if _truthy(record.data.get("instantiation")):
+        # Bambu Studio omits the system-profile ``instantiation`` marker from
+        # user-owned presets saved in its filament library. Those files are
+        # selectable presets; compatibility is still enforced after resolving
+        # their inherited data in ``_compatible_profile_catalog``.
+        user_filament = (
+            profile_type == "filament"
+            and record.is_user
+            and str(record.data.get("from", "")).strip().casefold() == "user"
+            and "instantiation" not in record.data
+        )
+        if user_filament or _truthy(record.data.get("instantiation")):
             current = selected.get(record.name)
             if current is None or (record.is_user and not current.is_user):
                 selected[record.name] = record

--- a/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
+++ b/src/Mod/VibeCADPrint/tests/test_bambu_backend.py
@@ -264,6 +264,74 @@ def test_bambu_catalog_resolves_inheritance_and_exact_compatibility(
     assert resolved["printer_model"] == "Test Printer"
 
 
+def test_bambu_catalog_includes_compatible_user_filament_without_instantiation(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "profiles"
+    config = tmp_path / "BambuStudio"
+    _profile_store(root)
+    user_filament = config / "user" / "123456" / "filament" / "base"
+    user_filament.mkdir(parents=True)
+    (user_filament / "Custom PETG.json").write_text(
+        json.dumps(
+            {
+                "name": "Custom PETG",
+                "from": "User",
+                "inherits": "Generic PLA @TEST",
+                "compatible_printers": ["Test Printer 0.4 nozzle"],
+                "filament_settings_id": ["Custom PETG"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    (user_filament / "Other Printer PETG.json").write_text(
+        json.dumps(
+            {
+                "name": "Other Printer PETG",
+                "from": "User",
+                "inherits": "Generic PLA @TEST",
+                "compatible_printers": ["Another Printer"],
+                "filament_settings_id": ["Other Printer PETG"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    cached_system_filament = config / "system" / "BBL" / "filament" / "base"
+    cached_system_filament.mkdir(parents=True)
+    (cached_system_filament / "Cached system base.json").write_text(
+        json.dumps(
+            {
+                "name": "Cached system base",
+                "from": "system",
+                "inherits": "Generic PLA @TEST",
+                "compatible_printers": ["Test Printer 0.4 nozzle"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    installation = VibeCADPrint.SlicerInstallation(
+        backend_id="bambustudio",
+        version="2.8.2.61",
+        gui_command=("bambu-studio",),
+        cli_command=("bambu-studio",),
+        source="path",
+        display_name="Bambu Studio",
+        config_dir=str(config),
+        resource_dir=str(root),
+        tested_version=(2, 8, 2),
+    )
+
+    catalog = BambuStudio.query_compatible_profiles(
+        installation,
+        "Test Printer 0.4 nozzle",
+    )
+
+    assert [
+        material.name for material in catalog.print_profiles[0].materials
+    ] == ["Custom PETG", "Generic PLA @TEST"]
+    assert catalog.print_profiles[0].materials[0].is_user is True
+
+
 def test_profile_store_uses_its_index_for_exact_name_queries(tmp_path: Path) -> None:
     root = tmp_path / "profiles"
     _profile_store(root)


### PR DESCRIPTION
AI-assisted implementation prepared with ChatGPT Codex.

## Summary

Bambu Studio user filament presets saved in its filament library omit the system-profile `instantiation` marker, so VibeCAD filtered compatible custom materials out of Print Setup.

This change:
- accepts config-side filament presets with `"from": "User"` and no `instantiation` field;
- still resolves inheritance before exact printer compatibility checks;
- excludes incompatible user filaments and cached system/base profiles.

## Verification

- [x] A regression test failed before implementation and passes afterward.
- [x] Exact commands and results are listed below.

Red:
```
python3 -m pytest -q src/Mod/VibeCADPrint/tests/test_bambu_backend.py::test_bambu_catalog_includes_compatible_user_filament_without_instantiation
1 failed in 0.20s
```

Green:
```
python3 -m pytest -q src/Mod/VibeCADPrint/tests/test_bambu_backend.py::test_bambu_catalog_includes_compatible_user_filament_without_instantiation
1 passed in 0.18s

python3 -m pytest -q src/Mod/VibeCADPrint/tests/test_bambu_backend.py
16 passed in 0.16s

python3 -m pytest -q src/Mod/VibeCADPrint/tests
68 passed in 0.53s

python3 -m compileall -q src/Mod/VibeCADPrint
passed

git diff --check
passed
```

## Compatibility checklist

- [x] Existing public functions/APIs remain present and compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing system profile selection behavior is preserved.
- [x] The new path is limited to explicit Bambu user filament presets.
- [x] No breaking changes or deprecations.

## Risk and non-goals

Limited to Bambu filament catalog discovery. It does not alter machine/process discovery, serialization, slicer launch behavior, or public APIs.

## Issues

Fixes #100

## Before and After Images

Before: compatible custom Bambu user filaments were absent from Print Setup.

After: compatible custom Bambu user filaments are included; incompatible user filaments and cached system bases remain excluded.

No screenshot is included because the regression is covered by a synthetic Bambu profile store in the backend tests.