### PR TITLE
Fix/vibecad component test reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,18 @@ for current platform-specific details.
 - **The assistant input is disabled:** save the active CAD document.
 - **The assistant panel was closed:** reopen it from **View > Panels > VibeCAD Assistant**.
 
+## Developer Tests
+
+Run the standalone Aero and 3D-printing component suites with one command:
+
+```bash
+python3 tools/run_vibecad_component_tests.py
+```
+
+The runner uses a separate pytest process for each component so their installed
+`tests` packages cannot collide. Use `--suite aero` or `--suite print` to run
+one component, and put additional pytest arguments after `--`.
+
 ## Project Status
 
 VibeCAD is under active development. The current focus is reliable, readable AI-assisted part design with explicit human control over the document, workbench, and design direction.

--- a/src/Mod/VibeCADAero/tests/conftest.py
+++ b/src/Mod/VibeCADAero/tests/conftest.py
@@ -6,5 +6,8 @@ import sys
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
-if str(ROOT) not in sys.path:
-    sys.path.insert(0, str(ROOT))
+VIBECAD_ROOT = ROOT.parent / "VibeCAD"
+
+for module_root in (VIBECAD_ROOT, ROOT):
+    if str(module_root) not in sys.path:
+        sys.path.insert(0, str(module_root))

--- a/tools/run_vibecad_component_tests.py
+++ b/tools/run_vibecad_component_tests.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Run standalone VibeCAD component tests in isolated pytest processes.
+
+The component suites use their own top-level ``tests`` packages, so collecting
+multiple suites in one pytest process causes import-name collisions.  Keeping
+one process per suite preserves their installed layouts and still provides one
+command for contributors.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Callable, Iterable, Sequence
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SUITES = {
+    "aero": Path("src/Mod/VibeCADAero/tests"),
+    "print": Path("src/Mod/VibeCADPrint/tests"),
+}
+
+
+def run_suites(
+    suite_names: Iterable[str],
+    pytest_args: Sequence[str] = (),
+    runner: Callable[..., Any] = subprocess.run,
+) -> int:
+    """Run each requested suite separately and aggregate their exit status."""
+    failed: list[str] = []
+    for name in suite_names:
+        suite = SUITES[name]
+        print(f"\n==> VibeCAD {name} tests: {suite}", flush=True)
+        command = [sys.executable, "-m", "pytest", "-q", str(suite), *pytest_args]
+        completed = runner(command, cwd=REPO_ROOT, check=False)
+        if completed.returncode:
+            failed.append(name)
+
+    if failed:
+        print("\nFailed component suites: " + ", ".join(failed))
+        return 1
+
+    print("\nAll requested VibeCAD component suites passed")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--suite",
+        action="append",
+        choices=tuple(SUITES),
+        dest="suites",
+        help="Run only this suite; repeat to select more than one",
+    )
+    args, pytest_args = parser.parse_known_args()
+    if pytest_args[:1] == ["--"]:
+        pytest_args = pytest_args[1:]
+    return run_suites(args.suites or SUITES, pytest_args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/run_vibecad_component_tests_selftest.py
+++ b/tools/run_vibecad_component_tests_selftest.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Self-test the isolated VibeCAD component test runner."""
+
+from __future__ import annotations
+
+import io
+from contextlib import redirect_stdout
+from types import SimpleNamespace
+
+import run_vibecad_component_tests as component_tests
+
+
+def main() -> int:
+    calls: list[tuple[list[str], object, bool]] = []
+    return_codes = iter((0, 3))
+
+    def fake_runner(command: list[str], *, cwd: object, check: bool) -> SimpleNamespace:
+        calls.append((command, cwd, check))
+        return SimpleNamespace(returncode=next(return_codes))
+
+    output = io.StringIO()
+    with redirect_stdout(output):
+        result = component_tests.run_suites(
+            ("aero", "print"),
+            pytest_args=("-x",),
+            runner=fake_runner,
+        )
+
+    scenarios = {
+        "each_suite_uses_a_separate_process": len(calls) == 2,
+        "failures_do_not_hide_later_suites": result == 1 and len(calls) == 2,
+        "commands_use_the_current_python": all(
+            command[:3] == [component_tests.sys.executable, "-m", "pytest"]
+            for command, _cwd, _check in calls
+        ),
+        "commands_target_one_suite_each": [
+            command[-2:] for command, _cwd, _check in calls
+        ]
+        == [
+            [str(component_tests.SUITES["aero"]), "-x"],
+            [str(component_tests.SUITES["print"]), "-x"],
+        ],
+        "commands_run_from_repository_root": all(
+            cwd == component_tests.REPO_ROOT for _command, cwd, _check in calls
+        ),
+        "subprocess_errors_are_return_codes": all(
+            check is False for _command, _cwd, check in calls
+        ),
+        "failed_suites_are_reported": "Failed component suites: print"
+        in output.getvalue(),
+    }
+    failed = [name for name, ok in scenarios.items() if not ok]
+    if failed:
+        print("failed scenarios: " + ", ".join(failed))
+        return 1
+
+    print(f"{len(scenarios)} component test runner scenarios passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION

  Summary

- Fixes standalone VibeCADAero test collection by loading the shared VibeCAD runtime.
- Adds one portable command for running the Aero and 3D-printing component suites.
- Runs each suite in a separate pytest process to prevent their identically named "tests" packages from colliding.
- Adds a seven-scenario self-test for the runner.
- Documents the new developer-testing command.

Why

Running the Aero tests directly failed because "VibeCADNativeAeroRuntime" is located in the sibling VibeCAD module.

Aero and Print also could not be collected together in one pytest process because both components contain a top-level package named "tests". The new runner preserves their existing layouts while safely executing each suite in an isolated process.

Verification

- [x] Tests failed before implementation and passed afterward.
- [x] Exact test commands and results are listed below.

Red

python3 -m pytest -q src/Mod/VibeCADAero/tests

Collection failed with:

ModuleNotFoundError: No module named 'VibeCADNativeAeroRuntime'

The runner self-test initially failed with:

ModuleNotFoundError: No module named 'run_vibecad_component_tests'

Green

python3 tools/run_vibecad_component_tests_selftest.py
7 component test runner scenarios passed

python3 tools/run_vibecad_component_tests.py
VibeCADAero: 108 passed
VibeCADPrint: 67 passed

python3 tools/run_vibecad_component_tests.py --suite aero -- -k honesty
2 passed, 106 deselected

python3 -m compileall -q tools/run_vibecad_component_tests.py tools/run_vibecad_component_tests_selftest.py src/Mod/VibeCADAero
passed

git diff --check
passed

Compatibility and Risk

- [x] Existing public functions and APIs remain unchanged.
- [x] No preference keys, tool names, or schemas were changed.
- [x] Existing component test-package layouts remain unchanged.
- [x] No production defaults or runtime behavior changed.

Risk is limited to developer test bootstrapping and tooling.
