### PR TITLE
Support multiple independent FEM studies and results

### DIFF
--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -230,6 +230,7 @@ set(VibeCAD_Scripts
     VibeCADNativeAnalyzeInspectBindings.py
     VibeCADNativeAnalyzeInspectRuntime.py
     VibeCADNativeAnalyzeInspectSchema.py
+    VibeCADNativeAnalyzeLabels.py
     VibeCADNativeAnalyzeMaterialCreate.py
     VibeCADNativeAnalyzeMaterialEdit.py
     VibeCADNativeAnalyzeMaterials.py
@@ -241,6 +242,8 @@ set(VibeCAD_Scripts
     VibeCADNativeAnalyzeSolidDomainSchema.py
     VibeCADNativeAnalyzeSnapshot.py
     VibeCADNativeAnalyzeStudy.py
+    VibeCADNativeAnalyzeOwnership.py
+    VibeCADNativeAnalyzeStudyDependencies.py
     VibeCADNativeAnalyzeStudyEdit.py
     VibeCADNativeAnalyzeStudyState.py
     VibeCADNativeAeroSnapshot.py

--- a/src/Mod/VibeCAD/VibeCADAnalyzeSolverGui.py
+++ b/src/Mod/VibeCAD/VibeCADAnalyzeSolverGui.py
@@ -12,6 +12,7 @@ from PySide import QtCore, QtWidgets
 
 from VibeCADCore import get_service
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeOwnership import owning_study, study_resource_scope
 from VibeCADNativeAnalyzeSolverExecution import (
     capture_solver_execution_request,
     commit_solver_execution,
@@ -114,6 +115,7 @@ class _SolverRunUi:
         document = self.document
         captured = self.captured
         workspace = self.workspace
+        scope = study_resource_scope(owning_study(document, captured.target.solver))
 
         def prepare(cancelled: Any, progress: Any) -> Any:
             progress(3, "Capturing exact FEM document")
@@ -149,6 +151,8 @@ class _SolverRunUi:
             dispatch_to_document_thread=VibeCADGui._dispatch_to_document_thread,
             finalize_message=f"Importing verified {self.backend} results",
             cleanup=lambda _prepared: workspace.cleanup(),
+            changes_document=True,
+            resource_scope=scope,
         )
         self.job_id = str(snapshot.job_id)
         _ACTIVE_RUNS[self.job_id] = self

--- a/src/Mod/VibeCAD/VibeCADAnalyzeStudyGui.py
+++ b/src/Mod/VibeCAD/VibeCADAnalyzeStudyGui.py
@@ -15,6 +15,7 @@ from VibeCADAnalyzeStudySetup import (
     analyses_in_document,
     analysis_for_selection,
     apply_study,
+    preferred_analysis,
     readiness_rows,
 )
 from VibeCADNativeAnalyzeStudy import (
@@ -265,23 +266,16 @@ class StudySetupWidget(QtWidgets.QWidget):
     def refresh(self) -> None:
         document = _active_document()
         previous = str(self.analysis_combo.currentData() or self._analysis_name)
-        selected = (
-            analysis_for_selection(document, _selected_objects())
+        analyses = analyses_in_document(document) if document is not None else ()
+        preferred = (
+            preferred_analysis(
+                document,
+                _selected_objects(),
+                previous_name=previous,
+            )
             if document is not None
             else None
         )
-        active = _active_analysis(document) if document is not None else None
-        analyses = analyses_in_document(document) if document is not None else ()
-        preferred = selected or active
-        if preferred is None and previous:
-            preferred = next(
-                (
-                    candidate
-                    for candidate in analyses
-                    if str(candidate.Name) == previous
-                ),
-                None,
-            )
 
         self.analysis_combo.blockSignals(True)
         self.analysis_combo.clear()
@@ -331,9 +325,6 @@ class StudySetupWidget(QtWidgets.QWidget):
             return
 
         try:
-            import FemGui
-
-            FemGui.setActiveAnalysis(analysis)
             self.label_edit.setText(str(analysis.Label))
             self._intent = study_intent_state(analysis)
             self._inventory = study_inventory(analysis)
@@ -562,12 +553,9 @@ class StudySetupWidget(QtWidgets.QWidget):
                 physics=physics,
                 regime=str(self.regime_combo.currentData()),
             )
-            import FemGui
-
-            FemGui.setActiveAnalysis(analysis)
             self._analysis_name = str(analysis.Name)
             self.refresh()
-            App.Console.PrintMessage(f"FEM study {analysis.Label} is active.\n")
+            App.Console.PrintMessage(f"FEM study {analysis.Label} was saved.\n")
         except Exception as exc:
             QtWidgets.QMessageBox.critical(
                 Gui.getMainWindow(),

--- a/src/Mod/VibeCAD/VibeCADAnalyzeStudySetup.py
+++ b/src/Mod/VibeCAD/VibeCADAnalyzeStudySetup.py
@@ -6,24 +6,20 @@ from __future__ import annotations
 
 from typing import Any, Iterable, Mapping
 
+from VibeCADNativeAnalyzeOwnership import (
+    is_study as _is_study,
+    studies_in_document,
+)
+
 
 def _is_analysis(value: Any, document: Any) -> bool:
-    if value is None or getattr(value, "Document", None) is not document:
-        return False
-    try:
-        return bool(value.isDerivedFrom("Fem::FemAnalysis"))
-    except (AttributeError, ReferenceError, RuntimeError):
-        return False
+    return _is_study(value, document)
 
 
 def analyses_in_document(document: Any) -> tuple[Any, ...]:
     """Return every live FEM analysis in document order."""
 
-    return tuple(
-        candidate
-        for candidate in tuple(getattr(document, "Objects", ()) or ())
-        if _is_analysis(candidate, document)
-    )
+    return studies_in_document(document)
 
 
 def analysis_for_selection(document: Any, selection: Iterable[Any]) -> Any | None:
@@ -41,15 +37,45 @@ def analysis_for_selection(document: Any, selection: Iterable[Any]) -> Any | Non
         return direct[0]
     if direct:
         return None
+    ancestors = {id(value): value for value in selected}
+    pending = list(selected)
+    while pending and len(ancestors) <= 4096:
+        current = pending.pop()
+        parents = tuple(getattr(current, "InList", ()) or ())
+        timeline_owner = getattr(current, "VibeCADTimelineOwner", None)
+        if timeline_owner is not None:
+            parents += (timeline_owner,)
+        for parent in parents:
+            if getattr(parent, "Document", None) is document and id(parent) not in ancestors:
+                ancestors[id(parent)] = parent
+                pending.append(parent)
     owners = tuple(
         analysis
         for analysis in analyses_in_document(document)
         if any(
             candidate in tuple(getattr(analysis, "Group", ()) or ())
-            for candidate in selected
+            for candidate in ancestors.values()
         )
     )
     return owners[0] if len(owners) == 1 else None
+
+
+def preferred_analysis(
+    document: Any,
+    selection: Iterable[Any],
+    *,
+    previous_name: str,
+) -> Any | None:
+    """Resolve UI focus from selection, then the dock's explicit prior choice."""
+
+    selected = analysis_for_selection(document, selection)
+    if selected is not None:
+        return selected
+    previous = str(previous_name or "")
+    if not previous:
+        return None
+    candidate = document.getObject(previous)
+    return candidate if _is_analysis(candidate, document) else None
 
 
 def readiness_rows(inventory: Mapping[str, Any]) -> tuple[tuple[str, str], ...]:

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -798,9 +798,10 @@ class VibeCADService:
             raise RuntimeError("The active ribbon has no Native provider surface.")
         background_job = None
         if surface.surface_id == "analyze":
-            background_job = self._native_background_jobs.latest_document_snapshot(
+            background_job = self._native_background_jobs.document_snapshots(
                 str(document.Uid),
                 capability_prefix="analyze.",
+                active_only=True,
             )
         elif surface.surface_id == "manufacture":
             background_job = self._native_background_jobs.document_snapshots(
@@ -838,9 +839,10 @@ class VibeCADService:
         ) != "native":
             return None
         native_state = self.native_document_state()
-        background_job = self._native_background_jobs.latest_document_snapshot(
+        background_job = self._native_background_jobs.document_snapshots(
             str(document.Uid),
             capability_prefix="analyze.",
+            active_only=True,
         )
         analysis_artifacts = drawing_analysis_artifact_names(document)
         base = capture_active_snapshot_base(
@@ -852,19 +854,18 @@ class VibeCADService:
         details = begin_analyze_snapshot_capture(
             document,
             background_job=background_job,
+            selection=base.get("_selection"),
             validate_brep=False,
             analysis_artifact_names=analysis_artifacts,
         )
         revision = int(native_state.get("structural_revision", 0) or 0)
-        cacheable = bool(
-            background_job is None or bool(getattr(background_job, "terminal", False))
-        )
+        cacheable = not bool(background_job)
         cache_hit = bool(
             cacheable
             and self._native_analyze_contexts.has_cached(
                 str(document.Uid),
                 revision,
-                variant=str(details.get("active_analysis_name") or ""),
+                variant=str(details.get("focused_analysis_name") or ""),
             )
         )
         detached_clipping = capture_analyze_clipping(document, details)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeAnalysis.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeAnalysis.py
@@ -15,6 +15,7 @@ from VibeCADNativeAnalyzeHistory import (
     require_boundary,
     verify_operation_block,
 )
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeState import analysis_state, is_live
 from VibeCADNativeAnalyzeStudy import (
     configure_study_intent,
@@ -83,7 +84,7 @@ def create_analysis(
     )
     if analysis is None or not analysis.isDerivedFrom("Fem::FemAnalysis"):
         raise NativeAnalyzeError("The FEM analysis factory returned the wrong object type.")
-    analysis.Label = prepared.label
+    prepared = assign_prepared_label(analysis, prepared)
     if prepared.study is not None:
         configure_study_intent(
             analysis,
@@ -144,9 +145,6 @@ def verify_analysis_create(
         or not bool(solver.isValid())
     ):
         raise NativeAnalyzeError("The default FEM solver failed its exact postcondition.")
-    import FemGui
-
-    FemGui.setActiveAnalysis(analysis)
     current_analysis = analysis_state(analysis)
     result = {
         "created_analysis": current_analysis,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeConnectionCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeConnectionCreate.py
@@ -14,6 +14,7 @@ from VibeCADNativeAnalyzeConnectionValues import (
     prepare_connection_values,
 )
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometryCreate import references_match
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
@@ -163,7 +164,7 @@ def create_connection(
     connection = _factory(document, prepared.kind)
     if connection is None or connection_kind(connection) != prepared.kind:
         raise NativeAnalyzeError("The FEM connection factory returned the wrong type.")
-    connection.Label = prepared.label
+    prepared = assign_prepared_label(connection, prepared)
     if prepared.kind == "contact":
         connection.SurfaceBehavior = "Linear"
         connection.EnableThermalContact = False

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeConnectionEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeConnectionEdit.py
@@ -18,6 +18,7 @@ from VibeCADNativeAnalyzeConnectionValues import (
     prepare_connection_values,
 )
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometryCreate import references_match
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
@@ -198,7 +199,7 @@ def update_connection(
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     connection = prepared.target.connection
-    connection.Label = prepared.label
+    prepared = assign_prepared_label(connection, prepared)
     if prepared.values_changed:
         apply_connection_values(connection, prepared.values)
     connection.References = reference_value(prepared.endpoints)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeConstraintCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeConstraintCreate.py
@@ -17,6 +17,7 @@ from VibeCADNativeAnalyzeConstraintValues import (
     prepare_constraint_values,
 )
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometryCreate import references_match
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
@@ -180,7 +181,7 @@ def create_constraint(
         raise NativeAnalyzeError(
             "The FEM constraint factory returned the wrong object type."
         )
-    constraint.Label = prepared.label
+    prepared = assign_prepared_label(constraint, prepared)
     apply_constraint_values(constraint, prepared.values)
     constraint.References = reference_value(prepared.references)
     prepared.analysis.analysis.addObject(constraint)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeConstraintEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeConstraintEdit.py
@@ -18,6 +18,7 @@ from VibeCADNativeAnalyzeConstraintValues import (
     prepare_constraint_values,
 )
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometryCreate import references_match
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
@@ -243,7 +244,7 @@ def update_constraint(
         ignore=prepared.target.constraint,
     )
     constraint = prepared.target.constraint
-    constraint.Label = prepared.label
+    prepared = assign_prepared_label(constraint, prepared)
     constraint.References = reference_value(prepared.references)
     if prepared.values_changed:
         apply_constraint_values(constraint, prepared.values)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeEquationCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeEquationCreate.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from VibeCADNativeAnalyzeEquationState import equation_kind, equation_state
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -139,7 +140,7 @@ def create_equation(
         ) from exc
     if equation_kind(equation) != prepared.kind:
         raise NativeAnalyzeError("The Elmer equation factory returned the wrong kind.")
-    equation.Label = prepared.label
+    prepared = assign_prepared_label(equation, prepared)
     if tuple(getattr(solver, "Group", ()) or ()) != (*prepared.children_before, equation):
         raise NativeAnalyzeError("The Elmer equation was not appended to the exact solver.")
     finalize_new_operation_resource(

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeFluidCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeFluidCreate.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeFluidState import fluid_constraint_kind, fluid_constraint_state
 from VibeCADNativeAnalyzeFluidValues import (
     PreparedFluidValues,
@@ -212,7 +213,7 @@ def create_fluid_constraint(
         raise NativeAnalyzeError(
             "The FEM fluid factory returned the wrong object type."
         )
-    constraint.Label = prepared.label
+    prepared = assign_prepared_label(constraint, prepared)
     apply_fluid_values(constraint, prepared.values)
     constraint.References = reference_value(prepared.references)
     prepared.analysis.analysis.addObject(constraint)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeFluidEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeFluidEdit.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeFluidCreate import (
     fluid_label,
     require_unassigned_boundary_faces,
@@ -247,7 +248,7 @@ def update_fluid_constraint(
             ignore=prepared.target.constraint,
         )
     constraint = prepared.target.constraint
-    constraint.Label = prepared.label
+    prepared = assign_prepared_label(constraint, prepared)
     constraint.References = reference_value(prepared.references)
     if prepared.values_changed:
         apply_fluid_values(constraint, prepared.values)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometricalCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometricalCreate.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometricalState import (
     geometrical_feature_kind,
     geometrical_feature_state,
@@ -146,7 +147,7 @@ def create_geometrical_feature(
         raise NativeAnalyzeError(
             "The FEM geometrical-feature factory returned the wrong object type."
         )
-    feature.Label = prepared.label
+    prepared = assign_prepared_label(feature, prepared)
     apply_geometrical_values(feature, prepared.values)
     feature.References = reference_value((prepared.face,))
     prepared.analysis.analysis.addObject(feature)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometricalEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometricalEdit.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometricalCreate import feature_label
 from VibeCADNativeAnalyzeGeometricalState import geometrical_feature_state
 from VibeCADNativeAnalyzeGeometricalValues import (
@@ -233,7 +234,7 @@ def update_geometrical_feature(
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     feature = prepared.target.feature
-    feature.Label = prepared.label
+    prepared = assign_prepared_label(feature, prepared)
     if prepared.values_changed:
         apply_geometrical_values(feature, prepared.values)
     feature.References = reference_value((prepared.face,))

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometryCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometryCreate.py
@@ -20,6 +20,7 @@ from VibeCADNativeAnalyzeElementValues import (
     prepare_shell_thickness,
 )
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -159,7 +160,7 @@ def create_element_definition(
         raise NativeAnalyzeError(
             "The FEM element-definition factory returned the wrong object type."
         )
-    element.Label = prepared.label
+    prepared = assign_prepared_label(element, prepared)
     apply_element_values(element, prepared.values)
     element.References = reference_value(prepared.references)
     prepared.analysis.analysis.addObject(element)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometryEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeGeometryEdit.py
@@ -13,6 +13,7 @@ from VibeCADNativeAnalyzeElementValues import (
     apply_element_values,
 )
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometryCreate import (
     _REFERENCE_KINDS,
     element_label,
@@ -207,7 +208,7 @@ def update_element_definition(
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     element = prepared.target.element
-    element.Label = prepared.label
+    prepared = assign_prepared_label(element, prepared)
     element.References = list(prepared.references)
     if prepared.values is not None:
         apply_element_values(element, prepared.values)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeInspect.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeInspect.py
@@ -23,6 +23,7 @@ from VibeCADNativeAnalyzeEquationState import prepare_equation_target, equation_
 from VibeCADNativeAnalyzeResultState import prepare_result_target, result_state
 from VibeCADNativeAnalyzeResults import result_purge_state
 from VibeCADNativeAnalyzeStudyState import study_state
+from VibeCADNativeAnalyzeOwnership import studies_in_document
 from VibeCADNativeAnalyzeMeshOutputState import (
     inspect_fem_mesh_elements as _inspect_fem_mesh_elements,
 )
@@ -52,6 +53,47 @@ def inspect_analysis(
     return {
         "analysis": analysis_state(prepared.analysis),
         "result_graph": result_purge_state(prepared.analysis),
+    }
+
+
+def list_studies(
+    document: Any,
+    *,
+    offset: Any = 0,
+    page_size: Any = 64,
+) -> dict[str, Any]:
+    """Return one bounded document-order page with exact study targets."""
+
+    if type(offset) is not int or offset < 0:
+        raise NativeAnalyzeError("offset must be a non-negative integer.")
+    if type(page_size) is not int or not 1 <= page_size <= 64:
+        raise NativeAnalyzeError("page_size must be an integer from 1 to 64.")
+    studies = studies_in_document(document)
+    selected = studies[offset : offset + page_size]
+    values = []
+    for study in selected:
+        state = analysis_state(study)
+        values.append(
+            {
+                "analysis_name": state["object_name"],
+                "label": state.get("label", state["object_name"]),
+                "intent": state["study"],
+                "dependencies": state["dependencies"],
+                "member_count": state["member_count"],
+                "analysis_target": {
+                    "object_name": state["object_name"],
+                    "expected_state_sha256": state["state_sha256"],
+                    "expected_member_count": state["member_count"],
+                },
+            }
+        )
+    next_offset = offset + len(values)
+    return {
+        "study_count": len(studies),
+        "offset": offset,
+        "returned_count": len(values),
+        "studies": values,
+        "next_offset": next_offset if next_offset < len(studies) else None,
     }
 
 

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeInspectRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeInspectRuntime.py
@@ -8,6 +8,7 @@ from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeInspect import (
     inspect_analysis,
+    list_studies,
     inspect_assignments,
     inspect_assignment_validation,
     inspect_study,
@@ -35,6 +36,7 @@ from VibeCADNativeRuntimeContext import NativeRuntimeContext
 
 
 _VARIANTS = {
+    "studies": frozenset({"offset", "page_size"}),
     "study": frozenset({"target"}),
     "analysis": frozenset({"target"}),
     "geometry_source": frozenset({"target", "offset", "page_size"}),
@@ -79,7 +81,10 @@ class NativeAnalyzeInspectRuntime:
                     "Material catalog arguments require query and category."
                 )
             values.setdefault("limit", 25)
-        elif isinstance(arguments, Mapping) and arguments.get("operation") == "fem_mesh_elements":
+        elif isinstance(arguments, Mapping) and arguments.get("operation") in {
+            "studies",
+            "fem_mesh_elements",
+        }:
             normalized = dict(arguments)
             normalized.setdefault("offset", 0)
             normalized.setdefault("page_size", 64)
@@ -88,7 +93,9 @@ class NativeAnalyzeInspectRuntime:
             operation, values = strict_variant_arguments(arguments, _VARIANTS)
         context = self._context
         context.guard()
-        if operation == "study":
+        if operation == "studies":
+            result = list_studies(context.document, **values)
+        elif operation == "study":
             result = inspect_study(
                 context.document,
                 context.document_uid,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeInspectSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeInspectSchema.py
@@ -50,6 +50,7 @@ _MATERIAL_CATALOG_PARAMETERS = {
 }
 
 _EXACT_TARGET_BY_OPERATION = {
+    "studies": "BoundedFemStudyCatalog",
     "study": "ExactFemStudyState",
     "analysis": "ExactFemAnalysisState",
     "assignments": "BoundedExactFemAssignmentPage",
@@ -107,6 +108,29 @@ def analyze_inspect_capability_definition() -> NativeCapabilityDefinition:
         ),
         primary_classification="read",
         variants=(
+            _variant(
+                "studies",
+                "List a bounded page of studies with exact targets.",
+                "VibeCAD_AnalyzeReadAnalysis",
+                {
+                    "type": "object",
+                    "properties": {
+                        "offset": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "default": 0,
+                        },
+                        "page_size": {
+                            "type": "integer",
+                            "minimum": 1,
+                            "maximum": 64,
+                            "default": 64,
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+                provider_supplemental=True,
+            ),
             _variant(
                 "study",
                 "Read intent, completeness, runtimes, and next requirements for one study.",

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeLabels.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeLabels.py
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Record the exact label assigned by the document host."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+
+
+def assign_prepared_label(obj: Any, prepared: Any) -> Any:
+    """Assign a requested label and return preparation with its exact result."""
+
+    obj.Label = str(prepared.label)
+    assigned = str(obj.Label or "").strip()
+    if not assigned:
+        raise NativeAnalyzeError("The document did not assign a usable object label.")
+    return replace(prepared, label=assigned)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeLoadCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeLoadCreate.py
@@ -17,6 +17,7 @@ from VibeCADNativeAnalyzeHistory import (
     require_boundary,
     verify_operation_block,
 )
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeLoadState import load_kind, load_state
 from VibeCADNativeAnalyzeLoadValues import (
     PreparedLoadValues,
@@ -446,7 +447,7 @@ def create_load(document: Any, prepared: PreparedLoadCreate) -> NativeMutationDr
     load = _factory(document, prepared.kind)
     if load is None or load_kind(load) != prepared.kind:
         raise NativeAnalyzeError("The FEM load factory returned the wrong object type.")
-    load.Label = prepared.label
+    prepared = assign_prepared_label(load, prepared)
     apply_load_values(load, prepared.values)
     load.References = reference_value(prepared.references)
     if prepared.kind == "force":

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeLoadEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeLoadEdit.py
@@ -9,6 +9,7 @@ import math
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometryCreate import references_match
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
@@ -350,7 +351,7 @@ def update_load(document: Any, prepared: PreparedLoadUpdate) -> NativeMutationDr
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     load = prepared.target.load
-    load.Label = prepared.label
+    prepared = assign_prepared_label(load, prepared)
     if prepared.values_changed:
         apply_load_values(load, prepared.values)
     load.References = reference_value(prepared.references)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMaterialCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMaterialCreate.py
@@ -19,6 +19,7 @@ from VibeCADNativeAnalyzeHistory import (
     verify_operation_block,
     verify_new_operation_resource,
 )
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeMaterials import material_map
 from VibeCADNativeAnalyzeState import (
     analysis_state,
@@ -187,7 +188,7 @@ def create_material(
     material = _factory(document, prepared.kind)
     if material is None or material_kind(material) != prepared.kind:
         raise NativeAnalyzeError("The FEM material factory returned the wrong object type.")
-    material.Label = prepared.label
+    prepared = assign_prepared_label(material, prepared)
     material.Material = _map(prepared.material)
     material.UUID = prepared.material_uuid
     material.References = reference_value(prepared.references)
@@ -392,7 +393,7 @@ def create_nonlinear_material(
     if nonlinear is None or material_kind(nonlinear) != "nonlinear":
         raise NativeAnalyzeError("The nonlinear-material factory returned the wrong type.")
     try:
-        nonlinear.Label = prepared.label
+        prepared = assign_prepared_label(nonlinear, prepared)
         nonlinear.MaterialModelNonlinearity = prepared.model
         nonlinear.YieldPoints = native_yield_points(prepared.yield_points)
     except Exception as exc:

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMaterialEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMaterialEdit.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -314,7 +315,7 @@ def update_material(
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     material = prepared.target.material
-    material.Label = prepared.label
+    prepared = assign_prepared_label(material, prepared)
     if prepared.target.kind != "nonlinear":
         material.Material = dict(prepared.material)
         material.UUID = prepared.material_uuid
@@ -363,4 +364,3 @@ def verify_material_update(
     ):
         raise NativeAnalyzeError("Material reference geometry changed before commit.")
     return {"updated_material": material_state(material)}
-

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshCreate.py
@@ -15,6 +15,7 @@ from VibeCADNativeAnalyzeHistory import (
     require_boundary,
     verify_operation_block,
 )
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeMeshState import (
     fem_mesh_definition_state,
     fem_mesher_kind,
@@ -133,18 +134,6 @@ def mesh_source_still_exact(source: PreparedMeshSource) -> bool:
         return False
 
 
-def _analysis_has_mesh(analysis: Any, *, excluding: Any = None) -> bool:
-    for member in tuple(analysis.Group or ()):
-        if member is excluding:
-            continue
-        try:
-            fem_mesher_kind(member)
-            return True
-        except NativeAnalyzeError:
-            continue
-    return False
-
-
 def prepare_mesh_definition_create(
     document: Any,
     document_uid: str,
@@ -156,11 +145,6 @@ def prepare_mesh_definition_create(
     settings: Any,
 ) -> PreparedMeshDefinitionCreate:
     target = prepare_analysis_target(document, document_uid, analysis)
-    if _analysis_has_mesh(target.analysis):
-        raise NativeAnalyzeError(
-            "This FEM analysis already contains a mesh definition; update or generate it "
-            "instead of creating an ambiguous second solver mesh."
-        )
     return PreparedMeshDefinitionCreate(
         creation_boundary(document),
         target,
@@ -205,12 +189,10 @@ def create_mesh_definition(
             "The FEM mesh source changed after preflight.",
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
-    if _analysis_has_mesh(prepared.analysis.analysis):
-        raise NativeAnalyzeError("The FEM analysis acquired another mesh after preflight.")
     mesh = _factory(document, prepared.kind)
     if mesh is None or fem_mesher_kind(mesh) != prepared.kind:
         raise NativeAnalyzeError("The FEM mesher factory returned the wrong object type.")
-    mesh.Label = prepared.label
+    prepared = assign_prepared_label(mesh, prepared)
     mesh.Shape = prepared.source.source
     apply_mesher_values(mesh, prepared.values)
     prepared.analysis.analysis.addObject(mesh)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshEdit.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -171,7 +172,7 @@ def update_mesh_definition(
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     mesh = prepared.target.mesh
-    mesh.Label = prepared.label
+    prepared = assign_prepared_label(mesh, prepared)
     mesh.Shape = prepared.source.source
     apply_mesher_values(mesh, prepared.values)
     if prepared.invalidates_mesh:

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshFieldCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshFieldCreate.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -281,7 +282,7 @@ def create_mesh_field(document: Any, prepared: PreparedMeshFieldCreate) -> Nativ
             f"The refinement-field factory failed: {exc}",
             error_code="NATIVE_ANALYZE_FACTORY_FAILED",
         ) from exc
-    field.Label = prepared.label
+    prepared = assign_prepared_label(field, prepared)
     if prepared.values.family == "manipulate":
         field.Refinement = prepared.dependencies.objects[0]
     else:

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshFieldEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshFieldEdit.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -305,7 +306,7 @@ def update_mesh_field(document: Any, prepared: PreparedMeshFieldUpdate) -> Nativ
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     field = prepared.target.refinement
-    field.Label = prepared.label
+    prepared = assign_prepared_label(field, prepared)
     if prepared.values.family == "manipulate":
         field.Refinement = prepared.dependencies.objects[0]
     else:

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshGenerationState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshGenerationState.py
@@ -10,6 +10,7 @@ from typing import Any
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
 from VibeCADNativeAnalyzeMeshRefinementState import mesh_refinement_state
 from VibeCADNativeAnalyzeMeshState import fem_mesh_definition_state
+from VibeCADNativeAnalyzeOwnership import owning_study, study_history_operations
 from VibeCADNativeAnalyzeTargets import (
     PreparedFemMeshDefinitionTarget,
     fem_mesh_definition_target_still_exact,
@@ -127,8 +128,7 @@ def prepare_mesh_generation_target(
         expected_kind=backend,
     )
     mesh = target.mesh
-    timeline = getattr(document, "VibeCADTimeline", None)
-    operations = tuple(getattr(timeline, "Operations", ()) or ())
+    operations = study_history_operations(owning_study(document, mesh))
     if (
         mesh not in operations
         or str(getattr(mesh, "VibeCADTimelineRole", "") or "") != "operation"
@@ -181,8 +181,8 @@ def mesh_generation_resources_still_exact(
     prepared: PreparedMeshGenerationTarget,
 ) -> bool:
     try:
-        timeline = getattr(prepared.mesh.Document, "VibeCADTimeline", None)
-        if tuple(getattr(timeline, "Operations", ()) or ()) != prepared.history_operations:
+        study = owning_study(prepared.mesh.Document, prepared.mesh)
+        if study_history_operations(study) != prepared.history_operations:
             return False
         if _resource_inventory(prepared.mesh) != tuple(
             item.resource for item in prepared.resources

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshOutputCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshOutputCreate.py
@@ -9,6 +9,7 @@ from bisect import bisect_left, bisect_right
 from typing import Any
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -211,7 +212,7 @@ def create_erased_elements(
     )
     if operation is None or result_mesh is None:
         raise NativeAnalyzeError("The FEM element-filter objects could not be created.")
-    operation.Label = prepared.label
+    prepared = assign_prepared_label(operation, prepared)
     result_mesh.Label = f"{source.Label} (filtered)"
     result_mesh.FemMesh = filtered
     operation.FemMesh = result_mesh
@@ -397,7 +398,7 @@ def create_fem_surface_conversion(
     result = document.addObject("Mesh::Feature", document.getUniqueObjectName("Mesh"))
     if result is None:
         raise NativeAnalyzeError("The converted Mesh feature could not be created.")
-    result.Label = prepared.label
+    prepared = assign_prepared_label(result, prepared)
     result.Mesh = converted_mesh
     _add_conversion_provenance(result, prepared)
     replaced = (prepared.target.mesh,) if prepared.target.source_visible else ()

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshRefinementCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshRefinementCreate.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -223,7 +224,7 @@ def create_mesh_refinement(
             f"The FEM mesh-refinement factory failed: {exc}",
             error_code="NATIVE_ANALYZE_FACTORY_FAILED",
         ) from exc
-    refinement.Label = prepared.label
+    prepared = assign_prepared_label(refinement, prepared)
     if prepared.references:
         refinement.References = reference_value(prepared.references)
     apply_refinement_values(refinement, prepared.values)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshRefinementEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshRefinementEdit.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -185,7 +186,7 @@ def update_mesh_refinement(
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     refinement = prepared.target.refinement
-    refinement.Label = prepared.label
+    prepared = assign_prepared_label(refinement, prepared)
     if prepared.target.mode != "shape":
         refinement.References = reference_value(prepared.references)
     apply_refinement_values(refinement, prepared.values)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshRuntime.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeOwnership import owning_study, study_resource_scope
 from VibeCADNativeAnalyzeGmshGeneration import (
     commit_gmsh_generation,
     discard_gmsh_generation_request,
@@ -169,6 +170,9 @@ class NativeAnalyzeMeshRuntime:
             committer = commit_netgen_generation
             verifier = verify_netgen_generation
             discard = discard_netgen_generation_request
+        scope = study_resource_scope(
+            owning_study(context.document, request.target.mesh)
+        )
 
         def prepare(cancelled: Any, progress: Any) -> Any:
             return runner(request, cancelled=cancelled, progress=progress)
@@ -197,6 +201,7 @@ class NativeAnalyzeMeshRuntime:
                 finalize_message="Importing verified FEM mesh",
                 cleanup=cleanup,
                 changes_document=True,
+                resource_scope=scope,
             )
         except NativeBackgroundError as exc:
             discard(request)
@@ -211,6 +216,7 @@ class NativeAnalyzeMeshRuntime:
             "job": {
                 "job_id": str(snapshot.job_id),
                 "capability": str(snapshot.capability_name),
+                "resource_scope": str(snapshot.resource_scope),
                 "phase": str(snapshot.phase),
                 "progress_percent": int(snapshot.progress_percent),
                 "progress_message": str(snapshot.progress_message),

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeMeshState.py
@@ -65,7 +65,10 @@ def _source(obj: Any) -> tuple[dict[str, Any], dict[str, Any]]:
         "shape_type": str(source.Shape.ShapeType),
         "topology": dict(source_state.get("topology") or {}),
     }
-    return visible, {**visible, "object_id": int(source.ID)}
+    return visible, {
+        **visible,
+        "object_id": int(source.ID),
+    }
 
 
 def _stable_property(value: Any) -> Any:

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeModelBindings.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeModelBindings.py
@@ -7,7 +7,12 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeModelRuntime import NativeAnalyzeModelRuntime
-from VibeCADNativeAnalyzeModelSchema import ANALYZE_MODEL_CAPABILITY_NAME
+from VibeCADNativeAnalyzeCurrentTargets import current_analysis_target
+from VibeCADNativeAnalyzeModelSchema import (
+    ANALYZE_CONFIGURE_STUDY,
+    ANALYZE_CREATE_STUDY,
+    ANALYZE_MODEL_CAPABILITY_NAME,
+)
 from VibeCADNativeCapabilityRegistry import (
     NativeCapabilityImplementation,
     NativeCapabilityRegistry,
@@ -24,6 +29,51 @@ def _execute(call: Any) -> Mapping[str, Any]:
     return runtime.execute(arguments, ticket=getattr(call, "ticket", None))
 
 
+def _focused_arguments(call: Any, operation: str) -> tuple[NativeAnalyzeModelRuntime, dict]:
+    runtime = getattr(call, "runtime", None)
+    arguments = getattr(call, "arguments", None)
+    if not isinstance(runtime, NativeAnalyzeModelRuntime):
+        raise TypeError("A focused study call requires its exact runtime.")
+    if not isinstance(arguments, Mapping):
+        raise TypeError("A focused study call requires argument data.")
+    values = dict(arguments)
+    if values.pop("operation", None) != operation:
+        raise ValueError(f"A focused study call requires the {operation} operation.")
+    return runtime, values
+
+
+def _create_study(call: Any) -> Mapping[str, Any]:
+    runtime, values = _focused_arguments(call, "create")
+    return runtime.execute(
+        {
+            "operation": "create_analysis",
+            "label": values.pop("label"),
+            "default_solver_policy": "none",
+            "study": {
+                "physics": values.pop("physics"),
+                "regime": values.pop("regime"),
+            },
+        },
+        ticket=getattr(call, "ticket", None),
+    )
+
+
+def _configure_study(call: Any) -> Mapping[str, Any]:
+    runtime, values = _focused_arguments(call, "configure")
+    target = current_analysis_target(runtime, values.pop("analysis_name"))
+    return runtime.execute(
+        {
+            "operation": "update_study",
+            "target": target,
+            "study": {
+                "physics": values.pop("physics"),
+                "regime": values.pop("regime"),
+            },
+        },
+        ticket=getattr(call, "ticket", None),
+    )
+
+
 def register_analyze_model_capability_implementation(
     registry: NativeCapabilityRegistry,
 ) -> None:
@@ -32,10 +82,19 @@ def register_analyze_model_capability_implementation(
     registry.register_implementation(
         NativeCapabilityImplementation(ANALYZE_MODEL_CAPABILITY_NAME, _execute)
     )
+    registry.register_implementation(
+        NativeCapabilityImplementation(ANALYZE_CREATE_STUDY, _create_study)
+    )
+    registry.register_implementation(
+        NativeCapabilityImplementation(ANALYZE_CONFIGURE_STUDY, _configure_study)
+    )
 
 
 def analyze_model_runtime_bindings(runtime: NativeAnalyzeModelRuntime) -> dict[str, Any]:
     if not isinstance(runtime, NativeAnalyzeModelRuntime):
         raise TypeError("runtime must be a NativeAnalyzeModelRuntime")
-    return {ANALYZE_MODEL_CAPABILITY_NAME: runtime}
-
+    return {
+        ANALYZE_MODEL_CAPABILITY_NAME: runtime,
+        ANALYZE_CREATE_STUDY: runtime,
+        ANALYZE_CONFIGURE_STUDY: runtime,
+    }

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeModelRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeModelRuntime.py
@@ -30,6 +30,11 @@ from VibeCADNativeAnalyzeStudyEdit import (
     update_study_intent,
     verify_study_update,
 )
+from VibeCADNativeAnalyzeStudyDependencies import (
+    prepare_study_dependency_update,
+    update_study_dependencies,
+    verify_study_dependency_update,
+)
 from VibeCADNativeAnalyzeSolidDomain import (
     create_solid_domain,
     prepare_solid_domain,
@@ -69,6 +74,10 @@ _FIELDS = {
     "update_study": (
         frozenset({"target", "study"}),
         frozenset({"target", "study"}),
+    ),
+    "update_study_dependencies": (
+        frozenset({"target", "depends_on"}),
+        frozenset({"target", "depends_on"}),
     ),
     "create_solid_material": (
         frozenset({"analysis", "label", "references"}),
@@ -186,6 +195,19 @@ class NativeAnalyzeModelRuntime:
                 transaction_name="Edit FEM Study",
                 mutate=lambda document: update_study_intent(document, prepared),
                 verify=verify_study_update,
+            )
+        if operation == "update_study_dependencies":
+            prepared = prepare_study_dependency_update(
+                context.document,
+                context.document_uid,
+                **values,
+            )
+            return run_immediate_mutation(
+                context,
+                ticket=ticket,
+                transaction_name="Edit FEM Study Dependencies",
+                mutate=lambda document: update_study_dependencies(document, prepared),
+                verify=verify_study_dependency_update,
             )
         if operation in _KINDS:
             prepared = prepare_material_create(

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeModelSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeModelSchema.py
@@ -13,6 +13,8 @@ from VibeCADNativeAnalyzeStudy import STUDY_INTENT_SCHEMA
 
 
 ANALYZE_MODEL_CAPABILITY_NAME = "analyze.model"
+ANALYZE_CREATE_STUDY = "analyze.create_study"
+ANALYZE_CONFIGURE_STUDY = "analyze.configure_study"
 _OBJECT_NAME = {
     "type": "string",
     "minLength": 1,
@@ -228,6 +230,26 @@ def analyze_model_capability_definition() -> NativeCapabilityDefinition:
                 provider_supplemental=True,
             ),
             _variant(
+                "update_study_dependencies",
+                "Set prerequisite studies for one analysis.",
+                "VibeCAD_AnalyzeConfigureStudy",
+                {
+                    "type": "object",
+                    "properties": {
+                        "target": _ANALYSIS_TARGET,
+                        "depends_on": {
+                            "type": "array",
+                            "items": _ANALYSIS_TARGET,
+                            "maxItems": 64,
+                            "uniqueItems": True,
+                        },
+                    },
+                    "required": ["target", "depends_on"],
+                    "additionalProperties": False,
+                },
+                provider_supplemental=True,
+            ),
+            _variant(
                 "create_solid_material",
                 "Create a solid material.",
                 "FEM_MaterialSolid",
@@ -303,7 +325,70 @@ def analyze_model_capability_definition() -> NativeCapabilityDefinition:
     )
 
 
+def _focused_study_definition(
+    name: str,
+    description: str,
+    operation: str,
+    action_id: str,
+    properties: dict,
+    required: list[str],
+) -> NativeCapabilityDefinition:
+    return NativeCapabilityDefinition(
+        name=name,
+        description=description,
+        primary_classification="mutation",
+        variants=(
+            NativeCapabilityVariant(
+                operation=operation,
+                description=description,
+                action_ids=frozenset({action_id}),
+                surface_ids=frozenset({"analyze"}),
+                exact_target_type="CurrentNamedFemStudy",
+                transaction_behavior="document",
+                background_required=False,
+                parameters={
+                    "type": "object",
+                    "properties": properties,
+                    "required": required,
+                    "additionalProperties": False,
+                },
+                provider_supplemental=True,
+            ),
+        ),
+    )
+
+
+def analyze_study_lifecycle_capability_definitions(
+) -> tuple[NativeCapabilityDefinition, ...]:
+    physics = dict(STUDY_INTENT_SCHEMA["properties"]["physics"])
+    regime = dict(STUDY_INTENT_SCHEMA["properties"]["regime"])
+    return (
+        _focused_study_definition(
+            ANALYZE_CREATE_STUDY,
+            "Create a FEM study.",
+            "create",
+            "VibeCAD_AnalyzeCreateStudyFocused",
+            {"label": _LABEL, "physics": physics, "regime": regime},
+            ["label", "physics", "regime"],
+        ),
+        _focused_study_definition(
+            ANALYZE_CONFIGURE_STUDY,
+            "Set a study's physics and regime.",
+            "configure",
+            "VibeCAD_AnalyzeConfigureStudyFocused",
+            {
+                "analysis_name": _OBJECT_NAME,
+                "physics": physics,
+                "regime": regime,
+            },
+            ["analysis_name", "physics", "regime"],
+        ),
+    )
+
+
 def register_analyze_model_capability_definition(registry: NativeCapabilityRegistry) -> None:
     if not isinstance(registry, NativeCapabilityRegistry):
         raise TypeError("registry must be a NativeCapabilityRegistry")
     registry.register_definition(analyze_model_capability_definition())
+    for definition in analyze_study_lifecycle_capability_definitions():
+        registry.register_definition(definition)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeOwnership.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeOwnership.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Exact FEM study ownership shared by foreground and background operations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+
+
+def is_study(value: Any, document: Any) -> bool:
+    if value is None or getattr(value, "Document", None) is not document:
+        return False
+    try:
+        return bool(value.isDerivedFrom("Fem::FemAnalysis"))
+    except (AttributeError, ReferenceError, RuntimeError):
+        return False
+
+
+def studies_in_document(document: Any) -> tuple[Any, ...]:
+    """Return every live FEM study in document order."""
+
+    return tuple(
+        value
+        for value in tuple(getattr(document, "Objects", ()) or ())
+        if is_study(value, document)
+    )
+
+
+def owning_studies(document: Any, resource: Any) -> tuple[Any, ...]:
+    """Return exact studies whose group directly owns *resource*."""
+
+    if getattr(resource, "Document", None) is not document:
+        return ()
+    return tuple(
+        study
+        for study in studies_in_document(document)
+        if resource in tuple(getattr(study, "Group", ()) or ())
+    )
+
+
+def owning_study(document: Any, resource: Any) -> Any:
+    """Require exactly one owning study for a mutable FEM resource."""
+
+    owners = owning_studies(document, resource)
+    if len(owners) != 1:
+        raise NativeAnalyzeError(
+            "The FEM resource must belong to exactly one study.",
+            error_code="NATIVE_ANALYZE_STUDY_OWNERSHIP_INVALID",
+        )
+    return owners[0]
+
+
+def study_resource_scope(study: Any) -> str:
+    """Return the stable background-job lock shared by one study's resources."""
+
+    document = getattr(study, "Document", None)
+    if not is_study(study, document):
+        raise NativeAnalyzeError(
+            "The FEM study is no longer live.",
+            error_code="NATIVE_ANALYZE_STUDY_OWNERSHIP_INVALID",
+        )
+    return f"analyze:{study.Name}"
+
+
+def study_history_operations(study: Any) -> tuple[Any, ...]:
+    """Return the exact History subsequence owned by one FEM study."""
+
+    document = getattr(study, "Document", None)
+    if not is_study(study, document):
+        raise NativeAnalyzeError(
+            "The FEM study is no longer live.",
+            error_code="NATIVE_ANALYZE_STUDY_OWNERSHIP_INVALID",
+        )
+    timeline = getattr(document, "VibeCADTimeline", None)
+    operations = tuple(getattr(timeline, "Operations", ()) or ())
+    study_member_ids = {
+        id(member) for member in tuple(getattr(study, "Group", ()) or ())
+    }
+
+    def belongs_to_study(operation: Any) -> bool:
+        current = operation
+        visited: set[int] = set()
+        while current is not None:
+            if id(current) in study_member_ids:
+                return True
+            identity = id(current)
+            if identity in visited:
+                raise NativeAnalyzeError(
+                    "A FEM History ownership graph contains a cycle.",
+                    error_code="NATIVE_ANALYZE_DEPENDENCY_CYCLE",
+                )
+            visited.add(identity)
+            current = getattr(current, "VibeCADTimelineOwner", None)
+        return False
+
+    return tuple(operation for operation in operations if belongs_to_study(operation))

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzePost.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzePost.py
@@ -9,6 +9,7 @@ import math
 from typing import Any
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -264,7 +265,7 @@ def create_post_pipeline(
             "Fem::FemPostPipeline",
             document.getUniqueObjectName("ResultPipeline"),
         )
-        pipeline.Label = prepared.label
+        prepared = assign_prepared_label(pipeline, prepared)
         analysis.addObject(pipeline)
         pipeline.load(result)
         pipeline.ViewObject.DisplayMode = "Surface"
@@ -418,7 +419,7 @@ def create_post_branch(
             "Fem::FemPostBranchFilter",
             document.getUniqueObjectName("Branch"),
         )
-        branch.Label = prepared.label
+        prepared = assign_prepared_label(branch, prepared)
         parent_group.addObject(branch)
         branch.Mode = prepared.mode.title()
         branch.Output = prepared.output.title()
@@ -587,7 +588,7 @@ def create_post_warp(
             "Fem::FemPostWarpVectorFilter",
             document.getUniqueObjectName("WarpVector"),
         )
-        warp.Label = prepared.label
+        prepared = assign_prepared_label(warp, prepared)
         parent_group.addObject(warp)
         warp.ViewObject.DisplayMode = "Surface"
         warp.ViewObject.SelectionStyle = "BoundBox"

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzePostCalculator.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzePostCalculator.py
@@ -10,6 +10,7 @@ import re
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -522,7 +523,7 @@ def create_post_calculator(
             "Fem::FemPostCalculatorFilter",
             document.getUniqueObjectName("Calculator"),
         )
-        calculator.Label = prepared.label
+        prepared = assign_prepared_label(calculator, prepared)
         prepared.parent_group.addObject(calculator)
         calculator.FieldName = prepared.result_field
         calculator.Function = prepared.expression

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzePostFilters.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzePostFilters.py
@@ -9,6 +9,7 @@ import math
 from typing import Any
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -220,7 +221,7 @@ def create_post_scalar_clip(
             "Fem::FemPostScalarClipFilter",
             document.getUniqueObjectName("ScalarClip"),
         )
-        clip.Label = prepared.label
+        prepared = assign_prepared_label(clip, prepared)
         parent_group.addObject(clip)
         clip.ViewObject.DisplayMode = "Surface"
         clip.ViewObject.SelectionStyle = "BoundBox"
@@ -441,7 +442,7 @@ def create_post_implicit_filter(
             type_id,
             document.getUniqueObjectName(name),
         )
-        post_filter.Label = prepared.label
+        prepared = assign_prepared_label(post_filter, prepared)
         parent_group.addObject(post_filter)
         post_filter.Function = function
         if prepared.kind == "region_clip":
@@ -684,7 +685,7 @@ def create_post_contours(
             "Fem::FemPostContoursFilter",
             document.getUniqueObjectName("Contours"),
         )
-        contours.Label = prepared.label
+        prepared = assign_prepared_label(contours, prepared)
         parent_group.addObject(contours)
         contours.ViewObject.DisplayMode = "Surface"
         contours.ViewObject.SelectionStyle = "BoundBox"

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzePostFunctions.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzePostFunctions.py
@@ -9,6 +9,7 @@ import math
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -258,7 +259,7 @@ def create_post_function(
             _FUNCTION_TYPES[prepared.kind],
             document.getUniqueObjectName(prepared.kind.title()),
         )
-        function.Label = prepared.label
+        prepared = assign_prepared_label(function, prepared)
         provider.addObject(function)
         for property_name, value in prepared.parameters:
             setattr(function, property_name, value)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzePostGlyph.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzePostGlyph.py
@@ -9,6 +9,7 @@ import math
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -343,7 +344,7 @@ def create_post_glyph(
             prepared.parent_group,
             document.getUniqueObjectName("Glyph"),
         )
-        glyph_filter.Label = prepared.label
+        prepared = assign_prepared_label(glyph_filter, prepared)
         glyph_filter.ViewObject.DisplayMode = "Surface"
         glyph_filter.ViewObject.SelectionStyle = "BoundBox"
         _copy_none_field_color(source, glyph_filter)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzePostSampling.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzePostSampling.py
@@ -9,6 +9,7 @@ import math
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -323,7 +324,7 @@ def create_post_line_sample(
             "Fem::FemPostDataAlongLineFilter",
             document.getUniqueObjectName("DataAlongLine"),
         )
-        sample.Label = prepared.label
+        prepared = assign_prepared_label(sample, prepared)
         prepared.parent_group.addObject(sample)
         sample.Point1 = prepared.start_mm
         sample.Point2 = prepared.end_mm
@@ -370,7 +371,7 @@ def create_post_point_sample(
             "Fem::FemPostDataAtPointFilter",
             document.getUniqueObjectName("DataAtPoint"),
         )
-        sample.Label = prepared.label
+        prepared = assign_prepared_label(sample, prepared)
         prepared.parent_group.addObject(sample)
         sample.Center = prepared.point_mm
         sample.ViewObject.DisplayMode = "Surface"

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeProviderScope.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeProviderScope.py
@@ -28,6 +28,10 @@ from VibeCADNativeAnalyzeLocalMeshSchema import (
     ANALYZE_LOCAL_MESH_SIZE,
 )
 from VibeCADNativeAnalyzeRunSchema import ANALYZE_RUN_SOLVER
+from VibeCADNativeAnalyzeModelSchema import (
+    ANALYZE_CONFIGURE_STUDY,
+    ANALYZE_CREATE_STUDY,
+)
 from VibeCADNativeAnalyzeSolidDomainSchema import ANALYZE_SOLID_DOMAIN
 from VibeCADNativeAnalyzeFlowResultSchema import (
     ANALYZE_COMPARE_FLOW,
@@ -86,7 +90,9 @@ _SHARED = frozenset(
         "view.control",
     }
 )
-_SETUP = frozenset({"analyze.model", ANALYZE_MATERIAL_CATALOG})
+_SETUP = frozenset(
+    {"analyze.model", ANALYZE_CREATE_STUDY, ANALYZE_MATERIAL_CATALOG}
+)
 _STUDY = frozenset(
     {
         "analyze.mesh",
@@ -164,6 +170,21 @@ _LIVE_KIND_SOURCES = {
         "thermal_conditions_truncated",
     ),
 }
+_FOCUSED_KIND_FIELDS = {
+    "materials": "material_kinds",
+    "element_definitions": "element_definition_kinds",
+    "electromagnetic_constraints": "electromagnetic_constraint_kinds",
+    "fluid_constraints": "fluid_constraint_kinds",
+    "geometrical_features": "geometrical_feature_kinds",
+    "support_conditions": "support_condition_kinds",
+    "connections": "connection_kinds",
+    "loads": "load_kinds",
+    "thermal_conditions": "thermal_condition_families",
+    "mesh_definitions": "mesh_kinds",
+    "mesh_refinements": "mesh_refinement_kinds",
+    "solvers": "solver_kinds",
+    "equations": "equation_kinds",
+}
 _PHYSICS = {
     "mechanical": frozenset(
         {
@@ -232,6 +253,16 @@ _MESH_SETUP = frozenset(
     }
 )
 _SOLVER_SETUP = frozenset({"analyze.solver_control"})
+_SOLVER_ONLY_BLOCKERS = frozenset(
+    {
+        "missing_solver",
+        "calculix_requires_thermomech",
+        "calculix_requires_pure_heat_transfer",
+        "calculix_requires_thermomechanical_mode",
+        "calculix_requires_steady_thermal",
+        "calculix_requires_transient_thermal",
+    }
+)
 def _nonnegative_int(value: Any) -> int | None:
     if isinstance(value, bool):
         return None
@@ -400,6 +431,18 @@ def _published_scope(
 def _engineering_readiness(
     domain: Mapping[str, Any],
 ) -> tuple[Mapping[str, Any], ...] | None:
+    focused = _focused_workflow(domain)
+    if focused is not None:
+        value = focused.get("engineering_readiness")
+        blockers = value.get("blockers") if isinstance(value, Mapping) else None
+        if (
+            isinstance(value, Mapping)
+            and type(value.get("ready_to_solve")) is bool
+            and isinstance(blockers, list)
+            and all(isinstance(blocker, str) for blocker in blockers)
+        ):
+            return (value,)
+        return None
     analysis_count = _nonnegative_int(domain.get("analysis_count"))
     workflows = domain.get("analysis_workflows")
     if (
@@ -433,8 +476,12 @@ def _solver_creation_ready(domain: Mapping[str, Any]) -> bool | None:
     if readiness is None:
         return None
     return any(
-        "missing_solver" in value["blockers"]
-        and set(value["blockers"]) == {"missing_solver"}
+        not [
+            blocker
+            for blocker in value["blockers"]
+            if blocker not in _SOLVER_ONLY_BLOCKERS
+            and not blocker.startswith("solver_runtime_unavailable:")
+        ]
         for value in readiness
     )
 
@@ -478,6 +525,24 @@ def _fully_conformal_shared_domain(domain: Mapping[str, Any]) -> bool:
     )
 
 
+def _focused_workflow(domain: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    workflows = [
+        value
+        for value in list(domain.get("analysis_workflows") or ())
+        if isinstance(value, Mapping)
+    ]
+    focused = [
+        value
+        for value in workflows
+        if isinstance(value.get("analysis"), Mapping)
+        and value["analysis"].get("focused") is True
+    ]
+    if len(focused) == 1:
+        return focused[0]
+    analysis_count = _nonnegative_int(domain.get("analysis_count"))
+    return workflows[0] if analysis_count == 1 and len(workflows) == 1 else None
+
+
 def analyze_provider_tool_names(
     domain: Mapping[str, Any],
     available_tool_names: Sequence[str],
@@ -499,6 +564,8 @@ def analyze_provider_tool_names(
     analysis_count = _nonnegative_int(domain.get("analysis_count"))
     if analysis_count is None:
         return tuple(name for name in available_tool_names if name in allowed)
+    if analysis_count > 0:
+        allowed.add(ANALYZE_CONFIGURE_STUDY)
 
     published = _published_scope(domain, analysis_count)
     if published is not None:
@@ -551,6 +618,30 @@ def analyze_provider_tool_names(
             solver_count += int(counts[2])
             result_count += int(counts[3])
 
+    focused_workflow = _focused_workflow(domain)
+    ambiguous_studies = analysis_count > 1 and focused_workflow is None
+    if focused_workflow is not None:
+        focused_study = focused_workflow.get("study")
+        focused_inventory = focused_workflow.get("study_inventory")
+        if isinstance(focused_study, Mapping) and isinstance(
+            focused_inventory, Mapping
+        ):
+            values = focused_study.get("physics")
+            if focused_study.get("declared") is True and isinstance(values, list):
+                physics = {str(value) for value in values if value in _PHYSICS}
+            mesh_count = _nonnegative_int(
+                focused_inventory.get("mesh_definition_count")
+            ) or 0
+            generated_mesh_count = _nonnegative_int(
+                focused_inventory.get("generated_mesh_count")
+            ) or 0
+            solver_count = _nonnegative_int(
+                focused_inventory.get("solver_count")
+            ) or 0
+            result_count = _nonnegative_int(
+                focused_inventory.get("result_count")
+            ) or 0
+
     if physics:
         allowed.update(_STUDY)
         for name in physics:
@@ -560,36 +651,37 @@ def analyze_provider_tool_names(
         if physics == {"fluid"}:
             allowed.discard("analyze.inspect")
             allowed.discard("analyze.mesh")
-            fluid_kinds, fluid_constraints_truncated = _collection_kinds(
+            fluid_kinds, fluid_constraints_truncated = _scoped_collection_kinds(
                 domain,
                 "fluid_constraints",
                 "constraint_kind",
                 "fluid_constraints_truncated",
             )
-            if "initial_flow_velocity" in fluid_kinds:
+            if "initial_flow_velocity" in fluid_kinds and not ambiguous_studies:
                 allowed.discard(ANALYZE_INITIAL_VELOCITY)
-            if "initial_pressure" in fluid_kinds:
+            if "initial_pressure" in fluid_kinds and not ambiguous_studies:
                 allowed.discard(ANALYZE_INITIAL_PRESSURE)
             if (
                 "fluid_boundary" not in fluid_kinds
                 and not fluid_constraints_truncated
+                and not ambiguous_studies
             ):
                 allowed.discard(ANALYZE_EDIT_FLUID_BOUNDARY)
-            solver_kinds, _solvers_truncated = _collection_kinds(
+            solver_kinds, _solvers_truncated = _scoped_collection_kinds(
                 domain,
                 "solvers",
                 "solver_kind",
                 "solvers_truncated",
             )
-            if "openfoam" in solver_kinds:
+            if "openfoam" in solver_kinds and not ambiguous_studies:
                 allowed.discard(ANALYZE_OPENFOAM_SOLVER)
-        load_kinds, loads_truncated = _collection_kinds(
+        load_kinds, loads_truncated = _scoped_collection_kinds(
             domain,
             "loads",
             "load_kind",
             "loads_truncated",
         )
-        if not loads_truncated:
+        if not loads_truncated and not ambiguous_studies:
             for kind, edit_tool in (
                 ("force", ANALYZE_EDIT_FORCE),
                 ("pressure", ANALYZE_EDIT_PRESSURE),
@@ -600,13 +692,13 @@ def analyze_provider_tool_names(
                     allowed.discard(edit_tool)
             if "gravity" in load_kinds:
                 allowed.discard(ANALYZE_GRAVITY)
-        support_kinds, supports_truncated = _collection_kinds(
+        support_kinds, supports_truncated = _scoped_collection_kinds(
             domain,
             "support_conditions",
             "condition_kind",
             "support_conditions_truncated",
         )
-        if not supports_truncated:
+        if not supports_truncated and not ambiguous_studies:
             for kind, edit_tool in (
                 ("fixed", ANALYZE_EDIT_FIXED_SUPPORT),
                 ("rigid_body", ANALYZE_EDIT_RIGID_COUPLING),
@@ -616,10 +708,10 @@ def analyze_provider_tool_names(
                 if kind not in support_kinds:
                     allowed.discard(edit_tool)
         material_required = _solid_material_required(domain, physics)
-        if material_required is False or (
+        if not ambiguous_studies and (material_required is False or (
             material_required is None
             and _solid_material_coverage_complete(domain, analysis_count)
-        ):
+        )):
             allowed.discard(ANALYZE_SOLID_MATERIAL)
             allowed.discard(ANALYZE_SOLID_REGION_MATERIAL)
             allowed.discard(ANALYZE_CATALOG_MATERIAL)
@@ -632,6 +724,7 @@ def analyze_provider_tool_names(
     )
     if (
         any(domain.get(name) is True for name in _ASSIGNMENT_TRUNCATION_NAMES)
+        or analysis_count > 1
         or generated_mesh_count > 0
         or (_nonnegative_int(domain.get("fem_mesh_output_count")) or 0) > 0
         or ("mechanical" in physics and result_count > 0)
@@ -640,10 +733,11 @@ def analyze_provider_tool_names(
     if assignment_count:
         allowed.add("analyze.assignment_view")
     if mesh_count:
-        allowed.discard(ANALYZE_SOLID_MESH)
-        allowed.discard(ANALYZE_FLOW_MESH)
+        if not ambiguous_studies:
+            allowed.discard(ANALYZE_SOLID_MESH)
+            allowed.discard(ANALYZE_FLOW_MESH)
         allowed.update(_MESH_SETUP)
-        refinement_kinds, refinements_truncated = _collection_kinds(
+        refinement_kinds, refinements_truncated = _scoped_collection_kinds(
             domain,
             "mesh_refinements",
             "refinement_mode",
@@ -651,7 +745,7 @@ def analyze_provider_tool_names(
         )
         if "region" not in refinement_kinds and not refinements_truncated:
             allowed.discard(ANALYZE_EDIT_LOCAL_MESH_SIZE)
-        mesh_kinds, mesh_kinds_truncated = _collection_kinds(
+        mesh_kinds, mesh_kinds_truncated = _scoped_collection_kinds(
             domain,
             "mesh_definitions",
             "mesher",
@@ -663,7 +757,7 @@ def analyze_provider_tool_names(
         allowed.add("analyze.mesh_output")
     if solver_count:
         allowed.update(_SOLVER_SETUP)
-        solver_kinds, solvers_truncated = _collection_kinds(
+        solver_kinds, solvers_truncated = _scoped_collection_kinds(
             domain,
             "solvers",
             "solver_kind",
@@ -694,13 +788,36 @@ def analyze_provider_tool_names(
         if "thermal" in physics:
             allowed.update({ANALYZE_TEMPERATURE_RESULTS, ANALYZE_SHOW_TEMPERATURE})
     run_status = domain.get("run_status")
-    if (
+    background_jobs = domain.get("background_jobs")
+    has_job = isinstance(background_jobs, list) and any(
+        isinstance(value, Mapping) and str(value.get("job_id") or "")
+        for value in background_jobs
+    )
+    if has_job or (
         isinstance(run_status, Mapping)
         and str(run_status.get("phase") or "idle") != "idle"
         and str(run_status.get("job_id") or "")
     ):
         allowed.add("native.job")
-        if run_status.get("terminal") is False:
+        active_scopes = {
+            str(value.get("resource_scope") or "")
+            for value in background_jobs
+            if isinstance(value, Mapping) and value.get("terminal") is False
+        } if isinstance(background_jobs, list) else set()
+        workflows = [
+            value
+            for value in list(domain.get("analysis_workflows") or ())
+            if isinstance(value, Mapping)
+        ]
+        focused_names = {
+            str(value.get("analysis", {}).get("object_name") or "")
+            for value in workflows
+            if isinstance(value.get("analysis"), Mapping)
+            and value["analysis"].get("focused") is True
+        }
+        focused_scopes = {f"analyze:{name}" for name in focused_names if name}
+        focused_busy = bool(focused_scopes.intersection(active_scopes))
+        if analysis_count <= 1 or focused_busy:
             allowed.discard(ANALYZE_GENERATE_GMSH)
             allowed.discard(ANALYZE_RUN_SOLVER)
 
@@ -727,7 +844,85 @@ def _collection_kinds(
     return kinds, domain.get(truncated_name) is True
 
 
+def _focused_inventory(domain: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    workflow = _focused_workflow(domain)
+    inventory = workflow.get("study_inventory") if workflow is not None else None
+    return inventory if isinstance(inventory, Mapping) else None
+
+
+def _scoped_collection_kinds(
+    domain: Mapping[str, Any],
+    collection_name: str,
+    kind_name: str,
+    truncated_name: str,
+) -> tuple[set[str], bool]:
+    inventory = _focused_inventory(domain)
+    inventory_name = _FOCUSED_KIND_FIELDS.get(collection_name, "")
+    if inventory is not None and inventory_name in inventory:
+        values = inventory.get(inventory_name)
+        if isinstance(values, list):
+            return {str(value) for value in values if str(value or "")}, False
+    return _collection_kinds(
+        domain,
+        collection_name,
+        kind_name,
+        truncated_name,
+    )
+
+
+def _scoped_count(domain: Mapping[str, Any], name: str) -> int:
+    inventory = _focused_inventory(domain)
+    if inventory is not None and name in inventory:
+        return _nonnegative_int(inventory.get(name)) or 0
+    return _nonnegative_int(domain.get(name)) or 0
+
+
 def _solver_setup_complete(domain: Mapping[str, Any], physics: set[str]) -> bool:
+    focused = _focused_workflow(domain)
+    workflows = (
+        [focused]
+        if focused is not None
+        else [
+            value
+            for value in list(domain.get("analysis_workflows") or ())
+            if isinstance(value, Mapping)
+        ]
+    )
+    for workflow in workflows:
+        inventory = workflow.get("study_inventory")
+        if not isinstance(inventory, Mapping):
+            continue
+        solver_kinds = {
+            str(value) for value in list(inventory.get("solver_kinds") or ())
+        }
+        if not solver_kinds:
+            continue
+        if any(value != "elmer" for value in solver_kinds):
+            return True
+        study = workflow.get("study")
+        study_physics = (
+            set(study.get("physics") or ()) if isinstance(study, Mapping) else physics
+        )
+        equations = {
+            str(value) for value in list(inventory.get("equation_kinds") or ())
+        }
+        if "mechanical" in study_physics and not equations.intersection(
+            {"elasticity", "deformation"}
+        ):
+            continue
+        if "thermal" in study_physics and "heat" not in equations:
+            continue
+        if "electromagnetic" in study_physics and not equations.intersection(
+            {
+                "electrostatic",
+                "electric_force",
+                "magnetodynamic",
+                "magnetodynamic_2d",
+                "static_current",
+            }
+        ):
+            continue
+        return True
     solvers, solvers_truncated = _collection_kinds(
         domain,
         "solvers",
@@ -785,6 +980,17 @@ def _physics_state(
     analysis_count = _nonnegative_int(domain.get("analysis_count"))
     if analysis_count is None:
         return None
+    focused = _focused_workflow(domain)
+    if focused is not None:
+        study = focused.get("study")
+        physics = study.get("physics") if isinstance(study, Mapping) else None
+        if (
+            isinstance(study, Mapping)
+            and study.get("declared") is True
+            and isinstance(physics, list)
+            and all(value in _PHYSICS for value in physics)
+        ):
+            return set(physics), analysis_count
     published = _published_scope(domain, analysis_count)
     if published is None:
         return None
@@ -800,12 +1006,13 @@ def _model_operations(
     if state is not None and state[1] > 0:
         physics = state[0]
         wanted.add("update_study")
+        wanted.add("update_study_dependencies")
         if "mechanical" in physics:
             wanted.add("create_reinforced_material")
-        material_count = _nonnegative_int(domain.get("material_count")) or 0
+        material_count = _scoped_count(domain, "material_count")
         if material_count and physics != {"fluid"}:
             wanted.add("update_material")
-        material_kinds, materials_truncated = _collection_kinds(
+        material_kinds, materials_truncated = _scoped_collection_kinds(
             domain,
             "materials",
             "material_kind",
@@ -851,7 +1058,7 @@ def _geometry_operations(
         wanted.update({"create_beam_section", "create_beam_rotation"})
     if dimensions is None or "shell" in dimensions:
         wanted.add("create_shell_thickness")
-    kinds, truncated = _collection_kinds(
+    kinds, truncated = _scoped_collection_kinds(
         domain,
         "element_definitions",
         "element_definition_kind",
@@ -881,6 +1088,7 @@ def _inspect_operations(
     state = _physics_state(domain)
     wanted = set()
     if state is not None and state[1] > 0:
+        wanted.add("studies")
         if any(domain.get(name) is True for name in _ASSIGNMENT_TRUNCATION_NAMES):
             wanted.update({"assignments", "validate_assignments"})
         generated_mesh_count = _published_scope(domain, state[1])
@@ -904,6 +1112,9 @@ def _operation_scope(
     has_selection: bool,
 ) -> dict[str, tuple[str, ...]]:
     result: dict[str, tuple[str, ...]] = {}
+    analysis_count = _nonnegative_int(domain.get("analysis_count")) or 0
+    focused = _focused_workflow(domain)
+    ambiguous_studies = analysis_count > 1 and focused is None
     for name in tool_names:
         available = tuple(authorized_operations.get(name, ()))
         if not available:
@@ -919,17 +1130,23 @@ def _operation_scope(
             result[name] = _model_operations(domain, available)
             continue
         if name == ANALYZE_FLUID_MATERIAL:
+            if ambiguous_studies:
+                result[name] = available
+                continue
             operation = (
-                "update"
-                if (_nonnegative_int(domain.get("material_count")) or 0) > 0
-                else "create"
+                "update" if _scoped_count(domain, "material_count") > 0 else "create"
             )
             result[name] = tuple(
                 value for value in available if value == operation
             )
             continue
         if name == ANALYZE_GMSH_MESH:
-            kinds, _truncated = _collection_kinds(
+            if ambiguous_studies:
+                result[name] = tuple(
+                    value for value in available if value == "create"
+                )
+                continue
+            kinds, _truncated = _scoped_collection_kinds(
                 domain,
                 "mesh_definitions",
                 "mesher",
@@ -949,7 +1166,7 @@ def _operation_scope(
             result[name] = _geometry_operations(domain, available)
             continue
         if name == "analyze.fluid":
-            kinds, truncated = _collection_kinds(
+            kinds, truncated = _scoped_collection_kinds(
                 domain,
                 "fluid_constraints",
                 "constraint_kind",
@@ -968,7 +1185,7 @@ def _operation_scope(
             continue
         source = _LIVE_KIND_SOURCES.get(name)
         if source is not None:
-            kinds, truncated = _collection_kinds(domain, *source)
+            kinds, truncated = _scoped_collection_kinds(domain, *source)
             scoped = _keep_exact_updates(available, kinds, truncated)
             if name == "analyze.support":
                 scoped = tuple(
@@ -989,7 +1206,7 @@ def _operation_scope(
             result[name] = scoped
             continue
         if name == "analyze.mesh":
-            kinds, truncated = _collection_kinds(
+            kinds, truncated = _scoped_collection_kinds(
                 domain,
                 "mesh_definitions",
                 "mesher",
@@ -1020,7 +1237,7 @@ def _operation_scope(
             )
             continue
         if name == "analyze.solver_control":
-            kinds, truncated = _collection_kinds(
+            kinds, truncated = _scoped_collection_kinds(
                 domain,
                 "solvers",
                 "solver_kind",

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeProviderState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeProviderState.py
@@ -128,7 +128,10 @@ def _compact_study(
         "intent": intent,
         "readiness": dict(workflow.get("engineering_readiness") or {}),
     }
-    for name in ("label", "active"):
+    dependencies = workflow.get("dependencies")
+    if isinstance(dependencies, Mapping):
+        result["dependencies"] = dict(dependencies)
+    for name in ("label", "active", "focused"):
         if name in source:
             result[name] = source[name]
     inventory = _nonempty_values(workflow.get("study_inventory"))
@@ -230,6 +233,13 @@ def compact_analyze_provider_state(state: Mapping[str, Any]) -> dict[str, Any]:
         or int(run_status.get("solver_result_count", 0) or 0) > 0
     ):
         compact_domain["run_status"] = dict(run_status)
+    background_jobs = [
+        dict(value)
+        for value in list(domain.get("background_jobs") or ())
+        if isinstance(value, Mapping)
+    ]
+    if background_jobs:
+        compact_domain["background_jobs"] = background_jobs
     clipping = domain.get("clipping")
     if isinstance(clipping, Mapping) and int(clipping.get("plane_count", 0) or 0):
         compact_domain["clipping"] = dict(clipping)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeResultState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeResultState.py
@@ -773,6 +773,9 @@ def result_state(obj: Any, *, include_ranges: bool = True) -> dict[str, Any]:
     analysis_owners = _analysis_owners(document, obj)
     post_pipeline_owners = _post_pipeline_owners(document, obj)
     timeline_chain = _timeline_chain(document, obj)
+    input_mesh_identity = _identity(
+        getattr(obj, "VibeCADAnalyzeInputMesh", None)
+    )
     details = (
         _legacy_result_state(obj, include_ranges=include_ranges)
         if kind == "result"
@@ -794,6 +797,7 @@ def result_state(obj: Any, *, include_ranges: bool = True) -> dict[str, Any]:
         "analysis_owners": analysis_owners,
         "post_pipeline_owners": post_pipeline_owners,
         "timeline_chain": timeline_chain,
+        "input_mesh": input_mesh_identity,
         "data": {
             key: value
             for key, value in details.items()
@@ -814,6 +818,9 @@ def result_state(obj: Any, *, include_ranges: bool = True) -> dict[str, Any]:
         "analysis_owners": [identity[0] for identity in analysis_owners],
         "post_pipeline_owners": [identity[0] for identity in post_pipeline_owners],
         "timeline_owner_chain": [identity[0] for identity in timeline_chain],
+        "input_mesh": (
+            input_mesh_identity[0] if input_mesh_identity is not None else None
+        ),
         **details,
         "presentation": presentation,
         "state_sha256": _digest(digest_payload),
@@ -833,6 +840,7 @@ def result_reference_state(obj: Any) -> dict[str, Any]:
             "analysis_owners",
             "post_pipeline_owners",
             "timeline_owner_chain",
+            "input_mesh",
             "data_available",
             "point_count",
             "cell_count",

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeRunBindings.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeRunBindings.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeCurrentTargets import current_target
+from VibeCADNativeAnalyzeMeshState import fem_mesh_definition_context_state
 from VibeCADNativeAnalyzeRunSchema import ANALYZE_RUN_SOLVER
 from VibeCADNativeAnalyzeSolverExecutionRuntime import (
     NativeAnalyzeSolverExecutionRuntime,
@@ -34,6 +35,13 @@ def _run(call: Any) -> Mapping[str, Any]:
         solver_state,
     )
     values["target"] = target
+    mesh_name = values.pop("mesh_name", None)
+    if mesh_name is not None:
+        values["mesh"] = current_target(
+            runtime,
+            mesh_name,
+            fem_mesh_definition_context_state,
+        )
     values.setdefault("timeout_seconds", 3600)
     result = dict(
         runtime.execute(

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeRunSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeRunSchema.py
@@ -34,6 +34,7 @@ def analyze_run_solver_capability_definition() -> NativeCapabilityDefinition:
                     "type": "object",
                     "properties": {
                         "solver_name": _OBJECT_NAME,
+                        "mesh_name": _OBJECT_NAME,
                         "timeout_seconds": {
                             "type": "integer",
                             "minimum": 1,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSnapshot.py
@@ -41,6 +41,7 @@ from VibeCADNativeAnalyzeClipping import (
 from VibeCADNativeAnalyzeGeometrySources import active_analyze_geometry_sources
 from VibeCADNativeMeshState import mesh_object_state, mesh_object_state_cache
 from VibeCADNativeSnapshot import objects_of_type
+from VibeCADAnalyzeStudySetup import analysis_for_selection
 
 
 MAX_ANALYSES = 16
@@ -193,6 +194,7 @@ def _analysis_workflows(
                     "object_name": name,
                     "label": analysis_summary.get("label", name),
                     "active": bool(analysis_summary.get("active")),
+                    "focused": bool(analysis_summary.get("focused")),
                     "state_sha256": analysis_summary["state_sha256"],
                 },
                 "graph": {
@@ -209,6 +211,7 @@ def _analysis_workflows(
                     "blockers": blockers,
                 },
                 "study": study["intent"],
+                "dependencies": study["dependencies"],
                 "study_inventory": study["inventory"],
                 "solver_runtimes": study["solver_runtimes"],
                 "engineering_readiness": study["readiness"],
@@ -270,6 +273,8 @@ def _run_status(
     background_job: Any | None,
 ) -> dict[str, Any]:
     result_count = sum(int(state.get("result_count", 0) or 0) for state in solvers)
+    if isinstance(background_job, tuple):
+        background_job = background_job[0] if background_job else None
     if background_job is None:
         return {
             "phase": "idle",
@@ -281,6 +286,7 @@ def _run_status(
     result = {
         "job_id": str(background_job.job_id),
         "capability": str(background_job.capability_name),
+        "resource_scope": str(getattr(background_job, "resource_scope", "document")),
         "phase": str(background_job.phase),
         "progress_percent": int(background_job.progress_percent),
         "progress_message": str(background_job.progress_message)[:160],
@@ -320,6 +326,25 @@ def _active_analysis(document: Any) -> Any | None:
         return analysis if getattr(analysis, "Document", None) is document else None
     except (ImportError, AttributeError, RuntimeError):
         return None
+
+
+def _focused_analysis(
+    document: Any,
+    selection: Mapping[str, Any] | None,
+) -> Any | None:
+    if not isinstance(selection, Mapping):
+        return None
+    selected = []
+    for item in list(selection.get("items") or ()):
+        if not isinstance(item, Mapping):
+            continue
+        reference = item.get("object")
+        if not isinstance(reference, Mapping):
+            continue
+        obj = document.getObject(str(reference.get("object_name") or ""))
+        if obj is not None and getattr(obj, "Document", None) is document:
+            selected.append(obj)
+    return analysis_for_selection(document, selected)
 
 
 def _materials(document: Any) -> tuple[int, list[dict[str, Any]]]:
@@ -667,6 +692,7 @@ def _background_job_payload(
     result: dict[str, Any] = {
         "job_id": str(background_job.job_id),
         "capability": str(background_job.capability_name),
+        "resource_scope": str(getattr(background_job, "resource_scope", "document")),
         "phase": str(background_job.phase),
         "progress_percent": int(background_job.progress_percent),
         "progress_message": str(background_job.progress_message)[:160],
@@ -697,10 +723,26 @@ def _background_job_payload(
     return result
 
 
+def _background_job_payloads(
+    document_uid: str,
+    background_jobs: Any,
+) -> list[dict[str, Any]]:
+    jobs = background_jobs if isinstance(background_jobs, tuple) else (
+        (background_jobs,) if background_jobs is not None else ()
+    )
+    return [
+        value
+        for job in jobs
+        for value in [_background_job_payload(document_uid, job)]
+        if value is not None
+    ]
+
+
 def begin_analyze_snapshot_capture(
     document: Any,
     *,
     background_job: Any | None = None,
+    selection: Mapping[str, Any] | None = None,
     defer_brep_validation: bool = False,
     validate_brep: bool = True,
     analysis_artifact_names: frozenset[str] | None = None,
@@ -747,6 +789,16 @@ def begin_analyze_snapshot_capture(
         "Fem::FemAnalysis",
     )
     active = _active_analysis(document)
+    focused = _focused_analysis(document, selection)
+    analysis_names = [str(value.Name) for value in analyses]
+    detailed_analysis_names = analysis_names[:MAX_ANALYSES]
+    focused_name = str(getattr(focused, "Name", "") or "")
+    if focused_name and focused_name not in detailed_analysis_names:
+        detailed_analysis_names = [
+            *detailed_analysis_names[: MAX_ANALYSES - 1],
+            focused_name,
+        ]
+    background_jobs = _background_job_payloads(document_uid, background_job)
     validation_root = (
         str(
             Path(tempfile.gettempdir())
@@ -758,11 +810,14 @@ def begin_analyze_snapshot_capture(
     return {
         "document_uid": document_uid,
         "object_names": object_names,
-        "analysis_names": [str(value.Name) for value in analyses],
+        "analysis_names": analysis_names,
+        "detailed_analysis_names": detailed_analysis_names,
         "active_analysis_name": (
             str(getattr(active, "Name", "") or "") if active is not None else ""
         ),
-        "background_job": _background_job_payload(document_uid, background_job),
+        "focused_analysis_name": focused_name,
+        "background_job": background_jobs[0] if background_jobs else None,
+        "background_jobs": background_jobs,
         "validate_brep": validate_brep,
         "defer_brep_validation": defer_brep_validation,
         "geometry_validation_artifact_root": validation_root,
@@ -774,10 +829,12 @@ def _analysis_capture_record(
     *,
     active_analysis_name: str,
     include_summary: bool,
+    focused_analysis_name: str = "",
 ) -> dict[str, Any]:
     if include_summary:
         summary = analysis_state(analysis)
         summary["active"] = str(analysis.Name) == active_analysis_name
+        summary["focused"] = str(analysis.Name) == focused_analysis_name
         result_graph = result_purge_state(analysis)
         summary["result_graph"] = {
             key: result_graph[key]
@@ -852,6 +909,12 @@ def _capture_analyze_snapshot_batch(
     batch = SimpleNamespace(Uid=document_uid, Objects=objects)
     analysis_names = [str(name) for name in list(request.get("analysis_names") or [])]
     analysis_indexes = {name: index for index, name in enumerate(analysis_names)}
+    detailed_names = set(
+        str(name)
+        for name in list(request.get("detailed_analysis_names") or ())
+    )
+    if not detailed_names:
+        detailed_names.update(analysis_names[:MAX_ANALYSES])
     analyses = []
     for obj in objects:
         name = str(getattr(obj, "Name", "") or "")
@@ -862,7 +925,10 @@ def _capture_analyze_snapshot_batch(
             _analysis_capture_record(
                 obj,
                 active_analysis_name=str(request.get("active_analysis_name") or ""),
-                include_summary=index < MAX_ANALYSES,
+                focused_analysis_name=str(
+                    request.get("focused_analysis_name") or ""
+                ),
+                include_summary=name in detailed_names,
             )
         )
 
@@ -1072,9 +1138,11 @@ def _analysis_workflows_from_records(
     result_states: Mapping[str, dict[str, Any]],
 ) -> list[dict[str, Any]]:
     workflows = []
-    for record in records[:MAX_ANALYSES]:
+    for record in records:
         analysis_summary = record.get("summary")
         study = record.get("study")
+        if analysis_summary is None:
+            continue
         if not isinstance(analysis_summary, Mapping) or not isinstance(study, Mapping):
             raise RuntimeError("Analyze workflow capture is incomplete.")
         name = str(record.get("object_name") or "")
@@ -1125,6 +1193,7 @@ def _analysis_workflows_from_records(
                     "object_name": name,
                     "label": analysis_summary.get("label", name),
                     "active": bool(analysis_summary.get("active")),
+                    "focused": bool(analysis_summary.get("focused")),
                     "state_sha256": analysis_summary["state_sha256"],
                 },
                 "graph": {
@@ -1141,6 +1210,7 @@ def _analysis_workflows_from_records(
                     "blockers": blockers,
                 },
                 "study": dict(study["intent"]),
+                "dependencies": dict(study["dependencies"]),
                 "study_inventory": dict(study["inventory"]),
                 "solver_runtimes": list(study.get("solver_runtimes") or []),
                 "engineering_readiness": dict(study.get("readiness") or {}),
@@ -1201,7 +1271,7 @@ def finish_analyze_snapshot_capture(
     )
     summarized = [
         dict(record["summary"])
-        for record in records[:MAX_ANALYSES]
+        for record in records
         if isinstance(record.get("summary"), Mapping)
     ]
     collections = {}
@@ -1259,7 +1329,14 @@ def finish_analyze_snapshot_capture(
     result_count = sum(
         int(state.get("result_count", 0) or 0) for state in solver_states.values()
     )
-    background_job = request.get("background_job")
+    background_jobs = [
+        dict(value)
+        for value in list(request.get("background_jobs") or ())
+        if isinstance(value, Mapping)
+    ]
+    background_job = background_jobs[0] if background_jobs else request.get(
+        "background_job"
+    )
     run_status = (
         dict(background_job)
         if isinstance(background_job, Mapping)
@@ -1277,6 +1354,7 @@ def finish_analyze_snapshot_capture(
         "analysis_workflows_truncated": analysis_count > len(workflows),
         "provider_scope": provider_scope,
         "run_status": run_status,
+        "background_jobs": background_jobs,
         **collections,
         "clipping": dict(clipping),
     }
@@ -1286,10 +1364,12 @@ def build_analyze_snapshot(
     document: Any,
     *,
     background_job: Any | None = None,
+    selection: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     request = begin_analyze_snapshot_capture(
         document,
         background_job=background_job,
+        selection=selection,
     )
     part = capture_analyze_snapshot_batch(
         document,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolidDomain.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolidDomain.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeMeshState import mesh_object_state
 from VibeCADNativeMutation import NativeMutationDraft
 from VibeCADNativeTargets import NativeObjectRef, object_identity, object_reference, resolve_object
@@ -193,7 +194,7 @@ def create_solid_domain(
         if prepared.interface_mode == "separate"
         else _create_shared_domain(document, prepared)
     )
-    domain.Label = prepared.label
+    prepared = assign_prepared_label(domain, prepared)
     _add_identity(domain, prepared)
     recomputed = document.recompute([domain], True, True)
     shape = getattr(domain, "Shape", None)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverBindings.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverBindings.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import Any, Mapping
 
+from VibeCADNativeAnalyzeCurrentTargets import current_analysis_target
 from VibeCADNativeAnalyzeSolverRuntime import NativeAnalyzeSolverRuntime
 from VibeCADNativeAnalyzeSolverSchema import ANALYZE_SOLVER_CAPABILITY_NAME
 from VibeCADNativeCapabilityRegistry import NativeCapabilityImplementation, NativeCapabilityRegistry
@@ -18,7 +19,17 @@ def _execute(call: Any) -> Mapping[str, Any]:
         raise TypeError("An Analyze solver call requires its exact runtime.")
     if not isinstance(arguments, Mapping):
         raise TypeError("An Analyze solver call requires argument data.")
-    return runtime.execute(arguments, ticket=getattr(call, "ticket", None))
+    values = dict(arguments)
+    analysis = values.get("analysis")
+    analysis_name = analysis if isinstance(analysis, str) else None
+    if analysis_name is not None:
+        values["analysis"] = current_analysis_target(runtime, analysis_name)
+    result = dict(
+        runtime.execute(values, ticket=getattr(call, "ticket", None))
+    )
+    if analysis_name is not None:
+        result["analysis_name"] = str(analysis_name)
+    return result
 
 
 def register_analyze_solver_capability_implementation(

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverCreate.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -116,7 +117,7 @@ def create_solver(
     if solver_kind(solver) != prepared.kind:
         raise NativeAnalyzeError("The FEM solver factory returned the wrong solver kind.")
 
-    solver.Label = prepared.label
+    prepared = assign_prepared_label(solver, prepared)
     if prepared.kind == "openfoam":
         solver.TurbulenceModel = (
             "kOmegaSST"

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecution.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecution.py
@@ -24,6 +24,13 @@ from VibeCADNativeAnalyzeSolverState import (
     solver_still_exact,
 )
 from VibeCADNativeAnalyzeState import is_live
+from VibeCADNativeAnalyzeOwnership import owning_study, study_history_operations
+from VibeCADNativeAnalyzeMeshState import fem_mesh_definition_context_state
+from VibeCADNativeAnalyzeTargets import (
+    PreparedFemMeshDefinitionTarget,
+    fem_mesh_definition_target_still_exact,
+    prepare_fem_mesh_definition_target,
+)
 from VibeCADNativeMutation import NativeMutationDraft
 from VibeCADNativeTargets import object_identity
 
@@ -69,6 +76,7 @@ class SolverExecutionRequest:
     keep_results: bool
     importer_state: Mapping[str, Any]
     runtime_preferences: tuple[tuple[str, str, str, Any], ...] = ()
+    mesh: PreparedFemMeshDefinitionTarget | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -80,6 +88,7 @@ class CapturedSolverExecutionRequest:
     timeout_seconds: int
     keep_results: bool
     runtime_preferences: tuple[tuple[str, str, str, Any], ...]
+    mesh: PreparedFemMeshDefinitionTarget | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -106,7 +115,56 @@ def _require_history_root(document: Any, solver: Any) -> tuple[Any, ...]:
             "The FEM solver is not one durable root operation in current History.",
             error_code="NATIVE_ANALYZE_HISTORY_TARGET_INVALID",
         )
-    return operations
+    return study_history_operations(owning_study(document, solver))
+
+
+def _analysis_meshes(analysis: Any) -> tuple[Any, ...]:
+    meshes = []
+    for member in tuple(getattr(analysis, "Group", ()) or ()):
+        try:
+            is_mesh = bool(member.isDerivedFrom("Fem::FemMeshObject"))
+        except Exception:
+            is_mesh = False
+        if is_mesh and not bool(getattr(member, "Suppressed", False)):
+            meshes.append(member)
+    return tuple(meshes)
+
+
+def _solver_mesh(
+    document: Any,
+    document_uid: str,
+    analysis: Any,
+    value: Any,
+) -> PreparedFemMeshDefinitionTarget | None:
+    meshes = _analysis_meshes(analysis)
+    if value is not None:
+        prepared = prepare_fem_mesh_definition_target(document, document_uid, value)
+        if prepared.mesh not in meshes:
+            raise NativeAnalyzeError(
+                "The selected FEM mesh does not belong to the solver's study.",
+                error_code="NATIVE_ANALYZE_SOLVER_MESH_INVALID",
+            )
+        return prepared
+    if len(meshes) > 1:
+        raise NativeAnalyzeError(
+            "This FEM study has several meshes; select the mesh for this solver run.",
+            error_code="NATIVE_ANALYZE_SOLVER_MESH_REQUIRED",
+            repair={
+                "analysis": str(analysis.Name),
+                "mesh_names": [str(mesh.Name) for mesh in meshes],
+            },
+        )
+    if len(meshes) == 1:
+        state = fem_mesh_definition_context_state(meshes[0])
+        kind = str(state["backend"])
+        if kind == "netgen_legacy":
+            kind = "netgen"
+        return PreparedFemMeshDefinitionTarget(
+            meshes[0],
+            kind,
+            str(state["state_sha256"]),
+        )
+    return None
 
 
 def _input_digest(root: Path) -> tuple[str, int]:
@@ -375,6 +433,7 @@ def capture_solver_execution_request(
     document_uid: str,
     *,
     target: Any,
+    mesh: Any = None,
     timeout_seconds: Any,
 ) -> CapturedSolverExecutionRequest:
     """Capture exact solver guards without generating files or running tools."""
@@ -385,6 +444,11 @@ def capture_solver_execution_request(
         raise NativeAnalyzeError("A suppressed FEM solver cannot be run.")
     analysis_name = str(state.get("analysis") or "")
     analysis = document.getObject(analysis_name) if analysis_name else None
+    selected_mesh = (
+        _solver_mesh(document, document_uid, analysis, mesh)
+        if analysis is not None
+        else None
+    )
     validation = validate_assignments(analysis) if analysis is not None else None
     if analysis_name and (
         not isinstance(validation, Mapping) or validation.get("valid") is not True
@@ -410,6 +474,7 @@ def capture_solver_execution_request(
         _timeout(timeout_seconds),
         _keep_results_from_runtime_preferences(runtime_preferences),
         runtime_preferences,
+        selected_mesh,
     )
 
 
@@ -435,6 +500,16 @@ def validate_captured_solver_execution(
             "Document History changed while FEM execution was being prepared.",
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
+    if captured.mesh is not None:
+        analysis = owning_study(document, solver)
+        if (
+            captured.mesh.mesh not in _analysis_meshes(analysis)
+            or not fem_mesh_definition_target_still_exact(captured.mesh)
+        ):
+            raise NativeAnalyzeError(
+                "The selected FEM mesh changed while execution was being prepared.",
+                error_code="NATIVE_ANALYZE_STATE_STALE",
+            )
     current_preferences = _current_solver_runtime_preferences(captured.target.kind)
     if (
         _keep_results_from_runtime_preferences(current_preferences)
@@ -456,6 +531,7 @@ def prepare_solver_execution_request(
     document_uid: str,
     *,
     target: Any,
+    mesh: Any = None,
     timeout_seconds: Any,
     working_directory: str | Path | None = None,
     progress: Callable[[int, str], None] | None = None,
@@ -471,6 +547,7 @@ def prepare_solver_execution_request(
         document,
         document_uid,
         target=target,
+        mesh=mesh,
         timeout_seconds=timeout_seconds,
     )
     prepared = captured.target
@@ -521,6 +598,7 @@ def prepare_solver_execution_request(
             captured.keep_results,
             importer_state,
             captured.runtime_preferences,
+            captured.mesh,
         )
     except Exception:
         shutil.rmtree(root, ignore_errors=True)
@@ -686,10 +764,16 @@ def commit_solver_execution(
             "The exact FEM solver changed while execution was running; results were not applied.",
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
-    timeline = getattr(document, "VibeCADTimeline", None)
-    if tuple(getattr(timeline, "Operations", ()) or ()) != request.history_operations:
+    if _require_history_root(document, solver) != request.history_operations:
         raise NativeAnalyzeError(
-            "Document History changed while the FEM solver was running; results were not applied.",
+            "The FEM study History changed while the solver was running; results were not applied.",
+            error_code="NATIVE_ANALYZE_STATE_STALE",
+        )
+    if request.mesh is not None and not fem_mesh_definition_target_still_exact(
+        request.mesh
+    ):
+        raise NativeAnalyzeError(
+            "The selected FEM mesh changed while the solver was running; results were not applied.",
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     if _current_keep_results() is not request.keep_results:
@@ -703,6 +787,15 @@ def commit_solver_execution(
     _ensure_exact_retained_result_graph(solver)
     graph = _unpack_result_graph(_import_tool(request).update_properties())
     root, resources, root_is_new, reconciliation = graph
+    if request.mesh is not None:
+        if "VibeCADAnalyzeInputMesh" not in tuple(root.PropertiesList):
+            root.addProperty(
+                "App::PropertyLink",
+                "VibeCADAnalyzeInputMesh",
+                "VibeCAD",
+                "Mesh used to produce this result.",
+            )
+        root.VibeCADAnalyzeInputMesh = request.mesh.mesh
     _finalize_timeline_result_graph(
         solver,
         root,
@@ -731,6 +824,11 @@ def _result_summary(
         "label": str(root.Label),
         "type_id": str(root.TypeId),
         "solver": str(solver.Name),
+        "mesh": (
+            str(getattr(root, "VibeCADAnalyzeInputMesh", None).Name)
+            if getattr(root, "VibeCADAnalyzeInputMesh", None) is not None
+            else None
+        ),
         "resource_count": len(resources),
         "resources": [
             {
@@ -815,6 +913,9 @@ def verify_solver_execution(
             "implementation": request.implementation,
             "input_sha256": request.input_sha256,
             "input_file_count": request.input_file_count,
+            "mesh_name": (
+                str(request.mesh.mesh.Name) if request.mesh is not None else None
+            ),
             "stages": list(prepared.stages),
         },
     }

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionChild.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionChild.py
@@ -258,7 +258,10 @@ def _request() -> tuple[dict[str, Any], Path, Path, str]:
     }
     if (
         not isinstance(value, dict)
-        or set(value) != required
+        or frozenset(value) not in {
+            frozenset(required),
+            frozenset({*required, "mesh"}),
+        }
         or value.get("protocol") != _PROTOCOL
         or Path(str(value.get("workspace") or "")).resolve() != root
         or value.get("snapshot") != "document.FCStd"
@@ -269,6 +272,7 @@ def _request() -> tuple[dict[str, Any], Path, Path, str]:
             "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
             "The detached FEM request failed protocol validation.",
         )
+    value.setdefault("mesh", None)
     return value, root, root / "result.json", request_sha256
 
 
@@ -298,6 +302,52 @@ def _solver_descriptor(value: Any) -> dict[str, Any]:
             "The detached FEM solver descriptor is invalid.",
         )
     return result
+
+
+def _mesh_descriptor(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    required = {"object_name", "object_id", "type_id", "kind", "state_sha256"}
+    if not isinstance(value, Mapping) or set(value) != required:
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM mesh descriptor is malformed.",
+        )
+    result = dict(value)
+    if (
+        not str(result["object_name"] or "")
+        or type(result["object_id"]) is not int
+        or result["object_id"] < 1
+        or not str(result["type_id"] or "")
+        or str(result["kind"]) not in {"gmsh", "netgen"}
+        or len(str(result["state_sha256"] or "")) != 64
+        or any(
+            character not in "0123456789abcdef"
+            for character in str(result["state_sha256"])
+        )
+    ):
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The detached FEM mesh descriptor is invalid.",
+        )
+    return result
+
+
+def _isolate_solver_mesh(analysis: Any, selected: Any) -> None:
+    """Keep one explicitly selected mesh in the private solver snapshot."""
+
+    if selected not in tuple(getattr(analysis, "Group", ()) or ()):
+        _fail(
+            "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+            "The selected FEM mesh is outside the solver's study.",
+        )
+    for member in tuple(analysis.Group or ()):
+        try:
+            is_mesh = bool(member.isDerivedFrom("Fem::FemMeshObject"))
+        except Exception:
+            is_mesh = False
+        if is_mesh and member is not selected:
+            analysis.removeObject(member)
 
 
 def _preferences(
@@ -389,6 +439,7 @@ def _execute(
     import FreeCAD as App
 
     solver_spec = _solver_descriptor(request["solver"])
+    mesh_spec = _mesh_descriptor(request["mesh"])
     timeout = request["timeout_seconds"]
     keep_results = request["keep_results"]
     snapshot_size = request["snapshot_bytes"]
@@ -459,6 +510,42 @@ def _execute(
                 "NATIVE_ANALYZE_STATE_STALE",
                 "The exact FEM solver changed in its frozen snapshot.",
             )
+        mesh = None
+        if mesh_spec is not None:
+            mesh = document.getObject(str(mesh_spec["object_name"]))
+            if (
+                mesh is None
+                or int(mesh.ID) != mesh_spec["object_id"]
+                or str(mesh.TypeId) != mesh_spec["type_id"]
+            ):
+                _fail(
+                    "NATIVE_ANALYZE_STATE_STALE",
+                    "The selected FEM mesh is unavailable in its frozen snapshot.",
+                )
+            from VibeCADNativeAnalyzeMeshState import (
+                fem_mesh_definition_context_state,
+                fem_mesh_definition_still_exact,
+            )
+
+            mesh_state = fem_mesh_definition_context_state(mesh)
+            if (
+                mesh_state["backend"] != mesh_spec["kind"]
+                or not fem_mesh_definition_still_exact(
+                    mesh,
+                    str(mesh_spec["state_sha256"]),
+                )
+            ):
+                _fail(
+                    "NATIVE_ANALYZE_STATE_STALE",
+                    "The selected FEM mesh changed in its frozen snapshot.",
+                )
+            analysis = document.getObject(str(state.get("analysis") or ""))
+            if analysis is None:
+                _fail(
+                    "NATIVE_ANALYZE_SOLVER_INPUT_INVALID",
+                    "The solver's FEM study is unavailable in its frozen snapshot.",
+                )
+            _isolate_solver_mesh(analysis, mesh)
         from VibeCADNativeAnalyzeSolverExecution import (
             prepare_solver_execution_request,
             run_solver_execution,
@@ -471,6 +558,14 @@ def _execute(
                 "object_name": str(solver.Name),
                 "expected_state_sha256": str(solver_spec["state_sha256"]),
             },
+            mesh=(
+                {
+                    "object_name": str(mesh.Name),
+                    "expected_state_sha256": str(mesh_spec["state_sha256"]),
+                }
+                if mesh is not None and mesh_spec is not None
+                else None
+            ),
             timeout_seconds=timeout,
             working_directory=root / "case",
             progress=report,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionInput.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionInput.py
@@ -162,6 +162,17 @@ def freeze_solver_execution_snapshot(
             error_code="NATIVE_ANALYZE_SOLVER_SNAPSHOT_FAILED",
         ) from exc
     preferences = [list(value) for value in captured.runtime_preferences]
+    selected_mesh = getattr(captured, "mesh", None)
+    mesh_request = None
+    if selected_mesh is not None:
+        mesh = selected_mesh.mesh
+        mesh_request = {
+            "object_name": str(mesh.Name),
+            "object_id": int(mesh.ID),
+            "type_id": str(mesh.TypeId),
+            "kind": str(selected_mesh.kind),
+            "state_sha256": str(selected_mesh.expected_state_sha256),
+        }
     request_value = {
         "protocol": ANALYZE_SOLVER_EXECUTION_PROTOCOL,
         "workspace": str(workspace.path),
@@ -175,6 +186,7 @@ def freeze_solver_execution_snapshot(
             "kind": str(captured.target.kind),
             "state_sha256": str(captured.target.expected_state_sha256),
         },
+        "mesh": mesh_request,
         "timeout_seconds": int(captured.timeout_seconds),
         "keep_results": bool(captured.keep_results),
         "runtime_preferences": preferences,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionRuntime.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeOwnership import owning_study, study_resource_scope
 from VibeCADNativeAnalyzeSolverExecution import (
     capture_solver_execution_request,
     commit_solver_execution,
@@ -42,7 +43,8 @@ class NativeAnalyzeSolverExecutionRuntime:
     ) -> dict[str, Any]:
         _operation, values = strict_variant_arguments(
             arguments,
-            {"run": frozenset({"target", "timeout_seconds"})},
+            {"run": frozenset({"target", "mesh", "timeout_seconds"})},
+            defaults={"run": {"mesh": None}},
         )
         context = self._context
         context.guard()
@@ -57,6 +59,9 @@ class NativeAnalyzeSolverExecutionRuntime:
             context.document,
             context.document_uid,
             **values,
+        )
+        scope = study_resource_scope(
+            owning_study(context.document, captured.target.solver)
         )
         workspace = create_solver_execution_workspace()
 
@@ -105,6 +110,7 @@ class NativeAnalyzeSolverExecutionRuntime:
                 finalize_message="Importing verified FEM results",
                 cleanup=cleanup,
                 changes_document=True,
+                resource_scope=scope,
             )
         except NativeBackgroundError as exc:
             workspace.cleanup()
@@ -137,6 +143,7 @@ class NativeAnalyzeSolverExecutionRuntime:
             "job": {
                 "job_id": str(snapshot.job_id),
                 "capability": str(snapshot.capability_name),
+                "resource_scope": str(snapshot.resource_scope),
                 "phase": str(snapshot.phase),
                 "progress_percent": int(snapshot.progress_percent),
                 "progress_message": str(snapshot.progress_message),

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionSchema.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from VibeCADNativeAnalyzeSolverSchema import SOLVER_TARGET
+from VibeCADNativeAnalyzeMeshSchema import _TARGET as MESH_TARGET
 from VibeCADNativeCapabilityRegistry import (
     NativeCapabilityDefinition,
     NativeCapabilityRegistry,
@@ -33,6 +34,7 @@ def analyze_solver_execution_capability_definition() -> NativeCapabilityDefiniti
                     "type": "object",
                     "properties": {
                         "target": SOLVER_TARGET,
+                        "mesh": MESH_TARGET,
                         "timeout_seconds": {
                             "type": "integer",
                             "minimum": 1,

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionWorker.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverExecutionWorker.py
@@ -449,6 +449,7 @@ def _read_result(frozen: FrozenSolverExecution) -> PreparedSolverExecution:
             implementation=implementation,
         ),
         runtime_preferences=frozen.captured.runtime_preferences,
+        mesh=frozen.captured.mesh,
     )
     return PreparedSolverExecution(request=request, stages=_stages(value["stages"]))
 

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverSchema.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSolverSchema.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-from VibeCADNativeAnalyzeModelSchema import _ANALYSIS_TARGET
+from VibeCADNativeAnalyzeModelSchema import _ANALYSIS_TARGET, _OBJECT_NAME
 from VibeCADNativeCapabilityRegistry import (
     NativeCapabilityDefinition,
     NativeCapabilityRegistry,
@@ -41,7 +41,13 @@ def _variant(
     purpose: str,
 ) -> NativeCapabilityVariant:
     properties = {
-        "analysis": _ANALYSIS_TARGET,
+        "analysis": {
+            "anyOf": [
+                {**_OBJECT_NAME, "description": "Study analysis_name."},
+                _ANALYSIS_TARGET,
+            ],
+            "description": "Study analysis_name or exact target.",
+        },
         "label": {"type": "string", "minLength": 1, "maxLength": 160},
     }
     if operation == "create_openfoam":
@@ -52,9 +58,7 @@ def _variant(
         }
     return NativeCapabilityVariant(
         operation=operation,
-        description=(
-            f"Add one {backend} solver for {purpose} to an exact analysis."
-        ),
+        description=f"Add one {backend} solver for {purpose}.",
         action_ids=frozenset({action_id}),
         surface_ids=frozenset({"analyze"}),
         exact_target_type="ExactFemAnalysisAndHistory",
@@ -73,8 +77,7 @@ def analyze_solver_capability_definition() -> NativeCapabilityDefinition:
     return NativeCapabilityDefinition(
         name=ANALYZE_SOLVER_CAPABILITY_NAME,
         description=(
-            "Add one explicitly selected FEM solver to one exact analysis using the same "
-            "factories and preference defaults as the human Analyze ribbon."
+            "Add one selected FEM solver to a study."
         ),
         primary_classification="mutation",
         variants=(

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeState.py
@@ -10,7 +10,7 @@ import math
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
-from VibeCADNativeAnalyzeStudy import study_intent_state
+from VibeCADNativeAnalyzeStudy import study_dependency_state, study_intent_state
 from VibeCADNativeSnapshot import concise_object
 
 
@@ -99,9 +99,11 @@ def analysis_state(analysis: Any) -> dict[str, Any]:
         if len(summaries) < MAX_ANALYSIS_MEMBERS:
             summaries.append({**concise_object(member), "category": category})
     study = study_intent_state(analysis)
+    dependencies = study_dependency_state(analysis)
     result = {
         **concise_object(analysis),
         "study": study,
+        "dependencies": dependencies,
         "member_count": len(members),
         "member_counts": counts,
         "members": summaries,
@@ -113,6 +115,7 @@ def analysis_state(analysis: Any) -> dict[str, Any]:
             "object_id": int(analysis.ID),
             "label": str(analysis.Label),
             "study": study,
+            "dependencies": dependencies,
             "members": identity_records,
         }
     )

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudy.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudy.py
@@ -9,6 +9,7 @@ import json
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeOwnership import is_study, studies_in_document
 
 
 STUDY_SCHEMA_VERSION = 1
@@ -34,6 +35,7 @@ STUDY_INTENT_SCHEMA = {
 _PHYSICS_PROPERTY = "StudyPhysics"
 _REGIME_PROPERTY = "StudyRegime"
 _VERSION_PROPERTY = "StudySchemaVersion"
+_DEPENDENCIES_PROPERTY = "StudyDependencies"
 _PROPERTY_GROUP = "Study"
 
 
@@ -132,6 +134,96 @@ def study_intent_state(analysis: Any) -> dict[str, Any]:
     return result
 
 
+def _study_dependencies(analysis: Any) -> tuple[Any, ...]:
+    properties = set(getattr(analysis, "PropertiesList", ()) or ())
+    if _DEPENDENCIES_PROPERTY not in properties:
+        return ()
+    if str(analysis.getTypeIdOfProperty(_DEPENDENCIES_PROPERTY)) != "App::PropertyLinkList":
+        raise NativeAnalyzeError(
+            "Existing analysis property StudyDependencies has an incompatible type."
+        )
+    document = getattr(analysis, "Document", None)
+    dependencies = tuple(getattr(analysis, _DEPENDENCIES_PROPERTY, ()) or ())
+    if (
+        len({id(value) for value in dependencies}) != len(dependencies)
+        or any(not is_study(value, document) for value in dependencies)
+        or analysis in dependencies
+    ):
+        raise NativeAnalyzeError("The FEM study dependency graph is invalid.")
+    return dependencies
+
+
+def _validate_dependency_graph(
+    analysis: Any,
+    dependencies: tuple[Any, ...],
+) -> None:
+    document = getattr(analysis, "Document", None)
+    studies = studies_in_document(document)
+    if analysis not in studies:
+        raise NativeAnalyzeError("The FEM study is no longer live in its document.")
+    complete: set[int] = set()
+    visiting: set[int] = set()
+
+    def visit(study: Any) -> None:
+        identity = id(study)
+        if identity in visiting:
+            raise NativeAnalyzeError(
+                "The FEM study dependency graph contains a cycle.",
+                error_code="NATIVE_ANALYZE_DEPENDENCY_CYCLE",
+            )
+        if identity in complete:
+            return
+        visiting.add(identity)
+        children = dependencies if study is analysis else _study_dependencies(study)
+        for child in children:
+            visit(child)
+        visiting.remove(identity)
+        complete.add(identity)
+
+    for study in studies:
+        visit(study)
+
+
+def configure_study_dependencies(
+    analysis: Any,
+    dependencies: Any,
+) -> dict[str, Any]:
+    """Persist an exact directed acyclic list of prerequisite studies."""
+
+    if isinstance(dependencies, (str, bytes, bytearray)) or not isinstance(
+        dependencies, (list, tuple)
+    ):
+        raise NativeAnalyzeError("depends_on must be an array of FEM studies.")
+    values = tuple(dependencies)
+    document = getattr(analysis, "Document", None)
+    if (
+        len(values) > 64
+        or len({id(value) for value in values}) != len(values)
+        or any(not is_study(value, document) for value in values)
+        or analysis in values
+    ):
+        raise NativeAnalyzeError(
+            "depends_on must contain up to 64 unique studies from the same document."
+        )
+    _validate_dependency_graph(analysis, values)
+    _ensure_property(
+        analysis,
+        "App::PropertyLinkList",
+        _DEPENDENCIES_PROPERTY,
+        "Studies whose results precede this study.",
+    )
+    setattr(analysis, _DEPENDENCIES_PROPERTY, list(values))
+    return study_dependency_state(analysis)
+
+
+def study_dependency_state(analysis: Any) -> dict[str, Any]:
+    """Return explicit prerequisite study names; absence means an independent root."""
+
+    return {
+        "depends_on": [str(value.Name) for value in _study_dependencies(analysis)]
+    }
+
+
 def solver_configuration_blockers(
     intent: Mapping[str, Any],
     solver_states: list[Mapping[str, Any]],
@@ -175,6 +267,8 @@ def evaluate_study_readiness(
     blockers: list[str] = []
     physics = tuple(intent.get("physics") or ()) if intent.get("declared") else ()
     regime = str(intent.get("regime") or "")
+    solver_kinds = tuple(dict.fromkeys(inventory.get("solver_kinds") or ()))
+    elmer_only = set(solver_kinds) == {"elmer"}
 
     if not physics:
         blockers.append("missing_study_intent")
@@ -189,7 +283,7 @@ def evaluate_study_readiness(
                 blockers.append("missing_support")
             if int(inventory.get("load_count", 0) or 0) < 1:
                 blockers.append("missing_mechanical_load")
-        if "elmer" in set(inventory.get("solver_kinds") or ()) and not {
+        if elmer_only and not {
             "elasticity",
             "deformation",
         }.intersection(set(inventory.get("equation_kinds") or ())):
@@ -211,7 +305,7 @@ def evaluate_study_readiness(
             or "calculix" in set(inventory.get("solver_kinds") or ())
         ) and "initial_temperature" not in thermal_families:
             blockers.append("missing_initial_temperature")
-        if "elmer" in set(inventory.get("solver_kinds") or ()) and "heat" not in set(
+        if elmer_only and "heat" not in set(
             inventory.get("equation_kinds") or ()
         ):
             blockers.append("missing_heat_equation")
@@ -226,7 +320,7 @@ def evaluate_study_readiness(
             {"initial_flow_velocity", "initial_pressure"}
         ):
             blockers.append("missing_initial_fluid_state")
-        if "elmer" in set(inventory.get("solver_kinds") or ()) and "flow" not in set(
+        if elmer_only and "flow" not in set(
             inventory.get("equation_kinds") or ()
         ):
             blockers.append("missing_flow_equation")
@@ -258,22 +352,49 @@ def evaluate_study_readiness(
         mesh_blockers.append("missing_generated_mesh")
     blockers.extend(mesh_blockers)
 
-    solver_kinds = tuple(dict.fromkeys(inventory.get("solver_kinds") or ()))
     if not solver_kinds:
         blockers.append("missing_solver")
-    elif len(solver_kinds) > 1:
-        blockers.append("multiple_active_solvers")
     else:
-        solver = solver_kinds[0]
-        status = runtimes.get(solver)
-        if status is None or status.get("engine_ready") is not True:
-            blockers.append(f"solver_runtime_unavailable:{solver}")
-
-    blockers.extend(
-        blocker
-        for blocker in inventory.get("solver_configuration_blockers", ())
-        if isinstance(blocker, str)
-    )
+        raw_configurations = inventory.get("solver_configurations")
+        configurations = (
+            [
+                value
+                for value in raw_configurations
+                if isinstance(value, Mapping)
+                and str(value.get("solver_kind") or "") in solver_kinds
+            ]
+            if isinstance(raw_configurations, list)
+            else []
+        )
+        if not configurations:
+            shared_blockers = [
+                blocker
+                for blocker in inventory.get("solver_configuration_blockers", ())
+                if isinstance(blocker, str)
+            ]
+            configurations = [
+                {"solver_kind": solver, "blockers": shared_blockers}
+                for solver in solver_kinds
+            ]
+        usable_solver = False
+        solver_blockers: list[str] = []
+        for configuration in configurations:
+            solver = str(configuration.get("solver_kind") or "")
+            configuration_blockers = [
+                value
+                for value in list(configuration.get("blockers") or ())
+                if isinstance(value, str)
+            ]
+            if configuration_blockers:
+                solver_blockers.extend(configuration_blockers)
+                continue
+            status = runtimes.get(solver)
+            if status is not None and status.get("engine_ready") is True:
+                usable_solver = True
+                break
+            solver_blockers.append(f"solver_runtime_unavailable:{solver}")
+        if not usable_solver:
+            blockers.extend(dict.fromkeys(solver_blockers))
 
     ready_to_mesh_blockers = {
         "missing_study_intent",

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudyDependencies.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudyDependencies.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Exact edits for directed FEM study dependencies."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeState import analysis_state
+from VibeCADNativeAnalyzeStudy import configure_study_dependencies
+from VibeCADNativeAnalyzeTargets import (
+    PreparedAnalysisTarget,
+    analysis_target_still_exact,
+    prepare_analysis_target,
+)
+from VibeCADNativeMutation import NativeMutationDraft
+from VibeCADNativeTargets import object_identity
+
+
+@dataclass(frozen=True, slots=True)
+class PreparedStudyDependencyUpdate:
+    target: PreparedAnalysisTarget
+    dependencies: tuple[PreparedAnalysisTarget, ...]
+
+
+def prepare_study_dependency_update(
+    document: Any,
+    document_uid: str,
+    *,
+    target: Any,
+    depends_on: Any,
+) -> PreparedStudyDependencyUpdate:
+    if isinstance(depends_on, (str, bytes, bytearray)) or not isinstance(
+        depends_on, (list, tuple)
+    ):
+        raise NativeAnalyzeError("depends_on must be an array of exact study targets.")
+    if len(depends_on) > 64:
+        raise NativeAnalyzeError("depends_on may contain at most 64 study targets.")
+    prepared_target = prepare_analysis_target(document, document_uid, target)
+    dependencies = tuple(
+        prepare_analysis_target(document, document_uid, value)
+        for value in depends_on
+    )
+    if len({id(value.analysis) for value in dependencies}) != len(dependencies):
+        raise NativeAnalyzeError("depends_on study targets must be unique.")
+    if any(value.analysis is prepared_target.analysis for value in dependencies):
+        raise NativeAnalyzeError("A FEM study cannot depend on itself.")
+    return PreparedStudyDependencyUpdate(prepared_target, dependencies)
+
+
+def update_study_dependencies(
+    document: Any,
+    prepared: PreparedStudyDependencyUpdate,
+) -> NativeMutationDraft:
+    if not isinstance(prepared, PreparedStudyDependencyUpdate):
+        raise TypeError("prepared must be a PreparedStudyDependencyUpdate")
+    if not analysis_target_still_exact(prepared.target) or any(
+        not analysis_target_still_exact(value) for value in prepared.dependencies
+    ):
+        raise NativeAnalyzeError(
+            "A FEM study changed after dependency preflight.",
+            error_code="NATIVE_ANALYZE_STATE_STALE",
+        )
+    analysis = prepared.target.analysis
+    configure_study_dependencies(
+        analysis,
+        [value.analysis for value in prepared.dependencies],
+    )
+    return NativeMutationDraft(
+        value={"analysis": analysis, "prepared": prepared},
+        recompute_targets=(analysis,),
+        changed=(object_identity(analysis),),
+    )
+
+
+def verify_study_dependency_update(
+    document: Any,
+    draft: NativeMutationDraft,
+) -> dict[str, Any]:
+    analysis = draft.value["analysis"]
+    prepared = draft.value["prepared"]
+    state = analysis_state(analysis)
+    expected = [value.analysis.Name for value in prepared.dependencies]
+    if state["dependencies"]["depends_on"] != expected:
+        raise NativeAnalyzeError(
+            "The FEM study dependencies failed their exact postcondition."
+        )
+    return {
+        "analysis": state,
+        "analysis_target": {
+            "object_name": state["object_name"],
+            "expected_state_sha256": state["state_sha256"],
+            "expected_member_count": state["member_count"],
+        },
+    }

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudyState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeStudyState.py
@@ -10,6 +10,7 @@ from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
 from VibeCADNativeAnalyzeStudy import (
     evaluate_study_readiness,
     solver_configuration_blockers,
+    study_dependency_state,
     study_intent_state,
 )
 from VibeCADNativeSnapshot import concise_object
@@ -49,9 +50,11 @@ def study_inventory(
     from VibeCADNativeAnalyzeConstraintState import electromagnetic_constraint_state
     from VibeCADNativeAnalyzeElementState import element_definition_state
     from VibeCADNativeAnalyzeFluidState import fluid_constraint_state
+    from VibeCADNativeAnalyzeGeometricalState import geometrical_feature_state
     from VibeCADNativeAnalyzeLoadState import load_state
     from VibeCADNativeAnalyzeState import material_state
     from VibeCADNativeAnalyzeMeshState import fem_mesh_definition_state
+    from VibeCADNativeAnalyzeMeshRefinementState import mesh_refinement_state
     from VibeCADNativeAnalyzeSolverState import solver_state
     from VibeCADNativeAnalyzeSupportState import support_condition_state
     from VibeCADNativeAnalyzeThermalState import thermal_condition_state
@@ -63,11 +66,13 @@ def study_inventory(
         ("element", element_definition_state),
         ("electromagnetic", electromagnetic_constraint_state),
         ("fluid", fluid_constraint_state),
+        ("geometrical", geometrical_feature_state),
         ("support", support_condition_state),
         ("connection", connection_state),
         ("load", load_state),
         ("thermal", thermal_condition_state),
         ("mesh", mesh_reader),
+        ("mesh_refinement", mesh_refinement_state),
         ("solver", solver_state),
     )
     states: dict[str, list[dict[str, Any]]] = {
@@ -105,6 +110,15 @@ def study_inventory(
                 equations.append(state)
 
     material_kinds = [str(state["material_kind"]) for state in states["material"]]
+
+    def kinds(category: str, field: str) -> list[str]:
+        return list(
+            dict.fromkeys(
+                str(state[field])
+                for state in states[category]
+                if str(state.get(field) or "")
+            )
+        )
     mechanical_material_count = 0
     thermal_material_count = 0
     transient_thermal_material_count = 0
@@ -132,8 +146,21 @@ def study_inventory(
     active_solver_states = [
         state for state in states["solver"] if not bool(state.get("suppressed"))
     ]
-    configuration_blockers = solver_configuration_blockers(
-        study_intent_state(analysis), active_solver_states
+    intent = study_intent_state(analysis)
+    solver_configurations = [
+        {
+            "object_name": str(state["object_name"]),
+            "solver_kind": str(state["solver_kind"]),
+            "blockers": solver_configuration_blockers(intent, [state]),
+        }
+        for state in active_solver_states
+    ]
+    configuration_blockers = list(
+        dict.fromkeys(
+            blocker
+            for configuration in solver_configurations
+            for blocker in configuration["blockers"]
+        )
     )
     assignment_validation = validate_assignments(analysis)
     mesh_coverage = assignment_validation.get("mesh_coverage")
@@ -149,9 +176,13 @@ def study_inventory(
         "equation_count": len(equations),
         "equation_kinds": [str(state["equation_kind"]) for state in equations],
         "element_definition_count": len(states["element"]),
+        "element_definition_kinds": kinds("element", "element_definition_kind"),
         "support_count": len(states["support"]),
+        "support_condition_kinds": kinds("support", "condition_kind"),
         "connection_count": len(states["connection"]),
+        "connection_kinds": kinds("connection", "connection_kind"),
         "load_count": len(states["load"]),
+        "load_kinds": kinds("load", "load_kind"),
         "thermal_condition_count": len(states["thermal"]),
         "thermal_condition_families": [
             str(state["thermal_mode"]) for state in states["thermal"]
@@ -161,12 +192,23 @@ def study_inventory(
             str(state["constraint_kind"]) for state in states["fluid"]
         ],
         "electromagnetic_constraint_count": len(states["electromagnetic"]),
+        "electromagnetic_constraint_kinds": kinds(
+            "electromagnetic", "constraint_kind"
+        ),
+        "geometrical_feature_count": len(states["geometrical"]),
+        "geometrical_feature_kinds": kinds("geometrical", "feature_kind"),
         "mesh_definition_count": len(states["mesh"]),
+        "mesh_kinds": kinds("mesh", "mesher"),
         "generated_mesh_count": sum(
             bool(state.get("generated")) for state in states["mesh"]
         ),
+        "mesh_refinement_count": len(states["mesh_refinement"]),
+        "mesh_refinement_kinds": kinds(
+            "mesh_refinement", "refinement_mode"
+        ),
         "solver_count": len(states["solver"]),
         "solver_kinds": [str(state["solver_kind"]) for state in active_solver_states],
+        "solver_configurations": solver_configurations,
         "solver_configuration_blockers": configuration_blockers,
         "assignment_validation_issue_count": int(
             assignment_validation.get("issue_count", 0) or 0
@@ -200,6 +242,7 @@ def study_state(
     return {
         "analysis": concise_object(analysis),
         "intent": intent,
+        "dependencies": study_dependency_state(analysis),
         "inventory": inventory,
         "solver_runtimes": list(statuses),
         "readiness": evaluate_study_readiness(intent, inventory, runtimes),

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSupportCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSupportCreate.py
@@ -16,6 +16,7 @@ from VibeCADNativeAnalyzeHistory import (
     require_boundary,
     verify_operation_block,
 )
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeState import analysis_state, is_live
 from VibeCADNativeAnalyzeSupportState import (
     support_condition_kind,
@@ -131,7 +132,7 @@ def create_support_condition(
         raise NativeAnalyzeError(
             "The FEM support-condition factory returned the wrong object type."
         )
-    condition.Label = prepared.label
+    prepared = assign_prepared_label(condition, prepared)
     apply_support_values(condition, prepared.values)
     condition.References = reference_value(prepared.references)
     prepared.analysis.analysis.addObject(condition)
@@ -183,4 +184,3 @@ def verify_support_create(
         },
         "created_condition": state,
     }
-

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeSupportEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeSupportEdit.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometryCreate import references_match
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
@@ -199,7 +200,7 @@ def update_support_condition(
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     condition = prepared.target.condition
-    condition.Label = prepared.label
+    prepared = assign_prepared_label(condition, prepared)
     if prepared.values_changed:
         apply_support_values(condition, prepared.values)
     condition.References = reference_value(prepared.references)
@@ -234,4 +235,3 @@ def verify_support_update(
             "The FEM support-condition edit failed its exact postcondition."
         )
     return {"updated_condition": state}
-

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeThermalCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeThermalCreate.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometryCreate import references_match
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
@@ -170,7 +171,7 @@ def create_thermal_condition(
     condition = _factory(document, prepared.family)
     if condition is None or thermal_condition_family(condition) != prepared.family:
         raise NativeAnalyzeError("The FEM thermal factory returned the wrong object type.")
-    condition.Label = prepared.label
+    prepared = assign_prepared_label(condition, prepared)
     apply_thermal_values(condition, prepared.values)
     if prepared.family != "initial_temperature":
         condition.References = reference_value(prepared.references)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeThermalEdit.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeThermalEdit.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeGeometryCreate import references_match
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
@@ -227,7 +228,7 @@ def update_thermal_condition(
             error_code="NATIVE_ANALYZE_STATE_STALE",
         )
     condition = prepared.target.condition
-    condition.Label = prepared.label
+    prepared = assign_prepared_label(condition, prepared)
     apply_thermal_values(condition, prepared.values)
     if prepared.family != "initial_temperature":
         condition.References = reference_value(prepared.references)

--- a/src/Mod/VibeCAD/VibeCADNativeAnalyzeVisualizationCreate.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAnalyzeVisualizationCreate.py
@@ -9,6 +9,7 @@ import math
 from typing import Any, Mapping
 
 from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
 from VibeCADNativeAnalyzeHistory import (
     AnalyzeCreationBoundary,
     creation_boundary,
@@ -340,7 +341,7 @@ def create_visualization(
         extractor = getattr(ObjectsFem, extractor_factory_name)(
             document, document.getUniqueObjectName(base_name + "Data")
         )
-        visualization.Label = prepared.label
+        prepared = assign_prepared_label(visualization, prepared)
         extractor.Label = prepared.extraction.series_name + " Data"
         visualization.addObject(extractor)
         prepared.analysis.analysis.addObject(visualization)

--- a/src/Mod/VibeCAD/VibeCADNativeCapabilityRegistry.py
+++ b/src/Mod/VibeCAD/VibeCADNativeCapabilityRegistry.py
@@ -456,6 +456,7 @@ def _compact_closed_object_options(
         option.get("type") != "object"
         or option.get("additionalProperties") is not False
         or not isinstance(option.get("properties"), Mapping)
+        or any(keyword in option for keyword in ("oneOf", "anyOf", "allOf"))
         for option in options
     ):
         return None

--- a/src/Mod/VibeCAD/VibeCADNativeContextManifest.py
+++ b/src/Mod/VibeCAD/VibeCADNativeContextManifest.py
@@ -198,6 +198,18 @@ NATIVE_CONTEXT_ACTIONS = (
         source_command_id="FEM_Analysis",
     ),
     _action(
+        "VibeCAD_AnalyzeCreateStudyFocused", ("analyze",), ("task_panel",),
+        "mutation", "analyze.create_study", "create",
+        "CurrentNamedFemStudy", "document",
+        source_command_id="FEM_Analysis",
+    ),
+    _action(
+        "VibeCAD_AnalyzeConfigureStudyFocused", ("analyze",), ("task_panel",),
+        "mutation", "analyze.configure_study", "configure",
+        "CurrentNamedFemStudy", "document",
+        source_command_id="VibeCAD_AnalyzeStudySetup",
+    ),
+    _action(
         "VibeCAD_AnalyzeReadGeometrySource", ("analyze",), ("task_panel",),
         "read", "analyze.faces", "read",
         "BoundedExactGeometryFacePage", "none",

--- a/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
+++ b/src/Mod/VibeCAD/VibeCADNativeSnapshot.py
@@ -172,6 +172,7 @@ def _domain_builder(
         return lambda document: build_analyze_snapshot(
             document,
             background_job=background_job,
+            selection=selection,
         )
     if surface_id == "manufacture":
         from VibeCADNativeManufactureSnapshot import build_manufacture_snapshot

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -1468,7 +1468,7 @@ def _build_responsive_analyze_native_state(
             raise RuntimeError("Analyze context request returned no object.")
         uid = str(request.get("document_uid") or "")
         revision = int(request.get("structural_revision", 0) or 0)
-        cache_variant = str(request.get("active_analysis_name") or "")
+        cache_variant = str(request.get("focused_analysis_name") or "")
         coordinator = coordinator_reader()
 
         def build(cancelled, report):

--- a/src/Mod/VibeCAD/vibecad_tests/analyze_study_setup_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/analyze_study_setup_gui_integration.py
@@ -17,7 +17,13 @@ from PySide import QtCore, QtWidgets
 
 import VibeCADGui as VibeGui
 from VibeCADAnalyzeStudyGui import DOCK_NAME, StudySetupWidget
-from VibeCADAnalyzeStudySetup import analyses_in_document
+from VibeCADAnalyzeStudySetup import analyses_in_document, apply_study
+from VibeCADNativeAnalyzeStudy import study_dependency_state
+from VibeCADNativeAnalyzeStudyDependencies import (
+    prepare_study_dependency_update,
+    update_study_dependencies,
+    verify_study_dependency_update,
+)
 from VibeCADNativeAnalyzeMaterialCreate import (
     create_material,
     prepare_material_create,
@@ -320,7 +326,61 @@ def _run() -> None:
         widget._validate_assignments()
         assert widget.assignment_validation.text() == "2 assignments valid"
 
+        thermal_study, _ = apply_study(
+            document,
+            analysis=None,
+            label="Thermal Prerequisite",
+            physics=("thermal", "fluid"),
+            regime="steady",
+        )
+        modal_study, _ = apply_study(
+            document,
+            analysis=None,
+            label="Independent Modal",
+            physics=("mechanical",),
+            regime="modal",
+        )
+        thermal_material = _create_fluid_material(
+            document,
+            thermal_study,
+            first_source,
+            "Inlet Air",
+        )
+        assert thermal_material in tuple(thermal_study.Group)
+        assert thermal_material not in tuple(analysis.Group)
+        assert str(first_material.Label) == "Inlet Air"
+        assert str(thermal_material.Label) == "Inlet Air001"
+        dependency = prepare_study_dependency_update(
+            document,
+            str(document.Uid),
+            target=_analysis_target(analysis),
+            depends_on=[_analysis_target(thermal_study)],
+        )
+        run_human_mutation(
+            document=document,
+            transaction_name="Link FEM Studies",
+            mutate=lambda current: update_study_dependencies(current, dependency),
+            verify=verify_study_dependency_update,
+        )
+        assert len(analyses_in_document(document)) == 3
+        assert study_dependency_state(analysis) == {
+            "depends_on": [thermal_study.Name]
+        }
+        assert study_dependency_state(modal_study) == {"depends_on": []}
+        document.undo()
+        assert study_dependency_state(analysis) == {"depends_on": []}
+        document.redo()
+        assert study_dependency_state(analysis) == {
+            "depends_on": [thermal_study.Name]
+        }
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(thermal_material)
+        widget.refresh()
+        assert widget.analysis_combo.currentData() == thermal_study.Name
+
         analysis_name = str(analysis.Name)
+        thermal_name = str(thermal_study.Name)
+        modal_name = str(modal_study.Name)
         document.save()
         App.closeDocument(document.Name)
         document = App.openDocument(str(save_path))
@@ -330,10 +390,16 @@ def _run() -> None:
         assert reopened is not None
         assert list(reopened.StudyPhysics) == ["thermal", "fluid"]
         assert str(reopened.StudyRegime) == "transient"
+        assert len(analyses_in_document(document)) == 3
+        assert study_dependency_state(reopened) == {"depends_on": [thermal_name]}
+        assert study_dependency_state(document.getObject(modal_name)) == {
+            "depends_on": []
+        }
         print(
             "VIBECAD_ANALYZE_STUDY_SETUP_GUI_OK "
             "ribbon=true create=true update=true exact_operations=true "
-            "undo_redo=true reopen=true controls_visible=true "
+            "undo_redo=true reopen=true multi_study=true dependencies=true "
+            "selection_focus=true controls_visible=true "
             "geometry_faces=true face_highlight=true face_isolate_restore=true "
             "assignments=true highlight=true isolate_restore=true validation=true",
             "results=true comparison=true",

--- a/src/Mod/VibeCAD/vibecad_tests/native_analyze_mesh_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_analyze_mesh_gui_integration.py
@@ -246,18 +246,19 @@ def _run() -> None:
         gmsh_before = fem_mesh_definition_state(gmsh)
         assert not gmsh_before["generated"]
 
-        duplicate = call(
+        alternative_result = call(
             ANALYZE_MESH_CAPABILITY_NAME,
             {
                 "operation": "create_gmsh",
                 "analysis": _analysis_target(analysis_state(analyses[0])),
                 "source": _source_target(first),
-                "label": "Ambiguous Mesh Must Fail",
+                "label": "Alternative Gmsh Definition",
                 "settings": gmsh_before["settings"],
             },
-            succeeds=False,
         )
-        assert "already contains a mesh definition" in duplicate["error"]
+        gmsh_alternative = document.getObject(
+            alternative_result["created_mesh_definition"]["object_name"]
+        )
 
         gmsh_updated = call(
             ANALYZE_MESH_CAPABILITY_NAME,
@@ -344,7 +345,7 @@ def _run() -> None:
         }
 
         read_revision = revision_store.current_revision(str(document.Uid))
-        for mesh in (gmsh, netgen):
+        for mesh in (gmsh, gmsh_alternative, netgen):
             current = fem_mesh_definition_state(mesh)
             read = call(
                 ANALYZE_INSPECT_CAPABILITY_NAME,
@@ -357,13 +358,13 @@ def _run() -> None:
         assert revision_store.current_revision(str(document.Uid)) == read_revision
 
         snapshot = build_analyze_snapshot(document)
-        assert snapshot["mesh_definition_count"] == 2
+        assert snapshot["mesh_definition_count"] == 3
         assert not snapshot["mesh_definitions_truncated"]
         assert {item["mesher"] for item in snapshot["mesh_definitions"]} == {
             "gmsh",
             "netgen",
         }
-        assert tuple(analyses[0].Group) == (gmsh,)
+        assert tuple(analyses[0].Group) == (gmsh, gmsh_alternative)
         assert tuple(analyses[1].Group) == (netgen,)
         operation_names = tuple(obj.Name for obj in document.VibeCADTimeline.Operations)
         assert operation_names == (
@@ -372,6 +373,7 @@ def _run() -> None:
             analyses[0].Name,
             analyses[1].Name,
             gmsh.Name,
+            gmsh_alternative.Name,
             netgen.Name,
         )
 
@@ -381,7 +383,8 @@ def _run() -> None:
         assert fem_mesh_definition_state(netgen)["settings"] == netgen_updated["settings"]
 
         expected = {
-            mesh.Name: fem_mesh_definition_state(mesh) for mesh in (gmsh, netgen)
+            mesh.Name: fem_mesh_definition_state(mesh)
+            for mesh in (gmsh, gmsh_alternative, netgen)
         }
         analysis_members = {
             analysis.Name: tuple(obj.Name for obj in analysis.Group)
@@ -402,8 +405,8 @@ def _run() -> None:
             assert new_state["source"] == old_state["source"]
 
         print(
-            "VIBECAD_NATIVE_ANALYZE_MESH_GUI_OK actions=2 meshers=2 edits=2 "
-            "exact_sources=true one_mesh_per_analysis=true definitions_only=true "
+            "VIBECAD_NATIVE_ANALYZE_MESH_GUI_OK actions=2 meshers=3 edits=2 "
+            "exact_sources=true multiple_meshes_per_analysis=true definitions_only=true "
             "history=true undo_redo=true reopen=true read_revision_stable=true",
             flush=True,
         )

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_context.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_context.py
@@ -95,6 +95,47 @@ def test_analyze_capture_schedules_only_effectively_available_objects(
     assert request["analysis_names"] == ["Analysis"]
 
 
+def test_analyze_capture_keeps_a_late_selected_study_in_bounded_detail(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSnapshot as analyze_snapshot
+
+    analyses = [
+        SimpleNamespace(
+            ID=index,
+            Name=f"Analysis{index}",
+            Label=f"Study {index}",
+            TypeId="Fem::FemAnalysis",
+            PropertiesList=(),
+            ViewObject=SimpleNamespace(Visibility=False),
+            getParentGroup=lambda: None,
+            getParentGeoFeatureGroup=lambda: None,
+        )
+        for index in range(1, 131)
+    ]
+    document = SimpleNamespace(
+        Uid="document-a",
+        Objects=tuple(analyses),
+        isObjectUsableAtCurrentTimelinePosition=lambda _candidate: True,
+    )
+    monkeypatch.setattr(analyze_snapshot, "_active_analysis", lambda _document: None)
+    monkeypatch.setattr(
+        analyze_snapshot,
+        "_focused_analysis",
+        lambda _document, _selection: analyses[-1],
+    )
+
+    request = begin_analyze_snapshot_capture(
+        document,
+        selection={"items": []},
+        validate_brep=False,
+    )
+
+    assert len(request["analysis_names"]) == 130
+    assert len(request["detailed_analysis_names"]) == 16
+    assert request["detailed_analysis_names"][-1] == "Analysis130"
+
+
 def test_context_coordinator_coalesces_callers_and_reuses_the_revision() -> None:
     coordinator = AnalyzeContextCoordinator()
     entered = threading.Event()

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_mesh_state.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_mesh_state.py
@@ -5,10 +5,43 @@
 from __future__ import annotations
 
 from io import BytesIO
+from types import SimpleNamespace
 import zipfile
 
 import VibeCADNativeAnalyzeMeshState as mesh_state
 from VibeCADNativeAnalyzeMeshState import _mesh_content_sha256
+
+
+def test_mesh_definition_source_state_ignores_process_local_shape_hash(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeMeshState as mesh_state
+
+    class Shape:
+        ShapeType = "Solid"
+
+        def __init__(self, value: int) -> None:
+            self.value = value
+
+        def hashCode(self) -> int:
+            return self.value
+
+    source = SimpleNamespace(Name="Source", ID=7, Shape=Shape(11))
+    source_state = {"state_sha256": "a" * 64}
+    monkeypatch.setattr(mesh_state, "mesh_object_state", lambda _source: source_state)
+
+    _visible, first = mesh_state._source(SimpleNamespace(Shape=source))
+    source.Shape = Shape(12)
+    _visible, second = mesh_state._source(SimpleNamespace(Shape=source))
+
+    assert first == second
+    assert "shape_hash" not in first
+
+    source_state = {"state_sha256": "b" * 64}
+    _visible, changed = mesh_state._source(SimpleNamespace(Shape=source))
+
+    assert changed["state_sha256"] == "b" * 64
+    assert changed != second
 
 
 def _archive(unv: str) -> bytes:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_multi_study.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_multi_study.py
@@ -1,0 +1,680 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import pytest
+from jsonschema import Draft202012Validator
+
+import VibeCADNativeAnalyzeSolverBindings as solver_bindings
+from VibeCADAnalyzeStudySetup import preferred_analysis
+from VibeCADNativeAnalyzeErrors import NativeAnalyzeError
+from VibeCADNativeAnalyzeInspect import list_studies
+from VibeCADNativeAnalyzeInspectRuntime import _VARIANTS as INSPECT_VARIANTS
+from VibeCADNativeAnalyzeInspectSchema import analyze_inspect_capability_definition
+from VibeCADNativeAnalyzeLabels import assign_prepared_label
+from VibeCADNativeAnalyzeCfdLifecycleSchema import ANALYZE_FLUID_MATERIAL
+from VibeCADNativeAnalyzeModelRuntime import _FIELDS as MODEL_FIELDS
+from VibeCADNativeAnalyzeModelSchema import (
+    ANALYZE_CONFIGURE_STUDY,
+    ANALYZE_CREATE_STUDY,
+    analyze_model_capability_definition,
+    analyze_study_lifecycle_capability_definitions,
+)
+from VibeCADNativeAnalyzeOwnership import (
+    owning_study,
+    study_history_operations,
+    study_resource_scope,
+)
+from VibeCADNativeAnalyzeProviderScope import (
+    _operation_scope,
+    _solver_operations,
+    analyze_provider_tool_names,
+)
+from VibeCADNativeAnalyzeStructuralLifecycleSchema import ANALYZE_GRAVITY
+from VibeCADNativeAnalyzeSnapshot import _background_job_payloads
+from VibeCADNativeAnalyzeSolverSchema import analyze_solver_capability_definition
+from VibeCADNativeAnalyzeStudy import (
+    configure_study_dependencies,
+    configure_study_intent,
+    evaluate_study_readiness,
+    study_dependency_state,
+)
+from VibeCADNativeCapabilityRegistry import provider_visible_native_schema
+from VibeCADNativeContextManifest import provider_context_actions_for_surface
+
+
+class _Analysis:
+    TypeId = "Fem::FemAnalysis"
+    State = ()
+
+    def __init__(self, name: str, object_id: int, label: str | None = None) -> None:
+        self.Name = name
+        self.ID = object_id
+        self.Label = label or name
+        self.Group = []
+        self.PropertiesList = []
+        self.Document = None
+        self._property_types = {}
+
+    def isDerivedFrom(self, type_id: str) -> bool:
+        return type_id == "Fem::FemAnalysis"
+
+    def addProperty(self, property_type, name, _group, _description):
+        self.PropertiesList.append(name)
+        self._property_types[name] = property_type
+
+    def getTypeIdOfProperty(self, name):
+        return self._property_types[name]
+
+
+class _Document:
+    def __init__(self, *objects) -> None:
+        self.Uid = "document-a"
+        self.Objects = list(objects)
+        for obj in self.Objects:
+            obj.Document = self
+
+    def getObject(self, name):
+        return next((obj for obj in self.Objects if obj.Name == name), None)
+
+
+def _studies(count: int = 3):
+    studies = tuple(
+        _Analysis(f"Analysis{index}", index, f"Study {index}")
+        for index in range(1, count + 1)
+    )
+    document = _Document(*studies)
+    for study in studies:
+        configure_study_intent(
+            study,
+            {"physics": ["mechanical"], "regime": "steady"},
+        )
+    return document, studies
+
+
+def _variant(definition, operation):
+    return next(item for item in definition.variants if item.operation == operation)
+
+
+def test_study_discovery_is_paged_and_returns_exact_mutation_targets() -> None:
+    document, studies = _studies(130)
+
+    page = list_studies(document, offset=128, page_size=64)
+
+    assert page["study_count"] == 130
+    assert page["offset"] == 128
+    assert page["returned_count"] == 2
+    assert page["next_offset"] is None
+    assert page["studies"][0]["analysis_name"] == studies[128].Name
+    assert page["studies"][0]["analysis_target"]["object_name"] == studies[128].Name
+    assert page["studies"][0]["analysis_target"]["expected_member_count"] == 0
+    assert len(page["studies"][0]["analysis_target"]["expected_state_sha256"]) == 64
+
+
+def test_study_catalog_is_a_real_bounded_inspect_operation() -> None:
+    schema = _variant(analyze_inspect_capability_definition(), "studies")
+
+    assert INSPECT_VARIANTS["studies"] == frozenset({"offset", "page_size"})
+    assert schema.parameters["properties"]["page_size"]["maximum"] == 64
+    assert schema.parameters["properties"]["offset"]["default"] == 0
+    assert schema.parameters["properties"]["page_size"]["default"] == 64
+    assert schema.parameters.get("required", []) == []
+    assert schema.transaction_behavior == "none"
+
+
+def test_focused_study_tools_have_one_obvious_schema_each() -> None:
+    definitions = {
+        definition.name: definition
+        for definition in analyze_study_lifecycle_capability_definitions()
+    }
+
+    create = definitions[ANALYZE_CREATE_STUDY].variants[0]
+    configure = definitions[ANALYZE_CONFIGURE_STUDY].variants[0]
+    assert create.action_ids == frozenset({"VibeCAD_AnalyzeCreateStudyFocused"})
+    assert configure.action_ids == frozenset(
+        {"VibeCAD_AnalyzeConfigureStudyFocused"}
+    )
+    assert set(create.parameters["properties"]) == {"label", "physics", "regime"}
+    assert create.parameters["required"] == ["label", "physics", "regime"]
+    assert set(configure.parameters["properties"]) == {
+        "analysis_name",
+        "physics",
+        "regime",
+    }
+    assert configure.parameters["required"] == [
+        "analysis_name",
+        "physics",
+        "regime",
+    ]
+
+    actions = {
+        action.capability_family: action
+        for action in provider_context_actions_for_surface("analyze")
+    }
+    assert actions[ANALYZE_CREATE_STUDY].source_command_id == "FEM_Analysis"
+    assert (
+        actions[ANALYZE_CONFIGURE_STUDY].source_command_id
+        == "VibeCAD_AnalyzeStudySetup"
+    )
+
+
+def test_prepared_label_records_the_exact_host_assigned_value() -> None:
+    @dataclass(frozen=True)
+    class Prepared:
+        label: str
+        marker: str
+
+    class UniqueLabelObject:
+        def __init__(self) -> None:
+            self._label = ""
+
+        @property
+        def Label(self) -> str:
+            return self._label
+
+        @Label.setter
+        def Label(self, value: str) -> None:
+            self._label = f"{value}001"
+
+    prepared = Prepared(label="Force", marker="unchanged")
+
+    assigned = assign_prepared_label(UniqueLabelObject(), prepared)
+
+    assert prepared.label == "Force"
+    assert assigned.label == "Force001"
+    assert assigned.marker == "unchanged"
+
+
+def test_study_dependencies_are_explicit_persistent_and_acyclic() -> None:
+    _document, (loads, thermal, structural) = _studies()
+
+    configure_study_dependencies(thermal, [loads])
+    configure_study_dependencies(structural, [thermal])
+
+    assert study_dependency_state(loads) == {"depends_on": []}
+    assert study_dependency_state(thermal) == {"depends_on": [loads.Name]}
+    assert study_dependency_state(structural) == {"depends_on": [thermal.Name]}
+    with pytest.raises(NativeAnalyzeError, match="cycle"):
+        configure_study_dependencies(loads, [structural])
+
+
+def test_study_dependency_edit_has_one_exact_dedicated_contract() -> None:
+    schema = _variant(
+        analyze_model_capability_definition(),
+        "update_study_dependencies",
+    )
+
+    assert MODEL_FIELDS["update_study_dependencies"][0] == frozenset(
+        {"target", "depends_on"}
+    )
+    assert set(schema.parameters["properties"]) == {"target", "depends_on"}
+
+
+def test_resource_ownership_is_exact_and_background_scope_is_per_study() -> None:
+    document, (first, second, _third) = _studies()
+    first_mesh = SimpleNamespace(Name="FirstMesh", Document=document)
+    second_mesh = SimpleNamespace(Name="SecondMesh", Document=document)
+    first.Group.append(first_mesh)
+    second.Group.append(second_mesh)
+
+    assert owning_study(document, first_mesh) is first
+    assert owning_study(document, second_mesh) is second
+    assert study_resource_scope(first) != study_resource_scope(second)
+
+
+def test_study_history_ignores_unrelated_study_operations() -> None:
+    document, (first, second, _third) = _studies()
+    first_mesh = SimpleNamespace(
+        Name="FirstMesh",
+        Document=document,
+        VibeCADTimelineOwner=None,
+    )
+    first_refinement = SimpleNamespace(
+        Name="FirstRefinement",
+        Document=document,
+        VibeCADTimelineOwner=first_mesh,
+    )
+    second_solver = SimpleNamespace(
+        Name="SecondSolver",
+        Document=document,
+        VibeCADTimelineOwner=None,
+    )
+    second_result = SimpleNamespace(
+        Name="SecondResult",
+        Document=document,
+        VibeCADTimelineOwner=second_solver,
+    )
+    first.Group.append(first_mesh)
+    second.Group.append(second_solver)
+    document.VibeCADTimeline = SimpleNamespace(
+        Operations=[first_refinement, first_mesh, second_result, second_solver]
+    )
+
+    captured = study_history_operations(first)
+    document.VibeCADTimeline.Operations.insert(-1, SimpleNamespace(
+        Name="AnotherSecondResult",
+        Document=document,
+        VibeCADTimelineOwner=second_solver,
+    ))
+
+    assert captured == (first_refinement, first_mesh)
+    assert study_history_operations(first) == captured
+
+
+def test_study_history_changes_with_an_owned_resource() -> None:
+    document, (first, _second, _third) = _studies()
+    solver = SimpleNamespace(
+        Name="Solver",
+        Document=document,
+        VibeCADTimelineOwner=None,
+    )
+    first.Group.append(solver)
+    document.VibeCADTimeline = SimpleNamespace(Operations=[solver])
+    captured = study_history_operations(first)
+
+    result = SimpleNamespace(
+        Name="Result",
+        Document=document,
+        VibeCADTimelineOwner=solver,
+    )
+    document.VibeCADTimeline.Operations.insert(0, result)
+
+    assert captured == (solver,)
+    assert study_history_operations(first) == (result, solver)
+
+
+def test_selection_only_focuses_a_study_and_never_supplies_a_global_default() -> None:
+    document, (first, second, _third) = _studies()
+    member = SimpleNamespace(Name="Load", Document=document)
+    second.Group.append(member)
+
+    assert preferred_analysis(document, [member], previous_name="") is second
+    assert preferred_analysis(document, [], previous_name=first.Name) is first
+    assert preferred_analysis(document, [], previous_name="") is None
+
+
+def test_selection_focuses_a_study_through_a_nested_solver_result() -> None:
+    document, (first, second, _third) = _studies()
+    solver = SimpleNamespace(Name="Solver", Document=document, InList=[])
+    result = SimpleNamespace(Name="Result", Document=document, InList=[solver])
+    first.Group.append(solver)
+    document.Objects.extend((solver, result))
+
+    assert preferred_analysis(document, [result], previous_name=second.Name) is first
+
+
+def test_analyze_background_context_preserves_each_study_scope() -> None:
+    jobs = tuple(
+        SimpleNamespace(
+            document_uid="document-a",
+            job_id=f"job-{index}",
+            capability_name="analyze.solver_execution.run",
+            resource_scope=f"analyze:Analysis{index}",
+            phase="preparing",
+            progress_percent=20,
+            progress_message="Running",
+            terminal=False,
+            cancel_requested=False,
+            error=None,
+            result=None,
+        )
+        for index in (1, 2)
+    )
+
+    values = _background_job_payloads("document-a", jobs)
+
+    assert [value["resource_scope"] for value in values] == [
+        "analyze:Analysis1",
+        "analyze:Analysis2",
+    ]
+
+
+def test_running_study_does_not_disable_an_independent_study() -> None:
+    domain = {
+        "kind": "analyze",
+        "analysis_count": 2,
+        "provider_scope": {
+            "analysis_count": 2,
+            "undeclared_analysis_count": 0,
+            "physics": ["mechanical"],
+            "mesh_definition_count": 2,
+            "generated_mesh_count": 2,
+            "solver_count": 2,
+            "result_count": 0,
+        },
+        "analysis_workflow_count": 2,
+        "analysis_workflows": [
+            {
+                "analysis": {"object_name": "Analysis1", "focused": False},
+                "study": {
+                    "declared": True,
+                    "physics": ["mechanical"],
+                    "regime": "steady",
+                },
+                "study_inventory": {
+                    "mesh_definition_count": 1,
+                    "generated_mesh_count": 1,
+                    "solver_count": 1,
+                    "solver_kinds": ["calculix"],
+                    "equation_kinds": [],
+                    "result_count": 0,
+                },
+                "engineering_readiness": {
+                    "ready_to_solve": True,
+                    "blockers": [],
+                },
+            },
+            {
+                "analysis": {"object_name": "Analysis2", "focused": False},
+                "study": {
+                    "declared": True,
+                    "physics": ["mechanical"],
+                    "regime": "steady",
+                },
+                "study_inventory": {
+                    "mesh_definition_count": 1,
+                    "generated_mesh_count": 1,
+                    "solver_count": 1,
+                    "solver_kinds": ["calculix"],
+                    "equation_kinds": [],
+                    "result_count": 0,
+                },
+                "engineering_readiness": {
+                    "ready_to_solve": True,
+                    "blockers": [],
+                },
+            },
+        ],
+        "background_jobs": [
+            {
+                "job_id": "job-1",
+                "resource_scope": "analyze:Analysis1",
+                "terminal": False,
+            }
+        ],
+    }
+    available = (
+        "analyze.generate_gmsh",
+        "analyze.run_solver",
+        "native.job",
+    )
+
+    assert set(analyze_provider_tool_names(domain, available)) == set(available)
+    domain["analysis_workflows"][0]["analysis"]["focused"] = True
+    assert set(analyze_provider_tool_names(domain, available)) == {"native.job"}
+
+
+def test_focused_study_tool_choices_ignore_resources_owned_by_other_studies() -> None:
+    domain = {
+        "kind": "analyze",
+        "analysis_count": 2,
+        "provider_scope": {
+            "analysis_count": 2,
+            "undeclared_analysis_count": 0,
+            "physics": ["mechanical", "fluid"],
+            "mesh_definition_count": 1,
+            "generated_mesh_count": 0,
+            "solver_count": 0,
+            "result_count": 0,
+        },
+        "analysis_workflow_count": 2,
+        "analysis_workflows": [
+            {
+                "analysis": {"object_name": "Analysis1", "focused": False},
+                "study": {
+                    "declared": True,
+                    "physics": ["mechanical"],
+                    "regime": "steady",
+                },
+                "study_inventory": {
+                    "material_count": 1,
+                    "material_kinds": ["solid"],
+                    "load_kinds": ["gravity"],
+                    "mesh_definition_count": 1,
+                    "mesh_kinds": ["gmsh"],
+                    "generated_mesh_count": 0,
+                    "solver_count": 0,
+                    "result_count": 0,
+                },
+                "engineering_readiness": {
+                    "ready_to_solve": False,
+                    "blockers": ["missing_solver"],
+                },
+            },
+            {
+                "analysis": {"object_name": "Analysis2", "focused": True},
+                "study": {
+                    "declared": True,
+                    "physics": ["mechanical", "fluid"],
+                    "regime": "steady",
+                },
+                "study_inventory": {
+                    "material_count": 0,
+                    "material_kinds": [],
+                    "fluid_constraint_kinds": [],
+                    "load_kinds": [],
+                    "mesh_definition_count": 0,
+                    "mesh_kinds": [],
+                    "generated_mesh_count": 0,
+                    "solver_count": 0,
+                    "result_count": 0,
+                },
+                "engineering_readiness": {
+                    "ready_to_solve": False,
+                    "blockers": [
+                        "missing_fluid_material",
+                        "missing_fluid_boundary",
+                        "missing_mesh_definition",
+                        "missing_generated_mesh",
+                        "missing_solver",
+                    ],
+                },
+            },
+        ],
+        "material_count": 1,
+        "materials": [{"material_kind": "solid"}],
+        "loads": [{"load_kind": "gravity"}],
+        "mesh_definitions": [{"mesher": "gmsh"}],
+    }
+
+    assert ANALYZE_GRAVITY in analyze_provider_tool_names(
+        domain,
+        (ANALYZE_GRAVITY,),
+    )
+    assert _operation_scope(
+        domain,
+        {ANALYZE_FLUID_MATERIAL: ("create", "update")},
+        (ANALYZE_FLUID_MATERIAL,),
+        has_selection=True,
+    )[ANALYZE_FLUID_MATERIAL] == ("create",)
+
+
+def test_multiple_solver_configurations_are_valid_independent_run_targets() -> None:
+    readiness = evaluate_study_readiness(
+        {"declared": True, "physics": ["mechanical"], "regime": "steady"},
+        {
+            "geometry_source_count": 1,
+            "mechanical_material_count": 1,
+            "thermal_material_count": 0,
+            "transient_thermal_material_count": 0,
+            "fluid_material_count": 0,
+            "equation_kinds": [],
+            "support_count": 1,
+            "load_count": 1,
+            "thermal_condition_count": 0,
+            "thermal_condition_families": [],
+            "fluid_constraint_count": 0,
+            "fluid_constraint_kinds": [],
+            "electromagnetic_constraint_count": 0,
+            "mesh_definition_count": 2,
+            "generated_mesh_count": 2,
+            "solver_kinds": ["calculix", "elmer"],
+            "solver_configuration_blockers": [],
+            "result_count": 0,
+        },
+        {
+            "calculix": {"solver": "calculix", "engine_ready": True},
+            "elmer": {"solver": "elmer", "engine_ready": True},
+        },
+    )
+
+    assert readiness["ready_to_solve"] is True
+    assert readiness["blockers"] == []
+
+
+def test_solver_creation_remains_available_for_an_established_study() -> None:
+    domain = {
+        "kind": "analyze",
+        "analysis_count": 1,
+        "analysis_workflow_count": 1,
+        "analysis_workflows": [
+            {
+                "analysis": {"object_name": "Analysis1", "focused": True},
+                "study": {
+                    "declared": True,
+                    "physics": ["mechanical"],
+                    "regime": "steady",
+                },
+                "study_inventory": {
+                    "solver_count": 1,
+                    "solver_kinds": ["calculix"],
+                },
+                "engineering_readiness": {
+                    "ready_to_solve": True,
+                    "blockers": [],
+                },
+            }
+        ],
+        "provider_scope": {
+            "analysis_count": 1,
+            "undeclared_analysis_count": 0,
+            "physics": ["mechanical"],
+            "mesh_definition_count": 1,
+            "generated_mesh_count": 1,
+            "solver_count": 1,
+            "result_count": 0,
+        },
+    }
+
+    assert set(
+        _solver_operations(
+            domain,
+            (
+                "create_calculix",
+                "create_elmer",
+                "create_mystran",
+                "create_z88",
+            ),
+        )
+    ) == {
+        "create_calculix",
+        "create_elmer",
+        "create_mystran",
+        "create_z88",
+    }
+
+
+def test_solver_creation_accepts_a_current_study_name_or_an_exact_target() -> None:
+    schema = _variant(analyze_solver_capability_definition(), "create_calculix")
+
+    assert set(schema.parameters["properties"]) == {"analysis", "label"}
+    assert schema.parameters["required"] == ["analysis", "label"]
+    assert [
+        branch["type"]
+        for branch in schema.parameters["properties"]["analysis"]["anyOf"]
+    ] == ["string", "object"]
+    exact = schema.provider_parameters()
+    validator = Draft202012Validator(exact)
+    assert not list(
+        validator.iter_errors(
+            {
+                "operation": "create_calculix",
+                "analysis": "Analysis001",
+                "label": "CalculiX",
+            }
+        )
+    )
+    assert not list(
+        validator.iter_errors(
+            {
+                "operation": "create_calculix",
+                "analysis": {
+                    "object_name": "Analysis001",
+                    "expected_state_sha256": "a" * 64,
+                    "expected_member_count": 4,
+                },
+                "label": "CalculiX",
+            }
+        )
+    )
+
+
+def test_solver_name_binding_resolves_the_current_exact_target(monkeypatch) -> None:
+    runtime = object.__new__(solver_bindings.NativeAnalyzeSolverRuntime)
+    target = {
+        "object_name": "Analysis001",
+        "expected_state_sha256": "b" * 64,
+        "expected_member_count": 5,
+    }
+    captured = {}
+
+    monkeypatch.setattr(
+        solver_bindings,
+        "current_analysis_target",
+        lambda actual_runtime, name: target
+        if actual_runtime is runtime and name == "Analysis001"
+        else None,
+    )
+
+    def execute(actual_runtime, arguments, *, ticket):
+        assert actual_runtime is runtime
+        captured.update(arguments)
+        assert ticket == "ticket"
+        return {"created_solver": {"object_name": "SolverCalculiX"}}
+
+    monkeypatch.setattr(solver_bindings.NativeAnalyzeSolverRuntime, "execute", execute)
+
+    result = solver_bindings._execute(
+        SimpleNamespace(
+            runtime=runtime,
+            ticket="ticket",
+            arguments={
+                "operation": "create_calculix",
+                "analysis": "Analysis001",
+                "label": "CalculiX",
+            },
+        )
+    )
+
+    assert captured == {
+        "operation": "create_calculix",
+        "analysis": target,
+        "label": "CalculiX",
+    }
+    assert result["analysis_name"] == "Analysis001"
+
+
+def test_solver_provider_surface_preserves_the_required_study_choice() -> None:
+    definition = analyze_solver_capability_definition()
+    surface_schema = provider_visible_native_schema(
+        definition.provider_schema(("create_calculix", "create_elmer"))
+    )["parameters"]
+    validator = Draft202012Validator(surface_schema)
+
+    assert list(
+        validator.iter_errors(
+            {"operation": "create_calculix", "label": "CalculiX"}
+        )
+    )
+    assert not list(
+        validator.iter_errors(
+            {
+                "operation": "create_calculix",
+                "analysis": "Analysis001",
+                "label": "CalculiX",
+            }
+        )
+    )

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_provider_scope.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_provider_scope.py
@@ -1425,6 +1425,9 @@ def test_operation_scope_publishes_only_calls_that_match_current_study_state() -
     fluid_domain["mesh_definition_count"] = 1
     fluid_domain["mesh_definitions"] = [{"mesher": "gmsh"}]
     fluid_domain["provider_scope"]["mesh_definition_count"] = 1
+    fluid_domain["analysis_workflows"][0]["study_inventory"][
+        "mesh_definition_count"
+    ] = 1
     fluid_with_mesh = scope_analyze_provider_surface(
         surface,
         {"surface_id": "analyze", "domain": fluid_domain},
@@ -1485,6 +1488,7 @@ def test_operation_scope_publishes_only_calls_that_match_current_study_state() -
     assert fluid_operations["analyze.model"] == {
         "create_analysis",
         "update_study",
+        "update_study_dependencies",
     }
     assert fluid_operations[ANALYZE_MATERIAL_CATALOG] == {"search"}
     assert "analyze.inspect" not in fluid_operations
@@ -1517,6 +1521,7 @@ def test_operation_scope_publishes_only_calls_that_match_current_study_state() -
     assert "analyze.inspect" not in mechanical_operations
     assert truncated_mechanical_operations["analyze.inspect"] == {
         "assignments",
+        "studies",
         "validate_assignments",
     }
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_solver_execution.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_analyze_solver_execution.py
@@ -22,6 +22,10 @@ from VibeCADNativeAnalyzeSolverExecutionProcess import run_solver_processes
 from VibeCADNativeAnalyzeSolverExecutionSchema import (
     analyze_solver_execution_capability_definition,
 )
+from VibeCADNativeAnalyzeSolverExecutionRuntime import (
+    NativeAnalyzeSolverExecutionRuntime,
+)
+from VibeCADNativeAnalyzeRunSchema import analyze_run_solver_capability_definition
 from VibeCADNativeBackground import NativeBackgroundCancelled
 
 
@@ -38,7 +42,50 @@ def test_solver_execution_schema_is_one_sharp_background_operation() -> None:
     variant = definition.variants[0]
     assert variant.background_required
     assert variant.transaction_behavior == "background"
-    assert set(variant.parameters["properties"]) == {"target", "timeout_seconds"}
+    assert set(variant.parameters["properties"]) == {
+        "target",
+        "mesh",
+        "timeout_seconds",
+    }
+
+
+def test_focused_solver_run_accepts_an_explicit_mesh_name() -> None:
+    variant = analyze_run_solver_capability_definition().variants[0]
+
+    assert set(variant.parameters["properties"]) == {
+        "solver_name",
+        "mesh_name",
+        "timeout_seconds",
+    }
+    assert variant.parameters["required"] == ["solver_name"]
+    assert variant.parameters["properties"]["mesh_name"]["type"] == "string"
+
+
+def test_solver_runtime_accepts_an_omitted_mesh_for_owner_resolution() -> None:
+    runtime = object.__new__(NativeAnalyzeSolverExecutionRuntime)
+    runtime._context = SimpleNamespace(
+        guard=lambda: None,
+        background_manager=None,
+        document_thread_dispatch=None,
+    )
+
+    with pytest.raises(NativeAnalyzeError) as raised:
+        runtime.execute(
+            {
+                "operation": "run",
+                "target": {
+                    "object_name": "SolverCalculiX",
+                    "expected_state_sha256": "a" * 64,
+                },
+                "timeout_seconds": 3600,
+            },
+            ticket=None,
+        )
+
+    assert (
+        raised.value.error_code
+        == "NATIVE_ANALYZE_SOLVER_BACKGROUND_UNAVAILABLE"
+    )
 
 
 def test_process_sequence_is_exact_bounded_and_shell_free(tmp_path: Path) -> None:
@@ -375,6 +422,133 @@ def test_solver_capture_does_not_generate_case_files(monkeypatch) -> None:
     )
 
 
+def test_solver_capture_requires_an_explicit_mesh_when_study_has_several(
+    monkeypatch,
+) -> None:
+    import VibeCADNativeAnalyzeSolverExecution as execution
+
+    class Mesh:
+        def __init__(self, name: str) -> None:
+            self.Name = name
+            self.Label = name
+            self.Suppressed = False
+
+        @staticmethod
+        def isDerivedFrom(type_id: str) -> bool:
+            return type_id == "Fem::FemMeshObject"
+
+    first = Mesh("CoarseMesh")
+    second = Mesh("FineMesh")
+    analysis = SimpleNamespace(Name="Analysis", Group=(first, second))
+    document = SimpleNamespace(
+        getObject=lambda name: analysis if name == "Analysis" else None
+    )
+    solver = SimpleNamespace(Name="Solver", Document=document)
+    target = SimpleNamespace(
+        solver=solver,
+        kind="calculix",
+        expected_state_sha256="a" * 64,
+    )
+    monkeypatch.setattr(execution, "prepare_solver_target", lambda *_args: target)
+    monkeypatch.setattr(
+        execution,
+        "solver_state",
+        lambda *_args: {
+            "suppressed": False,
+            "analysis": "Analysis",
+        },
+    )
+    monkeypatch.setattr(execution, "validate_assignments", lambda *_args: {"valid": True})
+
+    with pytest.raises(NativeAnalyzeError) as raised:
+        execution.capture_solver_execution_request(
+            document,
+            "document-a",
+            target={
+                "object_name": "Solver",
+                "expected_state_sha256": "a" * 64,
+            },
+            timeout_seconds=3600,
+        )
+
+    assert raised.value.error_code == "NATIVE_ANALYZE_SOLVER_MESH_REQUIRED"
+    assert raised.value.repair == {
+        "analysis": "Analysis",
+        "mesh_names": ["CoarseMesh", "FineMesh"],
+    }
+
+
+def test_solver_capture_keeps_the_explicit_mesh_with_its_solver(monkeypatch) -> None:
+    import VibeCADNativeAnalyzeSolverExecution as execution
+
+    class Mesh:
+        Name = "FineMesh"
+        Label = "Fine mesh"
+        Suppressed = False
+
+        @staticmethod
+        def isDerivedFrom(type_id: str) -> bool:
+            return type_id == "Fem::FemMeshObject"
+
+    mesh = Mesh()
+    analysis = SimpleNamespace(Name="Analysis", Group=(mesh,))
+    document = SimpleNamespace(
+        getObject=lambda name: analysis if name == "Analysis" else None
+    )
+    solver = SimpleNamespace(Name="Solver", Document=document)
+    target = SimpleNamespace(
+        solver=solver,
+        kind="calculix",
+        expected_state_sha256="a" * 64,
+    )
+    selected = SimpleNamespace(
+        mesh=mesh,
+        kind="gmsh",
+        expected_state_sha256="b" * 64,
+    )
+    monkeypatch.setattr(execution, "prepare_solver_target", lambda *_args: target)
+    monkeypatch.setattr(
+        execution,
+        "prepare_fem_mesh_definition_target",
+        lambda *_args: selected,
+    )
+    monkeypatch.setattr(
+        execution,
+        "solver_state",
+        lambda *_args: {"suppressed": False, "analysis": "Analysis"},
+    )
+    monkeypatch.setattr(execution, "validate_assignments", lambda *_args: {"valid": True})
+    monkeypatch.setattr(execution, "_require_history_root", lambda *_args: (solver,))
+    monkeypatch.setattr(
+        execution,
+        "_current_solver_runtime_preferences",
+        lambda *_args: (
+            (
+                "User parameter:BaseApp/Preferences/Mod/Fem/General",
+                "KeepResultsOnReRun",
+                "bool",
+                False,
+            ),
+        ),
+    )
+
+    captured = execution.capture_solver_execution_request(
+        document,
+        "document-a",
+        target={
+            "object_name": "Solver",
+            "expected_state_sha256": "a" * 64,
+        },
+        mesh={
+            "object_name": "FineMesh",
+            "expected_state_sha256": "b" * 64,
+        },
+        timeout_seconds=3600,
+    )
+
+    assert captured.mesh is selected
+
+
 def test_solver_capture_rejects_assignments_outside_the_generated_mesh(
     monkeypatch,
 ) -> None:
@@ -524,6 +698,15 @@ def test_solver_snapshot_is_materialized_only_inside_owned_workspace(
             Path(path).write_bytes(b"FCStd snapshot")
             return True
 
+    selected_mesh = SimpleNamespace(
+        mesh=SimpleNamespace(
+            Name="FineMesh",
+            ID=23,
+            TypeId="Fem::FemMeshObjectPython",
+        ),
+        kind="gmsh",
+        expected_state_sha256="c" * 64,
+    )
     captured = SimpleNamespace(
         target=SimpleNamespace(
             solver=SimpleNamespace(Name="Solver", ID=17, TypeId="Fem::FemSolverObject"),
@@ -534,6 +717,7 @@ def test_solver_snapshot_is_materialized_only_inside_owned_workspace(
         timeout_seconds=3600,
         keep_results=False,
         runtime_preferences=(),
+        mesh=selected_mesh,
     )
     workspace = execution_input.SolverExecutionWorkspace(
         temporary=SimpleNamespace(cleanup=lambda: None),
@@ -561,6 +745,50 @@ def test_solver_snapshot_is_materialized_only_inside_owned_workspace(
     assert frozen.snapshot.path == tmp_path / "document.FCStd"
     assert frozen.request.path == tmp_path / "request.json"
     assert frozen.solver_name == "Solver"
+    import json
+
+    request = json.loads(frozen.request.path.read_text(encoding="utf-8"))
+    assert request["mesh"] == {
+        "object_name": "FineMesh",
+        "object_id": 23,
+        "type_id": "Fem::FemMeshObjectPython",
+        "kind": "gmsh",
+        "state_sha256": "c" * 64,
+    }
+
+
+def test_detached_solver_snapshot_keeps_only_the_selected_mesh() -> None:
+    import VibeCADNativeAnalyzeSolverExecutionChild as child
+
+    class Mesh:
+        def __init__(self, name: str, object_id: int) -> None:
+            self.Name = name
+            self.ID = object_id
+            self.TypeId = "Fem::FemMeshObjectPython"
+
+        @staticmethod
+        def isDerivedFrom(type_id: str) -> bool:
+            return type_id == "Fem::FemMeshObject"
+
+    selected = Mesh("FineMesh", 23)
+    other = Mesh("CoarseMesh", 24)
+
+    class Analysis:
+        def __init__(self) -> None:
+            self.Group = [selected, other, object()]
+
+        def removeObject(self, obj) -> None:
+            self.Group.remove(obj)
+
+    analysis = Analysis()
+
+    child._isolate_solver_mesh(
+        analysis,
+        selected,
+    )
+
+    assert selected in analysis.Group
+    assert other not in analysis.Group
 
 
 def test_human_and_ai_solver_entrypoints_do_not_call_synchronous_case_builder() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_context_manifest.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_context_manifest.py
@@ -23,6 +23,8 @@ EXPECTED_CONTEXT_ACTION_IDS = {
     "VibeCAD_NativeSketchState",
     "SketchEditDeleteGeometry",
     "VibeCAD_AnalyzeReadAnalysis",
+    "VibeCAD_AnalyzeCreateStudyFocused",
+    "VibeCAD_AnalyzeConfigureStudyFocused",
     "VibeCAD_AnalyzeReadGeometrySource",
     "VibeCAD_AnalyzeCreateSolidDomain",
     "VibeCAD_AnalyzeReadAssignments",
@@ -256,6 +258,8 @@ def test_surface_filtering_never_leaks_context_actions() -> None:
     analyze = context_actions_for_surface("analyze")
     assert tuple(action.action_id for action in analyze) == (
         "VibeCAD_AnalyzeReadAnalysis",
+        "VibeCAD_AnalyzeCreateStudyFocused",
+        "VibeCAD_AnalyzeConfigureStudyFocused",
         "VibeCAD_AnalyzeReadGeometrySource",
         "VibeCAD_AnalyzeCreateSolidDomain",
         "VibeCAD_AnalyzeReadAssignments",

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_snapshot.py
@@ -405,7 +405,7 @@ def test_each_surface_builds_only_its_live_domain(
         monkeypatch.setattr(
             analyze_snapshot_module,
             "build_analyze_snapshot",
-            lambda _document, *, background_job=None: {
+            lambda _document, *, background_job=None, selection=None: {
                 "kind": "analyze",
                 "run_status": {
                     "phase": "idle" if background_job is None else "queued"


### PR DESCRIPTION
## Summary

- make each FEM study an explicit aggregate that owns its materials, constraints, meshes, solvers, runs, and results
- add focused create/configure study tools while retaining the existing Analyze surface
- resolve mutations against exact study targets instead of a document-wide singleton
- add explicit acyclic study dependencies, bounded catalogs, selection-based focus, and study-scoped provider state
- key mesh and solver background work to stable source and study snapshots so independent studies do not invalidate each other
- preserve study ownership through labels, undo/redo, save/reopen, result inspection, and GUI workflows
- sharpen the Native Analyze surface so stable study names are the preferred solver target while exact targets remain supported

## Verification

- [x] Red/green TDD was used. The new multi-study and solver-contract tests failed against the prior singleton/target behavior before implementation and pass afterward.
- [x] Exact commands and results are listed below.

Commands:

```text
PYTHONPATH=src/Mod/VibeCAD python3 -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_native_analyze_*.py
156 passed in 3.71s

cmake --build build/release -j2
completed successfully

git diff --check origin/main...HEAD
completed with no findings
```

Headless production-harness acceptance used the unchanged ordinary prompt to create and solve two independent cantilever studies:

- GPT-5.6 Terra, subscription, high: 29/29 production tool calls succeeded; exactly two studies, two generated meshes, two solvers, and two durable result sets survived save/reopen. Maximum displacement scaled from 0.9533 mm to 1.9064 mm.
- Qwen 3.5 9B, local: completed and persisted the same two-study workflow. 24/27 calls succeeded; three recoverable failures came from confusing material lookup with assignment, and the model created one redundant identical material assignment. No native mesh, solver, persistence, or ownership call failed.

## Compatibility

- [x] Existing public functions and APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing Analyze defaults remain available; focused study lifecycle tools are additive.
- [x] Legacy `analyze.model` remains registered for existing callers.
- [x] No breaking changes or deprecations are introduced.

## Risk and review focus

The main risk is ownership resolution across legacy documents containing several FEM analyses. Reviewers should focus on exact-target resolution, study-scoped snapshot/cache keys, dependency-cycle rejection, and save/reopen behavior. No unrelated workbench or packaging changes are included.

## Issues

Closes #128

## Before and After Images

No screenshot is included. The user-visible change is multi-study ownership and targeting rather than a visual redesign; GUI behavior is covered by the updated Analyze integration scenarios and headless production acceptance.