### PR TITLE
Fix VibeCAD issue contact links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,6 +2,6 @@
 blank_issues_enabled: false
 
 contact_links:
-  - name: 10-X Engineering on X
+  - name: RobitOverlord on X
     url: https://x.com/10_X_eng
-    about: Follow VibeCAD updates and contact 10-X Engineering on X.
+    about: Follow VibeCAD updates and contact RobitOverlord on X.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,20 +1,7 @@
 
-blank_issues_enabled : false
+blank_issues_enabled: false
 
 contact_links:
-
--   about : Join the community on our Discord.
-    name : 💬 𝗗𝗶𝘀𝗰𝗼𝗿𝗱
-    url : https://discord.gg/w2cTKGzccC
-
--   about : Join the community on our Forum.
-    name : 💬 𝗙𝗼𝗿𝘂𝗺
-    url : https://forum.freecad.org
-
--   about : Read on how FreeCAD is developed.
-    name : 📕 𝗛𝗮𝗻𝗱𝗯𝗼𝗼𝗸
-    url : https://freecad.github.io/DevelopersHandbook
-
--   about : Look up information about FreeCAD.
-    name : 🌐 𝗪𝗶𝗸𝗶
-    url : https://wiki.freecad.org
+  - name: 10-X Engineering on X
+    url: https://x.com/10_X_eng
+    about: Follow VibeCAD updates and contact 10-X Engineering on X.


### PR DESCRIPTION

## Summary

- Replace the nonexistent VibeCAD Discord contact with RobitOverlord on X at the existing `10_X_eng` account URL.
- Remove the unrelated FreeCAD forum, developer handbook, and wiki links from the VibeCAD issue chooser.
- Keep the issue chooser focused on support destinations that actually belong to this project.

## Verification

- [x] This is repository metadata only, so red/green TDD does not apply.
- [x] The exact validation commands and results are listed below.

Commands and results:

- `git diff --check` — passed.
- Python `yaml.safe_load` plus assertions for `blank_issues_enabled`, one contact entry, the display name, allowed contact-link keys, and the exact X URL — passed.
- `curl --head --location --max-time 20 https://x.com/10_X_eng` — HTTP 200.

## Compatibility

- [x] Existing public functions and APIs remain unchanged.
- [x] No preference keys, tool names, schemas, or wire formats changed.
- [x] Application defaults and saved documents are unaffected.
- [x] No deprecations or breaking runtime changes.

## Issues

Closes #133

## Before and After

Before: the issue chooser advertised an unavailable Discord and three upstream FreeCAD destinations.

After: it presents one accurate VibeCAD contact link, **RobitOverlord on X**, pointing to `https://x.com/10_X_eng`.
