### PR TITLE
feat(gui): clarify VibeScript model tree roles

### DIFF
--- a/src/Gui/ModelTreeBrowser.cpp
+++ b/src/Gui/ModelTreeBrowser.cpp
@@ -129,6 +129,33 @@ App::DocumentObject* geoParent(const App::DocumentObject* object)
     return App::GeoFeatureGroupExtension::getGroupOfObject(object);
 }
 
+App::DocumentObject* exactVibeScriptProgramFor(
+    App::Document* document,
+    const App::DocumentObject* operation
+)
+{
+    if (!document || !isDerivedFrom(operation, "PartDesign::DesignScriptOperation")
+        || stringProperty(operation, "VibeCADScriptedRole") != "implementation"
+        || stringProperty(operation, "VibeCADScriptedEngine") != "vibescript:partdesign") {
+        return nullptr;
+    }
+
+    const std::string programObjectName = stringProperty(operation, "ProgramObjectName");
+    const std::string programId = stringProperty(operation, "ProgramId");
+    if (programObjectName.empty() || programId.empty()) {
+        return nullptr;
+    }
+
+    auto* program = document->getObject(programObjectName.c_str());
+    if (!ModelTreeBrowserProjection::isVibeScriptProgram(program)
+        || stringProperty(program, "VibeCADScriptedModelId") != programId) {
+        // Incomplete or conflicting metadata remains at document root so the
+        // browser never guesses a semantic owner from labels or link shape.
+        return nullptr;
+    }
+    return program;
+}
+
 }  // namespace
 
 ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
@@ -283,6 +310,13 @@ ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
         // valid getSubObject() path.
         const Ownership selectionOwnership = resolveOwnership(object);
         Ownership ownership = selectionOwnership;
+        if (auto* program = exactVibeScriptProgramFor(document, object)) {
+            // DesignScriptOperation is deliberately Design-global and must
+            // not enter the App::Part containment graph. Its exact persisted
+            // program identity supplies presentation ownership only; logical
+            // selection paths continue to use selectionOwnership below.
+            ownership.component = program;
+        }
         if (const auto owner = modelOccurrenceOwners.find(object);
             owner != modelOccurrenceOwners.end() && owner->second) {
             ownership.component = owner->second;
@@ -499,6 +533,14 @@ bool ModelTreeBrowserProjection::isComponent(const App::DocumentObject* object)
 {
     return object && !isBody(object)
         && object->hasExtension(App::OriginGroupExtension::getExtensionClassTypeId());
+}
+
+bool ModelTreeBrowserProjection::isVibeScriptProgram(const App::DocumentObject* object)
+{
+    return isComponent(object)
+        && stringProperty(object, "VibeCADScriptedRole") == "model"
+        && stringProperty(object, "VibeCADScriptedEngine") == "vibescript:partdesign"
+        && !stringProperty(object, "VibeCADScriptedModelId").empty();
 }
 
 ModelTreeBrowserProjection::Ownership

--- a/src/Gui/ModelTreeBrowser.h
+++ b/src/Gui/ModelTreeBrowser.h
@@ -122,6 +122,7 @@ public:
 
     static bool isBody(const App::DocumentObject* object);
     static bool isComponent(const App::DocumentObject* object);
+    static bool isVibeScriptProgram(const App::DocumentObject* object);
 
 private:
     struct Ownership

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5787,7 +5787,7 @@ void DocumentItem::rebuildModelBrowser()
             entry.object,
             parent,
             logicalParent,
-            entry.publishedImplementation || entry.bodyRepresentation
+            entry.publishedImplementation
         );
         if (!item) {
             return nullptr;
@@ -6546,6 +6546,8 @@ void DocumentItem::rebuildModelBrowser()
         if (!componentItem) {
             return;
         }
+        const bool vibeScriptProgram =
+            Projection::isVibeScriptProgram(componentEntry.object);
 
         const auto nestedComponents = componentRoleEntries(componentEntry.object, Role::Component);
         for (const auto* nested : nestedComponents) {
@@ -6600,6 +6602,64 @@ void DocumentItem::rebuildModelBrowser()
             for (const auto* body : bodies) {
                 renderBody(*body, folder, componentItem);
             }
+            if (firstBuild && vibeScriptProgram) {
+                folder->setExpanded(true);
+            }
+        }
+
+        const auto renderComponentHistory = [&]() {
+            const auto operations = filterBucket(
+                findBucket(
+                    entriesByComponentRole,
+                    RoleContextKey {componentEntry.object, Role::History}
+                ),
+                [&](const Entry& entry) {
+                    return !entry.body && !isMeshesGroup(entry.group);
+                }
+            );
+            renderCategory(
+                componentItem,
+                componentItem,
+                componentEntry.object,
+                "design-history",
+                TreeWidget::tr("Design History"),
+                vibeScriptProgram ? "vibecad" : "PartDesignWorkbench",
+                operations
+            );
+        };
+
+        const auto renderComponentOutputs = [&]() {
+            const auto vibeCADOutputs = filterBucket(
+                findBucket(
+                    entriesByComponentRole,
+                    RoleContextKey {componentEntry.object, Role::VibeCADOutput}
+                ),
+                [&](const Entry& entry) {
+                    // A complete Body-backed publication is a secondary,
+                    // stable downstream interface for a VibeScript program.
+                    // Other components retain the compatibility behavior that
+                    // suppresses a duplicate Body representation.
+                    return vibeScriptProgram || !entry.bodyRepresentation;
+                }
+            );
+            renderCategory(
+                componentItem,
+                componentItem,
+                componentEntry.object,
+                vibeScriptProgram ? "published-outputs" : "vibecad-outputs",
+                vibeScriptProgram ? TreeWidget::tr("Published Outputs")
+                                  : TreeWidget::tr("VibeCAD Outputs"),
+                "vibecad",
+                vibeCADOutputs
+            );
+        };
+
+        // VibeScript's three primary roles stay together: editable Bodies,
+        // their source-level Design History, and stable published interfaces.
+        // Generic components retain the established category ordering below.
+        if (vibeScriptProgram) {
+            renderComponentHistory();
+            renderComponentOutputs();
         }
 
         const auto sketches = componentRoleEntries(componentEntry.object, Role::Sketch);
@@ -6631,43 +6691,10 @@ void DocumentItem::rebuildModelBrowser()
         renderAnalyze(componentItem, componentItem, componentEntry.object);
         renderDrawings(componentItem, componentItem, componentEntry.object);
 
-        const auto operations = filterBucket(
-            findBucket(
-                entriesByComponentRole,
-                RoleContextKey {componentEntry.object, Role::History}
-            ),
-            [&](const Entry& entry) {
-                return !entry.body && !isMeshesGroup(entry.group);
-            }
-        );
-        renderCategory(
-            componentItem,
-            componentItem,
-            componentEntry.object,
-            "operations",
-            TreeWidget::tr("Operations"),
-            "PartDesignWorkbench",
-            operations
-        );
-
-        const auto vibeCADOutputs = filterBucket(
-            findBucket(
-                entriesByComponentRole,
-                RoleContextKey {componentEntry.object, Role::VibeCADOutput}
-            ),
-            [](const Entry& entry) {
-                return !entry.bodyRepresentation;
-            }
-        );
-        renderCategory(
-            componentItem,
-            componentItem,
-            componentEntry.object,
-            "vibecad-outputs",
-            TreeWidget::tr("VibeCAD Outputs"),
-            "vibecad",
-            vibeCADOutputs
-        );
+        if (!vibeScriptProgram) {
+            renderComponentHistory();
+            renderComponentOutputs();
+        }
 
         const auto references = componentRoleEntries(componentEntry.object, Role::Reference);
         renderReferences(

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -152,6 +152,31 @@ static QString vibeCADProvenanceToolTip(
     return toolTip.isEmpty() ? provenance : provenance + QLatin1Char('\n') + toolTip;
 }
 
+static QString modelBrowserPresentationLabel(
+    const ModelTreeBrowserProjection::Entry& entry
+)
+{
+    if (!entry.object) {
+        return {};
+    }
+    if (entry.role == ModelTreeBrowserProjection::Role::History
+        && ModelTreeBrowserProjection::isVibeScriptProgram(entry.component)
+        && entry.object->getTypeId().getName()
+            == std::string_view("PartDesign::DesignScriptOperation")) {
+        // The saved operation Label and internal name remain available in the
+        // Property inspector. The browser describes the operation's role.
+        return TreeWidget::tr("VibeScript Build");
+    }
+    if (entry.publishedOutput && entry.bodyRepresentation) {
+        // FreeCAD makes sibling Labels unique by appending a numeric suffix.
+        // A publication row represents the exact paired Body to downstream
+        // consumers, so present that Body's human label while retaining the
+        // publication Link's own exact identity in the Property inspector.
+        return QString::fromUtf8(entry.bodyRepresentation->Label.getValue());
+    }
+    return QString::fromUtf8(entry.object->Label.getValue());
+}
+
 void TreeParams::onItemBackgroundChanged()
 {
     if (getItemBackground()) {
@@ -5792,6 +5817,7 @@ void DocumentItem::rebuildModelBrowser()
         if (!item) {
             return nullptr;
         }
+        item->setText(0, modelBrowserPresentationLabel(entry));
         try {
             const auto* detailProvider =
                 dynamic_cast<const TreeViewDetailProvider*>(item->object());
@@ -6621,7 +6647,7 @@ void DocumentItem::rebuildModelBrowser()
                 componentItem,
                 componentItem,
                 componentEntry.object,
-                "design-history",
+                "operations",
                 TreeWidget::tr("Design History"),
                 vibeScriptProgram ? "vibecad" : "PartDesignWorkbench",
                 operations
@@ -6859,7 +6885,7 @@ void DocumentItem::rebuildModelBrowser()
         nullptr,
         nullptr,
         "operations",
-        TreeWidget::tr("Operations"),
+        TreeWidget::tr("Design History"),
         "PartDesignWorkbench",
         rootOperations
     );
@@ -7666,11 +7692,41 @@ void TreeWidget::slotChangeObject(const Gui::ViewProviderDocumentObject& view, c
         const char* label = obj->Label.getValue();
         auto firstData = *itEntry->second.begin();
         if (firstData->label != label) {
+            ModelTreeBrowserProjection projection(obj->getDocument());
+            const auto* projectionEntry = projection.find(obj);
+            const QString browserLabel = projectionEntry
+                ? modelBrowserPresentationLabel(*projectionEntry)
+                : QString::fromUtf8(label);
             for (const auto& data : itEntry->second) {
                 data->label = label;
                 auto displayName = QString::fromUtf8(label);
                 for (auto item : data->items) {
-                    item->setText(0, displayName);
+                    item->setText(
+                        0,
+                        item->isBrowserProxy() ? browserLabel : displayName
+                    );
+                }
+            }
+
+            // A Body rename also changes the presentation name of its exact
+            // paired publication, even though the Link's own Label property
+            // did not change and therefore emits no separate notification.
+            for (const auto& entry : projection.entries()) {
+                if (entry.bodyRepresentation != obj || !entry.object) {
+                    continue;
+                }
+                const auto publicationIt = ObjectTable.find(entry.object);
+                if (publicationIt == ObjectTable.end()) {
+                    continue;
+                }
+                const QString publicationLabel =
+                    modelBrowserPresentationLabel(entry);
+                for (const auto& data : publicationIt->second) {
+                    for (auto* item : data->items) {
+                        if (item->isBrowserProxy()) {
+                            item->setText(0, publicationLabel);
+                        }
+                    }
                 }
             }
         }

--- a/src/Mod/PartDesign/App/DesignFeature.h
+++ b/src/Mod/PartDesign/App/DesignFeature.h
@@ -850,7 +850,7 @@ public:
 
     const char* getViewProviderName() const override
     {
-        return "PartDesignGui::ViewProviderDesignOperation";
+        return "PartDesignGui::ViewProviderDesignScriptOperation";
     }
 };
 

--- a/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
+++ b/src/Mod/PartDesign/Gui/AppPartDesignGui.cpp
@@ -40,6 +40,7 @@
 #include "ViewProviderBody.h"
 #include "ViewProviderBoolean.h"
 #include "ViewProviderDesignOperation.h"
+#include "ViewProviderDesignScriptOperation.h"
 #include "ViewProviderChamfer.h"
 #include "ViewProviderDatumCS.h"
 #include "ViewProviderDatumLine.h"
@@ -197,6 +198,7 @@ PyMOD_INIT_FUNC(PartDesignGui)
     PartDesignGui::ViewProviderSubShapeBinderPython::init();
     PartDesignGui::ViewProviderBoolean       ::init();
     PartDesignGui::ViewProviderDesignOperation::init();
+    PartDesignGui::ViewProviderDesignScriptOperation::init();
     PartDesignGui::ViewProviderPrimitive     ::init();
     PartDesignGui::ViewProviderPipe          ::init();
     PartDesignGui::ViewProviderLoft          ::init();

--- a/src/Mod/PartDesign/Gui/CMakeLists.txt
+++ b/src/Mod/PartDesign/Gui/CMakeLists.txt
@@ -107,6 +107,8 @@ SET(PartDesignGuiViewProvider_SRCS
     ViewProviderBoolean.h
     ViewProviderDesignOperation.cpp
     ViewProviderDesignOperation.h
+    ViewProviderDesignScriptOperation.cpp
+    ViewProviderDesignScriptOperation.h
     ViewProviderPrimitive.h
     ViewProviderPrimitive.cpp
     ViewProviderPipe.h

--- a/src/Mod/PartDesign/Gui/ViewProviderDesignOperation.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDesignOperation.cpp
@@ -34,6 +34,10 @@ void ViewProviderDesignOperation::attach(App::DocumentObject* object)
         sPixmap = "PartDesign_Boolean.svg";
     }
     ViewProvider::attach(object);
+    // Design-global operations are non-rendering History controllers. Their
+    // results are the durable Bodies they own, so an eye on the controller is
+    // both ineffective and misleading.
+    setToggleVisibility(ToggleVisibilityMode::NoToggleVisibility);
 }
 
 void ViewProviderDesignOperation::setupContextMenu(QMenu* menu, QObject* receiver, const char* member)

--- a/src/Mod/PartDesign/Gui/ViewProviderDesignScriptOperation.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDesignScriptOperation.cpp
@@ -2,16 +2,75 @@
 
 #include "ViewProviderDesignScriptOperation.h"
 
+#include <QMenu>
+#include <QObject>
+#include <QString>
+
 #include <algorithm>
 #include <cstddef>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
+#include <App/Document.h>
+#include <App/DocumentTimeline.h>
+#include <Gui/Application.h>
+#include <Gui/Command.h>
+#include <Gui/Selection/Selection.h>
 #include <Mod/PartDesign/App/DesignFeature.h>
 
 
 using namespace PartDesignGui;
+
+namespace
+{
+
+constexpr const char* timelineEditorCapability = "VibeCADTimelineOperationEditor";
+
+std::string utf8(const QString& text)
+{
+    return text.toUtf8().toStdString();
+}
+
+Gui::ApprovedDocumentTimelineCommand approvedScriptedModelCommand(
+    App::DocumentObject* operation,
+    bool requireActive
+)
+{
+    return Gui::approvedDocumentTimelineCommand(
+        operation,
+        App::DocumentTimeline::EditCommandPropertyName,
+        timelineEditorCapability,
+        requireActive
+    );
+}
+
+bool invokeScriptedModelCommand(App::DocumentObject* operation)
+{
+    if (!operation || !operation->isAttachedToDocument()
+        || !Gui::Application::Instance) {
+        return false;
+    }
+    const auto approved = approvedScriptedModelCommand(operation, false);
+    if (!approved.command) {
+        return false;
+    }
+
+    Gui::Selection().clearSelection();
+    Gui::Selection().addSelection(
+        operation->getDocument()->getName(),
+        operation->getNameInDocument()
+    );
+    const auto current = approvedScriptedModelCommand(operation, true);
+    if (!current.command || current.name != approved.name
+        || current.command != approved.command) {
+        return false;
+    }
+    current.command->invoke(0, Gui::Command::TriggerAction);
+    return true;
+}
+
+}  // namespace
 
 PROPERTY_SOURCE(
     PartDesignGui::ViewProviderDesignScriptOperation,
@@ -26,13 +85,48 @@ void ViewProviderDesignScriptOperation::attach(App::DocumentObject* object)
 {
     ViewProviderDesignOperation::attach(object);
     sPixmap = "vibecad.svg";
-    setToggleVisibility(ToggleVisibilityMode::NoToggleVisibility);
+}
+
+bool ViewProviderDesignScriptOperation::doubleClicked()
+{
+    if (invokeScriptedModelCommand(getObject())) {
+        return true;
+    }
+    return ViewProviderDesignOperation::doubleClicked();
+}
+
+const char* ViewProviderDesignScriptOperation::getTransactionText() const
+{
+    // The registered VibeScript editor owns its lifecycle. If that optional
+    // command is unavailable, preserve the complete native Part Design edit
+    // path, including its enclosing transaction.
+    return approvedScriptedModelCommand(getObject(), false).command
+        ? nullptr
+        : ViewProviderDesignOperation::getTransactionText();
+}
+
+void ViewProviderDesignScriptOperation::setupContextMenu(
+    QMenu* menu,
+    QObject* receiver,
+    const char* member
+)
+{
+    const auto approved = approvedScriptedModelCommand(getObject(), true);
+    if (approved.command) {
+        approved.command->addTo(menu);
+        // Skip ViewProviderDesignOperation's generic "Edit Operation" action:
+        // VibeScript source is edited by its exact lifecycle command, not by
+        // the native Design-target task dialog.
+        ViewProvider::setupContextMenu(menu, receiver, member);
+        return;
+    }
+    // Preserve standalone Part Design compatibility if the optional VibeCAD
+    // GUI module has not registered its source editor command.
+    ViewProviderDesignOperation::setupContextMenu(menu, receiver, member);
 }
 
 std::vector<Gui::TreeViewDetail> ViewProviderDesignScriptOperation::getTreeViewDetails() const
 {
-    constexpr std::size_t maxPublishedRows = 256;
-
     const auto* operation = dynamic_cast<const PartDesign::DesignScriptOperation*>(getObject());
     if (!operation) {
         return {};
@@ -52,13 +146,17 @@ std::vector<Gui::TreeViewDetail> ViewProviderDesignScriptOperation::getTreeViewD
         }
     }
 
-    const std::size_t outputCount = std::min(keys.size(), types.size());
+    // Output keys are the authoritative produced-output identities. Older or
+    // partially restored documents may not have a parallel type entry; that
+    // must not make a real produced Body disappear from Design History.
+    const std::size_t outputCount = keys.size();
     std::vector<Gui::TreeViewDetail> details;
-    details.reserve(std::min(outputCount, maxPublishedRows) + 1);
-    for (std::size_t index = 0; index < outputCount && index < maxPublishedRows; ++index) {
+    details.reserve(outputCount);
+    for (std::size_t index = 0; index < outputCount; ++index) {
         const std::string& key = keys[index];
-        const std::string& type = types[index];
-        if (key.empty() || type.empty()) {
+        const std::string type =
+            index < types.size() ? types[index] : std::string {};
+        if (key.empty()) {
             continue;
         }
         const auto label = humanLabels.find(key);
@@ -66,23 +164,27 @@ std::vector<Gui::TreeViewDetail> ViewProviderDesignScriptOperation::getTreeViewD
         const std::string icon = type == "solid"
             ? "PartDesign_Body"
             : (type == "component_link" ? "Geoassembly" : "vibecad");
+        const QString toolTip = type.empty()
+            ? QObject::tr(
+                  "VibeScript output '%1'. Its stable interface is listed "
+                  "under Published Outputs."
+              )
+                  .arg(QString::fromUtf8(key.c_str()))
+            : QObject::tr(
+                  "VibeScript output '%1' (%2). Its stable interface is "
+                  "listed under Published Outputs."
+              )
+                  .arg(QString::fromUtf8(key.c_str()))
+                  .arg(QString::fromUtf8(type.c_str()));
         details.push_back({
             "output:" + key,
-            "Produces " + displayName,
+            utf8(
+                QObject::tr("Produces %1")
+                    .arg(QString::fromUtf8(displayName.c_str()))
+            ),
             type,
-            "VibeScript output '" + key + "' (" + type
-                + "). Its stable interface is listed under Published Outputs.",
+            utf8(toolTip),
             icon,
-        });
-    }
-    if (outputCount > maxPublishedRows) {
-        details.push_back({
-            "output:remaining",
-            "Produces " + std::to_string(outputCount - maxPublishedRows) + " more outputs",
-            {},
-            "The Design History output summary is bounded; all stable interfaces "
-            "remain available under Published Outputs.",
-            "vibecad",
         });
     }
     return details;

--- a/src/Mod/PartDesign/Gui/ViewProviderDesignScriptOperation.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderDesignScriptOperation.cpp
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "ViewProviderDesignScriptOperation.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <Mod/PartDesign/App/DesignFeature.h>
+
+
+using namespace PartDesignGui;
+
+PROPERTY_SOURCE(
+    PartDesignGui::ViewProviderDesignScriptOperation,
+    PartDesignGui::ViewProviderDesignOperation
+)
+
+ViewProviderDesignScriptOperation::ViewProviderDesignScriptOperation() = default;
+
+ViewProviderDesignScriptOperation::~ViewProviderDesignScriptOperation() = default;
+
+void ViewProviderDesignScriptOperation::attach(App::DocumentObject* object)
+{
+    ViewProviderDesignOperation::attach(object);
+    sPixmap = "vibecad.svg";
+    setToggleVisibility(ToggleVisibilityMode::NoToggleVisibility);
+}
+
+std::vector<Gui::TreeViewDetail> ViewProviderDesignScriptOperation::getTreeViewDetails() const
+{
+    constexpr std::size_t maxPublishedRows = 256;
+
+    const auto* operation = dynamic_cast<const PartDesign::DesignScriptOperation*>(getObject());
+    if (!operation) {
+        return {};
+    }
+
+    const auto& keys = operation->ProgramOutputKeys.getValues();
+    const auto& types = operation->ProgramOutputTypes.getValues();
+    const auto& bodyKeys = operation->ScriptOutputKeys.getValues();
+    const auto& bodyLabels = operation->ScriptOutputLabels.getValues();
+
+    std::unordered_map<std::string, std::string> humanLabels;
+    const std::size_t bodyCount = std::min(bodyKeys.size(), bodyLabels.size());
+    humanLabels.reserve(bodyCount);
+    for (std::size_t index = 0; index < bodyCount; ++index) {
+        if (!bodyKeys[index].empty() && !bodyLabels[index].empty()) {
+            humanLabels.emplace(bodyKeys[index], bodyLabels[index]);
+        }
+    }
+
+    const std::size_t outputCount = std::min(keys.size(), types.size());
+    std::vector<Gui::TreeViewDetail> details;
+    details.reserve(std::min(outputCount, maxPublishedRows) + 1);
+    for (std::size_t index = 0; index < outputCount && index < maxPublishedRows; ++index) {
+        const std::string& key = keys[index];
+        const std::string& type = types[index];
+        if (key.empty() || type.empty()) {
+            continue;
+        }
+        const auto label = humanLabels.find(key);
+        const std::string displayName = label == humanLabels.end() ? key : label->second;
+        const std::string icon = type == "solid"
+            ? "PartDesign_Body"
+            : (type == "component_link" ? "Geoassembly" : "vibecad");
+        details.push_back({
+            "output:" + key,
+            "Produces " + displayName,
+            type,
+            "VibeScript output '" + key + "' (" + type
+                + "). Its stable interface is listed under Published Outputs.",
+            icon,
+        });
+    }
+    if (outputCount > maxPublishedRows) {
+        details.push_back({
+            "output:remaining",
+            "Produces " + std::to_string(outputCount - maxPublishedRows) + " more outputs",
+            {},
+            "The Design History output summary is bounded; all stable interfaces "
+            "remain available under Published Outputs.",
+            "vibecad",
+        });
+    }
+    return details;
+}

--- a/src/Mod/PartDesign/Gui/ViewProviderDesignScriptOperation.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderDesignScriptOperation.h
@@ -21,6 +21,9 @@ public:
     ~ViewProviderDesignScriptOperation() override;
 
     void attach(App::DocumentObject* object) override;
+    bool doubleClicked() override;
+    const char* getTransactionText() const override;
+    void setupContextMenu(QMenu* menu, QObject* receiver, const char* member) override;
     std::vector<Gui::TreeViewDetail> getTreeViewDetails() const override;
 };
 

--- a/src/Mod/PartDesign/Gui/ViewProviderDesignScriptOperation.h
+++ b/src/Mod/PartDesign/Gui/ViewProviderDesignScriptOperation.h
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <Gui/TreeViewDetail.h>
+
+#include "ViewProviderDesignOperation.h"
+
+
+namespace PartDesignGui
+{
+
+/** Presentation for one source-owned VibeScript Design History operation. */
+class PartDesignGuiExport ViewProviderDesignScriptOperation: public ViewProviderDesignOperation,
+                                                             public Gui::TreeViewDetailProvider
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(PartDesignGui::ViewProviderDesignScriptOperation);
+
+public:
+    ViewProviderDesignScriptOperation();
+    ~ViewProviderDesignScriptOperation() override;
+
+    void attach(App::DocumentObject* object) override;
+    std::vector<Gui::TreeViewDetail> getTreeViewDetails() const override;
+};
+
+}  // namespace PartDesignGui

--- a/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
@@ -36,6 +36,7 @@ except ImportError:
 BROWSER_FOLDER_TYPE = 1002
 BROWSER_DETAIL_TYPE = 1003
 TREE_PARAMETER_PATH = "User parameter:BaseApp/Preferences/TreeView"
+VIBESCRIPT_HISTORY_LABEL = "VibeScript Build"
 
 
 def _tag_scripted_object(obj, *, role, model_id, output_key=""):
@@ -375,6 +376,7 @@ class TestModelTreeBrowser(unittest.TestCase):
         _tag_timeline_role(self.internal_state, "internal")
 
         model_id = "browser-body-backed-publication"
+        self.vibe_model_id = model_id
         self.vibe_component = self.document.addObject(
             "App::Part",
             "VibeProgram",
@@ -486,7 +488,7 @@ class TestModelTreeBrowser(unittest.TestCase):
             "PartDesign::DesignScriptOperation",
             "VibeProgramOperation",
         )
-        self.vibe_operation.Label = "Vibe Program"
+        self.vibe_operation.Label = "Vibe Program Operation"
         edit = PartDesign.beginDesignOperationEdit(self.vibe_operation)
         PartDesign.setDesignScriptOutputs(
             edit,
@@ -506,6 +508,18 @@ class TestModelTreeBrowser(unittest.TestCase):
             role="implementation",
             model_id=model_id,
         )
+        _tag_timeline_role(self.vibe_operation, "operation")
+        for property_name, command_name in (
+            ("VibeCADTimelineEditCommand", "VibeCAD_EditScriptedModel"),
+            ("VibeCADTimelineDeleteCommand", "VibeCAD_DeleteScriptedModel"),
+        ):
+            if property_name not in self.vibe_operation.PropertiesList:
+                self.vibe_operation.addProperty(
+                    "App::PropertyString",
+                    property_name,
+                    "Timeline",
+                )
+            setattr(self.vibe_operation, property_name, command_name)
         self.document.commitTransaction()
 
         self.profile_alpha.Visibility = False
@@ -699,7 +713,11 @@ class TestModelTreeBrowser(unittest.TestCase):
         self.assertIn(self.feature.Label, visible_labels)
         self.assertNotIn(self.internal_state.Label, visible_labels)
 
-        root_operations = _child(document_item, "Operations", BROWSER_FOLDER_TYPE)
+        root_operations = _child(
+            document_item,
+            "Design History",
+            BROWSER_FOLDER_TYPE,
+        )
         self.assertEqual(
             [item.text(0) for item in _visible_children(root_operations)],
             [self.root_operation.Label],
@@ -767,8 +785,8 @@ class TestModelTreeBrowser(unittest.TestCase):
                 BROWSER_FOLDER_TYPE,
             )
             body = _child(bodies, self.vibe_body.Label)
-            operation = _child(history, self.vibe_operation.Label)
-            output = _child(published, self.vibe_output.Label)
+            operation = _child(history, VIBESCRIPT_HISTORY_LABEL)
+            output = _child(published, self.vibe_body.Label)
             values = (
                 tree,
                 document_item,
@@ -806,6 +824,7 @@ class TestModelTreeBrowser(unittest.TestCase):
             ["Bodies", "Design History", "Published Outputs"],
         )
         self.assertTrue(bodies.isExpanded())
+        self.assertEqual(operation.text(0), VIBESCRIPT_HISTORY_LABEL)
         self.assertEqual(
             [
                 child.text(0)
@@ -823,6 +842,19 @@ class TestModelTreeBrowser(unittest.TestCase):
             operation.icon(0).cacheKey(),
             body.icon(0).cacheKey(),
         )
+        manual_component = self._component_item(self.component.Label)
+        manual_bodies = _child(
+            manual_component,
+            "Bodies",
+            BROWSER_FOLDER_TYPE,
+        )
+        manual_body = _child(manual_bodies, self.feature_body.Label)
+        self.assertIsNotNone(manual_body)
+        self.assertNotEqual(
+            _icon_png(body.icon(0)),
+            _icon_png(manual_body.icon(0)),
+            "A generated Body must retain its VibeCAD provenance badge",
+        )
 
         operation_visibility = self.vibe_operation.Visibility
         body_visibility = self.vibe_body.Visibility
@@ -832,18 +864,281 @@ class TestModelTreeBrowser(unittest.TestCase):
         self.assertEqual(self.vibe_body.Visibility, body_visibility)
         self.assertEqual(self.vibe_output.Visibility, output_visibility)
 
-        Gui.Selection.clearSelection()
-        Gui.Selection.addSelection(self.vibe_operation)
-        self.assertIsNotNone(
+        def select_role_item(index, expected):
+            items = role_items()
+            if items is None:
+                return None
+            current_tree = items[0]
+            item = items[index]
+            Gui.Selection.clearSelection()
+            current_tree.clearSelection()
+            current_tree.setCurrentItem(item)
+            item.setSelected(True)
+            current_tree.setFocus()
+            # The model browser preserves native App::Part containment in the
+            # raw subname selection. The public resolved selection must still
+            # identify the exact semantic object represented by the row.
+            return Gui.Selection.getSelection(self.document.Name) == [expected]
+
+        for index, expected in (
+            (6, self.vibe_body),
+            (7, self.vibe_operation),
+            (8, self.vibe_output),
+        ):
+            self.assertIsNotNone(
+                _wait_until(lambda: select_role_item(index, expected)),
+                self._snapshot(),
+            )
+
+        # The role label is presentation-only. Exact saved identities remain
+        # available through the selected object's Property inspector.
+        self.assertEqual(self.vibe_operation.Name, "VibeProgramOperation")
+        self.assertEqual(self.vibe_operation.Label, "Vibe Program Operation")
+        self.assertEqual(self.vibe_operation.ProgramId, self.vibe_model_id)
+
+    def test_vibescript_multi_output_history_identifies_every_body(self):
+        output_keys = ["UtilityBlade", "FixtureClamp", "FixturePin"]
+        created_bodies = []
+        created_publications = []
+
+        self.document.openTransaction("Publish multiple VibeScript outputs")
+        for index, output_key in enumerate(output_keys[1:], start=1):
+            body = self.document.addObject(
+                "PartDesign::Body",
+                f"Vibe{output_key}Body",
+            )
+            body.Label = output_key
+            self.vibe_component.addObject(body)
+            _tag_scripted_object(
+                body,
+                role="implementation",
+                model_id=self.vibe_model_id,
+                output_key=output_key,
+            )
+            result = body.newObject(
+                "PartDesign::Feature",
+                f"Vibe{output_key}Result",
+            )
+            result.Shape = Part.makeBox(2 + index, 2, 1)
+            body.Tip = result
+            body.Visibility = True
+            created_bodies.append(body)
+
+            publication = self.document.addObject(
+                "App::Link",
+                f"Vibe{output_key}",
+            )
+            publication.Label = body.Label
+            publication.LinkedObject = (
+                self.vibe_component,
+                f"{body.Name}.",
+            )
+            publication.LinkTransform = True
+            publication.Visibility = False
+            _tag_scripted_object(
+                publication,
+                role="publication",
+                model_id=self.vibe_model_id,
+                output_key=output_key,
+            )
+            created_publications.append(publication)
+
+        edit = PartDesign.beginDesignOperationEdit(self.vibe_operation)
+        PartDesign.setDesignScriptOutputs(
+            edit,
+            self.vibe_component.Name,
+            self.vibe_model_id,
+            "accepted-multi-output",
+            [],
+            [],
+            [],
+            [],
+            output_keys,
+            ["solid"] * len(output_keys),
+        )
+        self.assertEqual(PartDesign.finalizeDesignOperationEdit(edit), [])
+        self.document.recompute()
+        self.document.commitTransaction()
+
+        def multi_output_snapshot():
+            _tree, document_item = self._tree_and_document_item()
+            component = _child(document_item, self.vibe_component.Label)
+            bodies = _child(component, "Bodies", BROWSER_FOLDER_TYPE)
+            history = _child(component, "Design History", BROWSER_FOLDER_TYPE)
+            published = _child(
+                component,
+                "Published Outputs",
+                BROWSER_FOLDER_TYPE,
+            )
+            operation = _child(history, VIBESCRIPT_HISTORY_LABEL)
+            values = (component, bodies, history, published, operation)
+            if not all(value is not None for value in values):
+                return None
+            return {
+                "details": tuple(
+                    child.text(0)
+                    for child in _visible_children(operation)
+                    if child.type() == BROWSER_DETAIL_TYPE
+                ),
+                "bodies": tuple(
+                    child.text(0) for child in _visible_children(bodies)
+                ),
+                "publications": tuple(
+                    child.text(0) for child in _visible_children(published)
+                ),
+                "history_count": sum(
+                    child.text(0) == VIBESCRIPT_HISTORY_LABEL
+                    for child in _visible_walk(component)
+                ),
+                "operation_parent": operation.parent().text(0),
+            }
+
+        observed = _wait_until(multi_output_snapshot)
+        self.assertIsNotNone(observed, self._snapshot())
+        self.assertEqual(
+            observed["details"],
+            tuple(f"Produces {output_key}" for output_key in output_keys),
+        )
+        for body in created_bodies:
+            self.assertIn(body.Label, observed["bodies"])
+        for body, publication in zip(created_bodies, created_publications):
+            self.assertNotEqual(publication.Label, body.Label)
+            self.assertIn(body.Label, observed["publications"])
+        self.assertEqual(observed["history_count"], 1)
+        self.assertEqual(observed["operation_parent"], "Design History")
+
+    def test_vibescript_role_hierarchy_survives_recompute_and_undo_redo(self):
+        def role_snapshot():
+            _tree, document_item = self._tree_and_document_item()
+            component = _child(document_item, self.vibe_component.Label)
+            if component is None:
+                return None
+            folders = tuple(
+                _child(component, label, BROWSER_FOLDER_TYPE)
+                for label in ("Bodies", "Design History", "Published Outputs")
+            )
+            if any(folder is None for folder in folders):
+                return None
+            return (
+                component.text(0),
+                component.type(),
+                tuple(_snapshot(folder) for folder in folders),
+            )
+
+        original = _wait_until(role_snapshot)
+        self.assertIsNotNone(original, self._snapshot())
+
+        for obj in (
+            self.vibe_component,
+            self.vibe_body,
+            self.vibe_operation,
+            self.vibe_output,
+        ):
+            obj.touch()
+        self.document.recompute()
+        self.assertEqual(_wait_until(role_snapshot), original)
+
+        self.document.openTransaction("Rename VibeScript presentation objects")
+        self.vibe_body.Label = "Renamed Utility Blade"
+        self.vibe_output.Label = "Renamed Utility Blade"
+        self.vibe_operation.Label = "Internal Program Operation Rename"
+        self.document.commitTransaction()
+        self.document.recompute()
+
+        renamed = _wait_until(
+            lambda: (
+                snapshot
+                if (
+                    (snapshot := role_snapshot()) is not None
+                    and snapshot != original
+                    and VIBESCRIPT_HISTORY_LABEL in _snapshot_labels(snapshot)
+                    and "Internal Program Operation Rename"
+                    not in _snapshot_labels(snapshot)
+                )
+                else None
+            )
+        )
+        self.assertIsNotNone(renamed, self._snapshot())
+
+        self.document.undo()
+        self.assertEqual(
             _wait_until(
                 lambda: (
-                    (items := role_items()) is not None
-                    and items[7].isSelected()
-                    and Gui.Selection.getSelection() == [self.vibe_operation]
+                    snapshot
+                    if (snapshot := role_snapshot()) == original
+                    else None
                 )
             ),
+            original,
+        )
+
+        self.document.redo()
+        self.assertEqual(
+            _wait_until(
+                lambda: (
+                    snapshot
+                    if (snapshot := role_snapshot()) == renamed
+                    else None
+                )
+            ),
+            renamed,
             self._snapshot(),
         )
+
+    def test_native_design_history_keeps_editing_without_a_fake_eye(self):
+        self.document.openTransaction("Create native Design operation")
+        generator = self.document.addObject(
+            "PartDesign::Feature",
+            "NativeHistoryGenerator",
+        )
+        generator.Shape = Part.makeBox(4, 3, 2)
+        self.document.classifyProvisionalTimelineInternalObject(generator)
+        operation = self.document.addObject(
+            "PartDesign::DesignGeneratedOperation",
+            "NativeHistoryOperation",
+        )
+        operation.Label = "Native Generated Build"
+        edit = PartDesign.beginDesignOperationEdit(operation)
+        operation.Generator = generator
+        operation.GeneratorKind = "model-tree-regression"
+        operation.OutputLabel = "Native Generated Body"
+        PartDesign.setDesignOperationTargets(edit, "New Body", [])
+        self.document.recompute()
+        bodies = PartDesign.finalizeDesignOperationEdit(edit)
+        self.document.commitTransaction()
+        self.assertEqual(len(bodies), 1)
+
+        def native_history_item():
+            _tree, document_item = self._tree_and_document_item()
+            history = _child(
+                document_item,
+                "Design History",
+                BROWSER_FOLDER_TYPE,
+            )
+            item = _child(history, operation.Label)
+            values = (history, item)
+            return values if all(value is not None for value in values) else None
+
+        observed = _wait_until(native_history_item)
+        self.assertIsNotNone(observed, self._snapshot())
+        self.assertEqual(
+            operation.ViewObject.ToggleVisibility,
+            "NoToggleVisibility",
+        )
+
+        entered = bool(Gui.activeDocument().setEdit(operation.Name))
+        try:
+            self.assertTrue(entered or Gui.Control.activeDialog())
+            self.assertIsNotNone(Gui.activeDocument().getInEdit())
+        finally:
+            if Gui.activeDocument() and Gui.activeDocument().getInEdit():
+                Gui.activeDocument().resetEdit()
+            if Gui.Control.activeDialog():
+                try:
+                    Gui.Control.activeTaskDialog().reject()
+                except Exception:
+                    Gui.Control.closeDialog()
+            _event_step(50)
 
     @unittest.skipIf(Fem is None, "Requires FEM")
     def test_analyze_folder_preserves_study_membership_without_duplicates(self):
@@ -901,7 +1196,7 @@ class TestModelTreeBrowser(unittest.TestCase):
         )
         self.assertIsNotNone(_child(analyze, loose_solver.Label))
 
-        operations = _child(document_item, "Operations", BROWSER_FOLDER_TYPE)
+        operations = _child(document_item, "Design History", BROWSER_FOLDER_TYPE)
         other = _child(document_item, "Other", BROWSER_FOLDER_TYPE)
         for label in (
             analysis.Label,
@@ -996,7 +1291,7 @@ class TestModelTreeBrowser(unittest.TestCase):
         self.assertIsNotNone(_child(page_item, annotation.Label))
         self.assertIsNotNone(_child(view_item, dimension.Label))
 
-        operations = _child(document_item, "Operations", BROWSER_FOLDER_TYPE)
+        operations = _child(document_item, "Design History", BROWSER_FOLDER_TYPE)
         other = _child(document_item, "Other", BROWSER_FOLDER_TYPE)
         for label in (
             page.Label,
@@ -2583,6 +2878,10 @@ class TestModelTreeBrowser(unittest.TestCase):
             ),
         )
 
+        _tree, document_item = self._tree_and_document_item()
+        pre_save_component = _child(document_item, self.vibe_component.Label)
+        pre_save_roles = _snapshot(pre_save_component)
+
         with tempfile.TemporaryDirectory(
             prefix="vibecad_body_visibility_",
         ) as temporary_directory:
@@ -2599,7 +2898,7 @@ class TestModelTreeBrowser(unittest.TestCase):
             self.vibe_operation = self.document.getObject("VibeProgramOperation")
             self.assertIsNotNone(_wait_until(self._browser_ready))
 
-            def restored_role_items():
+            def restored_role_snapshot():
                 _tree, document_item = self._tree_and_document_item()
                 component = _child(document_item, self.vibe_component.Label)
                 bodies = _child(component, "Bodies", BROWSER_FOLDER_TYPE)
@@ -2610,8 +2909,8 @@ class TestModelTreeBrowser(unittest.TestCase):
                     BROWSER_FOLDER_TYPE,
                 )
                 body = _child(bodies, self.vibe_body.Label)
-                operation = _child(history, self.vibe_operation.Label)
-                output = _child(published, self.vibe_output.Label)
+                operation = _child(history, VIBESCRIPT_HISTORY_LABEL)
+                output = _child(published, self.vibe_body.Label)
                 values = (
                     component,
                     bodies,
@@ -2621,9 +2920,15 @@ class TestModelTreeBrowser(unittest.TestCase):
                     operation,
                     output,
                 )
-                return values if all(value is not None for value in values) else None
+                return (
+                    _snapshot(component)
+                    if all(value is not None for value in values)
+                    else None
+                )
 
-            self.assertIsNotNone(_wait_until(restored_role_items), self._snapshot())
+            restored = _wait_until(restored_role_snapshot)
+            self.assertIsNotNone(restored, self._snapshot())
+            self.assertEqual(restored, pre_save_roles)
 
             from VibeCADVibeScriptDomainPublication import (
                 restore_partdesign_history_presentation,
@@ -3021,7 +3326,7 @@ class TestMeshGroupBrowser(unittest.TestCase):
         document_item, mesh_group, mesh_item = observed
         self.assertIs(mesh_item.parent(), mesh_group)
 
-        operations = _child(document_item, "Operations", BROWSER_FOLDER_TYPE)
+        operations = _child(document_item, "Design History", BROWSER_FOLDER_TYPE)
         self.assertTrue(
             operations is None
             or not _snapshot_has_label(_snapshot(operations), imported.Label)

--- a/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestModelTreeBrowser.py
@@ -481,6 +481,33 @@ class TestModelTreeBrowser(unittest.TestCase):
             output_key="UtilityBlade",
         )
 
+        self.document.openTransaction("Publish browser VibeScript history")
+        self.vibe_operation = self.document.addObject(
+            "PartDesign::DesignScriptOperation",
+            "VibeProgramOperation",
+        )
+        self.vibe_operation.Label = "Vibe Program"
+        edit = PartDesign.beginDesignOperationEdit(self.vibe_operation)
+        PartDesign.setDesignScriptOutputs(
+            edit,
+            self.vibe_component.Name,
+            model_id,
+            "accepted",
+            [],
+            [],
+            [],
+            [],
+            ["UtilityBlade"],
+            ["solid"],
+        )
+        self.assertEqual(PartDesign.finalizeDesignOperationEdit(edit), [])
+        _tag_scripted_object(
+            self.vibe_operation,
+            role="implementation",
+            model_id=model_id,
+        )
+        self.document.commitTransaction()
+
         self.profile_alpha.Visibility = False
         self.profile_beta.Visibility = False
         self.reference.Visibility = False
@@ -606,7 +633,7 @@ class TestModelTreeBrowser(unittest.TestCase):
                 "Parameters",
                 "Bodies",
                 "Sketches",
-                "Operations",
+                "Design History",
                 "References",
                 "Groups",
             },
@@ -661,7 +688,7 @@ class TestModelTreeBrowser(unittest.TestCase):
             [self.manufacturing_note.Label],
         )
 
-        operations = _child(component, "Operations", BROWSER_FOLDER_TYPE)
+        operations = _child(component, "Design History", BROWSER_FOLDER_TYPE)
         self.assertEqual(
             [item.text(0) for item in _visible_children(operations)],
             [self.component_operation.Label],
@@ -715,12 +742,108 @@ class TestModelTreeBrowser(unittest.TestCase):
                 for item in _visible_children(vibe_component)
                 if item.type() == BROWSER_FOLDER_TYPE
             },
-            {"Bodies", "Sketches", "References"},
+            {
+                "Bodies",
+                "Design History",
+                "Published Outputs",
+                "Sketches",
+                "References",
+            },
         )
 
         for item in _visible_walk(document_item):
             if item.type() == BROWSER_FOLDER_TYPE:
                 self.assertFalse(item.icon(0).isNull(), item.text(0))
+
+    def test_vibescript_program_roles_are_clear_and_keep_exact_identity(self):
+        def role_items():
+            tree, document_item = self._tree_and_document_item()
+            component = _child(document_item, self.vibe_component.Label)
+            bodies = _child(component, "Bodies", BROWSER_FOLDER_TYPE)
+            history = _child(component, "Design History", BROWSER_FOLDER_TYPE)
+            published = _child(
+                component,
+                "Published Outputs",
+                BROWSER_FOLDER_TYPE,
+            )
+            body = _child(bodies, self.vibe_body.Label)
+            operation = _child(history, self.vibe_operation.Label)
+            output = _child(published, self.vibe_output.Label)
+            values = (
+                tree,
+                document_item,
+                component,
+                bodies,
+                history,
+                published,
+                body,
+                operation,
+                output,
+            )
+            return values if all(value is not None for value in values) else None
+
+        observed = _wait_until(role_items)
+        self.assertIsNotNone(observed, self._snapshot())
+        (
+            tree,
+            _document_item,
+            component,
+            bodies,
+            _history,
+            _published,
+            body,
+            operation,
+            output,
+        ) = observed
+
+        folder_labels = [
+            item.text(0)
+            for item in _visible_children(component)
+            if item.type() == BROWSER_FOLDER_TYPE
+        ]
+        self.assertEqual(
+            folder_labels[:3],
+            ["Bodies", "Design History", "Published Outputs"],
+        )
+        self.assertTrue(bodies.isExpanded())
+        self.assertEqual(
+            [
+                child.text(0)
+                for child in _visible_children(operation)
+                if child.type() == BROWSER_DETAIL_TYPE
+            ],
+            ["Produces UtilityBlade"],
+        )
+        self.assertEqual(
+            self.vibe_operation.ViewObject.ToggleVisibility,
+            "NoToggleVisibility",
+        )
+        self.assertNotEqual(body.icon(0).cacheKey(), output.icon(0).cacheKey())
+        self.assertNotEqual(
+            operation.icon(0).cacheKey(),
+            body.icon(0).cacheKey(),
+        )
+
+        operation_visibility = self.vibe_operation.Visibility
+        body_visibility = self.vibe_body.Visibility
+        output_visibility = self.vibe_output.Visibility
+        self._toggle_tree_item(tree, operation)
+        self.assertEqual(self.vibe_operation.Visibility, operation_visibility)
+        self.assertEqual(self.vibe_body.Visibility, body_visibility)
+        self.assertEqual(self.vibe_output.Visibility, output_visibility)
+
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(self.vibe_operation)
+        self.assertIsNotNone(
+            _wait_until(
+                lambda: (
+                    (items := role_items()) is not None
+                    and items[7].isSelected()
+                    and Gui.Selection.getSelection() == [self.vibe_operation]
+                )
+            ),
+            self._snapshot(),
+        )
 
     @unittest.skipIf(Fem is None, "Requires FEM")
     def test_analyze_folder_preserves_study_membership_without_duplicates(self):
@@ -924,7 +1047,7 @@ class TestModelTreeBrowser(unittest.TestCase):
             component = _child(document_item, self.vibe_component.Label)
             category = _child(
                 component,
-                "VibeCAD Outputs",
+                "Published Outputs",
                 BROWSER_FOLDER_TYPE,
             )
             generated = _child(category, output.Label)
@@ -1497,7 +1620,7 @@ class TestModelTreeBrowser(unittest.TestCase):
             )
         )
 
-    def test_publication_is_internal_and_body_tip_is_the_only_solid(self):
+    def test_publication_is_secondary_and_body_tip_is_the_only_solid(self):
         def browser_state():
             document = self._snapshot()
             component = _snapshot_child(document, "Vibe Program")
@@ -1506,13 +1629,26 @@ class TestModelTreeBrowser(unittest.TestCase):
                 "Bodies",
                 BROWSER_FOLDER_TYPE,
             )
+            published = _snapshot_child(
+                component,
+                "Published Outputs",
+                BROWSER_FOLDER_TYPE,
+            )
             body = _snapshot_child(bodies, self.vibe_body.Label)
-            if component is None or bodies is None or body is None:
+            output = _snapshot_child(published, self.vibe_output.Label)
+            if (
+                component is None
+                or bodies is None
+                or published is None
+                or body is None
+                or output is None
+            ):
                 return None
             return (
                 [child[0] for child in bodies[2]],
                 _snapshot_labels(component),
                 len(body[2]),
+                [child[0] for child in published[2]],
             )
 
         state = _wait_until(browser_state)
@@ -1522,12 +1658,13 @@ class TestModelTreeBrowser(unittest.TestCase):
             [self.vibe_body.Label],
         )
         self.assertEqual(state[2], 0)
+        self.assertEqual(state[3], [self.vibe_output.Label])
 
         visible_labels = list(state[1])
         self.assertNotIn(self.vibe_result.Label, visible_labels)
         self.assertEqual(
             visible_labels.count(self.vibe_body.Label),
-            1,
+            2,
         )
         self.assertFalse(self.vibe_output.Visibility)
         self.assertIs(self.vibe_output.getLinkedObject(), self.vibe_body)
@@ -1544,7 +1681,7 @@ class TestModelTreeBrowser(unittest.TestCase):
         visible_labels = list(_snapshot_labels(component))
         self.assertEqual(
             visible_labels.count(self.vibe_body.Label),
-            1,
+            2,
         )
         self.document.ShowHidden = False
 
@@ -2458,7 +2595,35 @@ class TestModelTreeBrowser(unittest.TestCase):
             self.vibe_result = self.document.getObject("VibeResult")
             self.vibe_sketch = self.document.getObject("VibeBladeProfile")
             self.vibe_output = self.document.getObject("VibeUtilityBlade")
+            self.vibe_component = self.document.getObject("VibeProgram")
+            self.vibe_operation = self.document.getObject("VibeProgramOperation")
             self.assertIsNotNone(_wait_until(self._browser_ready))
+
+            def restored_role_items():
+                _tree, document_item = self._tree_and_document_item()
+                component = _child(document_item, self.vibe_component.Label)
+                bodies = _child(component, "Bodies", BROWSER_FOLDER_TYPE)
+                history = _child(component, "Design History", BROWSER_FOLDER_TYPE)
+                published = _child(
+                    component,
+                    "Published Outputs",
+                    BROWSER_FOLDER_TYPE,
+                )
+                body = _child(bodies, self.vibe_body.Label)
+                operation = _child(history, self.vibe_operation.Label)
+                output = _child(published, self.vibe_output.Label)
+                values = (
+                    component,
+                    bodies,
+                    history,
+                    published,
+                    body,
+                    operation,
+                    output,
+                )
+                return values if all(value is not None for value in values) else None
+
+            self.assertIsNotNone(_wait_until(restored_role_items), self._snapshot())
 
             from VibeCADVibeScriptDomainPublication import (
                 restore_partdesign_history_presentation,

--- a/src/Mod/VibeCAD/vibecad_tests/test_model_tree_role_clarity_schema.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_model_tree_role_clarity_schema.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Source contracts for the VibeScript model-tree presentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+SOURCE_ROOT = Path(__file__).resolve().parents[3]
+GUI_ROOT = SOURCE_ROOT / "Gui"
+PARTDESIGN_GUI_ROOT = SOURCE_ROOT / "Mod" / "PartDesign" / "Gui"
+
+
+def _source(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def test_projection_uses_exact_persisted_program_ownership() -> None:
+    source = _source(GUI_ROOT / "ModelTreeBrowser.cpp")
+
+    assert '"PartDesign::DesignScriptOperation"' in source
+    assert '"ProgramObjectName"' in source
+    assert '"ProgramId"' in source
+    assert '"VibeCADScriptedRole"' in source
+    assert '"model"' in source
+    assert "ownership.component =" in source
+
+
+def test_vibescript_component_has_clear_primary_tree_roles() -> None:
+    source = _source(GUI_ROOT / "Tree.cpp")
+
+    assert 'TreeWidget::tr("Design History")' in source
+    assert 'TreeWidget::tr("Published Outputs")' in source
+    assert 'TreeWidget::tr("Bodies")' in source
+    assert 'Projection::isVibeScriptProgram(' in source
+    assert 'vibeScriptProgram ? "design-history" : "operations"' not in source
+    assert (
+        '"design-history",\n                TreeWidget::tr("Design History"),'
+        in source
+    )
+    assert "return vibeScriptProgram || !entry.bodyRepresentation;" in source
+    assert "firstBuild && vibeScriptProgram" in source
+    assert (
+        "logicalParent,\n            entry.publishedImplementation\n        );"
+        in source
+    )
+
+
+def test_script_history_view_provider_is_non_rendering_and_lists_outputs() -> None:
+    header = _source(PARTDESIGN_GUI_ROOT / "ViewProviderDesignScriptOperation.h")
+    source = _source(PARTDESIGN_GUI_ROOT / "ViewProviderDesignScriptOperation.cpp")
+    app_source = _source(PARTDESIGN_GUI_ROOT / "AppPartDesignGui.cpp")
+    cmake_source = _source(PARTDESIGN_GUI_ROOT / "CMakeLists.txt")
+    design_header = _source(
+        SOURCE_ROOT / "Mod" / "PartDesign" / "App" / "DesignFeature.h"
+    )
+
+    assert "Gui::TreeViewDetailProvider" in header
+    assert "getTreeViewDetails() const override" in header
+    assert "NoToggleVisibility" in source
+    assert "ProgramOutputKeys" in source
+    assert "ProgramOutputTypes" in source
+    assert '"Produces "' in source
+    assert "ViewProviderDesignScriptOperation::init()" in app_source
+    assert "ViewProviderDesignScriptOperation.cpp" in cmake_source
+    assert "ViewProviderDesignScriptOperation.h" in cmake_source
+    assert 'return "PartDesignGui::ViewProviderDesignScriptOperation"' in design_header

--- a/src/Mod/VibeCAD/vibecad_tests/test_model_tree_role_clarity_schema.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_model_tree_role_clarity_schema.py
@@ -33,10 +33,16 @@ def test_vibescript_component_has_clear_primary_tree_roles() -> None:
     assert 'TreeWidget::tr("Design History")' in source
     assert 'TreeWidget::tr("Published Outputs")' in source
     assert 'TreeWidget::tr("Bodies")' in source
+    assert 'TreeWidget::tr("VibeScript Build")' in source
+    assert "modelBrowserPresentationLabel" in source
+    assert "entry.bodyRepresentation->Label.getValue()" in source
     assert 'Projection::isVibeScriptProgram(' in source
-    assert 'vibeScriptProgram ? "design-history" : "operations"' not in source
     assert (
-        '"design-history",\n                TreeWidget::tr("Design History"),'
+        '"operations",\n                TreeWidget::tr("Design History"),'
+        in source
+    )
+    assert (
+        'nullptr,\n        "operations",\n        TreeWidget::tr("Design History"),'
         in source
     )
     assert "return vibeScriptProgram || !entry.bodyRepresentation;" in source
@@ -45,6 +51,8 @@ def test_vibescript_component_has_clear_primary_tree_roles() -> None:
         "logicalParent,\n            entry.publishedImplementation\n        );"
         in source
     )
+    assert '"vibecad-tree-overlay"' in source
+    assert "isVibeCADCreatedObject" in source
 
 
 def test_script_history_view_provider_is_non_rendering_and_lists_outputs() -> None:
@@ -55,13 +63,24 @@ def test_script_history_view_provider_is_non_rendering_and_lists_outputs() -> No
     design_header = _source(
         SOURCE_ROOT / "Mod" / "PartDesign" / "App" / "DesignFeature.h"
     )
+    generic_source = _source(
+        PARTDESIGN_GUI_ROOT / "ViewProviderDesignOperation.cpp"
+    )
 
     assert "Gui::TreeViewDetailProvider" in header
     assert "getTreeViewDetails() const override" in header
-    assert "NoToggleVisibility" in source
+    assert "NoToggleVisibility" in generic_source
     assert "ProgramOutputKeys" in source
     assert "ProgramOutputTypes" in source
-    assert '"Produces "' in source
+    assert 'QObject::tr("Produces %1")' in source
+    assert "const std::size_t outputCount = keys.size();" in source
+    assert "index < types.size() ? types[index] : std::string {}" in source
+    assert "maxPublishedRows" not in source
+    assert "approvedDocumentTimelineCommand" in source
+    assert "EditCommandPropertyName" in source
+    assert '"VibeCADTimelineOperationEditor"' in source
+    assert "ViewProviderDesignOperation::getTransactionText()" in source
+    assert "doubleClicked()" in source
     assert "ViewProviderDesignScriptOperation::init()" in app_source
     assert "ViewProviderDesignScriptOperation.cpp" in cmake_source
     assert "ViewProviderDesignScriptOperation.h" in cmake_source


### PR DESCRIPTION
## Summary

Clarifies VibeScript model-tree roles so users can distinguish the primary editable Body, the non-rendering build operation, and the stable published output link without changing the saved document model.

A VibeScript component is presented as:

```text
VibeScript Component
├─ Bodies
│  └─ Generated Body
├─ Design History
│  └─ VibeScript Build
│      └─ Produces Generated Body
└─ Published Outputs
   └─ Generated Body
```

Closes #135.

## User-visible behavior

- Uses **Design History** instead of **Operations** for modeling history, including native/manual operations.
- Keeps VibeScript history at component scope and identifies every declared output.
- Gives generated Bodies, history operations, and published links distinct role presentation and icons.
- Removes the visibility affordance from non-rendering history operations.
- Preserves the requested human Body label in the browser while retaining exact internal object names and labels in Properties.
- Routes VibeScript history editing to the registered source editor; the native Part Design edit path remains the compatibility fallback when VibeCAD is unavailable.
- Keeps the primary **Bodies** folder expanded on first presentation.
- Preserves stable expansion storage by retaining the existing internal `operations` category key.

## Implementation

- Resolves VibeScript presentation ownership only from persisted role, engine, program-object name, and model-ID metadata; it never guesses from labels, object order, or link shape.
- Keeps presentation ownership separate from native selection ownership so virtual grouping does not create invalid `getSubObject()` paths.
- Adds a specialized `ViewProviderDesignScriptOperation` without removing or changing the existing generic Design-operation provider.
- Uses presentation-only labels for `VibeScript Build` and Body-backed published outputs; underlying `Name`, `Label`, IDs, ownership, and link targets remain unchanged.
- Treats output keys as authoritative so incomplete legacy type metadata cannot hide a real output, and does not truncate multi-output history.
- Refreshes paired publication presentation after Body renames.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults preserve existing behavior for non-VibeScript components.
- [x] The generic native Part Design edit path remains available as a fallback.
- [x] No breaking changes are included.
- [x] Stable Body identity, operation ownership, dependencies, and publication behavior are unchanged.

## Red/green TDD evidence

The focused source contract was extended before each missing behavior was implemented:

```powershell
.pixi\envs\default\python.exe -m pytest -q src\Mod\VibeCAD\vibecad_tests\test_model_tree_role_clarity_schema.py
```

Red results:

- `1 failed, 2 passed` before the stable presentation-label helper existed.
- `1 failed, 2 passed` while output rows were still limited by parallel type metadata.

Green result:

- `3 passed` after implementation.

## Build and test results

Frozen Windows Rattler build, matching the upstream recipe:

```powershell
cd package\rattler-build
pixi reinstall -e default vibecad --frozen
```

Result: **passed** — all 8,932 build targets compiled, `vibecad-26.3.1RC5-h3c70cbc_8.conda` was packaged, and the default environment was reinstalled successfully.

Focused native GUI tests were run independently against that installed build:

```text
TestPartDesignGui.TestModelTreeBrowser.test_vibescript_program_roles_are_clear_and_keep_exact_identity
TestPartDesignGui.TestModelTreeBrowser.test_vibescript_multi_output_history_identifies_every_body
TestPartDesignGui.TestModelTreeBrowser.test_vibescript_role_hierarchy_survives_recompute_and_undo_redo
TestPartDesignGui.TestModelTreeBrowser.test_native_design_history_keeps_editing_without_a_fake_eye
TestPartDesignGui.TestModelTreeBrowser.test_hidden_body_and_visible_sketch_survive_save_reopen
TestPartDesignGui.TestModelTreeBrowser.test_browser_uses_primary_categories_and_only_needed_fallbacks
```

Result: **6/6 passed**.

Complete VibeCAD schema suite:

```powershell
$schemaTests = Get-ChildItem src\Mod\VibeCAD\vibecad_tests -Filter 'test_*schema.py' | Select-Object -ExpandProperty FullName
.pixi\envs\default\python.exe -m pytest -q $schemaTests
```

Result: **263 passed in 13.32s**.

Additional checks:

```powershell
.pixi\envs\default\python.exe -m py_compile src\Mod\PartDesign\PartDesignTests\TestModelTreeBrowser.py
git diff --check
```

Result: **passed**.

## Risk and non-goals

Risk is limited to model-tree presentation and interaction for Design history. The patch does not flatten the multi-Body architecture, move Design operations into Bodies, alter saved-document schema, or change VibeScript execution/regeneration behavior.