### PR TITLE
Fix Anthropic action recovery and compaction compatibility

### DIFF
--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -40,9 +40,29 @@ MAX_PROVIDER_COMPLETE_READ_BYTES = 2 * 1024 * 1024
 MAX_PROVIDER_RESULT_TOP_LEVEL_FIELDS = 256
 MAX_PROVIDER_INSTRUCTIONS_BYTES = 8 * 1024
 DEFAULT_ANTHROPIC_MAX_TOKENS = 8192
+DEFAULT_ANTHROPIC_MAX_TURNS = 64
 ANTHROPIC_TURN_COMPACTION_MAX_TOKENS = 4096
 ANTHROPIC_TURN_COMPACTION_MAX_INPUT_BYTES = 32 * 1024
-ANTHROPIC_TURN_COMPACTION_MAX_ATTEMPTS = 2
+ANTHROPIC_TURN_COMPACTION_MAX_ATTEMPTS = 1
+ANTHROPIC_RECOVERY_MAX_TOKENS = 4096
+ANTHROPIC_RECOVERY_FINISH_TOOL = "vibecad_internal_finish_turn"
+ANTHROPIC_RECOVERY_BLOCK_TOOL = "vibecad_internal_block_turn"
+ANTHROPIC_RECOVERY_EXHAUSTED_MESSAGE = (
+    "I could not safely continue because the AI exhausted its bounded recovery "
+    "output without selecting a CAD action or a final outcome. No additional CAD "
+    "action was executed. Please retry the request or lower the reasoning effort."
+)
+ANTHROPIC_RECOVERY_INSTRUCTIONS = """This is VibeCAD's one bounded action-recovery turn.
+
+Produce one safe outcome now: call a CAD tool that makes or verifies concrete
+progress, return a concise final answer if the request is complete, or call the
+blocking tool with the exact blocker and required user input. Do not repeat an
+unchanged tool call, narrate future work, or defer the decision."""
+ANTHROPIC_TURN_LIMIT_MESSAGE = (
+    "I stopped this run at VibeCAD's Anthropic turn safety limit. Completed CAD "
+    "actions remain in the document, but the request did not reach a verified final "
+    "outcome. Please continue with a narrower follow-up request."
+)
 PROVIDER_STREAM_DELTA_FLUSH_SECONDS = 0.075
 ANTHROPIC_THINKING_BUDGETS = {
     "minimal": 1024,
@@ -70,7 +90,7 @@ Use only exposed tools and exact returned state. Never invent names, references,
 
 ANTHROPIC_TURN_COMPACTION_INSTRUCTIONS = """You compact one unfinished VibeCAD agent turn.
 
-Call commit_turn_compaction exactly once. Preserve the current user request,
+Return only the requested structured state. Preserve the current user request,
 explicit requirements and rejected directions, completed CAD actions and their
 observed results, live artifact identities and revisions, the blocking failure,
 and the next concrete action. Be concise and factual. Do not solve the CAD task.
@@ -1923,7 +1943,7 @@ class AnthropicProvider(BaseProvider):
         api_key: str | None = None,
         reasoning_effort: str = "high",
         timeout_seconds: float | None = None,
-        max_turns: int | None = None,
+        max_turns: int | None = DEFAULT_ANTHROPIC_MAX_TURNS,
         base_url: str | None = None,
         web_search_enabled: bool = False,
         compaction_model: str | None = None,
@@ -4964,6 +4984,165 @@ def _anthropic_turn_compaction_tool() -> dict[str, Any]:
     }
 
 
+def _anthropic_recovery_tool_definitions() -> list[dict[str, Any]]:
+    """Return private terminal exits used only by a bounded recovery turn."""
+
+    return [
+        {
+            "name": ANTHROPIC_RECOVERY_FINISH_TOOL,
+            "description": (
+                "Finish the current VibeCAD request with a concise, user-visible "
+                "answer when no additional CAD tool is required."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "answer": {"type": "string", "minLength": 1, "maxLength": 8000}
+                },
+                "required": ["answer"],
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": ANTHROPIC_RECOVERY_BLOCK_TOOL,
+            "description": (
+                "Stop the current VibeCAD request when it cannot continue safely. "
+                "State the exact blocker and any user input required."
+            ),
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "reason": {"type": "string", "minLength": 1, "maxLength": 4000},
+                    "required_input": {"type": "string", "maxLength": 2000},
+                },
+                "required": ["reason", "required_input"],
+                "additionalProperties": False,
+            },
+        },
+    ]
+
+
+def _anthropic_recovery_request_tools(
+    cad_tools: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    recovery_tools = _anthropic_recovery_tool_definitions()
+    existing = {str(tool.get("name") or "") for tool in cad_tools}
+    reserved = {str(tool["name"]) for tool in recovery_tools}
+    collision = sorted(existing & reserved)
+    if collision:
+        raise RuntimeError(
+            "Provider tool surface collides with reserved Anthropic recovery tools: "
+            + ", ".join(collision)
+        )
+    return [*cad_tools, *recovery_tools]
+
+
+def _anthropic_recovery_terminal_output(block: Any) -> str | None:
+    name = str(
+        getattr(block, "name", None) or _object_payload(block).get("name") or ""
+    )
+    value = getattr(block, "input", None)
+    if value is None:
+        value = _object_payload(block).get("input")
+    arguments = value if isinstance(value, dict) else {}
+    if name == ANTHROPIC_RECOVERY_FINISH_TOOL:
+        answer = str(arguments.get("answer") or "").strip()
+        return answer or ANTHROPIC_RECOVERY_EXHAUSTED_MESSAGE
+    if name == ANTHROPIC_RECOVERY_BLOCK_TOOL:
+        reason = str(arguments.get("reason") or "").strip()
+        required_input = str(arguments.get("required_input") or "").strip()
+        if not reason:
+            return ANTHROPIC_RECOVERY_EXHAUSTED_MESSAGE
+        output = f"I cannot safely continue: {reason}"
+        if required_input:
+            output += f" Required next step: {required_input}"
+        return output
+    return None
+
+
+def _anthropic_progress_fingerprint(value: Any) -> str:
+    encoded = json.dumps(
+        _json_safe(value),
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _anthropic_progress_state_fingerprint(context: dict[str, Any]) -> str:
+    """Fingerprint durable state without hashing complete geometry or image payloads."""
+
+    state = _anthropic_compaction_resume_state(context)
+    native_state = context.get("native_state")
+    if isinstance(native_state, dict):
+        durable_native_keys = (
+            "document_uid",
+            "structural_revision",
+            "revision",
+            "current_revision",
+            "surface_id",
+            "background_job",
+            "background_jobs",
+            "active_background_jobs",
+        )
+        state["native_progress"] = {
+            key: _bounded_compaction_value(native_state[key])
+            for key in durable_native_keys
+            if native_state.get(key) not in (None, "", [], {})
+        }
+    return _anthropic_progress_fingerprint(state)
+
+
+def _anthropic_validate_turn_compaction_state(value: Any) -> dict[str, Any]:
+    """Enforce constraints stripped from Anthropic's wire-compatible schema."""
+
+    if not isinstance(value, dict):
+        raise RuntimeError("Anthropic turn compaction returned invalid state.")
+    string_limits = {"current_request": 6000, "next_action": 1600}
+    list_limits = {
+        "requirements": (32, 1200),
+        "completed_actions": (32, 1200),
+        "live_artifacts": (32, 1200),
+        "open_issues": (32, 1200),
+    }
+    expected = set(string_limits) | set(list_limits)
+    if set(value) != expected:
+        raise RuntimeError(
+            "Anthropic turn compaction returned unexpected or missing state fields."
+        )
+    for field, max_length in string_limits.items():
+        item = value[field]
+        if not isinstance(item, str):
+            raise RuntimeError(
+                f"Anthropic turn compaction field {field} is not a string."
+            )
+        if len(item) > max_length:
+            raise RuntimeError(
+                f"Anthropic turn compaction field {field} exceeds {max_length} characters."
+            )
+    for field, (max_items, max_length) in list_limits.items():
+        items = value[field]
+        if not isinstance(items, list):
+            raise RuntimeError(
+                f"Anthropic turn compaction field {field} is not a list."
+            )
+        if len(items) > max_items:
+            raise RuntimeError(
+                f"Anthropic turn compaction field {field} exceeds {max_items} items."
+            )
+        if any(not isinstance(item, str) for item in items):
+            raise RuntimeError(
+                f"Anthropic turn compaction field {field} contains a non-string item."
+            )
+        if any(len(item) > max_length for item in items):
+            raise RuntimeError(
+                f"Anthropic turn compaction field {field} contains an item exceeding "
+                f"{max_length} characters."
+            )
+    return _json_safe(value)
+
+
 def _anthropic_compact_turn_in_thread(
     *,
     anthropic_module: Any,
@@ -4976,7 +5155,18 @@ def _anthropic_compact_turn_in_thread(
 ) -> dict[str, Any]:
     """Run a tool-less, bounded compaction request outside the provider loop thread."""
 
-    tool = _anthropic_turn_compaction_tool()
+    original_schema = _anthropic_turn_compaction_tool()["input_schema"]
+    transform_schema = getattr(anthropic_module, "transform_schema", None)
+    if not callable(transform_schema):
+        raise RuntimeError(
+            "The installed Anthropic SDK does not provide structured-output schema "
+            "transformation."
+        )
+    schema = transform_schema(original_schema)
+    if not isinstance(schema, dict):
+        raise RuntimeError(
+            "The Anthropic SDK returned an invalid structured-output schema."
+        )
     request = {
         "model": model,
         "max_tokens": ANTHROPIC_TURN_COMPACTION_MAX_TOKENS,
@@ -4992,8 +5182,12 @@ def _anthropic_compact_turn_in_thread(
                 ),
             }
         ],
-        "tools": [tool],
-        "tool_choice": {"type": "tool", "name": tool["name"]},
+        "output_config": {
+            "format": {
+                "type": "json_schema",
+                "schema": schema,
+            }
+        },
     }
     _capture_outbound_request(
         debug_context,
@@ -5011,28 +5205,27 @@ def _anthropic_compact_turn_in_thread(
             response = anthropic_module.Anthropic(
                 **dict(client_kwargs)
             ).messages.create(**request)
-            calls = [
+            text_blocks = [
                 block
                 for block in list(getattr(response, "content", []) or [])
-                if _anthropic_block_type(block) == "tool_use"
+                if _anthropic_block_type(block) == "text"
             ]
-            if len(calls) != 1:
+            if len(text_blocks) != 1:
                 raise RuntimeError(
                     "Anthropic turn compaction did not return exactly one "
-                    "structured state call."
+                    "structured state response."
                 )
-            call = calls[0]
-            call_name = getattr(call, "name", None) or _object_payload(call).get(
-                "name"
-            )
-            if str(call_name or "") != tool["name"]:
-                raise RuntimeError("Anthropic turn compaction called the wrong tool.")
-            value = getattr(call, "input", None)
-            if value is None:
-                value = _object_payload(call).get("input")
-            if not isinstance(value, dict):
-                raise RuntimeError("Anthropic turn compaction returned invalid state.")
-            result.append(_json_safe(value))
+            block = text_blocks[0]
+            encoded = getattr(block, "text", None)
+            if encoded is None:
+                encoded = _object_payload(block).get("text")
+            try:
+                value = json.loads(str(encoded or ""))
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError(
+                    "Anthropic turn compaction returned invalid JSON state."
+                ) from exc
+            result.append(_anthropic_validate_turn_compaction_state(value))
         except BaseException as exc:
             errors.append(exc)
 
@@ -5606,10 +5799,6 @@ def _anthropic_child_main(
         tools_by_name, tool_definitions = build_tool_surface(live_context)
         thinking = _anthropic_thinking_config(reasoning_effort)
         max_tokens = DEFAULT_ANTHROPIC_MAX_TOKENS
-        if thinking is not None:
-            max_tokens += int(
-                ANTHROPIC_THINKING_BUDGETS[str(reasoning_effort).strip().lower()]
-            )
 
         system_blocks = _anthropic_system_blocks(live_context)
         messages: list[dict[str, Any]] = [
@@ -5624,6 +5813,8 @@ def _anthropic_child_main(
         assistant_progress: list[str] = []
         previous_compaction: dict[str, Any] | None = None
         compaction_count = 0
+        recovery_required = False
+        last_tool_observation: tuple[str, str, str] | None = None
 
         client_kwargs: dict[str, Any] = {"max_retries": 2}
         if api_key:
@@ -5657,6 +5848,18 @@ def _anthropic_child_main(
                 **request_kwargs,
                 "system": system_blocks,
             }
+            if recovery_required:
+                sdk_request["max_tokens"] = ANTHROPIC_RECOVERY_MAX_TOKENS
+                sdk_request["tools"] = _anthropic_recovery_request_tools(
+                    list(request_kwargs["tools"])
+                )
+                sdk_request["tool_choice"] = {"type": "auto"}
+                sdk_request["system"] = [
+                    *system_blocks,
+                    {"type": "text", "text": ANTHROPIC_RECOVERY_INSTRUCTIONS},
+                ]
+                if thinking is not None:
+                    sdk_request["output_config"] = {"effort": "low"}
             _capture_outbound_request(
                 live_context,
                 provider="anthropic",
@@ -5675,9 +5878,10 @@ def _anthropic_child_main(
                     "model": model,
                     "message_count": len(messages),
                     "tool_count": len(request_kwargs["tools"]),
-                    "max_tokens": max_tokens,
+                    "max_tokens": sdk_request["max_tokens"],
                     "thinking": request_kwargs.get("thinking"),
-                    "output_config": request_kwargs.get("output_config"),
+                    "output_config": sdk_request.get("output_config"),
+                    "action_recovery": recovery_required,
                 },
             )
             delta_batcher = _ProviderStreamDeltaBatcher(
@@ -5825,11 +6029,24 @@ def _anthropic_child_main(
             if response_text.strip():
                 assistant_progress.append(response_text.strip())
             if response.stop_reason == "max_tokens":
-                if compaction_count >= ANTHROPIC_TURN_COMPACTION_MAX_ATTEMPTS:
-                    raise RuntimeError(
-                        "Anthropic exhausted its output budget after "
-                        f"{compaction_count} compacted continuations."
+                if recovery_required:
+                    conn.send(
+                        {
+                            "type": "done",
+                            "final_output": ANTHROPIC_RECOVERY_EXHAUSTED_MESSAGE,
+                            "raw": {"stalled": True, "reason": "output_budget"},
+                        }
                     )
+                    return
+                if compaction_count >= ANTHROPIC_TURN_COMPACTION_MAX_ATTEMPTS:
+                    conn.send(
+                        {
+                            "type": "done",
+                            "final_output": ANTHROPIC_RECOVERY_EXHAUSTED_MESSAGE,
+                            "raw": {"stalled": True, "reason": "output_budget"},
+                        }
+                    )
+                    return
                 compaction_count += 1
                 packet = _anthropic_turn_compaction_packet(
                     prompt=prompt,
@@ -5873,6 +6090,7 @@ def _anthropic_child_main(
                         ),
                     }
                 ]
+                recovery_required = True
                 _send_child_progress(
                     conn,
                     {
@@ -5910,6 +6128,38 @@ def _anthropic_child_main(
                     }
                 )
                 return
+            recovery_terminal_blocks = [
+                block
+                for block in tool_use_blocks
+                if str(
+                    getattr(block, "name", None)
+                    or _object_payload(block).get("name")
+                    or ""
+                )
+                in {ANTHROPIC_RECOVERY_FINISH_TOOL, ANTHROPIC_RECOVERY_BLOCK_TOOL}
+            ]
+            if recovery_terminal_blocks:
+                if not recovery_required or len(tool_use_blocks) != 1:
+                    conn.send(
+                        {
+                            "type": "done",
+                            "final_output": ANTHROPIC_RECOVERY_EXHAUSTED_MESSAGE,
+                            "raw": {"stalled": True, "reason": "invalid_recovery"},
+                        }
+                    )
+                    return
+                final_output = _anthropic_recovery_terminal_output(
+                    recovery_terminal_blocks[0]
+                )
+                conn.send(
+                    {
+                        "type": "done",
+                        "final_output": final_output
+                        or ANTHROPIC_RECOVERY_EXHAUSTED_MESSAGE,
+                        "raw": None,
+                    }
+                )
+                return
             server_use_ids = {
                 str(getattr(block, "id", "") or _object_payload(block).get("id") or "")
                 for block in content_blocks
@@ -5927,6 +6177,8 @@ def _anthropic_child_main(
             pending_server_tool = bool(server_use_ids - server_result_ids)
             tool_results: list[dict[str, Any]] = []
             visual_repin_blocks: list[dict[str, Any]] = []
+            repeated_unchanged_result = False
+            real_tool_executed = False
             for block in tool_use_blocks:
                 previous_context = live_context
                 tool_name = tools_by_name.get(block.name)
@@ -5937,6 +6189,7 @@ def _anthropic_child_main(
                         "error": f"Unknown VibeCAD tool: {block.name}",
                     }
                 else:
+                    real_tool_executed = True
                     arguments_json = json.dumps(
                         _json_safe(block.input or {}),
                         ensure_ascii=True,
@@ -5982,6 +6235,27 @@ def _anthropic_child_main(
                 )
                 if isinstance(result, dict) and state_after:
                     result["vibecad_state_after"] = state_after
+                if tool_name is not None and isinstance(result, dict):
+                    observation = (
+                        _anthropic_progress_fingerprint(
+                            {
+                                "tool": tool_name,
+                                "arguments": getattr(block, "input", None) or {},
+                            }
+                        ),
+                        _anthropic_progress_state_fingerprint(previous_context),
+                        _anthropic_progress_fingerprint(
+                            _provider_visible_tool_result(result, tool_name=tool_name)
+                        ),
+                    )
+                    if observation == last_tool_observation:
+                        repeated_unchanged_result = True
+                        result["vibecad_progress_guard"] = {
+                            "status": "no_progress",
+                            "reason": "repeated_unchanged_tool_result",
+                            "retry_same_call": False,
+                        }
+                    last_tool_observation = observation
                 if (
                     tool_name == "core.capture_view_screenshot"
                     and not pending_server_tool
@@ -6028,14 +6302,20 @@ def _anthropic_child_main(
                         ),
                     }
                 )
+            if repeated_unchanged_result:
+                recovery_required = True
+            elif real_tool_executed:
+                recovery_required = False
+                compaction_count = 0
             messages.append(
                 {"role": "user", "content": [*tool_results, *visual_repin_blocks]}
             )
             turn += 1
         conn.send(
             {
-                "type": "error",
-                "error": "Anthropic provider turn limit reached.",
+                "type": "done",
+                "final_output": ANTHROPIC_TURN_LIMIT_MESSAGE,
+                "raw": {"stalled": True, "reason": "turn_limit"},
             }
         )
     except BaseException as exc:

--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -5143,6 +5143,43 @@ def _anthropic_validate_turn_compaction_state(value: Any) -> dict[str, Any]:
     return _json_safe(value)
 
 
+def _anthropic_model_max_tokens(
+    client: Any,
+    model: str,
+    *,
+    sdk_fallback: int,
+) -> int:
+    """Return the selected model's maximum output reported by Anthropic."""
+
+    models = getattr(client, "models", None)
+    retrieve = getattr(models, "retrieve", None)
+    if not callable(retrieve):
+        # Preserve compatibility with older SDKs and Anthropic-compatible test
+        # clients that predate model capability metadata.
+        return int(sdk_fallback)
+    try:
+        model_info = retrieve(model)
+    except BaseException as exc:
+        raise RuntimeError(
+            f"Anthropic did not report the maximum output for model {model!r}: "
+            + _short_provider_error(exc)
+        ) from exc
+    value = getattr(model_info, "max_tokens", None)
+    if value is None:
+        value = _object_payload(model_info).get("max_tokens")
+    try:
+        maximum = int(value)
+    except (TypeError, ValueError) as exc:
+        raise RuntimeError(
+            f"Anthropic returned an invalid maximum output for model {model!r}."
+        ) from exc
+    if maximum <= 0:
+        raise RuntimeError(
+            f"Anthropic returned an invalid maximum output for model {model!r}."
+        )
+    return maximum
+
+
 def _anthropic_compact_turn_in_thread(
     *,
     anthropic_module: Any,
@@ -5152,6 +5189,7 @@ def _anthropic_compact_turn_in_thread(
     debug_context: dict[str, Any],
     base_url: str | None,
     generation: int,
+    max_tokens: int = ANTHROPIC_TURN_COMPACTION_MAX_TOKENS,
 ) -> dict[str, Any]:
     """Run a tool-less, bounded compaction request outside the provider loop thread."""
 
@@ -5169,7 +5207,7 @@ def _anthropic_compact_turn_in_thread(
         )
     request = {
         "model": model,
-        "max_tokens": ANTHROPIC_TURN_COMPACTION_MAX_TOKENS,
+        "max_tokens": int(max_tokens),
         "system": ANTHROPIC_TURN_COMPACTION_INSTRUCTIONS,
         "messages": [
             {
@@ -5798,7 +5836,6 @@ def _anthropic_child_main(
 
         tools_by_name, tool_definitions = build_tool_surface(live_context)
         thinking = _anthropic_thinking_config(reasoning_effort)
-        max_tokens = DEFAULT_ANTHROPIC_MAX_TOKENS
 
         system_blocks = _anthropic_system_blocks(live_context)
         messages: list[dict[str, Any]] = [
@@ -5824,6 +5861,20 @@ def _anthropic_child_main(
         if timeout_seconds is not None and timeout_seconds > 0:
             client_kwargs["timeout"] = timeout_seconds
         client = anthropic.Anthropic(**client_kwargs)
+        max_tokens = _anthropic_model_max_tokens(
+            client,
+            model,
+            sdk_fallback=DEFAULT_ANTHROPIC_MAX_TOKENS,
+        )
+        compaction_max_tokens = (
+            max_tokens
+            if compaction_model == model
+            else _anthropic_model_max_tokens(
+                client,
+                compaction_model,
+                sdk_fallback=ANTHROPIC_TURN_COMPACTION_MAX_TOKENS,
+            )
+        )
 
         request_kwargs: dict[str, Any] = {
             "model": model,
@@ -5849,7 +5900,7 @@ def _anthropic_child_main(
                 "system": system_blocks,
             }
             if recovery_required:
-                sdk_request["max_tokens"] = ANTHROPIC_RECOVERY_MAX_TOKENS
+                sdk_request["max_tokens"] = max_tokens
                 sdk_request["tools"] = _anthropic_recovery_request_tools(
                     list(request_kwargs["tools"])
                 )
@@ -6081,6 +6132,7 @@ def _anthropic_child_main(
                     debug_context=live_context,
                     base_url=base_url,
                     generation=compaction_count,
+                    max_tokens=compaction_max_tokens,
                 )
                 messages = [
                     {

--- a/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
@@ -550,8 +550,19 @@ def test_anthropic_thinking_only_max_tokens_compacts_and_continues(
         ),
     ]
     messages = _SequenceAnthropicMessages(responses)
+    model_requests: list[str] = []
+
+    class _Models:
+        @staticmethod
+        def retrieve(model_id):
+            model_requests.append(model_id)
+            return SimpleNamespace(max_tokens=128_000)
+
     anthropic_module = SimpleNamespace(
-        Anthropic=lambda **_kwargs: SimpleNamespace(messages=messages),
+        Anthropic=lambda **_kwargs: SimpleNamespace(
+            messages=messages,
+            models=_Models(),
+        ),
         BadRequestError=type("BadRequestError", (Exception,), {}),
     )
     monkeypatch.setitem(sys.modules, "anthropic", anthropic_module)
@@ -601,9 +612,11 @@ def test_anthropic_thinking_only_max_tokens_compacts_and_continues(
     ]
     assert len(compaction_calls) == 1
     assert compaction_calls[0]["model"] == "memory-model"
-    assert messages.requests[0]["max_tokens"] == provider.DEFAULT_ANTHROPIC_MAX_TOKENS
+    assert compaction_calls[0]["max_tokens"] == 128_000
+    assert model_requests == ["interactive-model", "memory-model"]
+    assert messages.requests[0]["max_tokens"] == 128_000
     recovery_request = messages.requests[1]
-    assert recovery_request["max_tokens"] == provider.ANTHROPIC_RECOVERY_MAX_TOKENS
+    assert recovery_request["max_tokens"] == 128_000
     assert recovery_request["tool_choice"] == {"type": "auto"}
     assert recovery_request["output_config"] == {"effort": "low"}
     assert "one bounded action-recovery turn" in json.dumps(

--- a/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import json
 import sys
 from types import SimpleNamespace
+from typing import Any, Sequence
 
 import pytest
 
@@ -395,10 +396,45 @@ def test_anthropic_turn_compaction_packet_excludes_deterministic_payloads() -> N
 
 def test_anthropic_turn_compaction_runs_on_its_named_worker_thread() -> None:
     calls: list[dict[str, object]] = []
+    transformed_schemas: list[dict[str, object]] = []
+
+    def transform_schema(schema):
+        transformed_schemas.append(schema)
+        transformed = json.loads(json.dumps(schema))
+
+        def strip_unsupported(value):
+            if isinstance(value, dict):
+                for keyword in (
+                    "maxItems",
+                    "minItems",
+                    "maxLength",
+                    "minLength",
+                    "maximum",
+                    "minimum",
+                ):
+                    value.pop(keyword, None)
+                for child in value.values():
+                    strip_unsupported(child)
+            elif isinstance(value, list):
+                for child in value:
+                    strip_unsupported(child)
+
+        strip_unsupported(transformed)
+        return transformed
 
     class _Messages:
         @staticmethod
         def create(**request):
+            encoded_schema = json.dumps(request["output_config"]["format"]["schema"])
+            for unsupported in (
+                "maxItems",
+                "minItems",
+                "maxLength",
+                "minLength",
+                "maximum",
+                "minimum",
+            ):
+                assert f'"{unsupported}"' not in encoded_schema
             calls.append(
                 {
                     "request": request,
@@ -408,23 +444,25 @@ def test_anthropic_turn_compaction_runs_on_its_named_worker_thread() -> None:
             return SimpleNamespace(
                 content=[
                     SimpleNamespace(
-                        type="tool_use",
-                        name="commit_turn_compaction",
-                        input={
-                            "current_request": "Continue.",
-                            "requirements": [],
-                            "completed_actions": [],
-                            "live_artifacts": [],
-                            "open_issues": [],
-                            "next_action": "Continue.",
-                        },
+                        type="text",
+                        text=json.dumps(
+                            {
+                                "current_request": "Continue.",
+                                "requirements": [],
+                                "completed_actions": [],
+                                "live_artifacts": [],
+                                "open_issues": [],
+                                "next_action": "Continue.",
+                            }
+                        ),
                     )
                 ],
-                stop_reason="tool_use",
+                stop_reason="end_turn",
             )
 
     anthropic_module = SimpleNamespace(
-        Anthropic=lambda **_kwargs: SimpleNamespace(messages=_Messages())
+        Anthropic=lambda **_kwargs: SimpleNamespace(messages=_Messages()),
+        transform_schema=transform_schema,
     )
     result = provider._anthropic_compact_turn_in_thread(
         anthropic_module=anthropic_module,
@@ -438,20 +476,41 @@ def test_anthropic_turn_compaction_runs_on_its_named_worker_thread() -> None:
 
     assert result["next_action"] == "Continue."
     assert len(calls) == 1
+    assert len(transformed_schemas) == 1
+    assert transformed_schemas[0]["properties"]["requirements"]["maxItems"] == 32
     assert calls[0]["thread"] == "VibeCAD-Anthropic-Turn-Compaction"
     request = calls[0]["request"]
     assert request["model"] == "memory-model"
-    assert request["tool_choice"] == {
-        "type": "tool",
-        "name": "commit_turn_compaction",
+    assert "tools" not in request
+    assert "tool_choice" not in request
+    assert request["output_config"]["format"]["type"] == "json_schema"
+    assert (
+        request["output_config"]["format"]["schema"]["properties"]["requirements"]
+        == {"type": "array", "items": {"type": "string"}}
+    )
+
+
+def test_anthropic_turn_compaction_preserves_local_output_bounds() -> None:
+    state = {
+        "current_request": "Continue.",
+        "requirements": ["requirement"] * 33,
+        "completed_actions": [],
+        "live_artifacts": [],
+        "open_issues": [],
+        "next_action": "Continue.",
     }
+
+    with pytest.raises(RuntimeError, match="requirements exceeds 32 items"):
+        provider._anthropic_validate_turn_compaction_state(state)
 
 
 class _SequenceAnthropicMessages:
-    def __init__(self, responses: list[object]) -> None:
+    def __init__(self, responses: Sequence[object]) -> None:
         self.responses = iter(responses)
+        self.requests: list[dict[str, Any]] = []
 
-    def stream(self, **_kwargs):
+    def stream(self, **kwargs):
+        self.requests.append(kwargs)
         response = next(self.responses)
 
         class _Stream:
@@ -526,7 +585,7 @@ def test_anthropic_thinking_only_max_tokens_compacts_and_continues(
         },
         "interactive-model",
         "test-key",
-        None,
+        "high",
         1.0,
         2,
         False,
@@ -542,6 +601,17 @@ def test_anthropic_thinking_only_max_tokens_compacts_and_continues(
     ]
     assert len(compaction_calls) == 1
     assert compaction_calls[0]["model"] == "memory-model"
+    assert messages.requests[0]["max_tokens"] == provider.DEFAULT_ANTHROPIC_MAX_TOKENS
+    recovery_request = messages.requests[1]
+    assert recovery_request["max_tokens"] == provider.ANTHROPIC_RECOVERY_MAX_TOKENS
+    assert recovery_request["tool_choice"] == {"type": "auto"}
+    assert recovery_request["output_config"] == {"effort": "low"}
+    assert "one bounded action-recovery turn" in json.dumps(
+        recovery_request["system"]
+    )
+    recovery_tool_names = {tool["name"] for tool in recovery_request["tools"]}
+    assert provider.ANTHROPIC_RECOVERY_FINISH_TOOL in recovery_tool_names
+    assert provider.ANTHROPIC_RECOVERY_BLOCK_TOOL in recovery_tool_names
     packet_text = json.dumps(compaction_calls[0]["packet"])
     assert "private reasoning" not in packet_text
     progress_events = [
@@ -557,6 +627,513 @@ def test_anthropic_thinking_only_max_tokens_compacts_and_continues(
         event.get("event") == "anthropic_turn_compaction_completed"
         for event in progress_events
     )
+    assert connection.closed
+
+
+@pytest.mark.parametrize(
+    ("tool_name", "tool_input", "expected_output"),
+    (
+        (
+            "vibecad_internal_finish_turn",
+            {"answer": "The requested CAD change is complete."},
+            "The requested CAD change is complete.",
+        ),
+        (
+            "vibecad_internal_block_turn",
+            {
+                "reason": "The selected face no longer exists.",
+                "required_input": "Select the replacement face.",
+            },
+            (
+                "I cannot safely continue: The selected face no longer exists. "
+                "Required next step: Select the replacement face."
+            ),
+        ),
+    ),
+)
+def test_anthropic_budget_recovery_has_structured_terminal_outcomes(
+    monkeypatch,
+    tool_name: str,
+    tool_input: dict[str, str],
+    expected_output: str,
+) -> None:
+    responses = [
+        SimpleNamespace(
+            content=[SimpleNamespace(type="thinking", thinking="unfinished")],
+            stop_reason="max_tokens",
+        ),
+        SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="tool_use",
+                    id="recovery-terminal",
+                    name=tool_name,
+                    input=tool_input,
+                )
+            ],
+            stop_reason="tool_use",
+        ),
+    ]
+    messages = _SequenceAnthropicMessages(responses)
+    anthropic_module = SimpleNamespace(
+        Anthropic=lambda **_kwargs: SimpleNamespace(messages=messages),
+        BadRequestError=type("BadRequestError", (Exception,), {}),
+    )
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic_module)
+    monkeypatch.setattr(
+        provider, "_validate_provider_wire_surface", lambda _context: None
+    )
+    monkeypatch.setattr(
+        provider,
+        "_anthropic_compact_turn_in_thread",
+        lambda **_kwargs: {
+            "current_request": "Finish the CAD task.",
+            "requirements": [],
+            "completed_actions": [],
+            "live_artifacts": [],
+            "open_issues": [],
+            "next_action": "Commit an actionable outcome.",
+        },
+    )
+    connection = _CollectingConnection()
+
+    provider._anthropic_child_main(
+        connection,
+        "Finish the CAD task.",
+        {"provider_tool_schemas": []},
+        "test-model",
+        "test-key",
+        "high",
+        1.0,
+        2,
+        False,
+    )
+
+    terminal = [
+        message
+        for message in connection.messages
+        if message.get("type") in {"done", "error"}
+    ]
+    assert terminal == [{"type": "done", "final_output": expected_output, "raw": None}]
+    assert not any(message.get("type") == "tool" for message in connection.messages)
+    assert connection.closed
+
+
+def test_anthropic_second_budget_exhaustion_returns_bounded_stall(monkeypatch) -> None:
+    responses = [
+        SimpleNamespace(
+            content=[SimpleNamespace(type="thinking", thinking="first")],
+            stop_reason="max_tokens",
+        ),
+        SimpleNamespace(
+            content=[SimpleNamespace(type="thinking", thinking="second")],
+            stop_reason="max_tokens",
+        ),
+    ]
+    messages = _SequenceAnthropicMessages(responses)
+    anthropic_module = SimpleNamespace(
+        Anthropic=lambda **_kwargs: SimpleNamespace(messages=messages),
+        BadRequestError=type("BadRequestError", (Exception,), {}),
+    )
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic_module)
+    monkeypatch.setattr(
+        provider, "_validate_provider_wire_surface", lambda _context: None
+    )
+    compaction_calls: list[dict[str, object]] = []
+
+    def compact(**kwargs):
+        compaction_calls.append(kwargs)
+        return {
+            "current_request": "Modify the model.",
+            "requirements": [],
+            "completed_actions": [],
+            "live_artifacts": [],
+            "open_issues": [],
+            "next_action": "Modify the model.",
+        }
+
+    monkeypatch.setattr(provider, "_anthropic_compact_turn_in_thread", compact)
+    connection = _CollectingConnection()
+
+    provider._anthropic_child_main(
+        connection,
+        "Modify the model.",
+        {"provider_tool_schemas": []},
+        "test-model",
+        "test-key",
+        "high",
+        1.0,
+        3,
+        False,
+    )
+
+    terminal = [
+        message
+        for message in connection.messages
+        if message.get("type") in {"done", "error"}
+    ]
+    assert terminal == [
+        {
+            "type": "done",
+            "final_output": provider.ANTHROPIC_RECOVERY_EXHAUSTED_MESSAGE,
+            "raw": {"stalled": True, "reason": "output_budget"},
+        }
+    ]
+    assert len(compaction_calls) == 1
+    assert len(messages.requests) == 2
+    assert connection.closed
+
+
+def test_anthropic_repeated_unchanged_tool_result_forces_recovery(monkeypatch) -> None:
+    tool_call = lambda call_id: SimpleNamespace(
+        type="tool_use",
+        id=call_id,
+        name="state_read",
+        input={"scope": "selection"},
+    )
+    responses = [
+        SimpleNamespace(content=[tool_call("read-1")], stop_reason="tool_use"),
+        SimpleNamespace(content=[tool_call("read-2")], stop_reason="tool_use"),
+        SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="tool_use",
+                    id="recovery-finish",
+                    name="vibecad_internal_finish_turn",
+                    input={"answer": "The available state is unchanged."},
+                )
+            ],
+            stop_reason="tool_use",
+        ),
+    ]
+    messages = _SequenceAnthropicMessages(responses)
+    anthropic_module = SimpleNamespace(
+        Anthropic=lambda **_kwargs: SimpleNamespace(messages=messages),
+        BadRequestError=type("BadRequestError", (Exception,), {}),
+    )
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic_module)
+    monkeypatch.setattr(
+        provider, "_validate_provider_wire_surface", lambda _context: None
+    )
+    context = {
+        "workbench": "PartDesignWorkbench",
+        "modeling_surface": {"engine": "native", "surface_id": "partdesign"},
+        "native_state": {"structural_revision": 7},
+        "provider_tool_schemas": [
+            {
+                "name": "state.read",
+                "description": "Read exact state.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"scope": {"type": "string"}},
+                    "required": ["scope"],
+                    "additionalProperties": False,
+                },
+            }
+        ],
+    }
+
+    class _Connection(_CollectingConnection):
+        def recv(self):
+            return {
+                "type": "tool_result",
+                "result": {"ok": True, "result": {"selection": []}},
+                "context": context,
+            }
+
+    connection = _Connection()
+    provider._anthropic_child_main(
+        connection,
+        "Inspect the selection.",
+        context,
+        "test-model",
+        "test-key",
+        None,
+        1.0,
+        4,
+        False,
+    )
+
+    tool_messages = [
+        message for message in connection.messages if message.get("type") == "tool"
+    ]
+    assert len(tool_messages) == 2
+    assert messages.requests[2]["tool_choice"] == {"type": "auto"}
+    repeated_result_message = next(
+        message["content"][0]
+        for message in reversed(messages.requests[2]["messages"])
+        if message.get("role") == "user"
+        and isinstance(message.get("content"), list)
+        and message["content"]
+        and message["content"][0].get("type") == "tool_result"
+    )
+    repeated_result = json.loads(repeated_result_message["content"])
+    assert repeated_result["vibecad_progress_guard"] == {
+        "status": "no_progress",
+        "reason": "repeated_unchanged_tool_result",
+        "retry_same_call": False,
+    }
+    terminal = [
+        message for message in connection.messages if message.get("type") == "done"
+    ]
+    assert terminal[-1]["final_output"] == "The available state is unchanged."
+    assert connection.closed
+
+
+def test_anthropic_budget_recovery_executes_a_real_tool_and_releases_gate(
+    monkeypatch,
+) -> None:
+    responses = [
+        SimpleNamespace(
+            content=[SimpleNamespace(type="thinking", thinking="unfinished")],
+            stop_reason="max_tokens",
+        ),
+        SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="tool_use",
+                    id="recovery-read",
+                    name="state_read",
+                    input={"scope": "selection"},
+                )
+            ],
+            stop_reason="tool_use",
+        ),
+        SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="Inspection complete.")],
+            stop_reason="end_turn",
+        ),
+    ]
+    messages = _SequenceAnthropicMessages(responses)
+    anthropic_module = SimpleNamespace(
+        Anthropic=lambda **_kwargs: SimpleNamespace(messages=messages),
+        BadRequestError=type("BadRequestError", (Exception,), {}),
+    )
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic_module)
+    monkeypatch.setattr(
+        provider, "_validate_provider_wire_surface", lambda _context: None
+    )
+    monkeypatch.setattr(
+        provider,
+        "_anthropic_compact_turn_in_thread",
+        lambda **_kwargs: {
+            "current_request": "Inspect the selection.",
+            "requirements": [],
+            "completed_actions": [],
+            "live_artifacts": [],
+            "open_issues": [],
+            "next_action": "Read the selection.",
+        },
+    )
+    context = {
+        "provider_tool_schemas": [
+            {
+                "name": "state.read",
+                "description": "Read exact state.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"scope": {"type": "string"}},
+                    "required": ["scope"],
+                    "additionalProperties": False,
+                },
+            }
+        ]
+    }
+
+    class _Connection(_CollectingConnection):
+        def recv(self):
+            return {
+                "type": "tool_result",
+                "result": {"ok": True, "result": {"selection": []}},
+                "context": context,
+            }
+
+    connection = _Connection()
+    provider._anthropic_child_main(
+        connection,
+        "Inspect the selection.",
+        context,
+        "test-model",
+        "test-key",
+        "high",
+        1.0,
+        3,
+        False,
+    )
+
+    assert messages.requests[1]["tool_choice"] == {"type": "auto"}
+    assert "tool_choice" not in messages.requests[2]
+    tool_messages = [
+        message for message in connection.messages if message.get("type") == "tool"
+    ]
+    assert [message["tool_name"] for message in tool_messages] == ["state.read"]
+    terminal = [
+        message for message in connection.messages if message.get("type") == "done"
+    ]
+    assert terminal[-1]["final_output"] == "Inspection complete."
+    assert connection.closed
+
+
+def test_anthropic_repeated_tool_is_productive_when_document_revision_changes(
+    monkeypatch,
+) -> None:
+    tool_call = lambda call_id: SimpleNamespace(
+        type="tool_use",
+        id=call_id,
+        name="state_read",
+        input={"scope": "selection"},
+    )
+    responses = [
+        SimpleNamespace(content=[tool_call("read-1")], stop_reason="tool_use"),
+        SimpleNamespace(content=[tool_call("read-2")], stop_reason="tool_use"),
+        SimpleNamespace(
+            content=[SimpleNamespace(type="text", text="Both revisions inspected.")],
+            stop_reason="end_turn",
+        ),
+    ]
+    messages = _SequenceAnthropicMessages(responses)
+    anthropic_module = SimpleNamespace(
+        Anthropic=lambda **_kwargs: SimpleNamespace(messages=messages),
+        BadRequestError=type("BadRequestError", (Exception,), {}),
+    )
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic_module)
+    monkeypatch.setattr(
+        provider, "_validate_provider_wire_surface", lambda _context: None
+    )
+
+    def context(revision: int) -> dict[str, object]:
+        return {
+            "workbench": "PartDesignWorkbench",
+            "modeling_surface": {"engine": "native", "surface_id": "partdesign"},
+            "native_state": {"structural_revision": revision},
+            "provider_tool_schemas": [
+                {
+                    "name": "state.read",
+                    "description": "Read exact state.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"scope": {"type": "string"}},
+                        "required": ["scope"],
+                        "additionalProperties": False,
+                    },
+                }
+            ],
+        }
+
+    contexts = iter((context(8), context(9)))
+
+    class _Connection(_CollectingConnection):
+        def recv(self):
+            return {
+                "type": "tool_result",
+                "result": {"ok": True, "result": {"selection": []}},
+                "context": next(contexts),
+            }
+
+    connection = _Connection()
+    provider._anthropic_child_main(
+        connection,
+        "Inspect two changing revisions.",
+        context(7),
+        "test-model",
+        "test-key",
+        None,
+        1.0,
+        3,
+        False,
+    )
+
+    assert "tool_choice" not in messages.requests[2]
+    assert not any(
+        "vibecad_progress_guard" in json.dumps(request["messages"])
+        for request in messages.requests
+    )
+    terminal = [
+        message for message in connection.messages if message.get("type") == "done"
+    ]
+    assert terminal[-1]["final_output"] == "Both revisions inspected."
+    assert connection.closed
+
+
+def test_anthropic_provider_has_a_finite_default_turn_limit() -> None:
+    anthropic = provider.AnthropicProvider()
+
+    assert anthropic.max_turns == provider.DEFAULT_ANTHROPIC_MAX_TURNS
+    assert isinstance(anthropic.max_turns, int)
+    assert anthropic.max_turns > 0
+
+
+def test_anthropic_turn_limit_returns_an_actionable_terminal_result(monkeypatch) -> None:
+    responses = [
+        SimpleNamespace(
+            content=[
+                SimpleNamespace(
+                    type="tool_use",
+                    id="bounded-read",
+                    name="state_read",
+                    input={"scope": "selection"},
+                )
+            ],
+            stop_reason="tool_use",
+        )
+    ]
+    messages = _SequenceAnthropicMessages(responses)
+    anthropic_module = SimpleNamespace(
+        Anthropic=lambda **_kwargs: SimpleNamespace(messages=messages),
+        BadRequestError=type("BadRequestError", (Exception,), {}),
+    )
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic_module)
+    monkeypatch.setattr(
+        provider, "_validate_provider_wire_surface", lambda _context: None
+    )
+    context = {
+        "provider_tool_schemas": [
+            {
+                "name": "state.read",
+                "description": "Read exact state.",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"scope": {"type": "string"}},
+                    "required": ["scope"],
+                    "additionalProperties": False,
+                },
+            }
+        ]
+    }
+
+    class _Connection(_CollectingConnection):
+        def recv(self):
+            return {
+                "type": "tool_result",
+                "result": {"ok": True},
+                "context": context,
+            }
+
+    connection = _Connection()
+    provider._anthropic_child_main(
+        connection,
+        "Inspect the selection.",
+        context,
+        "test-model",
+        "test-key",
+        None,
+        1.0,
+        1,
+        False,
+    )
+
+    terminal = [
+        message
+        for message in connection.messages
+        if message.get("type") in {"done", "error"}
+    ]
+    assert terminal == [
+        {
+            "type": "done",
+            "final_output": provider.ANTHROPIC_TURN_LIMIT_MESSAGE,
+            "raw": {"stalled": True, "reason": "turn_limit"},
+        }
+    ]
     assert connection.closed
 
 


### PR DESCRIPTION
﻿## Outcome

Anthropic turns now make bounded, observable progress instead of repeatedly consuming output budgets, and recovery/compaction requests work with current models that reject forced tool selection and unsupported raw JSON Schema constraints.

Closes #152

## What changed

- Adds one bounded recovery turn after output-budget exhaustion.
- Lets recovery execute a real CAD tool, finish with a user-visible result, or report an exact blocker.
- Detects identical tool calls that return identical results against unchanged CAD state and directs the model away from retrying them.
- Preserves legitimate repeated calls when document revisions or background-job state change.
- Adds a finite default turn ceiling while preserving explicit unlimited configuration through `None` or `0`.
- Uses Anthropic-compatible automatic tool selection during recovery instead of unsupported forced `any`/`tool` choices.
- Compacts unfinished turns through `output_config.format` without forced tool use.
- Runs compaction schemas through the packaged Anthropic SDK's `transform_schema()` before transmission, removing unsupported wire constraints such as `maxItems` and `maxLength`.
- Enforces the original item, field, and length bounds locally after parsing the compacted state.
- Returns actionable terminal results for exhausted recovery and turn-limit cases instead of a generic provider crash.

## Root cause

The original loop allowed multiple large open-ended continuations without requiring observable progress. The first local fix then exposed two model/API compatibility constraints during real testing: the selected model rejects forced tool choices, and Anthropic structured outputs accept only a restricted JSON Schema subset. Both request paths are now capability-safe without model-name guessing.

## TDD and verification

Red tests before implementation:

```powershell
$env:PYTHONPATH=(Resolve-Path 'src/Mod/VibeCAD').Path
& .pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py -k "turn_compaction_runs or thinking_only_max_tokens or repeated_unchanged_tool or budget_recovery_executes"
```

Result: `4 failed, 46 deselected` against the prior recovery/compaction behavior.

The production-schema regression also failed before the SDK transformation was wired in:

```powershell
& .pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py -k "turn_compaction_runs_on_its_named_worker_thread"
```

Result: `1 failed, 49 deselected`; the fake API found raw `maxItems` in the outbound schema.

Green verification:

```powershell
& .pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
```

Result: `50 passed, 1 skipped in 1.17s`.

```powershell
& .pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests
```

Result: `4315 passed, 9 skipped in 82.35s`.

```powershell
& .pixi\envs\default\python.exe -m py_compile src\Mod\VibeCAD\VibeCADProvider.py src\Mod\VibeCAD\vibecad_tests\test_provider_subprocess.py
```

Result: passed.

The compaction function was additionally exercised with the Anthropic SDK packaged in the Windows portable build (`anthropic 0.116.0`). The exact transmitted schema contained zero unsupported constraint keywords, and the transformed response passed local validation. The tested provider was deployed into and launched from the full RC6 Windows portable package.

## Compatibility

- [x] Existing public functions/APIs remain present.
- [x] No preference keys, provider tool names, CAD schemas, or wire result fields were renamed or removed.
- [x] Existing productive tool execution and background-job polling remain supported.
- [x] Explicit unlimited Anthropic turn configuration (`None` or `0`) remains supported.
- [x] No dependency, packaging, C++, or non-Anthropic provider changes.
- [x] No deprecations.
- [x] No public breaking API changes.

The owner-requested behavioral safety change is deliberate: the default Anthropic run is now capped at 64 turns, output-budget recovery is limited to one attempt, and terminal stalls return an actionable completed result instead of spinning or raising a generic provider error.

## Risk and non-goals

Risk is isolated to Anthropic orchestration after output exhaustion, repeated unchanged calls, or exceptionally long turns. Normal Anthropic tool calls and all other providers retain their existing paths. This PR does not change CAD tool contracts, UI behavior, authentication, model selection, or packaging.


## Model-reported output limit correction

Live testing showed that the initial implementation still imposed VibeCAD-owned output caps (`8,192` normally and `4,096` during recovery). This was incorrect because Anthropic thinking tokens consume the same output allowance.

The provider now calls Anthropic's Models API once when the child starts and uses the selected model's reported `max_tokens` for normal generation, recovery, and turn compaction. It does not infer the limit from model names. The existing packaged SDK fallback is retained only for older SDK-compatible clients that do not expose `models.retrieve`.

The configured live model is `claude-fable-5-1`; the authenticated Models API returned `max_tokens=128000`.

Red regression command:

```powershell
$env:PYTHONPATH=(Resolve-Path 'src/Mod/VibeCAD').Path
& .pixi\envs\default\python.exe -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py -k "thinking_only_max_tokens_compacts_and_continues"
```

Result before implementation: `1 failed, 50 deselected`; the compaction request received no model-reported maximum and normal/recovery requests retained the fixed local limits.

Green results after implementation:

- Provider module: `50 passed, 1 skipped in 1.32s`
- Complete VibeCAD suite: `4315 passed, 9 skipped in 87.42s`
- Python compilation: passed
- Authenticated Models API: `claude-fable-5-1`, `max_tokens=128000`
