### PR TITLE
Add atomic contextual patches for VibeScript source

### DIFF
--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -1222,6 +1222,7 @@ set(VibeCAD_Scripts
     VibeCADUpdateGui.py
     VibeCADVibeScriptDomains.py
     VibeCADVibeScriptDomainRuntime.py
+    VibeCADVibeScriptPatch.py
     VibeCADVibeScriptDomainPublication.py
     VibeCADVibeScriptCAM.py
     vibescript_assembly_api.py

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -1222,6 +1222,7 @@ set(VibeCAD_Scripts
     VibeCADUpdateGui.py
     VibeCADVibeScriptDomains.py
     VibeCADVibeScriptDomainRuntime.py
+    VibeCADVibeScriptFileIO.py
     VibeCADVibeScriptPatch.py
     VibeCADVibeScriptDomainPublication.py
     VibeCADVibeScriptCAM.py

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -2228,7 +2228,7 @@ def _format_progress_event(event: dict[str, Any]) -> str:
         return (
             f"Anthropic stream interrupted; retry "
             f"{event.get('next_attempt', '?')}/"
-            f"{event.get('max_attempts', 3)}."
+            f"{event.get('max_attempts', 6)}."
         )
     if name == "anthropic_stream_waiting":
         return f"Anthropic stream opened: waiting for turn {event.get('turn', '?')}."

--- a/src/Mod/VibeCAD/VibeCADPreferences.py
+++ b/src/Mod/VibeCAD/VibeCADPreferences.py
@@ -72,7 +72,10 @@ GEMINI_REASONING_EFFORTS = (
     "high",
 )
 DEFAULT_REASONING_EFFORT = "high"
-DEFAULT_SCRIPTED_TIMEOUT_SECONDS = 300.0
+# This is an inactivity lease for isolated VibeScript workers, not a total
+# build deadline. Advancing worker progress renews it.
+DEFAULT_SCRIPTED_TIMEOUT_SECONDS = 3600.0
+LEGACY_SCRIPTED_TIMEOUT_SECONDS = 300.0
 DEFAULT_SCRIPTED_MEMORY_LIMIT_MB = 6144
 NEW_DOCUMENT_AUTHORING_MODES = ("ask", "native", "vibescript")
 DEFAULT_NEW_DOCUMENT_AUTHORING_MODE = "ask"
@@ -232,6 +235,13 @@ def _positive_float(value: object, default: float) -> float:
     return clean if clean > 0 else default
 
 
+def _scripted_timeout_seconds(value: object) -> float:
+    clean = _positive_float(value, DEFAULT_SCRIPTED_TIMEOUT_SECONDS)
+    if clean == LEGACY_SCRIPTED_TIMEOUT_SECONDS:
+        return DEFAULT_SCRIPTED_TIMEOUT_SECONDS
+    return clean
+
+
 def _positive_int(value: object, default: int) -> int:
     try:
         clean = int(value)  # type: ignore[call-overload]
@@ -274,9 +284,8 @@ def load_settings() -> VibeCADSettings:
         chatgpt_intent_memory_model=pref.GetString("ChatGPTIntentMemoryModel", ""),
         grok_intent_memory_model=pref.GetString("GrokIntentMemoryModel", ""),
         gemini_intent_memory_model=pref.GetString("GeminiIntentMemoryModel", ""),
-        scripted_timeout_seconds=_positive_float(
-            pref.GetFloat("ScriptedTimeoutSeconds", DEFAULT_SCRIPTED_TIMEOUT_SECONDS),
-            DEFAULT_SCRIPTED_TIMEOUT_SECONDS,
+        scripted_timeout_seconds=_scripted_timeout_seconds(
+            pref.GetFloat("ScriptedTimeoutSeconds", DEFAULT_SCRIPTED_TIMEOUT_SECONDS)
         ),
         scripted_memory_limit_mb=_positive_int(
             pref.GetInt("ScriptedMemoryLimitMB", DEFAULT_SCRIPTED_MEMORY_LIMIT_MB),

--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -155,7 +155,8 @@ def _vibescript_authoring_instruction(context: dict[str, Any]) -> str:
             f"{', '.join(assembly_pack.output_types)}.\n"
             f"PARTS: {part_pack.instructions}\n"
             f"ASSEMBLIES: {assembly_pack.instructions}\n"
-            "For an existing source, read_source before edit_source; build_program runs "
+            "For an existing source, read_source first; prefer apply_patch for localized "
+            "code changes and edit_source for complete rewrites. build_program runs "
             "unchanged code and set_inputs changes values only. Use available_components "
             "before catalog search."
         )
@@ -175,11 +176,13 @@ def _vibescript_authoring_instruction(context: dict[str, Any]) -> str:
         "signatures override prior knowledge. Poll writes with read_operation. A failed "
         "create without program/revision saved nothing. "
         f"{pack.instructions}{component_instruction}\n"
-        "Read an existing source before editing it; build_program runs unchanged code. "
+        "Read an existing source before editing it. Prefer apply_patch for localized "
+        "code changes and edit_source for complete rewrites; build_program runs "
+        "unchanged code. "
         "Output names stay stable and types must be: "
         + ", ".join(pack.output_types)
-        + ". Use set_inputs for values only; otherwise include changed inputs, schema, "
-        "or outputs in edit_source."
+        + ". Use set_inputs for values only; include changed inputs, schema, or outputs "
+        "in edit_source."
     )
 
 
@@ -2710,6 +2713,8 @@ def _provider_visible_program_source(source: dict[str, Any]) -> dict[str, Any]:
         "read_arguments",
         "build_tool",
         "build_arguments",
+        "patch_tool",
+        "patch_target_arguments",
         "edit_tool",
         "edit_target_arguments",
         "delete_output_tool",
@@ -3501,6 +3506,7 @@ def _provider_visible_source_lifecycle_result(
             "warnings",
             "phase_timings_seconds",
             "lifecycle_elapsed_seconds",
+            "patch_summary",
         )
         if result.get(key) not in (None, "", [], {})
     }
@@ -3634,6 +3640,7 @@ def _provider_compact_terminal_operation(
             "phase_timings_seconds",
             "lifecycle_elapsed_seconds",
             "validation_scope",
+            "patch_summary",
             "next_action",
             "next_actions",
         )
@@ -3710,7 +3717,7 @@ def _provider_visible_source_read_result(result: dict[str, Any]) -> dict[str, An
     if isinstance(latest, dict) and latest.get("failure"):
         compact["latest_failure"] = latest["failure"]
     actions = []
-    for key in ("edit_source", "build_program"):
+    for key in ("edit_source", "apply_patch", "build_program"):
         action = result.get(key)
         if isinstance(action, dict):
             actions.append(action)

--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -155,10 +155,10 @@ def _vibescript_authoring_instruction(context: dict[str, Any]) -> str:
             f"{', '.join(assembly_pack.output_types)}.\n"
             f"PARTS: {part_pack.instructions}\n"
             f"ASSEMBLIES: {assembly_pack.instructions}\n"
-            "For an existing source, read_source first; prefer apply_patch for localized "
-            "code changes and edit_source for complete rewrites. build_program runs "
-            "unchanged code and set_inputs changes values only. Use available_components "
-            "before catalog search."
+            "For an existing source, read_source first, then use apply_patch for source "
+            "changes. build_program runs unchanged code and set_inputs changes values "
+            "only. Use reconfigure_program only to replace source, schema, inputs, and "
+            "outputs together. Use available_components before catalog search."
         )
     component_instruction = (
         " Use a definition in available_components with api.component or api.instances. "
@@ -176,13 +176,12 @@ def _vibescript_authoring_instruction(context: dict[str, Any]) -> str:
         "signatures override prior knowledge. Poll writes with read_operation. A failed "
         "create without program/revision saved nothing. "
         f"{pack.instructions}{component_instruction}\n"
-        "Read an existing source before editing it. Prefer apply_patch for localized "
-        "code changes and edit_source for complete rewrites; build_program runs "
-        "unchanged code. "
+        "Read an existing source before editing it, then use apply_patch for source "
+        "changes; build_program runs unchanged code. "
         "Output names stay stable and types must be: "
         + ", ".join(pack.output_types)
-        + ". Use set_inputs for values only; include changed inputs, schema, or outputs "
-        "in edit_source."
+        + ". Use set_inputs for values only; use reconfigure_program only to replace "
+        "source, schema, inputs, and outputs together."
     )
 
 
@@ -2715,8 +2714,6 @@ def _provider_visible_program_source(source: dict[str, Any]) -> dict[str, Any]:
         "build_arguments",
         "patch_tool",
         "patch_target_arguments",
-        "edit_tool",
-        "edit_target_arguments",
         "delete_output_tool",
         "delete_program_tool",
         "delete_target_arguments",
@@ -2734,6 +2731,13 @@ def _provider_visible_editable_sources(editable: dict[str, Any]) -> dict[str, An
         for key, value in editable.items()
         if key not in {"sources", "all_sources", "component_sources"}
     }
+    tools = result.get("tools")
+    if isinstance(tools, dict):
+        result["tools"] = {
+            key: value
+            for key, value in tools.items()
+            if key not in {"edit_source", "edit_source_arguments"}
+        }
     for key in ("sources", "all_sources"):
         if key in editable:
             result[key] = [
@@ -3717,7 +3721,7 @@ def _provider_visible_source_read_result(result: dict[str, Any]) -> dict[str, An
     if isinstance(latest, dict) and latest.get("failure"):
         compact["latest_failure"] = latest["failure"]
     actions = []
-    for key in ("edit_source", "apply_patch", "build_program"):
+    for key in ("apply_patch", "build_program"):
         action = result.get(key)
         if isinstance(action, dict):
             actions.append(action)

--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -78,7 +78,7 @@ ANTHROPIC_ADAPTIVE_EFFORT = {
     "high": "high",
     "xhigh": "xhigh",
 }
-ANTHROPIC_STREAM_MAX_ATTEMPTS = 3
+ANTHROPIC_STREAM_MAX_ATTEMPTS = 6
 
 
 VIBECAD_SYSTEM_INSTRUCTIONS = """You are VibeCAD, the mechanical engineer for the user's live FreeCAD model.

--- a/src/Mod/VibeCAD/VibeCADScriptedProcess.py
+++ b/src/Mod/VibeCAD/VibeCADScriptedProcess.py
@@ -146,14 +146,25 @@ def run_process(
     timeout_seconds: float,
     memory_limit_bytes: int,
     poll_callback: Callable[[], None] | None = None,
+    activity_check: Callable[[], object | None] | None = None,
 ) -> dict[str, Any]:
-    """Run one child process without a console window and enforce hard bounds."""
+    """Run one child process without a console window and enforce safe bounds.
+
+    Existing callers receive the original total wall-time deadline. Callers
+    that provide ``activity_check`` use ``timeout_seconds`` as an inactivity
+    lease instead: every distinct non-None activity token renews the lease.
+    This keeps long, observably progressing CAD work alive without weakening
+    cancellation, memory enforcement, or the legacy process-runner contract.
+    """
     creation_flags = (
         int(getattr(subprocess, "CREATE_NO_WINDOW", 0))
         if sys.platform == "win32"
         else 0
     )
     started = time.monotonic()
+    last_activity = started
+    activity_token: object | None = None
+    activity_observations = 0
     with tempfile.TemporaryFile(mode="w+b") as stdout_stream, tempfile.TemporaryFile(
         mode="w+b"
     ) as stderr_stream:
@@ -191,7 +202,20 @@ def run_process(
                     terminate_process_tree(process)
                     raise
             now = time.monotonic()
-            if now - started > timeout_seconds:
+            if activity_check is not None:
+                try:
+                    observed_activity = activity_check()
+                except OSError:
+                    observed_activity = None
+                if observed_activity is not None and (
+                    activity_observations == 0 or observed_activity != activity_token
+                ):
+                    activity_token = observed_activity
+                    activity_observations += 1
+                    last_activity = time.monotonic()
+                    now = last_activity
+            timeout_origin = last_activity if activity_check is not None else started
+            if now - timeout_origin > timeout_seconds:
                 timed_out = True
                 break
             if memory_limit_bytes > 0 and now >= next_memory_check:
@@ -209,11 +233,14 @@ def run_process(
             and hasattr(signal, "SIGXCPU")
             and process.returncode == -int(signal.SIGXCPU)
         )
+        timeout_mode = "inactivity" if activity_check is not None else "wall_time"
         termination_reason = (
             "host_cancellation_request"
             if cancelled
             else (
-                "wall_time_limit"
+                "inactivity_timeout"
+                if timed_out and activity_check is not None
+                else "wall_time_limit"
                 if timed_out
                 else (
                     "memory_limit"
@@ -233,7 +260,9 @@ def run_process(
             "cpu_exceeded": cpu_exceeded,
             "cancelled_by": "host" if cancelled else None,
             "limit_reached": (
-                "wall_time_seconds"
+                "inactivity_seconds"
+                if timed_out and activity_check is not None
+                else "wall_time_seconds"
                 if timed_out
                 else (
                     "memory_bytes"
@@ -243,6 +272,9 @@ def run_process(
             ),
             "termination_reason": termination_reason,
             "timeout_seconds": float(timeout_seconds),
+            "timeout_mode": timeout_mode,
+            "activity_observations": activity_observations,
+            "inactivity_seconds": max(0.0, time.monotonic() - last_activity),
             "memory_limit_bytes": int(memory_limit_bytes),
             "observed_memory_bytes": observed_memory,
             "elapsed_seconds": time.monotonic() - started,

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -2538,10 +2538,10 @@ def _run_domain_vibescript_tool(
             },
             "repair_rule": (
                 "Read the source when its text or latest revision is uncertain, then "
-                "repair the smallest exact cause. Prefer vibescript.apply_patch for a "
-                "localized code repair. Use vibescript.edit_source for a complete rewrite "
-                "or to include changed inputs, schema, or output declarations. "
-                "Use vibescript.set_inputs only for a value-only patch."
+                "repair the smallest exact cause with vibescript.apply_patch. Use "
+                "vibescript.reconfigure_program only to replace source, inputs, schema, "
+                "and output declarations together. Use vibescript.set_inputs only for "
+                "a value-only patch."
             ),
         }
 

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -5607,6 +5607,7 @@ def make_provider_tool_runner(
             "vibescript.read_placement",
             "vibescript.create_program",
             "vibescript.build_program",
+            "vibescript.apply_patch",
             "vibescript.edit_source",
             "vibescript.set_inputs",
             "vibescript.reconfigure_program",

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -105,6 +105,7 @@ VIBESCRIPT_BACKGROUND_SOURCE_TOOLS = frozenset(
         "vibescript.create_part",
         "vibescript.create_program",
         "vibescript.build_program",
+        "vibescript.apply_patch",
         "vibescript.edit_source",
         "vibescript.set_inputs",
         "vibescript.reconfigure_program",
@@ -2537,8 +2538,9 @@ def _run_domain_vibescript_tool(
             },
             "repair_rule": (
                 "Read the source when its text or latest revision is uncertain, then "
-                "repair the smallest exact cause. Use vibescript.edit_source for code and "
-                "include changed inputs, schema, or output declarations in that same call. "
+                "repair the smallest exact cause. Prefer vibescript.apply_patch for a "
+                "localized code repair. Use vibescript.edit_source for a complete rewrite "
+                "or to include changed inputs, schema, or output declarations. "
                 "Use vibescript.set_inputs only for a value-only patch."
             ),
         }
@@ -2572,6 +2574,8 @@ def _run_domain_vibescript_tool(
                 "model_state": candidate_model_state(prepared),
             }
         )
+        if prepared.get("patch_summary"):
+            payload["patch_summary"] = dict(prepared["patch_summary"])
         return finish(payload)
 
     parsed = parse_domain_tool(tool_name)
@@ -2978,6 +2982,16 @@ def _read_source_payload(
             "source_argument": (
                 "Pass the complete updated source text. Read the complete source first; "
                 "a line-range response cannot be edited by itself."
+            ),
+        },
+        "apply_patch": {
+            "tool": "vibescript.apply_patch",
+            "target_arguments": {
+                "source_id": source_id,
+                "expected_revision": revision,
+            },
+            "patch_argument": (
+                "Pass only Codex-style contextual update hunks for changed regions."
             ),
         },
         "build_program": {
@@ -4269,6 +4283,16 @@ def _run_universal_vibescript_tool(
                     "Pass the complete updated source text returned by this read."
                 ),
             }
+            payload["apply_patch"] = {
+                "tool": "vibescript.apply_patch",
+                "target_arguments": {
+                    "program": str(payload["program"]),
+                    "expected_revision": str(payload.get("current_revision") or ""),
+                },
+                "patch_argument": (
+                    "Pass only Codex-style contextual update hunks for changed regions."
+                ),
+            }
             payload["build_program"] = {
                 "tool": "vibescript.build_program",
                 "arguments": {
@@ -4398,6 +4422,7 @@ def _run_universal_vibescript_tool(
         "vibescript.create_assembly": "create_program",
         "vibescript.create_part": "create_program",
         "vibescript.create_program": "create_program",
+        "vibescript.apply_patch": "apply_patch",
         "vibescript.set_inputs": "set_inputs",
         "vibescript.reconfigure_program": "reconfigure_program",
         "vibescript.delete_program": "delete_program",
@@ -4618,7 +4643,12 @@ def build_domain_vibescript_editor_candidate(
             requested=args,
         )
     pack, operation = parsed
-    if operation not in {"edit_source", "set_inputs", "reconfigure_program"}:
+    if operation not in {
+        "apply_patch",
+        "edit_source",
+        "set_inputs",
+        "reconfigure_program",
+    }:
         return tool_failure(
             tool_name,
             "EDITOR_OPERATION_UNSUPPORTED",
@@ -4923,6 +4953,7 @@ def make_provider_tool_runner(
             "vibescript.create_part",
             "vibescript.create_program",
             "vibescript.build_program",
+            "vibescript.apply_patch",
             "vibescript.edit_source",
             "vibescript.set_inputs",
             "vibescript.reconfigure_program",

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
@@ -2764,7 +2764,10 @@ def prepare_candidate(captured: Mapping[str, Any]) -> dict[str, Any]:
             "max_operations": 200_000,
             "max_seconds": float(captured["timeout_seconds"]),
             "memory_limit_bytes": int(captured["memory_limit_bytes"]),
-            "cpu_limit_seconds": max(1, int(float(captured["timeout_seconds"]))),
+            # Source-authored Python is bounded by its trace operation and
+            # source-time budgets. RLIMIT_CPU covers trusted CAD kernels too,
+            # so applying that same deadline would kill healthy native work.
+            "cpu_limit_seconds": 0,
             "output_limit_bytes": 256 * 1024 * 1024,
             "point_artifacts": worker_point_artifacts,
         }
@@ -2877,6 +2880,22 @@ def _worker_progress(prepared: Mapping[str, Any]) -> dict[str, Any] | None:
     return value
 
 
+def _worker_progress_activity(prepared: Mapping[str, Any]) -> object | None:
+    """Return a cheap token that changes whenever worker progress is published."""
+
+    path = Path(str(prepared["staging"])) / "progress.json"
+    try:
+        status = path.stat()
+    except OSError:
+        return None
+    return (
+        int(status.st_mtime_ns),
+        int(status.st_ctime_ns),
+        int(status.st_size),
+        int(status.st_ino),
+    )
+
+
 def execute_candidate(
     prepared: Mapping[str, Any],
     *,
@@ -2896,6 +2915,7 @@ def execute_candidate(
         cancellation_check=cancellation_check,
         timeout_seconds=float(prepared["timeout_seconds"]),
         memory_limit_bytes=int(prepared["memory_limit_bytes"]),
+        activity_check=lambda: _worker_progress_activity(prepared),
     )
     progress = _worker_progress(prepared)
     if progress is not None:
@@ -2924,11 +2944,18 @@ def execute_candidate(
             cancelled=True,
         )
     if process.get("timed_out"):
+        timeout_error = (
+            f"VibeScript domain execution made no observable progress for "
+            f"{prepared['timeout_seconds']:g} seconds."
+            if process.get("timeout_mode") == "inactivity"
+            else f"VibeScript domain execution exceeded "
+            f"{prepared['timeout_seconds']:g} seconds."
+        )
         return _failure(
             str(prepared["tool_name"]),
             "DOMAIN_EXECUTION_TIMEOUT",
             "external_process",
-            f"VibeScript domain execution exceeded {prepared['timeout_seconds']:g} seconds.",
+            timeout_error,
             observed={
                 **process,
                 "accepted_live_outputs_preserved": bool(

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
@@ -2410,6 +2410,7 @@ def prepare_candidate(captured: Mapping[str, Any]) -> dict[str, Any]:
     arguments = dict(captured["arguments"])
     project_root = Path(str(captured["project_root"]))
     staging: Path | None = None
+    patch_summary: dict[str, Any] | None = None
     try:
         if operation == "create_program":
             label = str(arguments.get("program_name") or "").strip()
@@ -2554,6 +2555,37 @@ def prepare_candidate(captured: Mapping[str, Any]) -> dict[str, Any]:
                         "migration_action",
                     ):
                         manifest.pop(key, None)
+            elif operation == "apply_patch":
+                from VibeCADVibeScriptPatch import (
+                    SourcePatchError,
+                    apply_source_patch,
+                )
+
+                try:
+                    patched = apply_source_patch(
+                        previous_source,
+                        arguments.get("patch"),
+                    )
+                except SourcePatchError as exc:
+                    _raise(
+                        tool_name,
+                        exc.code,
+                        "precondition",
+                        str(exc),
+                        requested={
+                            "program_id": program_id,
+                            "expected_revision": base_revision,
+                        },
+                        observed=exc.details,
+                        required_changes=[
+                            {
+                                "tool": "vibescript.read_source",
+                                "arguments": {"source_id": program_id},
+                            }
+                        ],
+                    )
+                source = str(patched["source"])
+                patch_summary = dict(patched["summary"])
             elif operation == "set_inputs":
                 inputs = _merge_patch(dict(inputs or {}), arguments.get("patch"))
             elif operation == "reconfigure_program":
@@ -2764,6 +2796,8 @@ def prepare_candidate(captured: Mapping[str, Any]) -> dict[str, Any]:
             "allow_unchanged_revision": bool(captured.get("allow_unchanged_revision")),
             "finalized": False,
         }
+        if patch_summary is not None:
+            prepared["patch_summary"] = patch_summary
         return prepared if reference_requirements else finalize_candidate(prepared, [])
     except DomainRuntimeFailure:
         raise
@@ -16825,7 +16859,7 @@ def accept_candidate(
     domain = prepared["pack"].domain
     program_id = str(prepared["program_id"])
     revision = str(prepared["revision"])
-    return {
+    result = {
         "ok": True,
         "program_id": program_id,
         "program_name": str(prepared["program_name"]),
@@ -16844,6 +16878,9 @@ def accept_candidate(
             "next_write_expected_revision": revision,
         },
     }
+    if prepared.get("patch_summary"):
+        result["patch_summary"] = dict(prepared["patch_summary"])
+    return result
 
 
 def describe_api(pack: contracts.VibeScriptWorkbenchPack) -> dict[str, Any]:
@@ -17261,9 +17298,13 @@ class DeclarativeDomainAdapter:
                     "Never invent IDs, revisions, or API calls."
                 ),
                 "mutation_selection": {
+                    "apply_patch": (
+                        "Prefer for localized code edits. Supply only exact contextual "
+                        "update hunks and omit unchanged source."
+                    ),
                     "edit_source": (
-                        "Use for code edits. Include changed inputs, input_schema, or "
-                        "expected_outputs in the same call."
+                        "Use for intentional complete-source replacement or when inputs, "
+                        "input_schema, or expected_outputs must change in the same call."
                     ),
                     "set_inputs": (
                         "Use only for an RFC 7396 value patch while source, input_schema, "
@@ -17385,6 +17426,7 @@ class DeclarativeDomainAdapter:
                 "next_write_expected_revision": working_revision,
                 "mutation_selection": {
                     "source_only": "vibescript.edit_source",
+                    "localized_source": "vibescript.apply_patch",
                     "input_values_only": f"vibescript.{self.pack.domain}.set_inputs",
                     "contract_or_outputs": "vibescript.edit_source",
                 },

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
@@ -2488,7 +2488,7 @@ def prepare_candidate(captured: Mapping[str, Any]) -> dict[str, Any]:
                 )
             )
             if manifest.get("migration_required") and not complete_contract_replacement:
-                action = "vibescript.edit_source"
+                action = "vibescript.reconfigure_program"
                 _raise(
                     tool_name,
                     "PROGRAM_RECONFIGURATION_REQUIRED",
@@ -17299,19 +17299,16 @@ class DeclarativeDomainAdapter:
                 ),
                 "mutation_selection": {
                     "apply_patch": (
-                        "Prefer for localized code edits. Supply only exact contextual "
-                        "update hunks and omit unchanged source."
-                    ),
-                    "edit_source": (
-                        "Use for intentional complete-source replacement or when inputs, "
-                        "input_schema, or expected_outputs must change in the same call."
+                        "Use for source-code edits. Supply only exact contextual update "
+                        "hunks and omit unchanged source."
                     ),
                     "set_inputs": (
                         "Use only for an RFC 7396 value patch while source, input_schema, "
                         "and expected_outputs stay unchanged."
                     ),
                     "reconfigure_program": (
-                        "Alias: edit_source."
+                        "Use only when replacing source, input_schema, inputs, and "
+                        "expected_outputs together."
                     ),
                 },
                 "revision_rule": (
@@ -17425,13 +17422,14 @@ class DeclarativeDomainAdapter:
                 **({"migration_required": True} if migration_required else {}),
                 "next_write_expected_revision": working_revision,
                 "mutation_selection": {
-                    "source_only": "vibescript.edit_source",
+                    "source_only": "vibescript.apply_patch",
                     "localized_source": "vibescript.apply_patch",
                     "input_values_only": f"vibescript.{self.pack.domain}.set_inputs",
-                    "contract_or_outputs": "vibescript.edit_source",
+                    "contract_or_outputs": "vibescript.reconfigure_program",
                 },
                 "instruction": (
-                    "Replace the complete program contract with vibescript.edit_source, "
+                    "Replace the complete program contract with "
+                    "vibescript.reconfigure_program, "
                     "including input_schema, inputs, and expected_outputs in the same call. "
                     "The prior accepted live objects remain available until a valid v2 "
                     "candidate is accepted."
@@ -22920,7 +22918,7 @@ class TechDrawDomainAdapter(DeclarativeDomainAdapter):
                     "Create each independent view or orthographic projection group once; use a projection group for related front/top/side views and view for one orientation such as isometric.",
                     "When projected EdgeN/VertexN/FaceN names are not already known, first accept a template + view/projection + page discovery revision without dimensions.",
                     "Inspect the accepted view's dimension_reference_inventory, including the exact projection direction, geometry type, visibility, 2D coordinates, and source mapping.",
-                    "Use edit_source to add dimensions and their expected_outputs atomically, copying exact inventory names; never guess a projected index on complex geometry.",
+                    "Use reconfigure_program to add dimensions and their expected_outputs atomically, copying exact inventory names; never guess a projected index on complex geometry.",
                     "Add bounded annotations, compose every returned non-page value into exactly one page, and keep projection/page conventions identical.",
                     "After acceptance, inspect raw_value/display_text and page membership, then use a screenshot for overlap, clipping, title-block, and human drafting review.",
                 ],

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
@@ -54,6 +54,11 @@ from VibeCADMechanismGeometry import (
 )
 from VibeCADTools import tool_failure
 import VibeCADVibeScriptDomains as contracts
+from VibeCADVibeScriptFileIO import (
+    TELEMETRY_IO_TIMEOUT_SECONDS,
+    atomic_write_text,
+    read_text_shared,
+)
 from vibescript_domain_api import create_domain_api
 
 WORKER_SCHEMA = "vibecad-vibescript-domain-worker-v2"
@@ -319,30 +324,34 @@ def _raise(
 
 
 def _atomic_json(path: Path, payload: Mapping[str, Any]) -> None:
-    path.parent.mkdir(parents=True, exist_ok=True)
-    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    atomic_write_text(
+        path,
+        json.dumps(
+            dict(payload),
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+            allow_nan=False,
+        ),
+    )
+
+
+def _read_json(
+    path: Path,
+    label: str,
+    *,
+    retry_timeout_seconds: float | None = None,
+) -> dict[str, Any]:
     try:
-        temporary.write_text(
-            json.dumps(
-                dict(payload),
-                ensure_ascii=True,
-                sort_keys=True,
-                separators=(",", ":"),
-                allow_nan=False,
-            ),
-            encoding="utf-8",
+        text = (
+            read_text_shared(path)
+            if retry_timeout_seconds is None
+            else read_text_shared(
+                path,
+                retry_timeout_seconds=retry_timeout_seconds,
+            )
         )
-        temporary.replace(path)
-    finally:
-        try:
-            temporary.unlink()
-        except FileNotFoundError:
-            pass
-
-
-def _read_json(path: Path, label: str) -> dict[str, Any]:
-    try:
-        value = json.loads(path.read_text(encoding="utf-8"))
+        value = json.loads(text)
     except (OSError, ValueError) as exc:
         raise ValueError(f"Could not read {label} at {path}: {exc}") from exc
     if not isinstance(value, dict):
@@ -362,6 +371,7 @@ def _stage_worker_bundle(
             f"VibeScript domain {clean_domain!r} has no isolated worker bundle."
         )
     filenames = (
+        "VibeCADVibeScriptFileIO.py",
         "vibescript_domain_api.py",
         "vibescript_worker_progress.py",
         *domain_files,
@@ -2857,7 +2867,11 @@ def _worker_progress(prepared: Mapping[str, Any]) -> dict[str, Any] | None:
     if not path.is_file():
         return None
     try:
-        value = _read_json(path, "domain worker progress")
+        value = _read_json(
+            path,
+            "domain worker progress",
+            retry_timeout_seconds=TELEMETRY_IO_TIMEOUT_SECONDS,
+        )
     except ValueError as exc:
         return {"unavailable": True, "error": str(exc)}
     return value

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
@@ -547,7 +547,8 @@ class VibeScriptWorkbenchPack:
             *(
                 f"vibescript.{operation}"
                 for operation in UNIVERSAL_SOURCE_OPERATIONS
-                if not (
+                if operation != "edit_source"
+                and not (
                     self.domain in {"partdesign", "assembly"}
                     and operation == "create_program"
                 )
@@ -5864,7 +5865,7 @@ def migrate_program_manifest(
                 "accepted live objects remain available, but this source cannot execute "
                 "in the v2 domain runtime."
             ),
-            "migration_action": "vibescript.edit_source",
+            "migration_action": "vibescript.reconfigure_program",
         }
     else:
         raise ValueError("Unsupported VibeScript program manifest schema.")
@@ -6471,7 +6472,7 @@ def universal_tool_specs() -> tuple[dict[str, Any], ...]:
             "name": "vibescript.reconfigure_program",
             "description": (
                 "Replace source, schema, inputs, and outputs together, then "
-                "read_operation. Prefer edit_source for new calls."
+                "read_operation. Use apply_patch for source-only changes."
             ),
             "parameters": {
                 "type": "object",
@@ -6688,8 +6689,9 @@ def domain_tool_specs(pack: VibeScriptWorkbenchPack) -> tuple[dict[str, Any], ..
             pack,
             "reconfigure_program",
             description=(
-                f"Compatibility alias for editing a {pack.title} program. New callers "
-                "should use vibescript.edit_source."
+                f"Replace a {pack.title} program's complete source, schema, inputs, "
+                "and output contract together. Use vibescript.apply_patch for "
+                "source-only changes."
             ),
             properties={
                 "program_id": program_id,

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
@@ -84,6 +84,7 @@ LIFECYCLE_OPERATIONS: tuple[str, ...] = (
     "describe_api",
     "inspect_program",
     "create_program",
+    "apply_patch",
     "edit_source",
     "set_inputs",
     "reconfigure_program",
@@ -98,6 +99,7 @@ UNIVERSAL_SOURCE_OPERATIONS: tuple[str, ...] = (
     "read_placement",
     "create_program",
     "build_program",
+    "apply_patch",
     "edit_source",
     "set_inputs",
     "reconfigure_program",
@@ -1390,6 +1392,7 @@ def complete_editable_sources_snapshot(snapshot: Mapping[str, Any]) -> dict[str,
                 "include_logs": False,
             },
             "build_tool": "vibescript.build_program",
+            "patch_tool": "vibescript.apply_patch",
             "edit_tool": "vibescript.edit_source",
             "delete_output_tool": "vibescript.delete_output",
             "delete_program_tool": "vibescript.delete_program",
@@ -1403,6 +1406,10 @@ def complete_editable_sources_snapshot(snapshot: Mapping[str, Any]) -> dict[str,
                 "expected_revision": revision,
             }
             source["edit_target_arguments"] = {
+                "program": source["program"],
+                "expected_revision": revision,
+            }
+            source["patch_target_arguments"] = {
                 "program": source["program"],
                 "expected_revision": revision,
             }
@@ -1457,6 +1464,7 @@ def complete_editable_sources_snapshot(snapshot: Mapping[str, Any]) -> dict[str,
                 )
             ),
             "build_program": "vibescript.build_program",
+            "apply_patch": "vibescript.apply_patch",
             "edit_source": "vibescript.edit_source",
             "set_inputs": "vibescript.set_inputs",
             "reconfigure_program": "vibescript.reconfigure_program",
@@ -1467,6 +1475,15 @@ def complete_editable_sources_snapshot(snapshot: Mapping[str, Any]) -> dict[str,
                 "expected_revision",
                 "source",
             ],
+            "apply_patch_arguments": [
+                "program",
+                "expected_revision",
+                "patch",
+            ],
+            "patch_argument": (
+                "Pass only Codex-style contextual update hunks for the changed source "
+                "regions; unchanged source is omitted."
+            ),
             "source_argument": (
                 "Pass the complete updated source text returned by "
                 "vibescript.read_source."
@@ -6366,6 +6383,34 @@ def universal_tool_specs() -> tuple[dict[str, Any], ...]:
                     "expected_revision": revision,
                 },
                 "required": ["program", "expected_revision"],
+                "additionalProperties": False,
+            },
+            "safety": "SAFE_WRITE",
+            "contextual": True,
+            "requires_document": True,
+            "edit_modes": ["none"],
+        },
+        {
+            "name": "vibescript.apply_patch",
+            "description": (
+                "Atomically apply Codex-style contextual update hunks to an existing "
+                "program, build it, then read_operation. Prefer this for localized "
+                "source changes; unchanged source is omitted."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "program": program,
+                    "expected_revision": revision,
+                    "patch": _property_schema(
+                        "One or more @@ contextual update hunks, optionally wrapped in "
+                        "a *** Begin Patch / *** Update File envelope.",
+                        type="string",
+                        minLength=1,
+                        maxLength=MAX_SOURCE_BYTES,
+                    ),
+                },
+                "required": ["program", "expected_revision", "patch"],
                 "additionalProperties": False,
             },
             "safety": "SAFE_WRITE",

--- a/src/Mod/VibeCAD/VibeCADVibeScriptFileIO.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptFileIO.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Atomic VibeScript project-file I/O that cooperates with Windows readers."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import ctypes
+import errno
+import math
+import os
+from pathlib import Path
+import time
+from typing import BinaryIO, Iterator
+import uuid
+
+CRITICAL_IO_TIMEOUT_SECONDS = 10.0
+TELEMETRY_IO_TIMEOUT_SECONDS = 0.25
+_INITIAL_RETRY_SECONDS = 0.005
+_MAX_RETRY_SECONDS = 0.1
+_WINDOWS_SHARING_ERRORS = frozenset({5, 32, 33})
+
+if os.name == "nt":
+    from ctypes import wintypes
+
+    _kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    _windows_replace_file = _kernel32.ReplaceFileW
+    _windows_replace_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.LPCWSTR,
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.LPVOID,
+    )
+    _windows_replace_file.restype = wintypes.BOOL
+    _windows_create_file = _kernel32.CreateFileW
+    _windows_create_file.argtypes = (
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.LPVOID,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.HANDLE,
+    )
+    _windows_create_file.restype = wintypes.HANDLE
+    _windows_close_handle = _kernel32.CloseHandle
+    _windows_close_handle.argtypes = (wintypes.HANDLE,)
+    _windows_close_handle.restype = wintypes.BOOL
+
+
+def _replace_is_temporarily_blocked(exc: OSError) -> bool:
+    return getattr(exc, "winerror", None) in _WINDOWS_SHARING_ERRORS or exc.errno in {
+        errno.EACCES,
+        errno.EPERM,
+    }
+
+
+def _read_is_temporarily_blocked(exc: OSError) -> bool:
+    return isinstance(exc, FileNotFoundError) or _replace_is_temporarily_blocked(exc)
+
+
+def _replace_path(source: Path, destination: Path) -> None:
+    """Replace one file without rejecting VibeCAD's own Windows readers."""
+
+    if os.name != "nt" or not destination.exists():
+        os.replace(source, destination)
+        return
+
+    if _windows_replace_file(str(destination), str(source), None, 0, None, None):
+        return
+    error = ctypes.get_last_error()
+    if error in {2, 3} and source.exists():
+        # The destination may have disappeared between the existence check and
+        # ReplaceFileW. MoveFileExW (used by os.replace) can publish it anew.
+        os.replace(source, destination)
+        return
+    raise ctypes.WinError(error)
+
+
+def atomic_write_text(
+    path: str | Path,
+    content: str,
+    *,
+    replace_timeout_seconds: float = CRITICAL_IO_TIMEOUT_SECONDS,
+    best_effort: bool = False,
+) -> bool:
+    """Publish complete text through a unique sibling and atomic replacement.
+
+    Windows scanners and ordinary readers can briefly deny replacement of an
+    open destination. Retry those sharing violations until the caller's
+    deadline. Best-effort telemetry returns ``False`` instead of invalidating
+    otherwise valid CAD work; durable state continues to fail closed.
+    """
+
+    destination = Path(path)
+    timeout = float(replace_timeout_seconds)
+    if not math.isfinite(timeout) or timeout < 0.0:
+        raise ValueError("replace_timeout_seconds must be finite and non-negative")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    temporary = destination.with_name(
+        f".{destination.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    )
+    try:
+        try:
+            temporary.write_text(str(content), encoding="utf-8")
+        except OSError:
+            if best_effort:
+                return False
+            raise
+
+        deadline = time.monotonic() + timeout
+        delay = _INITIAL_RETRY_SECONDS
+        while True:
+            try:
+                _replace_path(temporary, destination)
+                return True
+            except OSError as exc:
+                remaining = deadline - time.monotonic()
+                if not _replace_is_temporarily_blocked(exc) or remaining <= 0.0:
+                    if best_effort:
+                        return False
+                    raise
+                time.sleep(min(delay, remaining))
+                delay = min(delay * 2.0, _MAX_RETRY_SECONDS)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            # A scanner may retain the unpublished unique sibling briefly.
+            # It is never treated as current state and can be cleaned later.
+            pass
+
+
+@contextmanager
+def open_shared_binary(path: str | Path) -> Iterator[BinaryIO]:
+    """Open a reader that permits concurrent replacement on Windows."""
+
+    source = Path(path)
+    if os.name != "nt":
+        with source.open("rb") as stream:
+            yield stream
+        return
+
+    import ctypes
+    import msvcrt
+
+    generic_read = 0x80000000
+    share_read = 0x00000001
+    share_write = 0x00000002
+    share_delete = 0x00000004
+    open_existing = 3
+    file_attribute_normal = 0x00000080
+    file_flag_sequential_scan = 0x08000000
+    invalid_handle_value = ctypes.c_void_p(-1).value
+
+    handle = _windows_create_file(
+        str(source),
+        generic_read,
+        share_read | share_write | share_delete,
+        None,
+        open_existing,
+        file_attribute_normal | file_flag_sequential_scan,
+        None,
+    )
+    if handle == invalid_handle_value:
+        raise ctypes.WinError(ctypes.get_last_error())
+    try:
+        descriptor = msvcrt.open_osfhandle(
+            int(handle),
+            os.O_RDONLY | os.O_BINARY,
+        )
+    except BaseException:
+        _windows_close_handle(handle)
+        raise
+    with os.fdopen(descriptor, "rb") as stream:
+        yield stream
+
+
+def read_text_shared(
+    path: str | Path,
+    *,
+    encoding: str = "utf-8",
+    retry_timeout_seconds: float = CRITICAL_IO_TIMEOUT_SECONDS,
+) -> str:
+    """Read one complete snapshot while cooperating with atomic replacement."""
+
+    timeout = float(retry_timeout_seconds)
+    if not math.isfinite(timeout) or timeout < 0.0:
+        raise ValueError("retry_timeout_seconds must be finite and non-negative")
+    deadline = time.monotonic() + timeout
+    delay = _INITIAL_RETRY_SECONDS
+    while True:
+        try:
+            with open_shared_binary(path) as stream:
+                return stream.read().decode(encoding)
+        except OSError as exc:
+            remaining = deadline - time.monotonic()
+            if not _read_is_temporarily_blocked(exc) or remaining <= 0.0:
+                raise
+            time.sleep(min(delay, remaining))
+            delay = min(delay * 2.0, _MAX_RETRY_SECONDS)

--- a/src/Mod/VibeCAD/VibeCADVibeScriptPatch.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptPatch.py
@@ -1,0 +1,412 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Atomic Codex-style contextual patches for VibeScript source text."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Any
+
+MAX_PATCH_BYTES = 256_000
+
+
+class SourcePatchError(ValueError):
+    """One contextual patch could not be applied without guessing."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = str(code)
+        self.details = dict(details or {})
+
+
+@dataclass(frozen=True)
+class _Hunk:
+    number: int
+    locator: str
+    operations: tuple[tuple[str, str], ...]
+    old_lines: tuple[str, ...]
+    new_lines: tuple[str, ...]
+    added_lines: int
+    removed_lines: int
+    end_of_file: bool
+
+
+@dataclass(frozen=True)
+class _ResolvedHunk:
+    hunk: _Hunk
+    start: int
+    end: int
+
+
+def _fail(
+    code: str,
+    message: str,
+    *,
+    hunk: int | None = None,
+    **details: Any,
+) -> None:
+    if hunk is not None:
+        details = {"hunk": hunk, **details}
+    raise SourcePatchError(code, message, details=details)
+
+
+def _normalize_newlines(value: str) -> str:
+    return value.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _source_lines(source: str) -> tuple[list[str], list[str], str]:
+    lines: list[str] = []
+    endings: list[str] = []
+    for match in re.finditer(r"([^\r\n]*)(\r\n|\r|\n|$)", source):
+        text, ending = match.groups()
+        if not text and not ending:
+            break
+        lines.append(text)
+        endings.append(ending)
+    default_newline = next((ending for ending in endings if ending), "\n")
+    return lines, endings, default_newline
+
+
+def _unwrap_patch(patch: str) -> list[str]:
+    if not isinstance(patch, str):
+        _fail("PATCH_FORMAT_INVALID", "patch must be a string.")
+    if not patch.strip():
+        _fail("PATCH_FORMAT_INVALID", "patch must contain at least one update hunk.")
+    if len(patch.encode("utf-8")) > MAX_PATCH_BYTES:
+        _fail(
+            "PATCH_FORMAT_INVALID",
+            f"patch exceeds the {MAX_PATCH_BYTES}-byte limit.",
+        )
+    if "\x00" in patch:
+        _fail("PATCH_FORMAT_INVALID", "patch cannot contain a NUL byte.")
+
+    lines = _normalize_newlines(patch).split("\n")
+    while lines and lines[-1] == "":
+        lines.pop()
+    if not lines:
+        _fail("PATCH_FORMAT_INVALID", "patch must contain at least one update hunk.")
+    if lines[0] != "*** Begin Patch":
+        if any(
+            line.startswith(
+                (
+                    "*** Begin Patch",
+                    "*** End Patch",
+                    "*** Update File:",
+                    "*** Add File:",
+                    "*** Delete File:",
+                    "*** Move to:",
+                )
+            )
+            for line in lines
+        ):
+            _fail(
+                "PATCH_FORMAT_INVALID",
+                "A patch envelope must begin with '*** Begin Patch'.",
+            )
+        return lines
+    if lines[-1] != "*** End Patch":
+        _fail(
+            "PATCH_FORMAT_INVALID",
+            "A patch envelope must end with '*** End Patch'.",
+        )
+    body = lines[1:-1]
+    file_markers = [
+        (index, line)
+        for index, line in enumerate(body)
+        if line.startswith(("*** Update File:", "*** Add File:", "*** Delete File:"))
+    ]
+    if len(file_markers) != 1 or not file_markers[0][1].startswith("*** Update File:"):
+        _fail(
+            "PATCH_FORMAT_INVALID",
+            "A VibeScript patch must contain exactly one Update File operation.",
+            operation_count=len(file_markers),
+        )
+    marker_index, marker = file_markers[0]
+    if marker_index != 0 or not marker.removeprefix("*** Update File:").strip():
+        _fail(
+            "PATCH_FORMAT_INVALID",
+            "The Update File operation must name one source and precede its hunks.",
+        )
+    content = body[1:]
+    while content and content[-1] == "":
+        content.pop()
+    if any(line.startswith("*** Move to:") for line in content):
+        _fail(
+            "PATCH_FORMAT_INVALID",
+            "VibeScript source patches cannot move or rename their program.",
+        )
+    return content
+
+
+def _parse_hunks(patch: str) -> list[_Hunk]:
+    lines = _unwrap_patch(patch)
+    hunks: list[_Hunk] = []
+    index = 0
+    while index < len(lines):
+        header = lines[index]
+        has_header = header == "@@" or header.startswith("@@ ")
+        if not has_header and (hunks or not header or header[0] not in {" ", "+", "-"}):
+            _fail(
+                "PATCH_FORMAT_INVALID",
+                "Only the first contextual hunk may omit '@@'.",
+                line=index + 1,
+            )
+        locator = header[2:].strip() if has_header else ""
+        if has_header:
+            index += 1
+        old_lines: list[str] = []
+        new_lines: list[str] = []
+        operations: list[tuple[str, str]] = []
+        added = 0
+        removed = 0
+        end_of_file = False
+        while index < len(lines) and not (
+            lines[index] == "@@" or lines[index].startswith("@@ ")
+        ):
+            line = lines[index]
+            if line == "*** End of File":
+                end_of_file = True
+                index += 1
+                if index < len(lines) and not (
+                    lines[index] == "@@" or lines[index].startswith("@@ ")
+                ):
+                    _fail(
+                        "PATCH_FORMAT_INVALID",
+                        "'*** End of File' must be the final line in its hunk.",
+                        hunk=len(hunks) + 1,
+                    )
+                break
+            if not line or line[0] not in {" ", "+", "-"}:
+                _fail(
+                    "PATCH_FORMAT_INVALID",
+                    "Hunk lines must begin with a space, '+', or '-'.",
+                    hunk=len(hunks) + 1,
+                    line=index + 1,
+                )
+            prefix, value = line[0], line[1:]
+            operations.append((prefix, value))
+            if prefix != "+":
+                old_lines.append(value)
+            if prefix != "-":
+                new_lines.append(value)
+            added += int(prefix == "+")
+            removed += int(prefix == "-")
+            index += 1
+        if added == 0 and removed == 0:
+            _fail(
+                "PATCH_FORMAT_INVALID",
+                "Each hunk must add or remove at least one line.",
+                hunk=len(hunks) + 1,
+            )
+        hunks.append(
+            _Hunk(
+                number=len(hunks) + 1,
+                locator=locator,
+                operations=tuple(operations),
+                old_lines=tuple(old_lines),
+                new_lines=tuple(new_lines),
+                added_lines=added,
+                removed_lines=removed,
+                end_of_file=end_of_file,
+            )
+        )
+    if not hunks:
+        _fail("PATCH_FORMAT_INVALID", "patch must contain at least one update hunk.")
+    return hunks
+
+
+def _matches(lines: list[str], needle: tuple[str, ...]) -> list[int]:
+    if not needle:
+        return list(range(len(lines) + 1))
+    width = len(needle)
+    return [
+        index
+        for index in range(0, len(lines) - width + 1)
+        if tuple(lines[index : index + width]) == needle
+    ]
+
+
+def _locator_allows(
+    lines: list[str],
+    candidate: int,
+    locator: str,
+    lower_bound: int,
+) -> bool:
+    if not locator:
+        return True
+    return any(
+        line == locator and lower_bound <= index < candidate
+        for index, line in enumerate(lines)
+    )
+
+
+def _resolve_hunks(lines: list[str], hunks: list[_Hunk]) -> list[_ResolvedHunk]:
+    resolved: list[_ResolvedHunk] = []
+    lower_bound = 0
+    last_start = -1
+    for hunk in hunks:
+        if not hunk.old_lines:
+            if hunk.locator:
+                locator_matches = [
+                    index
+                    for index, line in enumerate(lines)
+                    if line == hunk.locator and index >= lower_bound
+                ]
+                if not locator_matches:
+                    _fail(
+                        "PATCH_CONTEXT_NOT_FOUND",
+                        "The patch context does not match the current source.",
+                        hunk=hunk.number,
+                        locator=hunk.locator,
+                    )
+                if len(locator_matches) != 1:
+                    _fail(
+                        "PATCH_CONTEXT_AMBIGUOUS",
+                        "The patch context matches more than one source region.",
+                        hunk=hunk.number,
+                        match_count=len(locator_matches),
+                        locator=hunk.locator,
+                    )
+            # Codex apply_patch treats a chunk with no old/context lines as an
+            # append, even when the hunk does not carry an explicit EOF marker.
+            candidates = [len(lines)]
+        else:
+            all_matches = _matches(lines, hunk.old_lines)
+            candidates = [
+                candidate
+                for candidate in all_matches
+                if candidate >= lower_bound
+                and _locator_allows(lines, candidate, hunk.locator, lower_bound)
+                and (
+                    not hunk.end_of_file
+                    or candidate + len(hunk.old_lines) == len(lines)
+                )
+            ]
+            if not candidates and any(
+                candidate < lower_bound for candidate in all_matches
+            ):
+                _fail(
+                    "PATCH_HUNKS_OVERLAP",
+                    "A patch hunk overlaps or precedes an earlier hunk.",
+                    hunk=hunk.number,
+                )
+        if not candidates:
+            _fail(
+                "PATCH_CONTEXT_NOT_FOUND",
+                "The patch context does not match the current source.",
+                hunk=hunk.number,
+                locator=hunk.locator or None,
+            )
+        unique_candidates = sorted(set(candidates))
+        if len(unique_candidates) != 1:
+            _fail(
+                "PATCH_CONTEXT_AMBIGUOUS",
+                "The patch context matches more than one source region.",
+                hunk=hunk.number,
+                match_count=len(unique_candidates),
+                locator=hunk.locator or None,
+            )
+        start = unique_candidates[0]
+        end = start + len(hunk.old_lines)
+        if start < lower_bound or (not hunk.old_lines and start == last_start):
+            _fail(
+                "PATCH_HUNKS_OVERLAP",
+                "A patch hunk overlaps or conflicts with an earlier hunk.",
+                hunk=hunk.number,
+            )
+        resolved.append(_ResolvedHunk(hunk=hunk, start=start, end=end))
+        lower_bound = end
+        last_start = start
+    return resolved
+
+
+def apply_source_patch(source: str, patch: str) -> dict[str, Any]:
+    """Apply all contextual hunks to one source atomically.
+
+    Both the standard ``*** Begin Patch`` / ``*** Update File`` envelope and
+    the contained ``@@`` update hunks are accepted. The caller supplies the
+    authoritative VibeScript program separately, so the envelope path is only
+    descriptive and can never redirect the write.
+    """
+
+    if not isinstance(source, str):
+        _fail("PATCH_FORMAT_INVALID", "source must be a string.")
+    lines, endings, default_newline = _source_lines(source)
+    hunks = _parse_hunks(patch)
+    resolved = _resolve_hunks(lines, hunks)
+
+    output: list[tuple[str, str]] = []
+    cursor = 0
+    for item in resolved:
+        output.extend(zip(lines[cursor : item.start], endings[cursor : item.start]))
+        replacement_newline = next(
+            (ending for ending in endings[item.start : item.end] if ending),
+            (
+                endings[item.start]
+                if item.start < len(endings) and endings[item.start]
+                else (
+                    endings[item.start - 1]
+                    if item.start > 0 and endings[item.start - 1]
+                    else default_newline
+                )
+            ),
+        )
+        local_cursor = item.start
+        replacement: list[tuple[str, str]] = []
+        for prefix, value in item.hunk.operations:
+            if prefix == " ":
+                replacement.append((lines[local_cursor], endings[local_cursor]))
+                local_cursor += 1
+            elif prefix == "-":
+                local_cursor += 1
+            else:
+                replacement.append((value, replacement_newline))
+        if local_cursor != item.end:
+            raise AssertionError("Resolved patch hunk did not consume its old lines.")
+        touches_unterminated_eof = (
+            item.end == len(lines) and bool(endings) and endings[-1] == ""
+        )
+        if item.start == item.end == len(lines) and replacement:
+            if output and output[-1][1] == "":
+                output[-1] = (output[-1][0], default_newline)
+            touches_unterminated_eof = not endings or endings[-1] == ""
+        if touches_unterminated_eof and replacement:
+            replacement = [
+                (
+                    text,
+                    (
+                        default_newline
+                        if index < len(replacement) - 1 and not ending
+                        else ending
+                    ),
+                )
+                for index, (text, ending) in enumerate(replacement)
+            ]
+            replacement[-1] = (replacement[-1][0], "")
+        output.extend(replacement)
+        cursor = item.end
+    output.extend(zip(lines[cursor:], endings[cursor:]))
+    updated = "".join(text + ending for text, ending in output)
+    if updated == source:
+        _fail("PATCH_NO_CHANGES", "The patch does not change the current source.")
+
+    return {
+        "source": updated,
+        "summary": {
+            "hunk_count": len(resolved),
+            "added_lines": sum(item.hunk.added_lines for item in resolved),
+            "removed_lines": sum(item.hunk.removed_lines for item in resolved),
+            "first_changed_line": min(item.start for item in resolved) + 1,
+            "last_changed_line": max(
+                item.start + max(len(item.hunk.old_lines), len(item.hunk.new_lines), 1)
+                for item in resolved
+            ),
+        },
+    }

--- a/src/Mod/VibeCAD/vibecad_tests/partdesign_vibescript_schema_sha256.json
+++ b/src/Mod/VibeCAD/vibecad_tests/partdesign_vibescript_schema_sha256.json
@@ -10,13 +10,13 @@
   "vibescript.edit_source": "a0247d8a3b6e3c6772d683d668ce341d4be92bef0bffdd434c18a5c9b12043af",
   "vibescript.partdesign.create_program": "8b381baaef43ca3a1b78db19dbcce9b82696778b8170e94f01d74378141ae6fc",
   "vibescript.partdesign.delete_program": "4bc947149390f7d05cd59a922ee9ab11ad6cc1f9d610f9babf9a6fb2d8b0c94e",
-  "vibescript.partdesign.reconfigure_program": "05e79470d63f1fa464ae48eed55fbdd12b68177285ce118b8d6dc0481c897199",
+  "vibescript.partdesign.reconfigure_program": "658135bce7dba0cfd265e085d9c57af68295508260e8023e69a1e47db5a1b374",
   "vibescript.partdesign.set_inputs": "5c1079bfdffa5a1a01e9f9ad06b1d31c67f2f5f555a09f3f4da2e25ba8e4f6e8",
   "vibescript.read_api": "2f08397a9d7e8e4f71292c3f1f2bc04ff6cf0862f63044dbc396583b04accab6",
   "vibescript.read_geometry": "8ffe996294d5f9c31d6ee53d54cc94a87285d189ac5102a5aec102f32d1500bc",
   "vibescript.read_operation": "95069faa7a073ebd136b1a4cefe64c9f5551c32040eab23c5abaa8803294fb86",
   "vibescript.read_placement": "469936e55f12758be15812cde342e9253b1ac1bfb382dbb1c02fb831145f9a48",
   "vibescript.read_source": "b5b72c876053a26ebe500265ab533007cd255e3520fa2a616a489c0263bf1150",
-  "vibescript.reconfigure_program": "5318f88a5aab6a6b17af69e4a394ec4b42d3265dc3fbb40f316ed36e8b4f899d",
+  "vibescript.reconfigure_program": "6bdbe00d377ede388898b0db2ea070b179c5cf430965a66cc48c52853711e4cf",
   "vibescript.set_inputs": "a92a5163cb2572aa552586745720e99045a2416f712b0a9398894b28058c400d"
 }

--- a/src/Mod/VibeCAD/vibecad_tests/partdesign_vibescript_schema_sha256.json
+++ b/src/Mod/VibeCAD/vibecad_tests/partdesign_vibescript_schema_sha256.json
@@ -1,4 +1,5 @@
 {
+  "vibescript.apply_patch": "f212aa155b1a53724b73fec951a9aa51ff6423386f8cef74ca8294efbf3f7ecd",
   "vibescript.build_program": "41211ab603baab5530b8d73e0895e5cb1b1c9bb4e04f1dfce6e43a128b525723",
   "vibescript.create_assembly": "72cd0630c2ae316d2f8fcc2dd4b5a793f8f9555f31286ebca262c98a27c7a462",
   "vibescript.create_part": "8e364e2a24b9e0b2609f7977a6518ed0b1aba371e0c3966b487f05a3dec3a624",

--- a/src/Mod/VibeCAD/vibecad_tests/test_engine_contracts.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_engine_contracts.py
@@ -372,6 +372,29 @@ class TestAuthoringModeDefaults:
         assert not hasattr(settings, "vibescript_enabled")
         assert settings.new_document_authoring_mode == "ask"
 
+    def test_legacy_scripted_timeout_becomes_the_long_progress_lease(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import VibeCADPreferences as prefs
+
+        class LegacyPreferences(_UnsetPreferences):
+            def GetFloat(self, name: str, default: float = 0.0) -> float:
+                return 300.0 if name == "ScriptedTimeoutSeconds" else default
+
+        monkeypatch.setattr(prefs, "preferences", lambda: LegacyPreferences())
+        assert (
+            prefs.load_settings().scripted_timeout_seconds
+            == prefs.DEFAULT_SCRIPTED_TIMEOUT_SECONDS
+            == 3600.0
+        )
+
+        class CustomizedPreferences(_UnsetPreferences):
+            def GetFloat(self, name: str, default: float = 0.0) -> float:
+                return 7200.0 if name == "ScriptedTimeoutSeconds" else default
+
+        monkeypatch.setattr(prefs, "preferences", lambda: CustomizedPreferences())
+        assert prefs.load_settings().scripted_timeout_seconds == 7200.0
+
     def test_removed_vibescript_toggle_is_not_written_or_reset(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_mcp_control_mode.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_mcp_control_mode.py
@@ -64,6 +64,7 @@ def _wait_until(predicate, timeout: float = 2.0) -> None:
 def test_mcp_wire_names_are_concise_pascal_case() -> None:
     assert mcp_tool_wire_name("vibescript.create_program") == "CreateProgram"
     assert mcp_tool_wire_name("vibescript.read_source") == "ReadSource"
+    assert mcp_tool_wire_name("vibescript.apply_patch") == "ApplyPatch"
     assert mcp_tool_wire_name("core.set_view") == "SetView"
     assert mcp_tool_wire_name("conversation.ask_user") == "AskUser"
     assert mcp_tool_wire_name("assembly.fastener") == "AssemblyFastener"

--- a/src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py
@@ -997,6 +997,20 @@ def test_concise_source_read_states_current_revision_directly() -> None:
             "complete": True,
         },
         "model_state": {"status": "accepted_current"},
+        "apply_patch": {
+            "tool": "vibescript.apply_patch",
+            "target_arguments": {
+                "program": "Audit/partdesign/Part",
+                "expected_revision": "c" * 64,
+            },
+        },
+        "edit_source": {
+            "tool": "vibescript.edit_source",
+            "target_arguments": {
+                "program": "Audit/partdesign/Part",
+                "expected_revision": "c" * 64,
+            },
+        },
         "_vibecad_source_read_result": True,
     }
 
@@ -1005,6 +1019,10 @@ def test_concise_source_read_states_current_revision_directly() -> None:
     assert visible["program"] == "Audit/partdesign/Part"
     assert visible["revision"] == "c" * 64
     assert visible["state"] == {"status": "accepted_current"}
+    assert [action["tool"] for action in visible["next_actions"]] == [
+        "vibescript.edit_source",
+        "vibescript.apply_patch",
+    ]
 
 
 def test_successful_assembly_lifecycle_result_states_solver_scope() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py
@@ -1020,7 +1020,6 @@ def test_concise_source_read_states_current_revision_directly() -> None:
     assert visible["revision"] == "c" * 64
     assert visible["state"] == {"status": "accepted_current"}
     assert [action["tool"] for action in visible["next_actions"]] == [
-        "vibescript.edit_source",
         "vibescript.apply_patch",
     ]
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
@@ -7034,6 +7034,9 @@ def test_source_operation_budget_excludes_trusted_domain_api_frames() -> None:
     class TrustedAPI:
         @staticmethod
         def build() -> int:
+            import time
+
+            time.sleep(0.1)
             total = 0
             for value in range(100_000):
                 total += value % 7
@@ -7047,10 +7050,12 @@ def test_source_operation_budget_excludes_trusted_domain_api_frames() -> None:
         api=TrustedAPI(),
         expected_output_names=["Value"],
         max_operations=10,
-        max_seconds=1.0,
+        max_seconds=0.05,
     )
     assert result["Value"] > 0
     assert 1 <= budget["operations"] <= 10
+    assert budget["elapsed_seconds"] > budget["max_seconds"]
+    assert budget["source_elapsed_seconds"] < budget["max_seconds"]
 
     with pytest.raises(RuntimeError, match=r"exceeded its 10 operation budget"):
         _execute_source(

--- a/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
@@ -1362,6 +1362,151 @@ def test_vibescript_operation_manager_reports_progress_conflicts_and_result() ->
     assert manager.active() is None
 
 
+def test_provider_tool_runner_executes_apply_patch_through_session_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import VibeCADSession as session
+
+    source_id = "a" * 32
+    current_revision = "b" * 64
+    next_revision = "c" * 64
+    program = "Active/assembly/Robot"
+    observed: list[tuple[str, dict[str, object]]] = []
+
+    class Spec:
+        requires_document = False
+
+        @staticmethod
+        def validate_arguments(_arguments: dict[str, object]) -> None:
+            return None
+
+        @staticmethod
+        def supports_edit_mode(_edit_mode: str) -> bool:
+            return True
+
+    tool = type(
+        "Tool",
+        (),
+        {
+            "safety": SafetyLevel.WRITE,
+            "workbench": "AssemblyWorkbench",
+            "spec": Spec(),
+        },
+    )()
+
+    class Registry:
+        @staticmethod
+        def get(_name: str) -> object:
+            return tool
+
+        @staticmethod
+        def call(name: str, **_arguments: object) -> dict[str, object]:
+            raise AssertionError(f"{name} fell through to the native registry")
+
+    class Service:
+        registry = Registry()
+
+        @staticmethod
+        def note_provider_tool_targets(
+            _arguments: dict[str, object], _payload: dict[str, object]
+        ) -> None:
+            return None
+
+    def run_universal(
+        _service: object,
+        _workbench: str,
+        tool_name: str,
+        args: dict[str, object],
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        observed.append((tool_name, dict(args)))
+        return {
+            "ok": True,
+            "tool": tool_name,
+            "source_id": source_id,
+            "program_id": source_id,
+            "program": program,
+            "working_revision": next_revision,
+            "next_write_expected_revision": next_revision,
+            "_vibecad_source_lifecycle_result": True,
+        }
+
+    monkeypatch.setattr(session, "_run_universal_vibescript_tool", run_universal)
+    monkeypatch.setattr(
+        session,
+        "_live_provider_surface_state",
+        lambda _service: {
+            "workbench": "AssemblyWorkbench",
+            "engine": "vibescript",
+            "surface_id": "vibescript-assembly-v2",
+            "runtime_state": {"edit_mode": "none"},
+            "tool_names": [
+                "vibescript.apply_patch",
+                "vibescript.read_operation",
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        session,
+        "_minimal_runtime_state",
+        lambda _service: {"edit_mode": "none"},
+    )
+    monkeypatch.setattr(
+        session,
+        "_capture_editable_sources_for_workbench",
+        lambda _service, _workbench: {},
+    )
+    monkeypatch.setattr(
+        session,
+        "_complete_editable_sources_for_workbench",
+        lambda _captured: {
+            "schema": "vibecad-editable-sources-v1",
+            "domain": "assembly",
+            "workbench": "AssemblyWorkbench",
+            "sources": [],
+        },
+    )
+
+    runner = session.make_provider_tool_runner(
+        Service(),
+        tool_trace=[],
+        progress_callback=None,
+        cancellation_check=None,
+        steering_check=None,
+        question_callback=None,
+        document_thread_dispatch=lambda operation: operation(),
+    )
+    started = runner(
+        "vibescript.apply_patch",
+        json.dumps(
+            {
+                "program": program,
+                "expected_revision": current_revision,
+                "patch": "@@\n-old\n+new",
+            }
+        ),
+    )
+    operation_id = started["operation"]["operation_id"]
+    completed = runner(
+        "vibescript.read_operation",
+        json.dumps({"operation_id": operation_id, "wait_seconds": 2}),
+    )
+
+    assert completed["operation"]["status"] == "succeeded"
+    assert completed["result"]["ok"] is True
+    assert completed["result"]["working_revision"] == next_revision
+    assert observed == [
+        (
+            "vibescript.apply_patch",
+            {
+                "program": program,
+                "expected_revision": current_revision,
+                "patch": "@@\n-old\n+new",
+            },
+        )
+    ]
+
+
 def test_provider_tool_runner_authorizes_a_failed_source_created_in_the_same_turn(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -7339,6 +7484,7 @@ def test_worker_staging_contains_only_the_active_domain_bundle(
     )
     expected = {
         "worker.py",
+        "VibeCADVibeScriptFileIO.py",
         "vibescript_domain_api.py",
         "vibescript_worker_progress.py",
         *domain_files,
@@ -7359,6 +7505,7 @@ def test_every_isolated_worker_dependency_is_packaged() -> None:
     module_root = Path(runtime.__file__).resolve().parent
     cmake = (module_root / "CMakeLists.txt").read_text(encoding="utf-8")
     required = {
+        "VibeCADVibeScriptFileIO.py",
         "vibescript_domain_api.py",
         "vibescript_domain_worker.py",
         "vibescript_worker_progress.py",

--- a/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
@@ -315,6 +315,7 @@ def test_shared_vibescript_lifecycle_is_unambiguous_for_the_operating_model() ->
         pack = domains.get_vibescript_pack(workbench)
         assert pack is not None
         expected_provider_tools = set(universal)
+        expected_provider_tools.remove("vibescript.edit_source")
         if workbench in {"PartDesignWorkbench", "AssemblyWorkbench"}:
             expected_provider_tools.remove("vibescript.create_program")
         else:
@@ -328,7 +329,8 @@ def test_shared_vibescript_lifecycle_is_unambiguous_for_the_operating_model() ->
             for spec in domains.domain_tool_specs(pack)
         }
         assert "Change only input values" in specs["set_inputs"]["description"]
-        assert "Compatibility alias" in specs["reconfigure_program"]["description"]
+        assert "complete source, schema, inputs" in specs["reconfigure_program"]["description"]
+        assert "vibescript.apply_patch" in specs["reconfigure_program"]["description"]
 
         adapter = domains.get_domain_adapter(pack.domain)
         assert adapter is not None
@@ -341,7 +343,6 @@ def test_shared_vibescript_lifecycle_is_unambiguous_for_the_operating_model() ->
         assert "vibescript.read_placement" in operating["context_first"]
         assert set(operating["mutation_selection"]) == {
             "apply_patch",
-            "edit_source",
             "set_inputs",
             "reconfigure_program",
         }
@@ -582,10 +583,10 @@ def test_inspect_program_returns_machine_readable_model_state() -> None:
         "accepted_live_state_preserved": True,
         "next_write_expected_revision": accepted_revision,
         "mutation_selection": {
-            "source_only": "vibescript.edit_source",
+            "source_only": "vibescript.apply_patch",
             "localized_source": "vibescript.apply_patch",
             "input_values_only": "vibescript.assembly.set_inputs",
-            "contract_or_outputs": "vibescript.edit_source",
+            "contract_or_outputs": "vibescript.reconfigure_program",
         },
         "instruction": (
             "The accepted contract is current; verify domain-specific live evidence."
@@ -3519,7 +3520,7 @@ def test_schema_v1_migrates_to_partdesign_without_relocation(tmp_path: Path) -> 
     assert migrated["artifact_directory"] == str(v1_directory)
     assert migrated["expected_outputs"] == [{"name": "Body", "type": "solid"}]
     assert migrated["migration_required"] is True
-    assert migrated["migration_action"] == "vibescript.edit_source"
+    assert migrated["migration_action"] == "vibescript.reconfigure_program"
 
     v1_directory.mkdir(parents=True)
     (v1_directory / "model.py").write_text("result = {}\n", encoding="utf-8")

--- a/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
@@ -210,6 +210,17 @@ def test_domain_lifecycle_schemas_are_stable_and_domain_specific() -> None:
         assert output_enum == list(pack.output_types)
 
 
+def test_every_vibescript_domain_accepts_the_internal_apply_patch_route() -> None:
+    import VibeCADVibeScriptDomainRuntime as runtime
+
+    for workbench in USER_WORKBENCHES:
+        pack = domains.get_vibescript_pack(workbench)
+        assert pack is not None
+        assert runtime.parse_domain_tool(
+            f"vibescript.{pack.domain}.apply_patch"
+        ) == (pack, "apply_patch")
+
+
 def test_shared_vibescript_lifecycle_is_unambiguous_for_the_operating_model() -> None:
     universal = {spec["name"]: spec for spec in domains.universal_tool_specs()}
     assert set(universal) == {
@@ -222,6 +233,7 @@ def test_shared_vibescript_lifecycle_is_unambiguous_for_the_operating_model() ->
         "vibescript.create_assembly",
         "vibescript.create_program",
         "vibescript.build_program",
+        "vibescript.apply_patch",
         "vibescript.edit_source",
         "vibescript.set_inputs",
         "vibescript.reconfigure_program",
@@ -265,6 +277,13 @@ def test_shared_vibescript_lifecycle_is_unambiguous_for_the_operating_model() ->
         "inputs",
         "expected_outputs",
     } <= set(edit["parameters"]["properties"])
+    apply_patch = universal["vibescript.apply_patch"]
+    assert apply_patch["parameters"]["required"] == [
+        "program",
+        "expected_revision",
+        "patch",
+    ]
+    assert apply_patch["parameters"]["properties"]["patch"]["type"] == "string"
     delete_output = universal["vibescript.delete_output"]
     assert delete_output["parameters"]["required"] == [
         "program",
@@ -283,6 +302,7 @@ def test_shared_vibescript_lifecycle_is_unambiguous_for_the_operating_model() ->
     )
     for write_name in (
         "vibescript.create_program",
+        "vibescript.apply_patch",
         "vibescript.edit_source",
         "vibescript.set_inputs",
         "vibescript.reconfigure_program",
@@ -320,6 +340,7 @@ def test_shared_vibescript_lifecycle_is_unambiguous_for_the_operating_model() ->
         assert "vibescript.read_geometry" in operating["context_first"]
         assert "vibescript.read_placement" in operating["context_first"]
         assert set(operating["mutation_selection"]) == {
+            "apply_patch",
             "edit_source",
             "set_inputs",
             "reconfigure_program",
@@ -562,6 +583,7 @@ def test_inspect_program_returns_machine_readable_model_state() -> None:
         "next_write_expected_revision": accepted_revision,
         "mutation_selection": {
             "source_only": "vibescript.edit_source",
+            "localized_source": "vibescript.apply_patch",
             "input_values_only": "vibescript.assembly.set_inputs",
             "contract_or_outputs": "vibescript.edit_source",
         },
@@ -630,6 +652,10 @@ def test_universal_read_source_returns_complete_code_and_declared_outputs() -> (
     assert [item["name"] for item in payload["affected_outputs"]] == ["Body"]
     assert "object_name" not in payload["affected_outputs"][0]
     assert payload["edit_source"]["target_arguments"] == {
+        "source_id": "a" * 32,
+        "expected_revision": "b" * 64,
+    }
+    assert payload["apply_patch"]["target_arguments"] == {
         "source_id": "a" * 32,
         "expected_revision": "b" * 64,
     }
@@ -1580,6 +1606,77 @@ def test_universal_edit_source_maps_to_the_active_domain_with_complete_code(
     assert result["source_id"] == "a" * 32
 
 
+@pytest.mark.parametrize(
+    ("workbench", "domain"),
+    [
+        ("PartDesignWorkbench", "partdesign"),
+        ("DraftWorkbench", "draft"),
+    ],
+)
+def test_universal_apply_patch_routes_to_each_program_domain(
+    monkeypatch: pytest.MonkeyPatch,
+    workbench: str,
+    domain: str,
+) -> None:
+    import VibeCADSession as session
+
+    observed = {}
+
+    def run_internal(_service, tool_name, arguments, **_kwargs):
+        observed["tool_name"] = tool_name
+        observed["arguments"] = arguments
+        return {
+            "ok": True,
+            "program_id": arguments["program_id"],
+            "patch_summary": {"hunk_count": 1},
+        }
+
+    monkeypatch.setattr(session, "_run_domain_vibescript_tool", run_internal)
+    document = type(
+        "Document",
+        (),
+        {"Uid": "active-document", "Name": "Active", "FileName": "", "Objects": []},
+    )()
+    service = type("Service", (), {"_active_document": lambda self: document})()
+    program = f"Active/{domain}/Patched Program"
+    result = session._run_universal_vibescript_tool(
+        service,
+        workbench,
+        "vibescript.apply_patch",
+        {
+            "program": program,
+            "expected_revision": "b" * 64,
+            "patch": "@@\n-old\n+new",
+        },
+        editable_sources={
+            "sources": [
+                {
+                    "source_id": "a" * 32,
+                    "program": program,
+                    "label": "Patched Program",
+                    "domain": domain,
+                    "current_revision": "b" * 64,
+                    "affected_outputs": [],
+                }
+            ]
+        },
+        document_thread_dispatch=None,
+        cancellation_check=None,
+        progress_callback=None,
+    )
+
+    assert observed == {
+        "tool_name": f"vibescript.{domain}.apply_patch",
+        "arguments": {
+            "program_id": "a" * 32,
+            "expected_revision": "b" * 64,
+            "patch": "@@\n-old\n+new",
+        },
+    }
+    assert result["source_id"] == "a" * 32
+    assert result["patch_summary"] == {"hunk_count": 1}
+
+
 def test_universal_delete_output_reconfigures_the_remaining_exact_contract(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2506,6 +2603,7 @@ def test_editable_sources_indexes_hidden_outputs_and_sources_without_outputs() -
     assert index["tools"]["read_geometry"] == "vibescript.read_geometry"
     assert index["tools"]["read_placement"] == "vibescript.read_placement"
     assert index["tools"]["create_program"] == "vibescript.create_part"
+    assert index["tools"]["apply_patch"] == "vibescript.apply_patch"
     assert index["tools"]["edit_source"] == "vibescript.edit_source"
     assert index["tools"]["set_inputs"] == "vibescript.set_inputs"
     assert index["tools"]["reconfigure_program"] == ("vibescript.reconfigure_program")
@@ -2537,11 +2635,16 @@ def test_editable_sources_indexes_hidden_outputs_and_sources_without_outputs() -
         "include_logs": False,
     }
     assert hidden["build_tool"] == "vibescript.build_program"
+    assert hidden["patch_tool"] == "vibescript.apply_patch"
     assert hidden["build_arguments"] == {
         "program": "Design/partdesign/Body Source",
         "expected_revision": "b" * 64,
     }
     assert hidden["edit_target_arguments"] == {
+        "program": "Design/partdesign/Body Source",
+        "expected_revision": "b" * 64,
+    }
+    assert hidden["patch_target_arguments"] == {
         "program": "Design/partdesign/Body Source",
         "expected_revision": "b" * 64,
     }

--- a/src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py
@@ -1491,7 +1491,7 @@ def test_v1_saved_data_migrates_to_a_non_executable_v2_view(tmp_path: Path) -> N
     assert migrated["domain"] == "partdesign"
     assert migrated["artifact_directory"] == str(directory)
     assert migrated["migration_required"] is True
-    assert migrated["migration_action"] == "vibescript.edit_source"
+    assert migrated["migration_action"] == "vibescript.reconfigure_program"
     assert migrated["accepted_revision"] == "saved-v1-revision"
     assert migrated["live_outputs"]["Part"]["object_name"] == "SavedPartResult"
 
@@ -1521,7 +1521,7 @@ def test_v1_source_cannot_edit_set_inputs_or_execute(tmp_path: Path) -> None:
         )
         assert failure.value.payload["retry"]["required_changes"] == [
             {
-                "tool": "vibescript.edit_source",
+                "tool": "vibescript.reconfigure_program",
                 "arguments": {
                     "source_id": PROGRAM_ID,
                     "expected_revision": "saved-v1-revision",

--- a/src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py
@@ -1183,6 +1183,139 @@ def test_unchanged_saved_partdesign_source_gets_private_compatibility_runtime(
     runtime.abandon_prepared_candidate(prepared)
 
 
+def test_apply_patch_prepares_the_same_guarded_partdesign_candidate(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = "result = {'Part': api.box(10, 20, 30)}\n"
+    _directory, revision = _write_v2_program(tmp_path, source)
+    monkeypatch.setattr(runtime, "_freecadcmd", lambda _home: Path("/FreeCADCmd"))
+    capture = _capture(
+        tmp_path,
+        operation="apply_patch",
+        arguments={
+            "program_id": PROGRAM_ID,
+            "expected_revision": revision,
+            "patch": "@@\n-result = {'Part': api.box(10, 20, 30)}\n+result = {'Part': api.box(12, 20, 30)}",
+        },
+    )
+
+    prepared = runtime.prepare_candidate(capture)
+
+    assert prepared["source"] == "result = {'Part': api.box(12, 20, 30)}\n"
+    assert prepared["patch_summary"] == {
+        "hunk_count": 1,
+        "added_lines": 1,
+        "removed_lines": 1,
+        "first_changed_line": 1,
+        "last_changed_line": 1,
+    }
+    assert prepared["worker_request"]["source"] == prepared["source"]
+    assert prepared["base_revision"] == revision
+    assert prepared["revision"] != revision
+    runtime.abandon_prepared_candidate(prepared)
+
+
+def test_apply_patch_failure_does_not_change_the_saved_program(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = "result = {'Part': api.box(10, 20, 30)}\n"
+    directory, revision = _write_v2_program(tmp_path, source)
+    before = (directory / "program.json").read_bytes()
+    monkeypatch.setattr(runtime, "_freecadcmd", lambda _home: Path("/FreeCADCmd"))
+    capture = _capture(
+        tmp_path,
+        operation="apply_patch",
+        arguments={
+            "program_id": PROGRAM_ID,
+            "expected_revision": revision,
+            "patch": "@@\n-missing = True\n+missing = False",
+        },
+    )
+
+    with pytest.raises(runtime.DomainRuntimeFailure) as failure:
+        runtime.prepare_candidate(capture)
+
+    assert failure.value.payload["failure_code"] == "PATCH_CONTEXT_NOT_FOUND"
+    assert (directory / "program.json").read_bytes() == before
+    assert not (tmp_path / "vibescript" / "partdesign" / ".staging").exists()
+
+
+def test_apply_patch_rejects_a_stale_revision_before_patch_matching(
+    tmp_path: Path,
+) -> None:
+    source = "result = {'Part': api.box(10, 20, 30)}\n"
+    _directory, revision = _write_v2_program(tmp_path, source)
+    capture = _capture(
+        tmp_path,
+        operation="apply_patch",
+        arguments={
+            "program_id": PROGRAM_ID,
+            "expected_revision": "f" * 64,
+            "patch": "@@\n-result = {'Part': api.box(10, 20, 30)}\n+result = {'Part': api.box(12, 20, 30)}",
+        },
+    )
+
+    with pytest.raises(runtime.DomainRuntimeFailure) as failure:
+        runtime.prepare_candidate(capture)
+
+    assert failure.value.payload["failure_code"] == "STALE_PROGRAM_REVISION"
+    assert failure.value.payload["observed"]["current_revision"] == revision
+
+
+def test_failed_patched_candidate_preserves_the_accepted_contract_and_outputs(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source = "result = {'Part': api.box(10, 20, 30)}\n"
+    directory, revision = _write_v2_program(tmp_path, source)
+    manifest_path = directory / "program.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["accepted_contract"] = {
+        "source": source,
+        "revision": revision,
+    }
+    manifest["live_outputs"] = {
+        "Part": {"object_name": "AcceptedPart", "type": "solid"}
+    }
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+    monkeypatch.setattr(runtime, "_freecadcmd", lambda _home: Path("/FreeCADCmd"))
+    prepared = runtime.prepare_candidate(
+        _capture(
+            tmp_path,
+            operation="apply_patch",
+            arguments={
+                "program_id": PROGRAM_ID,
+                "expected_revision": revision,
+                "patch": "@@\n-result = {'Part': api.box(10, 20, 30)}\n+result = {'Part': api.box(12, 20, 30)}",
+            },
+        )
+    )
+
+    runtime.retain_candidate(
+        prepared,
+        status="failed",
+        failure={
+            "failure_code": "DOMAIN_CANDIDATE_FAILED",
+            "failure_stage": "external_process",
+            "error": "synthetic worker failure",
+        },
+    )
+
+    retained = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert retained["working_revision"] == prepared["revision"]
+    assert retained["accepted_revision"] == revision
+    assert retained["accepted_contract"] == {
+        "source": source,
+        "revision": revision,
+    }
+    assert retained["live_outputs"] == {
+        "Part": {"object_name": "AcceptedPart", "type": "solid"}
+    }
+    assert retained["latest_candidate"]["status"] == "failed"
+
+
 def test_saved_loft_subtractive_keyword_is_detected_but_new_source_is_rejected(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
@@ -219,6 +219,69 @@ def test_anthropic_empty_completion_returns_explicit_error(monkeypatch) -> None:
     assert connection.closed
 
 
+def test_anthropic_stream_recovers_on_the_sixth_attempt(monkeypatch) -> None:
+    class RetryableStreamError(Exception):
+        pass
+
+    class SuccessfulStream(_EmptyAnthropicStream):
+        @staticmethod
+        def get_final_message():
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text="Recovered.")],
+                stop_reason="end_turn",
+            )
+
+    attempts: list[int] = []
+
+    def stream(**_request):
+        attempts.append(len(attempts) + 1)
+        if len(attempts) < 6:
+            raise RetryableStreamError("server disconnected")
+        return SuccessfulStream()
+
+    anthropic_module = SimpleNamespace(
+        Anthropic=lambda **_kwargs: SimpleNamespace(
+            messages=SimpleNamespace(stream=stream)
+        ),
+        BadRequestError=type("BadRequestError", (Exception,), {}),
+        APIConnectionError=RetryableStreamError,
+    )
+    monkeypatch.setitem(sys.modules, "anthropic", anthropic_module)
+    monkeypatch.setattr(
+        provider, "_validate_provider_wire_surface", lambda _context: None
+    )
+    monkeypatch.setattr(provider.time, "sleep", lambda _seconds: None)
+    connection = _CollectingConnection()
+
+    provider._anthropic_child_main(
+        connection,
+        "Inspect the model.",
+        {"provider_tool_schemas": []},
+        "test-model",
+        "test-key",
+        None,
+        1.0,
+        1,
+        False,
+    )
+
+    retries = [
+        message["event"]
+        for message in connection.messages
+        if message.get("type") == "progress"
+        and message.get("event", {}).get("event") == "anthropic_stream_retrying"
+    ]
+    assert attempts == [1, 2, 3, 4, 5, 6]
+    assert [event["next_attempt"] for event in retries] == [2, 3, 4, 5, 6]
+    assert {event["max_attempts"] for event in retries} == {6}
+    assert any(
+        message.get("type") == "done"
+        and message.get("final_output") == "Recovered."
+        for message in connection.messages
+    )
+    assert not any(message.get("type") == "error" for message in connection.messages)
+
+
 def test_anthropic_child_forwards_the_exact_tool_use_id(monkeypatch) -> None:
     tool_block = SimpleNamespace(
         type="tool_use",

--- a/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
@@ -1601,7 +1601,9 @@ def test_vibescript_guidance_keeps_lifecycle_rules_concise_across_domains() -> N
     )
     for instruction in (partdesign, assembly):
         assert "failed create without program/revision saved nothing" in instruction
-        assert "read_source before edit_source" in instruction
+        assert "read_source first" in instruction
+        assert "prefer apply_patch for localized" in instruction
+        assert "edit_source for complete rewrites" in instruction
         assert "build_program runs unchanged code" in instruction
         assert "set_inputs" in instruction
         assert "reconfigure_program" not in instruction
@@ -2099,6 +2101,13 @@ def test_source_write_result_is_compact_readable_and_actionable() -> None:
                 }
             },
             "outputs": [{"name": "Mount", "duplicate": True}],
+            "patch_summary": {
+                "hunk_count": 2,
+                "added_lines": 3,
+                "removed_lines": 1,
+                "first_changed_line": 4,
+                "last_changed_line": 18,
+            },
             "model_state": {"status": "accepted", "accepted_is_current": True},
             "_vibecad_source_lifecycle_result": True,
         }
@@ -2108,6 +2117,13 @@ def test_source_write_result_is_compact_readable_and_actionable() -> None:
         "ok": True,
         "program": "Design/partdesign/Motor Mount",
         "revision": "b" * 64,
+        "patch_summary": {
+            "hunk_count": 2,
+            "added_lines": 3,
+            "removed_lines": 1,
+            "first_changed_line": 4,
+            "last_changed_line": 18,
+        },
         "outputs": [
                 {
                     "name": "Mount",

--- a/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
@@ -1588,7 +1588,8 @@ def test_vibescript_guidance_contains_only_cad_authoring_text() -> None:
     assert "vibescript_authoring_contract_json" in text
     assert "read_operation" in text
     assert "read_source" in text
-    assert "edit_source" in text
+    assert "edit_source" not in text
+    assert "reconfigure_program" in text
     assert "build_program" in text
     assert "set_inputs" in text
     assert "api.name" in text
@@ -1602,11 +1603,11 @@ def test_vibescript_guidance_keeps_lifecycle_rules_concise_across_domains() -> N
     for instruction in (partdesign, assembly):
         assert "failed create without program/revision saved nothing" in instruction
         assert "read_source first" in instruction
-        assert "prefer apply_patch for localized" in instruction
-        assert "edit_source for complete rewrites" in instruction
+        assert "use apply_patch for source" in instruction
+        assert "edit_source" not in instruction
+        assert "reconfigure_program" in instruction
         assert "build_program runs unchanged code" in instruction
         assert "set_inputs" in instruction
-        assert "reconfigure_program" not in instruction
         assert "before writing the first program" not in instruction
         assert "after success" not in instruction
 
@@ -2314,6 +2315,12 @@ def test_vibescript_model_context_includes_only_the_editable_source_index(
     editable_sources = {
         "schema": "vibecad-editable-sources-v1",
         "domain": "part",
+        "tools": {
+            "create_program": "vibescript.create_program",
+            "apply_patch": "vibescript.apply_patch",
+            "edit_source": "vibescript.edit_source",
+            "edit_source_arguments": ["program", "expected_revision", "source"],
+        },
         "sources": [
             {
                 "source_id": "a" * 32,
@@ -2350,6 +2357,10 @@ def test_vibescript_model_context_includes_only_the_editable_source_index(
     assert visible["editable_sources"] == {
         "schema": "vibecad-editable-sources-v1",
         "domain": "part",
+        "tools": {
+            "create_program": "vibescript.create_program",
+            "apply_patch": "vibescript.apply_patch",
+        },
         "sources": [
             {
                 "program": "Design/part/Body Source",
@@ -2358,6 +2369,7 @@ def test_vibescript_model_context_includes_only_the_editable_source_index(
         ],
     }
     assert "source_id" not in json.dumps(visible)
+    assert "edit_source" not in json.dumps(visible)
     assert "vibescript_domain" not in visible
 
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_scripted_process.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_scripted_process.py
@@ -111,6 +111,63 @@ def test_worker_cancellation_reports_exact_actor_and_preserved_limit() -> None:
     assert result["memory_limit_bytes"] == 123_456
 
 
+def test_worker_activity_renews_the_inactivity_timeout(tmp_path: Path) -> None:
+    progress = tmp_path / "progress.txt"
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import sys,time\n"
+            "from pathlib import Path\n"
+            "progress=Path(sys.argv[1])\n"
+            "for value in range(12):\n"
+            "    progress.write_text(str(value), encoding='ascii')\n"
+            "    time.sleep(0.1)\n"
+        ),
+        str(progress),
+    ]
+
+    result = run_process(
+        command,
+        cwd=tmp_path,
+        environment=dict(os.environ),
+        cancellation_check=None,
+        timeout_seconds=0.5,
+        memory_limit_bytes=0,
+        activity_check=(
+            lambda: progress.read_text(encoding="ascii")
+            if progress.is_file()
+            else None
+        ),
+    )
+
+    assert result["started"] is True
+    assert result["returncode"] == 0
+    assert result["timed_out"] is False
+    assert result["elapsed_seconds"] > result["timeout_seconds"]
+    assert result["timeout_mode"] == "inactivity"
+    assert result["activity_observations"] >= 6
+
+
+def test_worker_inactivity_still_terminates_a_stalled_process(tmp_path: Path) -> None:
+    result = run_process(
+        [sys.executable, "-c", "import time; time.sleep(10)"],
+        cwd=tmp_path,
+        environment=dict(os.environ),
+        cancellation_check=None,
+        timeout_seconds=0.1,
+        memory_limit_bytes=0,
+        activity_check=lambda: "unchanged",
+    )
+
+    assert result["started"] is True
+    assert result["timed_out"] is True
+    assert result["termination_reason"] == "inactivity_timeout"
+    assert result["limit_reached"] == "inactivity_seconds"
+    assert result["timeout_mode"] == "inactivity"
+    assert result["activity_observations"] == 1
+
+
 def test_worker_cpu_signal_reports_cpu_limit_instead_of_generic_exit() -> None:
     if sys.platform == "win32" or not hasattr(signal, "SIGXCPU"):
         return

--- a/src/Mod/VibeCAD/vibecad_tests/test_tool_surface_guardrails.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_tool_surface_guardrails.py
@@ -509,6 +509,7 @@ def test_partdesign_vibescript_surface_is_its_exact_domain_pack() -> None:
         "vibescript.read_geometry",
         "vibescript.read_placement",
         "vibescript.build_program",
+        "vibescript.apply_patch",
         "vibescript.edit_source",
         "vibescript.set_inputs",
         "vibescript.reconfigure_program",
@@ -552,6 +553,7 @@ def test_model_and_assembly_share_one_stable_provider_contract() -> None:
         "assembly.stop_simulation",
         "material_catalog.search",
         "vibescript.create_part",
+        "vibescript.apply_patch",
         "vibescript.edit_source",
     } <= set(model.tool_names)
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_tool_surface_guardrails.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_tool_surface_guardrails.py
@@ -510,7 +510,6 @@ def test_partdesign_vibescript_surface_is_its_exact_domain_pack() -> None:
         "vibescript.read_placement",
         "vibescript.build_program",
         "vibescript.apply_patch",
-        "vibescript.edit_source",
         "vibescript.set_inputs",
         "vibescript.reconfigure_program",
         "vibescript.delete_output",
@@ -554,8 +553,9 @@ def test_model_and_assembly_share_one_stable_provider_contract() -> None:
         "material_catalog.search",
         "vibescript.create_part",
         "vibescript.apply_patch",
-        "vibescript.edit_source",
+        "vibescript.reconfigure_program",
     } <= set(model.tool_names)
+    assert "vibescript.edit_source" not in model.tool_names
 
 
 def test_model_authoring_contract_survives_document_and_task_transitions(

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_file_io.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_file_io.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Windows-safe VibeScript project-file publication contracts."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+from pathlib import Path
+import threading
+
+import pytest
+
+
+def _access_denied(path: Path) -> PermissionError:
+    error = PermissionError(errno.EACCES, "Access is denied", str(path))
+    error.winerror = 5
+    return error
+
+
+def test_atomic_write_retries_a_transient_windows_sharing_violation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import VibeCADVibeScriptFileIO as file_io
+
+    destination = tmp_path / "program.json"
+    real_replace = file_io._replace_path
+    attempted_sources: list[Path] = []
+    attempts = 0
+
+    def transient_replace(source: Path, target: Path) -> None:
+        nonlocal attempts
+        attempts += 1
+        attempted_sources.append(Path(source))
+        if attempts < 3:
+            raise _access_denied(Path(target))
+        real_replace(source, target)
+
+    monkeypatch.setattr(file_io, "_replace_path", transient_replace)
+
+    published = file_io.atomic_write_text(
+        destination,
+        json.dumps({"revision": 1}),
+        replace_timeout_seconds=1.0,
+    )
+
+    assert published is True
+    assert attempts == 3
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"revision": 1}
+    assert len(set(attempted_sources)) == 1
+    assert not list(tmp_path.glob("*.tmp"))
+
+    file_io.atomic_write_text(
+        destination,
+        json.dumps({"revision": 2}),
+        replace_timeout_seconds=1.0,
+    )
+    assert attempted_sources[-1] != attempted_sources[0]
+    assert json.loads(destination.read_text(encoding="utf-8")) == {"revision": 2}
+
+
+def test_best_effort_progress_write_never_rejects_valid_cad_work(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import VibeCADVibeScriptFileIO as file_io
+
+    destination = tmp_path / "progress.json"
+    destination.write_text('{"phase":"prior"}', encoding="utf-8")
+
+    def permanently_locked(_source: Path, target: Path) -> None:
+        raise _access_denied(Path(target))
+
+    monkeypatch.setattr(file_io, "_replace_path", permanently_locked)
+
+    published = file_io.atomic_write_text(
+        destination,
+        '{"phase":"next"}',
+        replace_timeout_seconds=0.0,
+        best_effort=True,
+    )
+
+    assert published is False
+    assert destination.read_text(encoding="utf-8") == '{"phase":"prior"}'
+    assert not list(tmp_path.glob("*.tmp"))
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows sharing flags are NT-specific")
+def test_windows_reader_allows_atomic_replacement_while_open(tmp_path: Path) -> None:
+    import VibeCADVibeScriptFileIO as file_io
+
+    destination = tmp_path / "program.json"
+    destination.write_bytes(b"before")
+
+    with file_io.open_shared_binary(destination) as stream:
+        assert file_io.atomic_write_text(
+            destination,
+            "after",
+            replace_timeout_seconds=2.0,
+        )
+        assert stream.read() == b"before"
+
+    assert destination.read_bytes() == b"after"
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows sharing flags are NT-specific")
+def test_windows_progress_polling_never_observes_a_partial_snapshot(
+    tmp_path: Path,
+) -> None:
+    import VibeCADVibeScriptFileIO as file_io
+
+    destination = tmp_path / "progress.json"
+    file_io.atomic_write_text(destination, json.dumps({"revision": 0}))
+    stop = threading.Event()
+    failures: list[BaseException] = []
+    observed: list[int] = []
+
+    def poll() -> None:
+        while not stop.is_set():
+            try:
+                value = json.loads(file_io.read_text_shared(destination))
+                observed.append(int(value["revision"]))
+            except BaseException as exc:
+                failures.append(exc)
+                stop.set()
+
+    reader = threading.Thread(target=poll)
+    reader.start()
+    try:
+        for revision in range(1, 201):
+            assert file_io.atomic_write_text(
+                destination,
+                json.dumps({"revision": revision}),
+            )
+    finally:
+        stop.set()
+        reader.join(timeout=5.0)
+
+    assert not reader.is_alive()
+    assert failures == []
+    assert observed
+    assert json.loads(file_io.read_text_shared(destination)) == {"revision": 200}
+
+
+def test_worker_result_uses_in_memory_progress_when_status_file_is_locked() -> None:
+    import vibescript_domain_worker as worker
+
+    source = Path(worker.__file__).read_text(encoding="utf-8")
+    assert 'response["worker_progress"] = worker_progress.snapshot()' in source
+    assert '(root / "progress.json").read_text' not in source

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_file_io.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_file_io.py
@@ -150,3 +150,48 @@ def test_worker_result_uses_in_memory_progress_when_status_file_is_locked() -> N
     source = Path(worker.__file__).read_text(encoding="utf-8")
     assert 'response["worker_progress"] = worker_progress.snapshot()' in source
     assert '(root / "progress.json").read_text' not in source
+
+
+def test_domain_execution_renews_its_lease_from_worker_progress(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import VibeCADScriptedProcess as scripted
+    import VibeCADVibeScriptDomainRuntime as runtime
+
+    observed: dict[str, object] = {}
+
+    def run_process(_command, **kwargs):
+        observed.update(kwargs)
+        return {
+            "started": True,
+            "returncode": -1,
+            "cancelled": False,
+            "timed_out": True,
+            "memory_exceeded": False,
+            "cpu_exceeded": False,
+            "timeout_mode": "inactivity",
+        }
+
+    monkeypatch.setattr(scripted, "run_process", run_process)
+    prepared = {
+        "tool_name": "vibescript.assembly.edit_source",
+        "freecadcmd_executable": "FreeCADCmd",
+        "staging": str(tmp_path),
+        "timeout_seconds": 3600.0,
+        "memory_limit_bytes": 1024,
+        "live_outputs_before": {},
+    }
+
+    result = runtime.execute_candidate(prepared, cancellation_check=None)
+
+    activity_check = observed["activity_check"]
+    assert callable(activity_check)
+    assert activity_check() is None
+    (tmp_path / "progress.json").write_text('{"frame":1}', encoding="utf-8")
+    first = activity_check()
+    assert first is not None
+    (tmp_path / "progress.json").write_text('{"frame":22}', encoding="utf-8")
+    assert activity_check() != first
+    assert result["failure_code"] == "DOMAIN_EXECUTION_TIMEOUT"
+    assert "made no observable progress for 3600 seconds" in result["error"]

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_source_patch.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_source_patch.py
@@ -1,0 +1,200 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Atomic contextual patch behavior for persisted VibeScript source."""
+
+from __future__ import annotations
+
+import pytest
+
+from VibeCADVibeScriptPatch import SourcePatchError, apply_source_patch
+
+
+def test_applies_one_codex_style_update_without_complete_source() -> None:
+    result = apply_source_patch(
+        "def main():\n    width = 10\n    return width\n",
+        """*** Begin Patch
+*** Update File: source.py
+@@
+-    width = 10
++    width = 12
+*** End Patch""",
+    )
+
+    assert result["source"] == "def main():\n    width = 12\n    return width\n"
+    assert result["summary"] == {
+        "hunk_count": 1,
+        "added_lines": 1,
+        "removed_lines": 1,
+        "first_changed_line": 2,
+        "last_changed_line": 2,
+    }
+
+
+def test_applies_multiple_non_overlapping_hunks_atomically() -> None:
+    result = apply_source_patch(
+        "alpha = 1\nbeta = 2\ngamma = 3\ndelta = 4\n",
+        """*** Begin Patch
+*** Update File: source.py
+@@
+-alpha = 1
++alpha = 10
+ beta = 2
+@@
+ gamma = 3
+-delta = 4
++delta = 40
+*** End Patch""",
+    )
+
+    assert result["source"] == ("alpha = 10\nbeta = 2\ngamma = 3\ndelta = 40\n")
+    assert result["summary"]["hunk_count"] == 2
+
+
+def test_rejects_missing_context_without_returning_a_partial_result() -> None:
+    source = "alpha = 1\nbeta = 2\ngamma = 3\n"
+    patch = """@@
+-alpha = 1
++alpha = 10
+@@
+-missing = 4
++missing = 40"""
+
+    with pytest.raises(SourcePatchError) as caught:
+        apply_source_patch(source, patch)
+
+    assert caught.value.code == "PATCH_CONTEXT_NOT_FOUND"
+    assert source == "alpha = 1\nbeta = 2\ngamma = 3\n"
+
+
+def test_rejects_ambiguous_context_instead_of_guessing() -> None:
+    with pytest.raises(SourcePatchError) as caught:
+        apply_source_patch(
+            "value = 1\nvalue = 1\n",
+            """@@
+-value = 1
++value = 2""",
+        )
+
+    assert caught.value.code == "PATCH_CONTEXT_AMBIGUOUS"
+    assert caught.value.details["match_count"] == 2
+
+
+def test_rejects_overlapping_hunks() -> None:
+    with pytest.raises(SourcePatchError) as caught:
+        apply_source_patch(
+            "alpha\nbeta\ngamma\n",
+            """@@
+ alpha
+-beta
++BETA
+ gamma
+@@
+-gamma
++GAMMA""",
+        )
+
+    assert caught.value.code == "PATCH_HUNKS_OVERLAP"
+
+
+def test_preserves_crlf_unicode_and_indentation_and_supports_deletion() -> None:
+    result = apply_source_patch(
+        "def main():\r\n    label = 'café'\r\n    obsolete = True\r\n    return label\r\n",
+        """@@ def main():
+     label = 'café'
+-    obsolete = True
+     return label""",
+    )
+
+    assert result["source"] == (
+        "def main():\r\n    label = 'café'\r\n    return label\r\n"
+    )
+    assert result["summary"]["added_lines"] == 0
+    assert result["summary"]["removed_lines"] == 1
+
+
+def test_preserves_unchanged_mixed_line_endings() -> None:
+    result = apply_source_patch(
+        "first = 1\r\nsecond = 2\nthird = 3\r",
+        """@@
+-second = 2
++second = 20""",
+    )
+
+    assert result["source"] == "first = 1\r\nsecond = 20\nthird = 3\r"
+
+
+def test_end_of_file_anchor_supports_an_insertion_only_hunk() -> None:
+    result = apply_source_patch(
+        "result = main()\n",
+        """@@
++assert result is not None
+*** End of File""",
+    )
+
+    assert result["source"] == "result = main()\nassert result is not None\n"
+
+
+def test_unanchored_insertion_only_hunk_appends_like_codex_apply_patch() -> None:
+    result = apply_source_patch(
+        "first = 1\nsecond = 2\n",
+        """@@
++third = 3""",
+    )
+
+    assert result["source"] == "first = 1\nsecond = 2\nthird = 3\n"
+
+
+def test_appending_to_an_unterminated_source_preserves_its_eof_style() -> None:
+    result = apply_source_patch(
+        "result = main()",
+        """@@
+ result = main()
++assert result is not None
+*** End of File""",
+    )
+
+    assert result["source"] == "result = main()\nassert result is not None"
+
+
+def test_accepts_codex_first_chunk_without_an_explicit_at_header() -> None:
+    result = apply_source_patch(
+        "import api\nresult = api.box(1, 2, 3)\n",
+        """*** Begin Patch
+*** Update File: source.py
+ import api
+-result = api.box(1, 2, 3)
++result = api.box(4, 5, 6)
+*** End Patch""",
+    )
+
+    assert result["source"] == "import api\nresult = api.box(4, 5, 6)\n"
+
+
+def test_accepts_codex_blank_line_before_end_patch_marker() -> None:
+    result = apply_source_patch(
+        "result = 1\n",
+        """*** Begin Patch
+*** Update File: source.py
+@@
+-result = 1
++result = 2
+
+*** End Patch""",
+    )
+
+    assert result["source"] == "result = 2\n"
+
+
+@pytest.mark.parametrize(
+    "patch",
+    [
+        "*** Begin Patch\n*** Add File: source.py\n+new\n*** End Patch",
+        "*** Begin Patch\n*** Delete File: source.py\n*** End Patch",
+        "*** Begin Patch\n*** Update File: one.py\n@@\n-a\n+b\n*** Update File: two.py\n@@\n-c\n+d\n*** End Patch",
+    ],
+)
+def test_rejects_non_atomic_or_multi_file_envelopes(patch: str) -> None:
+    with pytest.raises(SourcePatchError) as caught:
+        apply_source_patch("a\nc\n", patch)
+
+    assert caught.value.code == "PATCH_FORMAT_INVALID"

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_timeline_publication.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_timeline_publication.py
@@ -51,6 +51,7 @@ def test_every_runner_owned_write_has_an_explicit_history_lifecycle() -> None:
     assert universal_writes == {
         "vibescript.create_program",
         "vibescript.build_program",
+        "vibescript.apply_patch",
         "vibescript.edit_source",
         "vibescript.set_inputs",
         "vibescript.reconfigure_program",
@@ -71,6 +72,7 @@ def test_every_runner_owned_write_has_an_explicit_history_lifecycle() -> None:
     contracts: dict[str, str] = {
         "vibescript.create_program": "delegated_domain_strategy",
         "vibescript.build_program": "exact_regeneration",
+        "vibescript.apply_patch": "exact_regeneration",
         "vibescript.edit_source": "exact_regeneration",
         "vibescript.set_inputs": "exact_regeneration",
         "vibescript.reconfigure_program": "exact_regeneration",
@@ -100,7 +102,7 @@ def test_every_runner_owned_write_has_an_explicit_history_lifecycle() -> None:
         contracts[f"vibescript.{pack.domain}.delete_program"] = "semantic_deletion"
 
     # Ten canonical writes plus four callable compatibility aliases per shipped pack.
-    assert len(registered_writes) == 10 + 4 * len(packs) == 78
+    assert len(registered_writes) == 11 + 4 * len(packs) == 79
     assert set(contracts) == registered_writes
     assert set(contracts.values()) <= {
         *domain_publication._TIMELINE_PUBLICATION_STRATEGY_BY_DOMAIN.values(),

--- a/src/Mod/VibeCAD/vibescript_domain_worker.py
+++ b/src/Mod/VibeCAD/vibescript_domain_worker.py
@@ -17,6 +17,7 @@ from types import MappingProxyType
 from typing import Any
 
 from VibeCADAssemblySolverPolicy import set_joint_connectors_without_auto_solve
+from VibeCADVibeScriptFileIO import atomic_write_text, read_text_shared
 from vibescript_domain_api import DomainValue, create_domain_api
 import vibescript_worker_progress as worker_progress
 
@@ -93,12 +94,10 @@ def _immutable_input(value: Any) -> Any:
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:
-    temporary = path.with_name(f"{path.name}.tmp")
-    temporary.write_text(
+    atomic_write_text(
+        path,
         json.dumps(payload, ensure_ascii=True, separators=(",", ":")),
-        encoding="utf-8",
     )
-    temporary.replace(path)
 
 
 def _resource_limits(request: dict[str, Any]) -> None:
@@ -1339,9 +1338,7 @@ def _run(request: dict[str, Any], root: Path) -> dict[str, Any]:
         elif domain == "techdraw":
             response["techdraw_validation"] = techdraw_validation
         worker_progress.finish()
-        response["worker_progress"] = json.loads(
-            (root / "progress.json").read_text(encoding="utf-8")
-        )
+        response["worker_progress"] = worker_progress.snapshot()
         return response
     finally:
         App.closeDocument(document.Name)
@@ -1353,7 +1350,7 @@ def main() -> int:
     try:
         request_path = Path(os.environ[REQUEST_ENV]).resolve()
         root = request_path.parent
-        request = json.loads(request_path.read_text(encoding="utf-8"))
+        request = json.loads(read_text_shared(request_path))
         if not isinstance(request, dict):
             raise TypeError("Domain worker request must be an object.")
         _resource_limits(request)

--- a/src/Mod/VibeCAD/vibescript_domain_worker.py
+++ b/src/Mod/VibeCAD/vibescript_domain_worker.py
@@ -219,18 +219,26 @@ def _execute_source(
     started = time.monotonic()
     operations = 0
     source_filename = "<vibecad-domain-vibescript>"
+    source_elapsed = 0.0
+    last_trace_at = started
+    source_active = False
 
     def trace(frame: Any, event: str, _arg: Any):
-        nonlocal operations
-        if frame.f_code.co_filename == source_filename and event in {"line", "call"}:
+        nonlocal last_trace_at, operations, source_active, source_elapsed
+        now = time.monotonic()
+        if source_active:
+            source_elapsed += max(0.0, now - last_trace_at)
+        last_trace_at = now
+        source_active = frame.f_code.co_filename == source_filename
+        if source_active and source_elapsed > max_seconds:
+            raise TimeoutError(
+                f"VibeScript exceeded its {max_seconds:g} second source budget."
+            )
+        if source_active and event in {"line", "call"}:
             operations += 1
             if operations > max_operations:
                 raise RuntimeError(
                     f"VibeScript exceeded its {max_operations} operation budget."
-                )
-            if time.monotonic() - started > max_seconds:
-                raise TimeoutError(
-                    f"VibeScript exceeded its {max_seconds:g} second source budget."
                 )
         return trace
 
@@ -267,6 +275,9 @@ def _execute_source(
             setattr(exc, "vibescript_stdout", output.getvalue()[-MAX_STDOUT_CHARS:])
             raise
     finally:
+        now = time.monotonic()
+        if source_active:
+            source_elapsed += max(0.0, now - last_trace_at)
         sys.settrace(previous_trace)
     result = namespace.get("result")
     if not isinstance(result, dict):
@@ -285,6 +296,7 @@ def _execute_source(
             "operations": operations,
             "max_operations": max_operations,
             "elapsed_seconds": time.monotonic() - started,
+            "source_elapsed_seconds": source_elapsed,
             "max_seconds": max_seconds,
         },
     )

--- a/src/Mod/VibeCAD/vibescript_worker_progress.py
+++ b/src/Mod/VibeCAD/vibescript_worker_progress.py
@@ -9,6 +9,11 @@ from pathlib import Path
 import time
 from typing import Any
 
+from VibeCADVibeScriptFileIO import (
+    TELEMETRY_IO_TIMEOUT_SECONDS,
+    atomic_write_text,
+)
+
 
 _SCHEMA = "vibecad-vibescript-worker-progress-v1"
 _MAX_TIMINGS = 512
@@ -22,18 +27,25 @@ _state: dict[str, Any] = {}
 def _write() -> None:
     if _path is None:
         return
+    payload = snapshot()
+    atomic_write_text(
+        _path,
+        json.dumps(payload, ensure_ascii=True, separators=(",", ":")),
+        replace_timeout_seconds=TELEMETRY_IO_TIMEOUT_SECONDS,
+        best_effort=True,
+    )
+
+
+def snapshot() -> dict[str, Any]:
+    """Return current progress without depending on the status file."""
+
     payload = dict(_state)
     payload["elapsed_seconds"] = round(time.monotonic() - _started, 6)
     payload["phase_elapsed_seconds"] = round(
         time.monotonic() - _phase_started,
         6,
     )
-    temporary = _path.with_suffix(".tmp")
-    temporary.write_text(
-        json.dumps(payload, ensure_ascii=True, separators=(",", ":")),
-        encoding="utf-8",
-    )
-    temporary.replace(_path)
+    return payload
 
 
 def configure(path: str | Path, domain: str) -> None:

--- a/src/Tools/tests/test_vibecad_update.py
+++ b/src/Tools/tests/test_vibecad_update.py
@@ -1106,7 +1106,10 @@ class UpdateServiceTests(unittest.TestCase):
                 0,
                 f"stdout={completed.stdout}\nstderr={completed.stderr}",
             )
-            deadline = time.time() + 5
+            # Cold powershell.exe startup can exceed five seconds on hosted
+            # Windows runners while antivirus scans a newly checked-out tree.
+            # This verifies process survival, not PowerShell startup latency.
+            deadline = time.time() + 30
             while time.time() < deadline and not marker.is_file():
                 time.sleep(0.05)
             self.assertTrue(


### PR DESCRIPTION
﻿## Summary

Adds `vibescript.apply_patch`, a universal atomic contextual source-editing tool for VibeScript changes. It accepts Codex-style `*** Begin Patch` / `*** Update File` envelopes (or the contained `@@` hunks), requires the current `expected_revision`, validates every hunk against the same persisted source, and uses the existing validate/build/publish/accept lifecycle.

The AI-facing lifecycle is intentionally small and unambiguous:

- `create_program` creates the initial source;
- `apply_patch` changes existing source without resending the whole file;
- `set_inputs` changes input values only;
- `reconfigure_program` replaces source, schema, inputs, and outputs together.

The legacy `edit_source` entry point remains registered and callable for backend compatibility, but is no longer advertised to the operating model or included in model-visible source actions.

The patch implementation:

- works through every shipped VibeScript workbench/domain;
- rejects stale revisions, missing or ambiguous context, overlapping hunks, malformed/multi-file operations, and no-op patches without partial mutation;
- preserves line endings, indentation, Unicode, deletion semantics, and Codex append behavior;
- returns a concise changed-region summary through operation/readback results.

## Issues

Closes #154

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing defaults and backend `vibescript.edit_source` behavior are unchanged.
- [x] Existing domain-qualified lifecycle aliases remain callable.
- [x] The owner explicitly approved removing the legacy alias from the AI-advertised surface; backend callers retain compatibility.

## Verification

- [x] Red/green TDD was used.
- [x] Exact build and test commands and results are listed below.

Red tests observed before implementation/correction:

- `.\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_vibescript_source_patch.py -q --tb=short`
  - failed at collection with `ModuleNotFoundError: No module named 'VibeCADVibeScriptPatch'` before the implementation existed;
  - later failed `test_unanchored_insertion_only_hunk_appends_like_codex_apply_patch` because an unanchored addition was inserted at the start instead of appended.
- `$env:PYTHONPATH=(Resolve-Path 'src/Mod/VibeCAD').Path; .\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py::test_shared_vibescript_lifecycle_is_unambiguous_for_the_operating_model src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py::test_vibescript_guidance_keeps_lifecycle_rules_concise_across_domains src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py::test_concise_source_read_states_current_revision_directly -q --tb=short`
  - `3 failed`, proving the legacy alias was still exposed in provider schemas, instructions, and source actions before the correction.
- `test_vibescript_model_context_includes_only_the_editable_source_index`
  - failed after a legacy tool entry was injected, proving the top-level editable-source tool index also needed filtering.

Green verification:

- `$env:PYTHONPATH=(Resolve-Path 'src/Mod/VibeCAD').Path; .\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_vibescript_source_patch.py -q --tb=short`
  - `15 passed in 0.71s`
- `$env:PYTHONPATH=(Resolve-Path 'src/Mod/VibeCAD').Path; .\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py -q --tb=short`
  - `224 passed, 1 skipped in 4.91s`
- `$env:PYTHONPATH=(Resolve-Path 'src/Mod/VibeCAD').Path; .\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_tool_surface_guardrails.py src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py -q --tb=short`
  - `83 passed in 4.07s`
- `$env:PYTHONPATH=(Resolve-Path 'src/Mod/VibeCAD').Path; .\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests -q --tb=short`
  - `4328 passed, 9 skipped in 84.31s`
- `.\.pixi\envs\default\python.exe -m black --check src/Mod/VibeCAD/VibeCADVibeScriptPatch.py src/Mod/VibeCAD/vibecad_tests/test_vibescript_source_patch.py`
  - `2 files would be left unchanged`
- `.\.pixi\envs\default\python.exe -m py_compile src/Mod/VibeCAD/VibeCADVibeScriptPatch.py src/Mod/VibeCAD/VibeCADProvider.py src/Mod/VibeCAD/VibeCADSession.py src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py src/Mod/VibeCAD/VibeCADVibeScriptDomains.py`
  - passed
- `& $env:USERPROFILE\.pixi\bin\pixi.exe reinstall -e default vibecad` from `package/rattler-build`
  - full Windows Rattler build, package creation, and default-environment reinstall passed with exit code 0 for the additive patch implementation;
  - package: `vibecad-26.3.1RC6-h3c70cbc_1.conda` (8,372 files, 489.09 MiB).
- Installed-artifact verification:
  - source and installed `VibeCADVibeScriptPatch.py` SHA-256 both `D057BC93E5318E0BB712EBE8A33BF5CEBE630B81FAF6AFD3C78B3E6F49C07486`;
  - installed `freecadcmd.exe` smoke passed, confirming the public schema, all 17 workbench surfaces, contextual replacement, and unanchored append behavior.

## Risk and non-goals

Risk is confined to the additive source operation, shared result metadata, and provider projection. Existing source replacement, input patching, regeneration, deletion, and backend contracts remain intact. This PR deliberately does not add/delete/rename VibeScript programs through patch syntax; the `program` argument identifies one existing persisted source.

## Before and After Images

Not applicable; no GUI layout changes.

## Windows worker-publication reliability follow-up

The same PR now also fixes two failures found while exercising the new operation through the real Windows provider path:

- Concurrent worker status polling could race fixed-name temporary files and one-shot replacements for `progress.json`, `result.json`, and durable program manifests. Windows sharing violations (`WinError 5`, `32`, or `33`) could therefore fail otherwise-valid CAD work.
- Background `vibescript.apply_patch` re-entry was absent from the provider-session universal dispatch set, so it fell through to the intentionally adapter-only registry placeholder and returned `Tool vibescript.apply_patch is executed by the provider-session adapter.`

The file publication fix is shared by the host and bundled worker. It uses unique sibling temporary files, retry-bounded atomic publication, Windows shared reads, and native replacement semantics. Durable program/result writes retry and fail closed; disposable progress telemetry is best effort so a transient status-file lock cannot invalidate completed CAD output. The worker returns its final progress from memory instead of rereading its own telemetry file. No public tool, schema, preference, or wire contract changed.

Additional red/green TDD evidence:

- Red: `test_provider_tool_runner_executes_apply_patch_through_session_adapter` completed its background operation with status `failed` before the routing correction.
- Red: the new file-publication tests initially produced four failures; a real open-reader Windows test proved one-shot replacement insufficient, and the concurrent stress case exposed transient sharing and not-found windows until symmetric read/write retry handling was added.
- `$env:PYTHONPATH=(Resolve-Path 'src/Mod/VibeCAD').Path; .\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_vibescript_file_io.py src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py::test_provider_tool_runner_executes_apply_patch_through_session_adapter -q --tb=short`
  - `6 passed`
- Targeted VibeScript architecture/domain-worker suite:
  - `161 passed in 4.61s`
- `$env:PYTHONPATH=(Resolve-Path 'src/Mod/VibeCAD').Path; .\.pixi\envs\default\python.exe -m pytest src/Mod/VibeCAD/vibecad_tests -q --tb=short`
  - `4344 passed, 9 skipped in 105.03s`
- Python compilation and `git diff --check` passed.
- Ten repeated Windows concurrency stress runs against the freshly packaged module all passed (`5 passed` per run): 2,000 total atomic status publications under concurrent polling, with no access-denied, missing, or partial JSON observations.

Additional full Windows build verification:

- `.\Launch-VibeCAD-Dev.ps1`
  - canonical Rattler build/reinstall completed successfully;
  - all `8946` Ninja targets completed;
  - package: `vibecad-26.3.1RC6-h3c70cbc_1.conda` (`8,374` files, `489.18 MiB`);
  - source and installed hashes match for the new file-I/O helper, provider session, and domain runtime;
  - packaged file-I/O plus provider-session routing tests: `6 passed in 4.28s`;
  - normal-mode GUI launched successfully from the current checkout at commit `6dd47ab309bf17996aab189a2a6931b0def30cf7`.


### Required-check stabilization

The required Windows updater survival check exposed a separate test-harness timing assumption after the new Windows module increased cold checkout/scanner load. The updater implementation, updater test source, and workflow were byte-identical to prior passing head `cd26be61`; rerunning that known-good commit passed as a control. The production updater remains unchanged. Only the test's observation window was increased from 5 to 30 seconds because it verifies that a detached PowerShell child survives its parent, not PowerShell startup latency.

- Red: current-head required check timed out at the five-second marker deadline on four hosted Windows attempts with empty child stderr/log.
- Control: the byte-identical known-good updater at `cd26be61` passed on a fresh hosted Windows rerun.
- Local exact three-test workflow command repeated five times: all 15 test executions passed.
- Green: both required checks passed on head `f97b282f` (`Validate Windows updater process launch`, 35 seconds; `Validate release and update contracts`, 21 seconds).


## Long-running VibeScript and Anthropic stream resilience

Follow-up testing exposed a hidden five-minute total wall-clock cutoff inherited from the older scripted runtime. That one value incorrectly bounded source-authored Python, trusted CAD kernels, native validation, result publication, process exit, and Unix worker CPU time. A healthy 161-frame assembly sweep could therefore publish completed progress and still be killed before its durable result reached the host.

The corrected lifecycle is additive for the shared process runner and deliberately changes the VibeScript default as approved by the owner:

- legacy process-runner callers retain total wall-time semantics;
- VibeScript supplies a worker-progress activity token, so its timeout is an inactivity lease renewed by every published phase/item/graph update;
- the default lease is now 3,600 seconds without observable progress, and persisted hidden legacy values of 300 seconds migrate automatically;
- trusted CAD/API execution time is excluded from the source-authored Python time budget;
- the Unix `RLIMIT_CPU` duplicate is disabled for VibeScript because it also counted trusted CAD kernels; source operation/time budgets, memory/output limits, explicit cancellation, and stalled-worker termination remain active;
- completion progress renews the lease, allowing atomic `result.json` publication and normal worker exit rather than a boundary kill;
- Anthropic interrupted-stream recovery now permits six total attempts and reports `retry n/6` in the UI.

Red/green TDD evidence:

- Red: advancing-activity test failed because `run_process` had no activity lease API.
- Red: trusted API test failed at 0.05 seconds because trusted execution was charged to the source budget.
- Red: Anthropic recovery stopped after attempts `[1, 2, 3]` instead of reaching attempt six.
- Red: a persisted hidden `300` timeout remained 300 instead of migrating to the new lease.
- Focused red/green contracts: `4 passed in 2.73s`.
- Impacted suites: `255 passed, 1 skipped in 8.08s`.
- Complete VibeCAD suite: `4349 passed, 9 skipped in 87.74s`.
- Five repeated reliability runs: all passed (`5 passed` per run), covering advancing lease renewal, stagnant-process termination, trusted API accounting, persisted-setting migration, and sixth-attempt Anthropic recovery.
- Python compilation and `git diff --check` passed.
