### PR TITLE
Fix clean startup packaging and FEM mesh restore

### DIFF
--- a/src/App/PropertyContainer.cpp
+++ b/src/App/PropertyContainer.cpp
@@ -465,9 +465,20 @@ void PropertyData::addProperty(OffsetBase offsetBase,const char* PropName, Prope
         auto &index = impl->propertyData.get<1>();
         auto it = index.find(PropName);
         if(it == index.end()) {
-            if(parentMerged)
-                throw Base::RuntimeError("Cannot add static property");
-            index.emplace(PropName, PropertyGroup, PropertyDocu, offset, Type);
+            const bool restoreParentMerge = parentMerged;
+            auto* parent = const_cast<PropertyData*>(parentPropertyData);
+            if(restoreParentMerge)
+                split(parent);
+            try {
+                index.emplace(PropName, PropertyGroup, PropertyDocu, offset, Type);
+            }
+            catch(...) {
+                if(restoreParentMerge)
+                    merge(parent);
+                throw;
+            }
+            if(restoreParentMerge)
+                merge(parent);
         } else{
 #ifdef FC_DEBUG
             if(it->Offset != offset) {
@@ -653,4 +664,3 @@ void PropertyData::visitProperties(OffsetBase offsetBase,
         visitor(reinterpret_cast<Property*>(spec.Offset + offset));
     };
 }
-

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -758,6 +758,7 @@ set(VibeCAD_Scripts
     VibeCADNativeMeshBooleanRuntime.py
     VibeCADNativeMeshBooleanSchema.py
     VibeCADIsolatedMeshWorker.py
+    VibeCADMeshCacheAtomic.py
     VibeCADMeshBooleanChild.py
     VibeCADMeshBooleanGui.py
     VibeCADMeshBooleanJob.py

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibecad_package_manifest.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibecad_package_manifest.py
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+
+VIBECAD = Path(__file__).resolve().parents[1]
+
+
+def test_cmake_installs_every_top_level_vibecad_python_module() -> None:
+    """A clean package must not depend on files left by an older install."""
+
+    cmake = (VIBECAD / "CMakeLists.txt").read_text(encoding="utf-8")
+    match = re.search(
+        r"set\(VibeCAD_Scripts\s*(.*?)^\)",
+        cmake,
+        flags=re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None
+    packaged = set(
+        re.findall(r"^[ \t]*([A-Za-z0-9_]+\.py)[ \t]*$", match.group(1), re.MULTILINE)
+    )
+    source = {path.name for path in VIBECAD.glob("*.py")}
+
+    assert packaged == source

--- a/tests/src/App/Property.cpp
+++ b/tests/src/App/Property.cpp
@@ -23,6 +23,9 @@
  *                                                                          *
  ****************************************************************************/
 
+#include <array>
+#include <cstddef>
+
 #include <gtest/gtest.h>
 
 #include <FCConfig.h>
@@ -88,6 +91,50 @@ TEST_F(PropertyFloatTest, testWriteRead)
     App::PropertyFloat prop2;
     prop2.Restore(reader);
     EXPECT_DOUBLE_EQ(prop2.getValue(), value);
+}
+
+namespace
+{
+struct LateStaticPropertyStorage
+{
+    std::array<std::byte, 256> containerStorage;
+    App::PropertyInteger parentProperty;
+    App::PropertyInteger childProperty;
+};
+}
+
+TEST(PropertyData, addStaticPropertyAfterParentMetadataWasRead)
+{
+    LateStaticPropertyStorage storage;
+    App::PropertyData parentData;
+    App::PropertyData childData;
+    auto* container = reinterpret_cast<App::PropertyContainer*>(&storage);
+    parentData.parentPropertyData = nullptr;
+    childData.parentPropertyData = &parentData;
+
+    parentData.addProperty(
+        container,
+        "ParentProperty",
+        &storage.parentProperty
+    );
+    childData.merge();
+    ASSERT_TRUE(childData.parentMerged);
+
+    EXPECT_NO_THROW(
+        childData.addProperty(
+            container,
+            "ChildProperty",
+            &storage.childProperty
+        )
+    );
+    EXPECT_EQ(
+        childData.getPropertyByName(container, "ParentProperty"),
+        &storage.parentProperty
+    );
+    EXPECT_EQ(
+        childData.getPropertyByName(container, "ChildProperty"),
+        &storage.childProperty
+    );
 }
 
 std::string RenameProperty::_docName;


### PR DESCRIPTION
## Outcome

Fixes #138.

Clean VibeCAD packages now include the atomic mesh-cache module required by GUI bootstrap, so startup registers the VibeCAD fastener and Inspection commands/icons instead of aborting partway through initialization. Saved documents can also restore FEM mesh view providers after parent property metadata has already been inspected.

## Root causes and changes

- `VibeCADMeshCacheAtomic.py` existed in source but was absent from `VibeCAD_Scripts`. Incremental build trees retained an older copy and masked the clean-package failure. The module is now installed, and a manifest test requires every top-level VibeCAD Python module to be listed.
- Loading the FEM GUI after another caller had read inherited property metadata caused `PropertyData::addProperty()` to reject the first derived static property. Late registration now temporarily separates inherited metadata, adds the new child property, and restores the parent merge. Existing duplicate-name behavior and public interfaces are unchanged.

## TDD and verification

Red observations before implementation:

- The new package-manifest test failed with `VibeCADMeshCacheAtomic.py` missing.
- The shipped Build 8 GUI reproduced `VibeCAD GUI bootstrap failed`, unknown fastener commands, and missing VibeCAD/Inspection icons.
- Opening the saved 2,406-object FEM document reproduced `Cannot create object 'FEMMeshGmsh': (Cannot add static property)`.

Focused source tests:

```powershell
$env:PYTHONPATH=(Resolve-Path 'src\Mod\VibeCAD').Path
.\.pixi\envs\default\python.exe -m pytest -q `
  src\Mod\VibeCAD\vibecad_tests\test_vibecad_package_manifest.py `
  src\Mod\VibeCAD\vibecad_tests\test_native_analyze_solver_execution.py `
  src\Mod\VibeCAD\vibecad_tests\test_fasteners_packaging_contract.py `
  src\Mod\VibeCAD\vibecad_tests\test_mesh_cache_atomic_paths.py --tb=short
```

Result: `34 passed in 3.60s`.

The added C++ regression test compiled successfully in the Windows `App_tests_run` target. The existing Windows gtest runner linked but registered zero tests, so the same late-registration sequence was also exercised by a direct native probe against the final bundle; it returned `late static property registration passed` with exit code 0.

Clean Windows build and official portable-bundle path:

```powershell
pixi install -e default --frozen
pixi install -e package --frozen
$env:PATH=$HOME\.pixi\bin;$env:PATH
$env:BUILD_TAG='issue138-local'
$env:MAKE_INSTALLER='false'
$env:MAKE_PORTABLE_ARCHIVE='true'
pixi run -e package create_bundle
```

Results:

- Clean Rattler build completed with exit code 0.
- The installed and bundled `VibeCADMeshCacheAtomic.py` hashes match source.
- All official bundle smoke tests passed: Python/keyring dependencies, McMaster helper, Codex app-server, geometry worker, and windowless provider subprocess.
- The final portable GUI registered all six reported commands with non-null icons.
- The saved FEM document restored 2,406 objects, including `FEMMeshGmsh`, in 46.6 seconds.
- Final GUI log counts: 0 bootstrap failures, 0 unknown commands, 0 missing icons, 0 static-property failures.
- `7z t VibeCAD-26.3.1-RC5-build8-Windows-x86_64.7z` passed: 48,075 files, `Everything is Ok`.

## Risk and non-goals

The core behavior change only affects registering a previously unseen static child property after inherited metadata was merged. It retains and re-merges the inherited metadata and does not change existing duplicate-property handling. No packaging, signing, release workflow, preference, tool-schema, or unrelated bootstrap behavior is changed.

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed or removed.
- [x] Defaults preserve previous behavior for users who do not opt into new features.
- [x] No deprecations were introduced.
- [x] No breaking changes require owner approval.