### PR TITLE
Enable direct constrained assembly dragging

### DIFF
--- a/src/Gui/VibeCADRibbon.cpp
+++ b/src/Gui/VibeCADRibbon.cpp
@@ -1489,6 +1489,20 @@ struct Gui::VibeCADRibbon::Private
         button->setAutoRaise(true);
         button->setIconSize(QSize(20, 20));
         if (action) {
+            auto* sourceCommand = Application::Instance->commandManager().getCommandByName(
+                command.toUtf8().constData()
+            );
+            QAction* shortcutAction = sourceCommand && sourceCommand->getAction()
+                ? sourceCommand->getAction()->action()
+                : nullptr;
+            if (shortcutAction && shortcutAction != action
+                && !shortcutAction->shortcut().isEmpty()
+                && !root->actions().contains(shortcutAction)) {
+                // Undo and Redo use shortcut-free toolbar actions. Associate
+                // their existing command actions with the visible ribbon so
+                // shortcuts remain active while the standard menu is hidden.
+                root->addAction(shortcutAction);
+            }
             if (ownedAction) {
                 action->setParent(button);
             }

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -78,7 +78,7 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
     ADD_PROPERTY_TYPE(BoundingBox, (false), dogroup, App::Prop_None, "Display object bounding box");
     ADD_PROPERTY_TYPE(
         Selectable,
-        (true),
+        (isSelectionEnabled()),
         sgroup,
         App::Prop_None,
         "Set if the object is selectable in the 3d view"
@@ -88,7 +88,7 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
     pickStyle->ref();
     pickStyle->style.setValue(SoPickStyle::SHAPE);
     pcRoot->insertChild(pickStyle, 1);
-    Selectable.setValue(isSelectionEnabled());
+    setSelectable(Selectable.getValue());
 
     pcShapeMaterial = new SoMaterial;
     setCoinAppearance(mat);

--- a/src/Mod/Assembly/AssemblyTests/TestVibeCADRibbonTools.py
+++ b/src/Mod/Assembly/AssemblyTests/TestVibeCADRibbonTools.py
@@ -248,7 +248,14 @@ class TestVibeCADAssemblyRibbonTools(unittest.TestCase):
             loop.exec()
 
     @staticmethod
-    def _send_mouse(widget, event_type, position, button, buttons):
+    def _send_mouse(
+        widget,
+        event_type,
+        position,
+        button,
+        buttons,
+        modifiers=QtCore.Qt.NoModifier,
+    ):
         global_position = widget.mapToGlobal(position)
         event = QtGui.QMouseEvent(
             event_type,
@@ -256,7 +263,7 @@ class TestVibeCADAssemblyRibbonTools(unittest.TestCase):
             global_position,
             button,
             buttons,
-            QtCore.Qt.NoModifier,
+            modifiers,
         )
         QtGui.QApplication.sendEvent(widget, event)
 
@@ -354,6 +361,91 @@ class TestVibeCADAssemblyRibbonTools(unittest.TestCase):
             QtCore.Qt.NoButton,
         )
         self._process_events(100)
+
+    def _drag_rendered_component(
+        self,
+        component,
+        *,
+        delta_x=72,
+        expect_start=True,
+        expected_transaction=0,
+        modifiers=QtCore.Qt.NoModifier,
+        move=True,
+        release=True,
+    ):
+        """Press and drag a visible Assembly occurrence without using its dragger."""
+        view = Gui.activeDocument().activeView()
+        view.viewAxonometric()
+        view.fitAll()
+        self._process_events(100)
+        viewport = view.graphicsView().viewport()
+        self.assertTrue(viewport.isVisible())
+
+        linked = component.getLinkedObject()
+        self.assertIsNotNone(linked)
+        center = component.Placement.multVec(linked.Shape.BoundBox.Center)
+        press_position = self._viewport_point(view, viewport, center)
+        bounds = viewport.rect().adjusted(8, 8, -8, -8)
+        self.assertTrue(
+            bounds.contains(press_position),
+            "The rendered Assembly occurrence is outside the viewport",
+        )
+        signed_delta_x = delta_x if press_position.x() < bounds.center().x() else -delta_x
+        target = press_position + QtCore.QPoint(signed_delta_x, 0)
+        target.setX(max(bounds.left(), min(target.x(), bounds.right())))
+
+        self._send_mouse(
+            viewport,
+            QtCore.QEvent.MouseMove,
+            press_position,
+            QtCore.Qt.NoButton,
+            QtCore.Qt.NoButton,
+        )
+        self._process_events(80)
+        preselection = Gui.Selection.getPreselection()
+        self.assertTrue(
+            preselection.ObjectName,
+            f"The rendered component was not preselected: {preselection}",
+        )
+        self._send_mouse(
+            viewport,
+            QtCore.QEvent.MouseButtonPress,
+            press_position,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.LeftButton,
+            modifiers,
+        )
+        if move:
+            self._send_mouse(
+                viewport,
+                QtCore.QEvent.MouseMove,
+                target,
+                QtCore.Qt.NoButton,
+                QtCore.Qt.LeftButton,
+                modifiers,
+            )
+            self._process_events(80)
+        transaction = self.document.getBookedTransactionID()
+        if expect_start:
+            self.assertNotEqual(
+                transaction,
+                0,
+                "Direct manipulation did not begin a move transaction for "
+                f"{preselection.ObjectName} {preselection.SubElementNames}",
+            )
+        else:
+            self.assertEqual(transaction, expected_transaction)
+        if release:
+            self._send_mouse(
+                viewport,
+                QtCore.QEvent.MouseButtonRelease,
+                target,
+                QtCore.Qt.LeftButton,
+                QtCore.Qt.NoButton,
+                modifiers,
+            )
+            self._process_events(100)
+        return viewport, target
 
     def _dismiss_task(self, *, accept):
         self.assertTrue(Gui.Control.activeDialog())
@@ -1980,6 +2072,251 @@ class TestVibeCADAssemblyRibbonTools(unittest.TestCase):
         )
         self.assertFalse(self.document.HasPendingTransaction)
         self.assertEqual(self.document.getBookedTransactionID(), 0)
+
+    def test_component_can_be_dragged_directly_outside_assembly_edit(self):
+        assembly, components = self._create_assembly_with_components(1)
+        component = components[0]
+        gui_document = Gui.getDocument(self.document.Name)
+        gui_document.resetEdit()
+        self._process_events(100)
+        self.assertIsNone(gui_document.getInEdit())
+
+        before_placement = App.Placement(component.Placement)
+        before_undo = int(self.document.UndoCount)
+        self._drag_rendered_component(component)
+
+        self.assertNotEqual(component.Placement, before_placement)
+        self.assertEqual(int(self.document.UndoCount), before_undo + 1)
+        self.assertFalse(self.document.HasPendingTransaction)
+        self.assertEqual(self.document.getBookedTransactionID(), 0)
+
+        moved_placement = App.Placement(component.Placement)
+        self.document.undo()
+        self._process_events(100)
+        self.assertEqual(component.Placement, before_placement)
+        self.document.redo()
+        self._process_events(100)
+        self.assertEqual(component.Placement, moved_placement)
+
+    def test_component_can_be_dragged_directly_from_model_ribbon(self):
+        _assembly, components = self._create_assembly_with_components(1)
+        component = components[0]
+        Gui.activeDocument().resetEdit()
+        Gui.activateWorkbench("PartDesignWorkbench")
+        self._process_events(100)
+
+        before_placement = App.Placement(component.Placement)
+        before_undo = int(self.document.UndoCount)
+        self._drag_rendered_component(component)
+
+        self.assertNotEqual(component.Placement, before_placement)
+        self.assertEqual(int(self.document.UndoCount), before_undo + 1)
+        self.assertFalse(self.document.HasPendingTransaction)
+
+    def test_direct_component_drag_preserves_clicks_modifiers_and_escape(self):
+        _assembly, components = self._create_assembly_with_components(1)
+        component = components[0]
+        Gui.activeDocument().resetEdit()
+        self._process_events(100)
+        before_placement = App.Placement(component.Placement)
+        before_undo = int(self.document.UndoCount)
+
+        self._drag_rendered_component(
+            component,
+            expect_start=False,
+            move=False,
+        )
+        self.assertEqual(component.Placement, before_placement)
+        self.assertEqual(int(self.document.UndoCount), before_undo)
+        self.assertTrue(Gui.Selection.getSelectionEx())
+
+        self._drag_rendered_component(
+            component,
+            expect_start=False,
+            modifiers=QtCore.Qt.ControlModifier,
+        )
+        self.assertEqual(component.Placement, before_placement)
+        self.assertEqual(int(self.document.UndoCount), before_undo)
+
+        viewport, target = self._drag_rendered_component(component, release=False)
+        self.assertNotEqual(component.Placement, before_placement)
+        QtGui.QApplication.sendEvent(
+            viewport,
+            QtGui.QKeyEvent(
+                QtCore.QEvent.KeyPress,
+                QtCore.Qt.Key_Escape,
+                QtCore.Qt.NoModifier,
+            ),
+        )
+        self._process_events(100)
+        self._send_mouse(
+            viewport,
+            QtCore.QEvent.MouseButtonRelease,
+            target,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.NoButton,
+        )
+        self._process_events(100)
+        self.assertEqual(component.Placement, before_placement)
+        self.assertEqual(int(self.document.UndoCount), before_undo)
+        self.assertFalse(self.document.HasPendingTransaction)
+
+    def test_grounded_component_cannot_be_dragged_directly(self):
+        import JointObject
+
+        assembly, components = self._create_assembly_with_components(1)
+        component = components[0]
+        joint_group = next(
+            child for child in assembly.Group if child.TypeId == "Assembly::JointGroup"
+        )
+        self.document.UndoMode = False
+        grounded_joint = joint_group.newObject(
+            "App::FeaturePython",
+            "DirectManipulationGround",
+        )
+        JointObject.GroundedJoint(grounded_joint, component)
+        JointObject.ViewProviderGroundedJoint(grounded_joint.ViewObject)
+        self.document.recompute()
+        self.document.UndoMode = True
+        self._process_events(100)
+        self.assertTrue(assembly.isPartGrounded(component))
+        Gui.Selection.clearSelection()
+        Gui.activeDocument().resetEdit()
+        self._process_events(100)
+
+        before_placement = App.Placement(component.Placement)
+        before_undo = int(self.document.UndoCount)
+        self._drag_rendered_component(component, expect_start=False)
+
+        self.assertEqual(component.Placement, before_placement)
+        self.assertEqual(int(self.document.UndoCount), before_undo)
+        self.assertFalse(self.document.HasPendingTransaction)
+
+    def test_revolute_component_drag_preserves_its_joint(self):
+        import JointObject
+
+        assembly, components = self._create_assembly_with_components(2)
+        moving_component, fixed_component = components
+        joint_group = next(
+            child for child in assembly.Group if child.TypeId == "Assembly::JointGroup"
+        )
+        self.document.UndoMode = False
+        grounded_joint = joint_group.newObject(
+            "App::FeaturePython",
+            "DirectManipulationGround",
+        )
+        JointObject.GroundedJoint(grounded_joint, fixed_component)
+        JointObject.ViewProviderGroundedJoint(grounded_joint.ViewObject)
+        revolute_joint = joint_group.newObject(
+            "App::FeaturePython",
+            "DirectManipulationRevolute",
+        )
+        JointObject.Joint(revolute_joint, 1)
+        JointObject.ViewProviderJoint(revolute_joint.ViewObject)
+        revolute_joint.Proxy.setJointConnectors(
+            revolute_joint,
+            [
+                [fixed_component, ["Face1"]],
+                [moving_component, ["Face2"]],
+            ],
+        )
+        self.document.recompute()
+        assembly.solve()
+        self.document.recompute()
+        joint_group.Visibility = False
+        self.document.UndoMode = True
+        Gui.Selection.clearSelection()
+        Gui.activeDocument().resetEdit()
+        self._process_events(100)
+
+        before_fixed = App.Placement(fixed_component.Placement)
+        before_moving = App.Placement(moving_component.Placement)
+        before_undo = int(self.document.UndoCount)
+        self._drag_rendered_component(moving_component)
+
+        first_joint_frame = fixed_component.Placement * revolute_joint.Placement1
+        second_joint_frame = moving_component.Placement * revolute_joint.Placement2
+        first_axis = first_joint_frame.Rotation.multVec(App.Vector(0, 0, 1))
+        second_axis = second_joint_frame.Rotation.multVec(App.Vector(0, 0, 1))
+        self.assertEqual(fixed_component.Placement, before_fixed)
+        self.assertNotEqual(moving_component.Placement, before_moving)
+        self.assertLess(
+            (first_joint_frame.Base - second_joint_frame.Base).Length,
+            1e-5,
+        )
+        self.assertAlmostEqual(abs(first_axis.dot(second_axis)), 1.0, places=6)
+        self.assertTrue(assembly.isValid())
+        self.assertEqual(int(self.document.UndoCount), before_undo + 1)
+        self.assertFalse(self.document.HasPendingTransaction)
+
+    def test_direct_component_drag_does_not_take_over_a_caller_transaction(self):
+        _assembly, components = self._create_assembly_with_components(1)
+        component = components[0]
+        Gui.activeDocument().resetEdit()
+        self._process_events(100)
+        before_placement = App.Placement(component.Placement)
+
+        self.document.openTransaction("Caller-owned direct manipulation conflict")
+        caller_transaction = self.document.getBookedTransactionID()
+        self._drag_rendered_component(
+            component,
+            expect_start=False,
+            expected_transaction=caller_transaction,
+        )
+
+        self.assertEqual(component.Placement, before_placement)
+        self.assertEqual(
+            self.document.getBookedTransactionID(),
+            caller_transaction,
+        )
+        self.document.abortTransaction()
+        self.assertFalse(self.document.HasPendingTransaction)
+
+    def test_direct_component_drag_cancels_when_leaving_supported_ribbons(self):
+        _assembly, components = self._create_assembly_with_components(1)
+        component = components[0]
+        Gui.activeDocument().resetEdit()
+        self._process_events(100)
+        before_placement = App.Placement(component.Placement)
+        before_undo = int(self.document.UndoCount)
+
+        viewport, target = self._drag_rendered_component(component, release=False)
+        self.assertNotEqual(component.Placement, before_placement)
+        Gui.activateWorkbench("PartDesignWorkbench")
+        self._process_events(100)
+
+        self.assertEqual(component.Placement, before_placement)
+        self.assertEqual(int(self.document.UndoCount), before_undo)
+        self.assertFalse(self.document.HasPendingTransaction)
+        self._send_mouse(
+            viewport,
+            QtCore.QEvent.MouseButtonRelease,
+            target,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.NoButton,
+        )
+
+        viewport, target = self._drag_rendered_component(component, release=False)
+        self.assertNotEqual(component.Placement, before_placement)
+        Gui.activateWorkbench("TechDrawWorkbench")
+        self._process_events(100)
+
+        self.assertEqual(component.Placement, before_placement)
+        self.assertEqual(int(self.document.UndoCount), before_undo)
+        self.assertFalse(self.document.HasPendingTransaction)
+        self._send_mouse(
+            viewport,
+            QtCore.QEvent.MouseButtonRelease,
+            target,
+            QtCore.Qt.LeftButton,
+            QtCore.Qt.NoButton,
+        )
+
+        Gui.activateWorkbench("AssemblyWorkbench")
+        self._process_events(100)
+        self._drag_rendered_component(component)
+        self.assertNotEqual(component.Placement, before_placement)
+        self.assertEqual(int(self.document.UndoCount), before_undo + 1)
 
     def test_activate_assembly_refuses_a_caller_owned_transaction(self):
         Gui.runCommand("Assembly_CreateAssembly")

--- a/src/Mod/Assembly/AssemblyTests/TestVibeCADRibbonTools.py
+++ b/src/Mod/Assembly/AssemblyTests/TestVibeCADRibbonTools.py
@@ -2091,12 +2091,57 @@ class TestVibeCADAssemblyRibbonTools(unittest.TestCase):
         self.assertEqual(self.document.getBookedTransactionID(), 0)
 
         moved_placement = App.Placement(component.Placement)
-        self.document.undo()
+        undo_button = Gui.getMainWindow().findChild(
+            QtGui.QToolButton,
+            "VibeCADRibbonUndo",
+        )
+        self.assertIsNotNone(undo_button)
+        ribbon = Gui.getMainWindow().findChild(QtGui.QWidget, "VibeCADRibbon")
+        self.assertIsNotNone(ribbon)
+        undo_action = next(
+            (
+                action
+                for action in ribbon.actions()
+                if _action_command_id(action) == "Std_Undo"
+            ),
+            None,
+        )
+        self.assertIsNotNone(undo_action)
+        self.assertEqual(
+            undo_action.shortcut().toString(),
+            QtGui.QKeySequence(QtGui.QKeySequence.Undo).toString(),
+        )
+        self.assertTrue(undo_action.isEnabled())
+        undo_action.trigger()
         self._process_events(100)
         self.assertEqual(component.Placement, before_placement)
         self.document.redo()
         self._process_events(100)
         self.assertEqual(component.Placement, moved_placement)
+
+    def test_gui_observer_preserves_assembly_view_provider_python_type(self):
+        class ChangeObserver:
+            def slotChangedObject(self, _view_provider, _property_name):
+                pass
+
+        observer = ChangeObserver()
+        Gui.addDocumentObserver(observer)
+        try:
+            box = self.document.addObject("Part::Box", "ObservedBox")
+            assembly, _components = self._create_assembly_with_components(1)
+        finally:
+            Gui.removeDocumentObserver(observer)
+
+        self.assertEqual(
+            f"{type(box.ViewObject).__module__}.{type(box.ViewObject).__name__}",
+            "PartGui.ViewProviderPartExt",
+        )
+        self.assertEqual(
+            f"{type(assembly.ViewObject).__module__}."
+            f"{type(assembly.ViewObject).__name__}",
+            "AssemblyGui.ViewProviderAssembly",
+        )
+        self.assertTrue(hasattr(assembly.ViewObject, "isInEditMode"))
 
     def test_component_can_be_dragged_directly_from_model_ribbon(self):
         _assembly, components = self._create_assembly_with_components(1)

--- a/src/Mod/Assembly/Gui/AppAssemblyGui.cpp
+++ b/src/Mod/Assembly/Gui/AppAssemblyGui.cpp
@@ -27,6 +27,7 @@
 #include <Base/PyObjectBase.h>
 
 #include "Commands.h"
+#include "AssemblyDirectManipulation.h"
 #include "ViewProviderAssembly.h"
 #include "ViewProviderAssemblyLink.h"
 #include "ViewProviderBom.h"
@@ -68,6 +69,7 @@ PyMOD_INIT_FUNC(AssemblyGui)
     AssemblyGui::ViewProviderJointGroup::init();
     AssemblyGui::ViewProviderViewGroup::init();
     AssemblyGui::ViewProviderSimulationGroup::init();
+    AssemblyGui::AssemblyDirectManipulation::install();
 
     PyMOD_Return(mod);
 }

--- a/src/Mod/Assembly/Gui/AssemblyDirectManipulation.cpp
+++ b/src/Mod/Assembly/Gui/AssemblyDirectManipulation.cpp
@@ -240,6 +240,9 @@ bool AssemblyDirectManipulation::finishCandidate(bool commit)
         assemblyView->finishDirectManipulation(commit && moving);
     }
     clearCandidate();
+    if (commit && wasMoving && Gui::Application::Instance) {
+        Gui::Application::Instance->updateActions();
+    }
     return wasMoving;
 }
 

--- a/src/Mod/Assembly/Gui/AssemblyDirectManipulation.cpp
+++ b/src/Mod/Assembly/Gui/AssemblyDirectManipulation.cpp
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "AssemblyDirectManipulation.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+
+#include <QApplication>
+#include <QEvent>
+#include <QGuiApplication>
+#include <QKeyEvent>
+#include <QMouseEvent>
+
+#include <Inventor/SbVec2s.h>
+
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+
+#include <Gui/Application.h>
+#include <Gui/Control.h>
+#include <Gui/Document.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Quarter/devices/InputDevice.h>
+#include <Gui/Selection/Selection.h>
+#include <Gui/View3DInventor.h>
+#include <Gui/View3DInventorViewer.h>
+#include <Gui/WorkbenchManager.h>
+
+#include <Mod/Assembly/App/AssemblyObject.h>
+#include <Mod/Assembly/App/AssemblyUtils.h>
+
+#include "ViewProviderAssembly.h"
+
+namespace AssemblyGui
+{
+
+namespace
+{
+
+constexpr auto controllerObjectName = "AssemblyDirectManipulationController";
+
+bool containsAssemblyMember(Assembly::AssemblyObject* assembly, App::DocumentObject* object)
+{
+    return assembly && object && assembly != object && assembly->hasObject(object, true);
+}
+
+SbVec2s eventPosition(const Gui::View3DInventorViewer* viewer, const QMouseEvent* event)
+{
+    return SIM::Coin3D::Quarter::InputDevice::toDevicePixelPosition(
+        event->position(),
+        SbVec2s(viewer->width(), viewer->height()),
+        viewer->devicePixelRatio()
+    );
+}
+
+}  // namespace
+
+void AssemblyDirectManipulation::install()
+{
+    auto* mainWindow = Gui::getMainWindow();
+    if (!mainWindow || mainWindow->findChild<QObject*>(controllerObjectName)) {
+        return;
+    }
+    auto* controller = new AssemblyDirectManipulation(mainWindow);
+    controller->setObjectName(controllerObjectName);
+}
+
+AssemblyDirectManipulation::AssemblyDirectManipulation(QObject* parent)
+    : QObject(parent)
+{
+    auto* application = Gui::Application::Instance;
+    activateWorkbenchConnection = application->signalActivateWorkbench.connect([this](const char*) {
+        finishCandidate(false);
+        refreshViewer();
+    });
+    activateViewConnection = application->signalActivateView.connect([this](const Gui::MDIView* view) {
+        auto* view3d = dynamic_cast<const Gui::View3DInventor*>(view);
+        setViewer(supportsActiveWorkbench() && view3d ? view3d->getViewer() : nullptr);
+    });
+    closeViewConnection = application->signalCloseView.connect([this](const Gui::MDIView* view) {
+        auto* view3d = dynamic_cast<const Gui::View3DInventor*>(view);
+        if (view3d && view3d->getViewer() == viewer) {
+            setViewer(nullptr);
+        }
+    });
+    enterEditConnection = application->signalInEdit.connect(
+        [this](const Gui::ViewProviderDocumentObject&) { finishCandidate(false); }
+    );
+    connect(Gui::getMainWindow(), &Gui::MainWindow::mainWindowClosed, this, [this]() {
+        setViewer(nullptr);
+    });
+    connect(qApp, &QGuiApplication::applicationStateChanged, this, [this](Qt::ApplicationState state) {
+        if (state != Qt::ApplicationActive) {
+            finishCandidate(false);
+        }
+    });
+    refreshViewer();
+}
+
+AssemblyDirectManipulation::~AssemblyDirectManipulation()
+{
+    setViewer(nullptr);
+}
+
+bool AssemblyDirectManipulation::supportsActiveWorkbench() const
+{
+    const std::string workbench = Gui::WorkbenchManager::instance()->activeName();
+    return workbench == "AssemblyWorkbench" || workbench == "PartDesignWorkbench";
+}
+
+void AssemblyDirectManipulation::refreshViewer()
+{
+    if (!supportsActiveWorkbench()) {
+        setViewer(nullptr);
+        return;
+    }
+    auto* view = dynamic_cast<Gui::View3DInventor*>(Gui::getMainWindow()->activeWindow());
+    setViewer(view ? view->getViewer() : nullptr);
+}
+
+void AssemblyDirectManipulation::setViewer(Gui::View3DInventorViewer* nextViewer)
+{
+    if (viewer == nextViewer) {
+        return;
+    }
+    const bool wasMoving = finishCandidate(false);
+    if (viewer) {
+        if (wasMoving) {
+            viewer->setSelectionEnabled(true);
+        }
+        viewer->removeEventFilter(this);
+        viewer->viewport()->removeEventFilter(this);
+    }
+    viewer = nextViewer;
+    if (viewer) {
+        viewer->installEventFilter(this);
+        viewer->viewport()->installEventFilter(this);
+    }
+}
+
+ViewProviderAssembly* AssemblyDirectManipulation::resolveAssemblyAtPreselection() const
+{
+    if (!viewer || viewer->isEditingViewProvider() || !Gui::Selection().hasPreselection()) {
+        return nullptr;
+    }
+    auto* guiDocument = viewer->getDocument();
+    auto* document = guiDocument ? guiDocument->getDocument() : nullptr;
+    const auto& preselection = Gui::Selection().getPreselection();
+    auto* selectedRoot = preselection.Object.getObject();
+    if (!document || !selectedRoot || selectedRoot->getDocument() != document
+        || Gui::Control().activeDialog(document)) {
+        return nullptr;
+    }
+
+    Assembly::AssemblyObject* selectedAssembly = nullptr;
+    if (selectedRoot->is<Assembly::AssemblyObject>()) {
+        selectedAssembly = static_cast<Assembly::AssemblyObject*>(selectedRoot);
+    }
+    else {
+        for (auto* assembly : document->getObjectsOfType<Assembly::AssemblyObject>()) {
+            if (!Assembly::isTimelineOperationActive(assembly)
+                || !containsAssemblyMember(assembly, selectedRoot)) {
+                continue;
+            }
+            if (!selectedAssembly || containsAssemblyMember(selectedAssembly, assembly)) {
+                selectedAssembly = assembly;
+            }
+            else if (!containsAssemblyMember(assembly, selectedAssembly)) {
+                return nullptr;
+            }
+        }
+    }
+    if (!selectedAssembly || !Assembly::isTimelineOperationActive(selectedAssembly)) {
+        return nullptr;
+    }
+    return freecad_cast<ViewProviderAssembly*>(guiDocument->getViewProvider(selectedAssembly));
+}
+
+ViewProviderAssembly* AssemblyDirectManipulation::resolveCandidate() const
+{
+    auto* guiDocument = viewer ? viewer->getDocument() : nullptr;
+    auto* document = guiDocument ? guiDocument->getDocument() : nullptr;
+    if (!document || document->Uid.getValueStr() != documentUid || assemblyId < 0) {
+        return nullptr;
+    }
+    auto* assembly = freecad_cast<Assembly::AssemblyObject*>(document->getObjectByID(assemblyId));
+    if (!assembly) {
+        return nullptr;
+    }
+    return freecad_cast<ViewProviderAssembly*>(guiDocument->getViewProvider(assembly));
+}
+
+void AssemblyDirectManipulation::beginCandidate(const SbVec2s& position)
+{
+    finishCandidate(false);
+    auto* assemblyView = resolveAssemblyAtPreselection();
+    auto* assembly = assemblyView ? assemblyView->getObject<Assembly::AssemblyObject>() : nullptr;
+    if (!assembly || !assemblyView->prepareDirectManipulation()) {
+        return;
+    }
+    documentUid = assembly->getDocument()->Uid.getValueStr();
+    assemblyId = assembly->getID();
+    pressPosition = position;
+    leftButtonDown = true;
+}
+
+bool AssemblyDirectManipulation::moveCandidate(const SbVec2s& position)
+{
+    if (!leftButtonDown || assemblyId < 0) {
+        return false;
+    }
+    auto* assemblyView = resolveCandidate();
+    if (!assemblyView) {
+        clearCandidate();
+        return false;
+    }
+    if (!moving) {
+        const int dx = std::abs(int(position[0]) - int(pressPosition[0]));
+        const int dy = std::abs(int(position[1]) - int(pressPosition[1]));
+        const int threshold = std::lround(
+            QApplication::startDragDistance() * viewer->devicePixelRatio()
+        );
+        if (std::max(dx, dy) < threshold) {
+            return false;
+        }
+        moving = assemblyView->beginDirectManipulation(pressPosition, viewer);
+        if (!moving) {
+            clearCandidate();
+            return false;
+        }
+    }
+    return assemblyView->updateDirectManipulation(position, viewer);
+}
+
+bool AssemblyDirectManipulation::finishCandidate(bool commit)
+{
+    const bool wasMoving = moving;
+    if (auto* assemblyView = resolveCandidate()) {
+        assemblyView->finishDirectManipulation(commit && moving);
+    }
+    clearCandidate();
+    return wasMoving;
+}
+
+void AssemblyDirectManipulation::clearCandidate()
+{
+    documentUid.clear();
+    assemblyId = -1;
+    leftButtonDown = false;
+    moving = false;
+}
+
+bool AssemblyDirectManipulation::eventFilter(QObject* watched, QEvent* event)
+{
+    if (!viewer || !event || (watched != viewer && watched != viewer->viewport())) {
+        return QObject::eventFilter(watched, event);
+    }
+
+    if (event->type() == QEvent::KeyPress) {
+        const auto* keyEvent = static_cast<const QKeyEvent*>(event);
+        if (keyEvent->key() == Qt::Key_Escape && finishCandidate(false)) {
+            return true;
+        }
+        return QObject::eventFilter(watched, event);
+    }
+
+    if (event->type() == QEvent::MouseButtonPress) {
+        const auto* mouseEvent = static_cast<const QMouseEvent*>(event);
+        if (watched == viewer->viewport() && mouseEvent->button() == Qt::LeftButton
+            && mouseEvent->modifiers() == Qt::NoModifier) {
+            beginCandidate(eventPosition(viewer, mouseEvent));
+        }
+        return QObject::eventFilter(watched, event);
+    }
+
+    if (event->type() == QEvent::MouseMove) {
+        const auto* mouseEvent = static_cast<const QMouseEvent*>(event);
+        if (watched == viewer->viewport() && mouseEvent->buttons().testFlag(Qt::LeftButton)
+            && moveCandidate(eventPosition(viewer, mouseEvent))) {
+            return true;
+        }
+        return QObject::eventFilter(watched, event);
+    }
+
+    if (event->type() == QEvent::MouseButtonRelease) {
+        const auto* mouseEvent = static_cast<const QMouseEvent*>(event);
+        if (watched == viewer->viewport() && mouseEvent->button() == Qt::LeftButton) {
+            finishCandidate(true);
+        }
+        return QObject::eventFilter(watched, event);
+    }
+
+    if (event->type() == QEvent::WindowDeactivate) {
+        finishCandidate(false);
+    }
+    return QObject::eventFilter(watched, event);
+}
+
+}  // namespace AssemblyGui

--- a/src/Mod/Assembly/Gui/AssemblyDirectManipulation.h
+++ b/src/Mod/Assembly/Gui/AssemblyDirectManipulation.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <string>
+
+#include <QObject>
+
+#include <Inventor/SbVec2s.h>
+
+#include <fastsignals/connection.h>
+
+namespace Gui
+{
+class MDIView;
+class View3DInventorViewer;
+}  // namespace Gui
+
+namespace AssemblyGui
+{
+
+class ViewProviderAssembly;
+
+class AssemblyDirectManipulation final: public QObject
+{
+public:
+    static void install();
+
+private:
+    explicit AssemblyDirectManipulation(QObject* parent);
+    ~AssemblyDirectManipulation() override;
+
+    bool eventFilter(QObject* watched, QEvent* event) override;
+
+    void refreshViewer();
+    void setViewer(Gui::View3DInventorViewer* viewer);
+    bool supportsActiveWorkbench() const;
+
+    void beginCandidate(const SbVec2s& position);
+    bool moveCandidate(const SbVec2s& position);
+    bool finishCandidate(bool commit);
+    void clearCandidate();
+
+    ViewProviderAssembly* resolveCandidate() const;
+    ViewProviderAssembly* resolveAssemblyAtPreselection() const;
+
+    Gui::View3DInventorViewer* viewer = nullptr;
+    std::string documentUid;
+    long assemblyId {-1};
+    SbVec2s pressPosition;
+    bool leftButtonDown {false};
+    bool moving {false};
+
+    fastsignals::scoped_connection activateWorkbenchConnection;
+    fastsignals::scoped_connection activateViewConnection;
+    fastsignals::scoped_connection closeViewConnection;
+    fastsignals::scoped_connection enterEditConnection;
+};
+
+}  // namespace AssemblyGui

--- a/src/Mod/Assembly/Gui/CMakeLists.txt
+++ b/src/Mod/Assembly/Gui/CMakeLists.txt
@@ -40,6 +40,8 @@ SOURCE_GROUP("Python" FILES ${Python_SRCS})
 SET(AssemblyGui_SRCS_Module
     AppAssemblyGui.cpp
     AppAssemblyGuiPy.cpp
+    AssemblyDirectManipulation.cpp
+    AssemblyDirectManipulation.h
     PreCompiled.h
     Commands.cpp
     Commands.h

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.cpp
@@ -539,7 +539,7 @@ bool ViewProviderAssembly::mouseMove(const SbVec2s& cursorPos, Gui::View3DInvent
 
 bool ViewProviderAssembly::tryMouseMove(const SbVec2s& cursorPos, Gui::View3DInventorViewer* viewer)
 {
-    if (!isInEditMode()) {
+    if (!isInEditMode() && !partMoving) {
         return false;
     }
 
@@ -691,6 +691,52 @@ bool ViewProviderAssembly::tryMouseMove(const SbVec2s& cursorPos, Gui::View3DInv
         }
     }
     return false;
+}
+
+bool ViewProviderAssembly::prepareDirectManipulation()
+{
+    if (isInEditMode() || partMoving || moveTransactionId != App::NullTransaction
+        || !enableMovement) {
+        return false;
+    }
+    canStartDragging = false;
+    return getSelectedObjectsWithinAssembly(true);
+}
+
+bool ViewProviderAssembly::beginDirectManipulation(
+    const SbVec2s& cursorPos,
+    Gui::View3DInventorViewer* viewer
+)
+{
+    if (isInEditMode() || docsToMove.empty() || partMoving
+        || moveTransactionId != App::NullTransaction) {
+        return false;
+    }
+    initMove(cursorPos, viewer);
+    return partMoving;
+}
+
+bool ViewProviderAssembly::updateDirectManipulation(
+    const SbVec2s& cursorPos,
+    Gui::View3DInventorViewer* viewer
+)
+{
+    if (!partMoving) {
+        return false;
+    }
+    mouseMove(cursorPos, viewer);
+    return partMoving;
+}
+
+void ViewProviderAssembly::finishDirectManipulation(bool commit)
+{
+    if (partMoving || moveTransactionId != App::NullTransaction) {
+        finishMove(commit);
+    }
+    else {
+        canStartDragging = false;
+        docsToMove.clear();
+    }
 }
 
 bool ViewProviderAssembly::mouseButtonPressed(

--- a/src/Mod/Assembly/Gui/ViewProviderAssembly.h
+++ b/src/Mod/Assembly/Gui/ViewProviderAssembly.h
@@ -47,6 +47,7 @@ class View3DInventorViewer;
 
 namespace AssemblyGui
 {
+class AssemblyDirectManipulation;
 class TaskAssemblyMessages;
 
 struct MovingObject
@@ -260,7 +261,20 @@ public:
         signalSetUp;
 
 private:
+    friend class AssemblyDirectManipulation;
+
     void disconnectEditSignals();
+
+    bool prepareDirectManipulation();
+    bool beginDirectManipulation(
+        const SbVec2s& cursorPos,
+        Gui::View3DInventorViewer* viewer
+    );
+    bool updateDirectManipulation(
+        const SbVec2s& cursorPos,
+        Gui::View3DInventorViewer* viewer
+    );
+    void finishDirectManipulation(bool commit);
 
     std::vector<App::DocumentObject*> dependentObjectsToDeleteWith(
         App::DocumentObject* object


### PR DESCRIPTION
## Summary

- lets users grab movable Assembly occurrences directly in the Model or Assemble canvas without entering Assembly edit mode or creating a simulation
- reuses the existing Assembly `preDrag` / `doDragStep` / `postDrag` solver and transaction engine, including joint limits, grounding, downstream motion, and rollback
- preserves normal clicks, modifier gestures, non-Assembly navigation, task dialogs, and existing edit-mode draggers
- cancels safely on Escape, ribbon/view changes, application deactivation, edit entry, and teardown
- keeps ordinary pointer movement constant-time; assembly resolution and solver preparation occur once when a valid drag starts
- keeps Ctrl+Z active with the standard menu hidden by associating the existing shortcut-bearing Undo/Redo command actions with the visible ribbon; no duplicate shortcuts or replacement commands
- fixes #151 at the core: `ViewProviderGeometryObject` no longer emits a property-change notification while a derived module view provider is only half constructed, so Part, Assembly, Mesh, and FEM can retain their dedicated Python wrappers

Closes #158
Closes #151

## TDD and verification

Red tests reproduced all three user-visible failures before implementation:

- dragging a rendered Assembly occurrence outside edit mode did not move it
- after a committed direct drag, the visible ribbon had no active `Std_Undo` shortcut action and Undo left the placement unchanged
- with a GUI document observer installed, `Part::Box` and `Assembly::AssemblyObject` cached the generic `Gui.ViewProviderGeometryObject` Python wrapper

Builds (passed):

```bash
cmake --build build/release --target AssemblyGui --parallel 4
cmake --build build/release --parallel 4
```

Focused GUI regressions (all passed; each was run through `xvfb-run -a ./build/release/bin/FreeCAD -t`):

```text
TestAssemblyWorkbench.TestVibeCADAssemblyRibbonTools.test_component_can_be_dragged_directly_outside_assembly_edit
TestAssemblyWorkbench.TestVibeCADAssemblyRibbonTools.test_component_can_be_dragged_directly_from_model_ribbon
TestAssemblyWorkbench.TestVibeCADAssemblyRibbonTools.test_direct_component_drag_preserves_clicks_modifiers_and_escape
TestAssemblyWorkbench.TestVibeCADAssemblyRibbonTools.test_grounded_component_cannot_be_dragged_directly
TestAssemblyWorkbench.TestVibeCADAssemblyRibbonTools.test_revolute_component_drag_preserves_its_joint
TestAssemblyWorkbench.TestVibeCADAssemblyRibbonTools.test_direct_component_drag_does_not_take_over_a_caller_transaction
TestAssemblyWorkbench.TestVibeCADAssemblyRibbonTools.test_direct_component_drag_cancels_when_leaving_supported_ribbons
TestAssemblyWorkbench.TestVibeCADAssemblyRibbonTools.test_gui_observer_preserves_assembly_view_provider_python_type
```

Core GUI suite (passed, 133/133):

```bash
./build/release/tests/Gui_tests_run
```

Manual acceptance used the saved 150-object, 8-joint robot-base assembly. The owner confirmed direct constrained movement and in-gesture Escape cancellation in the real Model canvas.

## Existing unrelated validation failures

- `qt_ribbon_theme_integration.py` passes through the application-strip checks changed here, then fails on the existing missing `print` provider surface: `Unknown ribbon surface 'print'`.
- The older rendered transform-dragger fixture now gets the correct Assembly Python wrapper after #151, but its Xvfb screen-space probe misses the X-axis handle. The new direct-manipulation viewport regressions and the real GUI acceptance pass.

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, schema fields, or wire formats changed.
- [x] Existing defaults and explicit Assembly edit-mode draggers remain available.
- [x] No deprecations or breaking changes.

## Before and After Images

Not applicable as a static comparison: these are pointer-driven constrained-motion, keyboard-action, and Python binding fixes covered by rendered-viewport tests and manual GUI acceptance.