### PR TITLE
Fix Windows update installer handoff

### DIFF
--- a/.github/workflows/vibecad-update-validate.yml
+++ b/.github/workflows/vibecad-update-validate.yml
@@ -73,3 +73,24 @@ jobs:
           src.Tools.tests.test_generate_update_manifest
           src.Tools.tests.test_release_workflow
           src.Tools.tests.test_vibecad_update
+
+  validate-windows-launch:
+    name: Validate Windows updater process launch
+    runs-on: windows-2022
+    timeout-minutes: 5
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+
+      - name: Exercise the Windows installer handoff
+        shell: pwsh
+        run: >-
+          python -m unittest
+          src.Tools.tests.test_vibecad_update.UpdateServiceTests.test_windows_detached_helper_executes_powershell_after_parent_exits
+          src.Tools.tests.test_vibecad_update.UpdateServiceTests.test_spawn_detached_helper_outlives_the_parent_process
+          src.Tools.tests.test_windows_installer_version.TestWindowsInstallerVersion.test_in_app_updater_launches_normal_installer_without_flags

--- a/src/Mod/VibeCAD/VibeCADUpdate.py
+++ b/src/Mod/VibeCAD/VibeCADUpdate.py
@@ -493,10 +493,12 @@ def spawn_detached_install_helper(
             "close_fds": True,
         }
         if os.name == "nt":
+            # Keep the proven Windows launcher contract.  Adding
+            # DETACHED_PROCESS prevents the PowerShell update helper from
+            # reaching its script body on the supported Windows runtime.
             kwargs["creationflags"] = (
                 getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
                 | getattr(subprocess, "CREATE_NO_WINDOW", 0)
-                | getattr(subprocess, "DETACHED_PROCESS", 0)
             )
         else:
             kwargs["start_new_session"] = True

--- a/src/Mod/VibeCAD/VibeCADUpdateGui.py
+++ b/src/Mod/VibeCAD/VibeCADUpdateGui.py
@@ -283,12 +283,16 @@ def _launch_windows_install_helper(plan: InstallPlan) -> None:
     helper_dir = default_update_directory() / "install-helper"
     helper_dir.mkdir(parents=True, exist_ok=True)
     helper = helper_dir / "install-windows-update.ps1"
+    started = helper_dir / "install-helper.started"
+    started.unlink(missing_ok=True)
     helper.write_text(
         """param(
     [Parameter(Mandatory=$true)][string]$Installer,
-    [Parameter(Mandatory=$true)][int]$VibeCADProcessId
+    [Parameter(Mandatory=$true)][int]$VibeCADProcessId,
+    [Parameter(Mandatory=$true)][string]$Started
 )
 $ErrorActionPreference = 'Stop'
+[IO.File]::WriteAllText($Started, "$PID")
 $vibecad = Get-Process -Id $VibeCADProcessId -ErrorAction SilentlyContinue
 if ($null -ne $vibecad) {
     $vibecad | Wait-Process
@@ -310,9 +314,12 @@ Start-Process -FilePath $Installer
             str(helper),
             str(plan.package),
             str(os.getpid()),
+            str(started),
         ],
         log_path=helper_dir / "install-helper.log",
     )
+    if not wait_for_install_helper_start(started):
+        raise RuntimeError("The Windows install helper did not start.")
 
 
 def _launch_appimage_install_helper(plan: InstallPlan) -> None:

--- a/src/Tools/tests/test_release_workflow.py
+++ b/src/Tools/tests/test_release_workflow.py
@@ -7,6 +7,9 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 WORKFLOW = REPO_ROOT / ".github" / "workflows" / "vibecad-release.yml"
+UPDATE_VALIDATION_WORKFLOW = (
+    REPO_ROOT / ".github" / "workflows" / "vibecad-update-validate.yml"
+)
 
 
 def _job_source(workflow: str, job: str) -> str:
@@ -64,6 +67,20 @@ class TestReleaseWorkflow(unittest.TestCase):
             with self.subTest(pattern=required_pattern):
                 self.assertIn(required_pattern, release)
         self.assertIn("-o -name '*.dmg'", release)
+
+    def test_windows_update_launcher_is_exercised_on_a_windows_runner(self) -> None:
+        workflow = UPDATE_VALIDATION_WORKFLOW.read_text(encoding="utf-8")
+        windows = _job_source(workflow, "validate-windows-launch")
+        self.assertIn("runs-on: windows-2022", windows)
+        self.assertIn(
+            "test_windows_detached_helper_executes_powershell_after_parent_exits",
+            windows,
+        )
+        self.assertIn("test_spawn_detached_helper_outlives_the_parent_process", windows)
+        self.assertIn(
+            "test_in_app_updater_launches_normal_installer_without_flags",
+            windows,
+        )
 
 
 if __name__ == "__main__":

--- a/src/Tools/tests/test_vibecad_update.py
+++ b/src/Tools/tests/test_vibecad_update.py
@@ -1064,6 +1064,56 @@ class UpdateServiceTests(unittest.TestCase):
                 f"stderr={completed.stderr}\nlog={log.read_text(encoding='utf-8') if log.is_file() else ''}",
             )
 
+    def test_windows_detached_helper_executes_powershell_after_parent_exits(self) -> None:
+        if os.name != "nt":
+            self.skipTest("Requires the Windows process-launch runtime")
+        with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
+            root = Path(temp_dir)
+            marker = root / "powershell-alive"
+            log = root / "helper.log"
+            escaped_marker = str(marker).replace("'", "''")
+            helper_command = [
+                "powershell.exe",
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-ExecutionPolicy",
+                "Bypass",
+                "-Command",
+                (
+                    "Start-Sleep -Milliseconds 400; "
+                    f"[IO.File]::WriteAllText('{escaped_marker}', 'ready')"
+                ),
+            ]
+            launcher = (
+                "from pathlib import Path\n"
+                "from VibeCADUpdate import spawn_detached_install_helper\n"
+                "spawn_detached_install_helper(\n"
+                f"    {helper_command!r},\n"
+                f"    log_path=Path({str(log)!r}),\n"
+                ")\n"
+            )
+            completed = subprocess.run(
+                [sys.executable, "-c", launcher],
+                check=False,
+                cwd=str(VIBECAD_MODULE_DIR),
+                capture_output=True,
+                text=True,
+                env={**os.environ, "PYTHONPATH": str(VIBECAD_MODULE_DIR)},
+            )
+            self.assertEqual(
+                completed.returncode,
+                0,
+                f"stdout={completed.stdout}\nstderr={completed.stderr}",
+            )
+            deadline = time.time() + 5
+            while time.time() < deadline and not marker.is_file():
+                time.sleep(0.05)
+            self.assertTrue(
+                marker.is_file(),
+                f"stderr={completed.stderr}\nlog={log.read_text(encoding='utf-8') if log.is_file() else ''}",
+            )
+
     def test_macos_helper_replaces_the_app_and_keeps_a_live_update(self) -> None:
         if sys.platform != "darwin" or shutil.which("hdiutil") is None:
             self.skipTest("Requires macOS hdiutil")

--- a/src/Tools/tests/test_windows_installer_version.py
+++ b/src/Tools/tests/test_windows_installer_version.py
@@ -88,6 +88,12 @@ class TestWindowsInstallerVersion(unittest.TestCase):
 
         self.assertIn("$vibecad | Wait-Process", helper)
         self.assertIn("Start-Process -FilePath $Installer", helper)
+        self.assertIn('[IO.File]::WriteAllText($Started, "$PID")', helper)
+        self.assertIn("wait_for_install_helper_start(started)", helper)
+        self.assertLess(
+            helper.index('[IO.File]::WriteAllText($Started, "$PID")'),
+            helper.index("$vibecad | Wait-Process"),
+        )
         self.assertNotIn("-ArgumentList", helper)
         self.assertNotIn("/S", helper)
         self.assertNotIn("/VIBECADUPDATE", helper)


### PR DESCRIPTION
## User-visible outcome

Windows updates once again launch the verified installer after VibeCAD closes. VibeCAD now confirms that the PowerShell helper has actually reached its script body before hard-exiting; if it cannot start, VibeCAD remains open and reports the failure.

Closes #144.

## Root cause

The macOS lifecycle fix in `7e7badae` routed all platforms through a shared detached-process helper and unintentionally added `DETACHED_PROCESS` to Windows. On the supported Windows runtime, that flag combination creates PowerShell without executing the helper script. The previous Windows flags still hide the console, survive the VibeCAD parent, and execute successfully.

The existing updater validation ran only on Ubuntu and only inspected the Windows PowerShell text, so it could not catch a Windows process-creation regression.

## Changes

- Restore the proven Windows process flags: `CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW`.
- Keep the normal `Start-Process -FilePath $Installer` invocation with no installer arguments.
- Add a startup-stamp handshake before VibeCAD exits.
- Add a behavioral Windows test that launches PowerShell through the real detached-helper path and proves it runs after its launcher parent exits.
- Run the Windows launcher tests on the same `windows-2022` environment used by the release builder.
- Leave macOS and Linux helper behavior unchanged.

## Red/green TDD evidence

Red, before implementation:

```text
.\.pixi\envs\default\python.exe -m unittest -v src.Tools.tests.test_vibecad_update.UpdateServiceTests.test_windows_detached_helper_executes_powershell_after_parent_exits

FAILED: marker was never created; helper log was empty.
```

Green, after implementation:

```text
.\.pixi\envs\default\python.exe -m unittest src.Tools.tests.test_sync_version src.Tools.tests.test_release_artifact_name src.Tools.tests.test_windows_installer_version src.Tools.tests.test_generate_update_manifest src.Tools.tests.test_release_workflow src.Tools.tests.test_vibecad_update

Ran 117 tests in 2.570s
OK (skipped=4 macOS/TUF environment-specific tests)
```

Additional validation:

```text
Python AST parse: passed for all changed Python files
PyYAML parse: passed for vibecad-update-validate.yml
git diff --check: passed
```

## Risk and non-goals

Risk is low and isolated to the Windows updater handoff. No installer flags, download behavior, release metadata, trust policy, or non-Windows lifecycle is changed. This PR does not build or publish a new release.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields are renamed or removed.
- [x] Defaults preserve previous behavior outside the corrected Windows launch path.
- [x] No deprecations are introduced.
- [x] No breaking changes are present.