### PR TITLE
Fix/vibecad core test bootstrap

### DIFF
--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -1702,6 +1702,7 @@ if(BUILD_TEST AND BUILD_GUI)
         vibecad_tests/qt_ribbon_theme_integration.py
         vibecad_tests/read_geometry_integration.py
         vibecad_tests/test_geometry_worker_fallback.py
+        vibecad_tests/test_source_checkout_bootstrap.py
         vibecad_tests/ribbon_surface_gui_integration.py
         vibecad_tests/test_aero_ribbon_and_context.py
         vibecad_tests/test_aero_ribbon_install.py

--- a/src/Mod/VibeCAD/vibecad_tests/conftest.py
+++ b/src/Mod/VibeCAD/vibecad_tests/conftest.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""Test bootstrap: stub the FreeCAD runtime and put the module dir on sys.path.
+"""Test bootstrap: stub FreeCAD and expose required source module directories.
 
 The guardrail tests validate tool contracts and pack wiring, none of which
 require a running FreeCAD. Tool modules defer their FreeCAD imports into
@@ -15,6 +15,7 @@ import sys
 import types
 
 VIBECAD_DIR = Path(__file__).resolve().parent.parent
+TECHDRAW_DIR = VIBECAD_DIR.parent / "TechDraw"
 
 
 def _install_freecad_stubs() -> None:
@@ -27,5 +28,6 @@ def _install_freecad_stubs() -> None:
 
 _install_freecad_stubs()
 
-if str(VIBECAD_DIR) not in sys.path:
-    sys.path.insert(0, str(VIBECAD_DIR))
+for module_dir in (TECHDRAW_DIR, VIBECAD_DIR):
+    if str(module_dir) not in sys.path:
+        sys.path.insert(0, str(module_dir))

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_section_position.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_drawing_section_position.py
@@ -37,15 +37,39 @@ def test_section_position_schema_is_closed_exact_and_unambiguous() -> None:
         "align_edge_to_vertex",
     )
     assert definition.primary_classification == "mutation"
-    assert len(schema["parameters"]["oneOf"]) == 2
+    parameters = schema["parameters"]
+    assert "oneOf" not in parameters
+    assert parameters["additionalProperties"] is False
+    assert parameters["required"] == ["operation", "page", "section_view"]
+    assert parameters["properties"]["operation"]["enum"] == [
+        "align_axis",
+        "align_edge_to_vertex",
+    ]
+    assert set(parameters["properties"]) == {
+        "operation",
+        "page",
+        "section_view",
+        "axis",
+        "section_edge",
+        "base_view",
+        "base_vertex",
+    }
 
-    axis = _branch(schema, "align_axis")
+    exact_schema = {
+        "parameters": {
+            "oneOf": [
+                variant.provider_parameters() for variant in definition.variants
+            ]
+        }
+    }
+
+    axis = _branch(exact_schema, "align_axis")
     assert axis["additionalProperties"] is False
     assert axis["properties"]["axis"]["enum"] == ["horizontal", "vertical"]
     assert axis["required"] == ["operation", "page", "section_view", "axis"]
     assert axis["properties"]["section_view"]["additionalProperties"] is False
 
-    geometry = _branch(schema, "align_edge_to_vertex")
+    geometry = _branch(exact_schema, "align_edge_to_vertex")
     assert geometry["additionalProperties"] is False
     assert geometry["required"] == [
         "operation",

--- a/src/Mod/VibeCAD/vibecad_tests/test_source_checkout_bootstrap.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_source_checkout_bootstrap.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Source-checkout import contracts for the VibeCAD test bootstrap."""
+
+from __future__ import annotations
+
+from importlib import import_module
+
+
+def test_source_checkout_exposes_techdraw_python_helpers() -> None:
+    helper = import_module("SectionViewPosition")
+
+    assert callable(helper.apply_section_view_position)


### PR DESCRIPTION
## Summary

- Expose TechDraw helpers from the source-checkout pytest bootstrap
- Add a regression test for importing `SectionViewPosition`
- Align the Drawing section-position test with the compact provider schema

## Testing

- 4,026 tests collected without collection errors
- Focused suite: 36 passed
- Offline comparison:
  - `main`: 3,652 passed, 85 failed, 6 skipped
  - branch: 3,654 passed, 84 failed, 6 skipped

No production runtime behavior is changed.