### PR TITLE
Bump VibeCAD to RC6 build 0

### DIFF
--- a/package/fedora/freecad.spec
+++ b/package/fedora/freecad.spec
@@ -16,7 +16,7 @@
 
 Name:           vibecad
 Epoch:          1
-Version:        26.3.1~RC5
+Version:        26.3.1~RC6
 Release:        1%{?dist}
 
 Summary:        A general purpose 3D CAD modeler

--- a/package/rattler-build/pixi.toml
+++ b/package/rattler-build/pixi.toml
@@ -8,7 +8,7 @@ preview = ["pixi-build"]
 
 [package]
 name = "vibecad"
-version = "26.3.1RC5"
+version = "26.3.1RC6"
 homepage = "https://freecad.org"
 repository = "https://github.com/FreeCAD/FreeCAD"
 description = "VibeCAD"

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -1,5 +1,5 @@
 context:
-  version: "26.3.1RC5"
+  version: "26.3.1RC6"
 
 package:
   name: vibecad
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 8
+  number: 0
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/version.json
+++ b/version.json
@@ -4,8 +4,8 @@
   "version_minor": 3,
   "version_patch": 1,
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
-  "version_suffix": "RC5",
+  "version_suffix": "RC6",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 8,
+  "build_version": 0,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Outcome
Advances the release identity from VibeCAD 26.3.1-RC5 Build 8 to VibeCAD 26.3.1-RC6 Build 0.

The build counter resets to zero because this is a new release-candidate identity, matching the established RC4-to-RC5 convention.

## Changed surfaces
- `version.json` canonical suffix/build
- Rattler package and recipe versions
- Fedora package version

## Test plan
This is a metadata-only change, so red/green code TDD does not apply.

- `python src/Tools/sync_version.py --check` — passed; every version surface is synchronized.
- `python -m pytest -q src/Tools/tests/test_sync_version.py src/Tools/tests/test_release_artifact_name.py src/Tools/tests/test_windows_installer_version.py src/Tools/tests/test_generate_update_manifest.py` — 68 passed.
- `git diff --check` — passed.

## Compatibility
- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults outside the requested release identity are unchanged.
- [x] No breaking changes.