### PR TITLE
Fix VibeScript publication UI starvation

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -687,11 +687,19 @@ bool Application::closeDocument(const char* name)
 {
     const std::string documentName(name);
 
-    cancelRecomputeRequestsForDocument(documentName);
-
     const auto pos = DocMap.find( name );
     if (pos == DocMap.end()) // no such document
         return false;
+
+    if (pos->second->isCooperativeMutationActive()) {
+        Base::Console().warning(
+            "Cannot close document '%s' while a cooperative mutation is active\n",
+            name
+        );
+        return false;
+    }
+
+    cancelRecomputeRequestsForDocument(documentName);
 
     // Give scoped transaction owners one synchronous boundary at which to
     // roll back and release their own critical lock. The document remains

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -179,6 +179,10 @@ bool Document::checkOnCycle()
 
 bool Document::undo(const int id)
 {
+    if (isCooperativeMutationActive()) {
+        FC_WARN("Cannot undo while a cooperative document mutation is active");
+        return false;
+    }
     if (d->iUndoMode != 0) {
         if (id != 0) {
             const auto it = mUndoMap.find(id);
@@ -236,6 +240,10 @@ bool Document::undo(const int id)
 
 bool Document::redo(const int id)
 {
+    if (isCooperativeMutationActive()) {
+        FC_WARN("Cannot redo while a cooperative document mutation is active");
+        return false;
+    }
     if (d->iUndoMode != 0) {
         if (id != 0) {
             const auto it = mRedoMap.find(id);
@@ -518,6 +526,32 @@ void Document::unlockTransaction()
 bool Document::isTransactionLocked() const
 {
     return d->TransactionLock > 0;
+}
+
+void Document::beginCooperativeMutation()
+{
+    if (++d->cooperativeMutationDepth == 1) {
+        signalCooperativeMutationChanged(*this, true);
+    }
+}
+
+void Document::endCooperativeMutation()
+{
+    if (d->cooperativeMutationDepth == 0) {
+        FC_WARN("Ignoring unmatched cooperative document mutation end");
+        return;
+    }
+    if (--d->cooperativeMutationDepth == 0) {
+        signalCooperativeMutationChanged(*this, false);
+        // Projection observers may have ignored the transaction's earlier
+        // stable signal while this explicit bulk mutation was still active.
+        signalBecameStable(*this);
+    }
+}
+
+bool Document::isCooperativeMutationActive() const
+{
+    return d->cooperativeMutationDepth > 0;
 }
 bool Document::transacting() const
 {
@@ -2705,7 +2739,7 @@ void Document::setClosable(bool c)  // NOLINT
 
 bool Document::isClosable() const
 {
-    return testStatus(Document::Closable);
+    return testStatus(Document::Closable) && !isCooperativeMutationActive();
 }
 
 int Document::countObjects() const
@@ -3112,6 +3146,11 @@ void Document::renameObjectIdentifiers(
 int Document::recompute(const std::vector<DocumentObject*>& objs, bool force, bool* hasError, int options)
 {
     ZoneScoped;
+
+    if (isCooperativeMutationActive()) {
+        FC_WARN("Cannot recompute while a cooperative document mutation is active");
+        return 0;
+    }
 
     // Recompute can execute Python-backed features. Keep the GIL for the full
     // recompute so async recompute still serializes Python execution the same

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -295,6 +295,8 @@ public:
         signalBookedTransactionChanged;
     /// Signal whenever this document's transaction lock count changes.
     App::MainThreadSignal<void(const Document&)> signalTransactionLockChanged;
+    /// Signal when the outermost cooperative document mutation begins or ends.
+    App::MainThreadSignal<void(const Document&, bool)> signalCooperativeMutationChanged;
     /// Signal after document recompute/transaction state has fully unwound and
     /// observers may treat the document as stable again.
     App::MainThreadSignal<void(const Document&)> signalBecameStable;
@@ -1123,6 +1125,17 @@ public:
     void lockTransaction();
     void unlockTransaction();
     bool isTransactionLocked() const;
+
+    /** Mark a resumable document-thread mutation as active.
+     *
+     * Cooperative mutations deliberately return to the GUI event loop between
+     * bounded slices while retaining one logical transaction. The nested
+     * state prevents destructive user actions and lets projections coalesce
+     * their work until the outermost mutation finishes.
+     */
+    void beginCooperativeMutation();
+    void endCooperativeMutation();
+    bool isCooperativeMutationActive() const;
 
     bool transacting() const;
 

--- a/src/App/Document.pyi
+++ b/src/App/Document.pyi
@@ -84,6 +84,9 @@ class Document(PropertyContainer):
     Transacting: Final[bool] = False
     """Indicate whether the document is undoing/redoing"""
 
+    CooperativeMutationActive: Final[bool] = False
+    """Indicate whether a resumable document-thread mutation is active."""
+
     OldLabel: Final[str] = ""
     """Contains the old label before change"""
 
@@ -198,6 +201,14 @@ class Document(PropertyContainer):
         """
         Commit an Undo/Redo transaction
         """
+        ...
+
+    def beginCooperativeMutation(self) -> None:
+        """Begin a nested resumable document-thread mutation."""
+        ...
+
+    def endCooperativeMutation(self) -> None:
+        """End a nested resumable document-thread mutation."""
         ...
 
     @overload

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -761,6 +761,24 @@ PyObject* DocumentPy::commitTransaction(PyObject* args)
     Py_Return;
 }
 
+PyObject* DocumentPy::beginCooperativeMutation(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    getDocumentPtr()->beginCooperativeMutation();
+    Py_Return;
+}
+
+PyObject* DocumentPy::endCooperativeMutation(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    getDocumentPtr()->endCooperativeMutation();
+    Py_Return;
+}
+
 Py::Boolean DocumentPy::getHasPendingTransaction() const
 {
     return {getDocumentPtr()->hasPendingTransaction()};
@@ -2368,6 +2386,11 @@ Py::Boolean DocumentPy::getRecomputePending() const
 Py::Boolean DocumentPy::getTransacting() const
 {
     return {getDocumentPtr()->isPerformingTransaction()};
+}
+
+Py::Boolean DocumentPy::getCooperativeMutationActive() const
+{
+    return {getDocumentPtr()->isCooperativeMutationActive()};
 }
 
 Py::String DocumentPy::getOldLabel() const

--- a/src/App/private/DocumentP.h
+++ b/src/App/private/DocumentP.h
@@ -99,6 +99,7 @@ struct DocumentP
     unsigned int UndoMemSize {0};
     unsigned int UndoMaxStackSize {20};
     unsigned int TransactionLock {0};
+    unsigned int cooperativeMutationDepth {0};
     // Id and name that the next transaction will take
     // as soon as there is a change to the document
     int bookedTransaction { 0 }; 

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <ranges>
 #include <sstream>
+#include <string_view>
 #include <QApplication>
 #include <QByteArray>
 #include <QDir>
@@ -651,8 +652,16 @@ bool Command::canInvoke()
         return false;
     }
 
+    App::Document* document = getDocument();
+    if (document && document->isCooperativeMutationActive()) {
+        const std::string_view name(getName());
+        if ((eType & AlterDoc) || name == "Std_Undo" || name == "Std_Redo"
+            || name == "Std_Refresh") {
+            return false;
+        }
+    }
+
     if (!(eType & ForEdit)) {
-        App::Document* document = getDocument();
         if ((!Gui::Control().isAllowedAlterDocument(document) && eType & AlterDoc)
             || (!Gui::Control().isAllowedAlterView(document) && eType & Alter3DView)
             || (!Gui::Control().isAllowedAlterSelection(document) && eType & AlterSelection)) {

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -1417,6 +1417,26 @@ ViewProvider* Document::getViewProviderByName(const char* name) const
     return nullptr;
 }
 
+bool Document::projectionRefreshBlocked(const App::Document* document)
+{
+    return document
+        && (document->isCooperativeMutationActive()
+            || document->isPerformingTransaction()
+            || document->testStatus(App::Document::Recomputing)
+            || App::GetApplication().hasPendingRecomputeRequest(document->getName())
+            || document->testStatus(App::Document::Restoring)
+            || App::GetApplication().isRestoring());
+}
+
+bool Document::historyMutationBlocked(const App::Document* document)
+{
+    return projectionRefreshBlocked(document)
+        || (document
+            && (document->getBookedTransactionID() != App::NullTransaction
+                || document->hasPendingTransaction()
+                || document->isTransactionLocked()));
+}
+
 bool Document::isShow(const char* name)
 {
     ViewProvider* pcProv = getViewProviderByName(name);

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -385,6 +385,22 @@ public:
     /// get all tree root objects (objects that are at the root of the object tree)
     std::vector<App::DocumentObject*> getTreeRootObjects() const;
 
+    /** Return true while a document projection must defer incremental refresh.
+     *
+     * Tree, timeline, and other GUI projections must not repeatedly rebuild a
+     * partially mutated document.  They can accumulate dirty state and refresh
+     * once signalBecameStable() is emitted.
+     */
+    static bool projectionRefreshBlocked(const App::Document* document);
+
+    /** Return true while user-driven History mutations must remain disabled.
+     *
+     * This deliberately includes normal open/edit transactions. Projection
+     * refresh uses the narrower projectionRefreshBlocked() predicate so task
+     * panels keep receiving ordinary incremental Tree updates.
+     */
+    static bool historyMutationBlocked(const App::Document* document);
+
 protected:
     // pointer to the python class
     Gui::DocumentPy* _pcDocPy;

--- a/src/Gui/FeatureTimeline.cpp
+++ b/src/Gui/FeatureTimeline.cpp
@@ -1211,11 +1211,8 @@ void FeatureTimeline::scheduleRefresh()
 bool FeatureTimeline::canChangeHistory() const
 {
     auto* document = activeAppDocument();
-    if (!document || document->getBookedTransactionID() != App::NullTransaction
-        || document->hasPendingTransaction() || document->isPerformingTransaction()
-        || document->isTransactionLocked() || document->testStatus(App::Document::Recomputing)
-        || App::GetApplication().hasPendingRecomputeRequest(document->getName())
-        || App::GetApplication().isRestoring() || !Gui::Application::Instance) {
+    if (!document || Gui::Document::historyMutationBlocked(document)
+        || !Gui::Application::Instance) {
         return false;
     }
 
@@ -1230,10 +1227,7 @@ bool FeatureTimeline::canChangeHistory() const
 void FeatureTimeline::rebuild()
 {
     App::Document* document = activeAppDocument();
-    if (document
-        && (document->isPerformingTransaction() || document->testStatus(App::Document::Recomputing)
-            || App::GetApplication().hasPendingRecomputeRequest(document->getName())
-            || App::GetApplication().isRestoring())) {
+    if (Gui::Document::projectionRefreshBlocked(document)) {
         // Undo, redo, and transaction rollback recreate objects in dependency
         // order, and recompute may replace generated results. Wait for the
         // corresponding stable/recomputed signal before resolving item names.

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -4248,7 +4248,7 @@ void TreeWidget::slotChangedViewObject(const Gui::ViewProvider& vp, const App::P
     if (!App::GetApplication().isRestoring() && vp.isDerivedFrom<ViewProviderDocumentObject>()) {
         const auto& vpd = static_cast<const ViewProviderDocumentObject&>(vp);
         auto* document = vpd.getObject() ? vpd.getObject()->getDocument() : nullptr;
-        if (document && document->isPerformingTransaction()) {
+        if (Gui::Document::projectionRefreshBlocked(document)) {
             if (auto documentIt = DocumentMap.find(vpd.getDocument());
                 documentIt != DocumentMap.end()) {
                 documentIt->second->modelBrowserDirty = true;
@@ -4266,7 +4266,7 @@ void TreeWidget::slotChangedViewObject(const Gui::ViewProvider& vp, const App::P
 void TreeWidget::slotTouchedObject(const App::DocumentObject& obj)
 {
     auto* document = obj.getDocument();
-    if (document && document->isPerformingTransaction()) {
+    if (Gui::Document::projectionRefreshBlocked(document)) {
         auto* guiDocument = Application::Instance->getDocument(document);
         if (auto documentIt = DocumentMap.find(guiDocument);
             documentIt != DocumentMap.end()) {
@@ -4389,16 +4389,21 @@ void TreeWidget::onUpdateStatus()
         return;
     }
 
+    bool projectionBlocked = false;
     for (auto& v : DocumentMap) {
-        if (v.first->isPerformingTransaction()) {
-            // We have to delay item creation until undo/redo is done, because the
-            // object re-creation while in transaction may break tree view item
-            // update logic. For example, a parent object re-created before its
-            // children, but the parent's link property already contains all the
-            // (detached) children.
-            _updateStatus();
-            return;
+        if (!Gui::Document::projectionRefreshBlocked(v.first->getDocument())) {
+            continue;
         }
+        // A transaction, restore, or recompute exposes a deliberately partial
+        // graph.  Keep collecting object identities, but never poll and rebuild
+        // the entire tree while that graph is changing. signalBecameStable()
+        // schedules one authoritative refresh from the completed document.
+        v.second->modelBrowserDirty = true;
+        v.second->transactionRefreshPending = true;
+        projectionBlocked = true;
+    }
+    if (projectionBlocked) {
+        return;
     }
 
     FC_LOG("begin update status");
@@ -5329,6 +5334,14 @@ DocumentItem::DocumentItem(const Gui::Document* doc, QTreeWidgetItem* parent)
     connectDocumentStable = adoc->signalBecameStable.connect(
         std::bind(&DocumentItem::slotDocumentStable, this, sp::_1)
     );
+    connectRecomputeRequestFinished =
+        App::GetApplication().signalRecomputeRequestFinished.connect(
+            [this, adoc](const std::string& documentName) {
+                if (documentName == adoc->getName()) {
+                    slotDocumentStable(*adoc);
+                }
+            }
+        );
     // NOLINTEND
 
     setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable /*|Qt::ItemIsEditable*/);
@@ -5350,6 +5363,7 @@ DocumentItem::~DocumentItem()
     connectRecomputed.disconnect();
     connectRecomputedObj.disconnect();
     connectDocumentStable.disconnect();
+    connectRecomputeRequestFinished.disconnect();
 }
 
 TreeWidget* DocumentItem::getTree() const
@@ -7672,7 +7686,7 @@ void TreeWidget::slotChangeObject(const Gui::ViewProviderDocumentObject& view, c
     // only partially restored. Mark the document projection dirty and rebuild
     // it from live document objects at signalBecameStable() instead.
     if (auto* document = obj->getDocument();
-        document && document->isPerformingTransaction()) {
+        Gui::Document::projectionRefreshBlocked(document)) {
         if (auto documentIt = DocumentMap.find(view.getDocument());
             documentIt != DocumentMap.end()) {
             documentIt->second->modelBrowserDirty = true;
@@ -8198,6 +8212,9 @@ void DocumentItem::slotDocumentStable(const App::Document& stableDocument)
 {
     if (!transactionRefreshPending
         || document()->getDocument() != &stableDocument) {
+        return;
+    }
+    if (Gui::Document::projectionRefreshBlocked(&stableDocument)) {
         return;
     }
 

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -530,6 +530,7 @@ private:
     Connection connectRecomputed;
     Connection connectRecomputedObj;
     Connection connectDocumentStable;
+    Connection connectRecomputeRequestFinished;
 
     friend class TreeWidget;
     friend class DocumentObjectData;

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -18,9 +18,11 @@ set(VibeCAD_Scripts
     VibeCADCodex.py
     VibeCADCodexResponses.py
     VibeCADComponentCatalog.py
+    VibeCADCooperativeExecution.py
     VibeCADCore.py
     VibeCADDebug.py
     VibeCADDesignReview.py
+    VibeCADDocumentChangeBatch.py
     VibeCADDocumentReferences.py
     VibeCADEditState.py
     VibeCADFasteners.py
@@ -1209,6 +1211,7 @@ set(VibeCAD_Scripts
     VibeCADReferenceSelection.py
     VibeCADRibbonSurface.py
     VibeCADProject.py
+    VibeCADPublicationProgress.py
     VibeCADSession.py
     VibeCADSessionRecovery.py
     VibeCADScriptedEditor.py

--- a/src/Mod/VibeCAD/VibeCADCooperativeExecution.py
+++ b/src/Mod/VibeCAD/VibeCADCooperativeExecution.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Shared cooperative execution for thread-affine FreeCAD document work.
+
+Heavy preparation belongs on a worker.  Live FreeCAD document access remains
+on its owning thread, but a long logical operation must expose resumable steps
+so Qt regains its event loop between every bounded mutation slice.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping
+import time
+from typing import Any
+
+DEFAULT_DOCUMENT_SLICE_BUDGET_SECONDS = 0.05
+
+
+class CooperativeExecutionCancelled(RuntimeError):
+    """Cancellation injected between two atomic document-thread slices."""
+
+
+def _advance(steps: Iterator[Any]) -> tuple[bool, Any]:
+    try:
+        return False, next(steps)
+    except StopIteration as completed:
+        return True, completed.value
+
+
+def _cancel(steps: Iterator[Any]) -> None:
+    cancellation = CooperativeExecutionCancelled(
+        "The operation was cancelled between document mutation slices."
+    )
+    try:
+        steps.throw(cancellation)
+    except (CooperativeExecutionCancelled, StopIteration):
+        pass
+    raise cancellation
+
+
+def _emit(callback: Callable[[dict[str, Any]], None] | None, event: Any) -> None:
+    if callback is None or not isinstance(event, Mapping):
+        return
+    callback(dict(event))
+
+
+def run_document_thread_steps(
+    steps: Iterator[Any],
+    *,
+    dispatch: Callable[[Callable[[], Any]], Any] | None,
+    cancellation_check: Callable[[], bool] | None = None,
+    progress_callback: Callable[[dict[str, Any]], None] | None = None,
+    clock: Callable[[], float] = time.monotonic,
+    slice_budget_seconds: float = DEFAULT_DOCUMENT_SLICE_BUDGET_SECONDS,
+) -> Any:
+    """Drive one resumable document job from its background owner.
+
+    ``dispatch`` must queue one callable to the document thread and wait for
+    just that callable.  It is deliberately invoked once per iterator step;
+    the Qt event loop therefore regains control without re-entrant
+    ``processEvents()`` calls.  A missing dispatcher preserves headless and
+    legacy direct-call behavior.
+    """
+
+    if not hasattr(steps, "__next__") or not hasattr(steps, "throw"):
+        raise TypeError("Document-thread steps must be a resumable iterator.")
+    if dispatch is not None and not callable(dispatch):
+        raise TypeError("dispatch must be callable or None")
+    budget = max(0.001, float(slice_budget_seconds))
+    invoke = dispatch or (lambda operation: operation())
+
+    def advance_or_cancel() -> tuple[bool, Any]:
+        # Check again inside the dispatched callable.  Cancellation can arrive
+        # after a worker queues a slice but before Qt starts executing it.
+        if cancellation_check is not None and cancellation_check():
+            _cancel(steps)
+        return _advance(steps)
+
+    try:
+        while True:
+            if cancellation_check is not None and cancellation_check():
+                invoke(lambda: _cancel(steps))
+            started = clock()
+            completed, value = invoke(advance_or_cancel)
+            elapsed = clock() - started
+            if elapsed > budget:
+                _emit(
+                    progress_callback,
+                    {
+                        "event": "document_thread_slice_over_budget",
+                        "elapsed_seconds": round(elapsed, 6),
+                        "budget_seconds": budget,
+                    },
+                )
+            if completed:
+                return value
+            _emit(progress_callback, value)
+    except CooperativeExecutionCancelled:
+        # _cancel() throws through the generator on the document thread, so its
+        # cleanup has already run at the only thread-safe boundary.
+        raise
+    except BaseException:
+        # Worker-side progress, timing, or dispatch plumbing can fail after a
+        # slice leaves the generator suspended.  Never let CPython finalize
+        # that generator on the worker: its finally blocks release live
+        # FreeCAD document guards and must execute on the document thread.
+        try:
+            invoke(steps.close)
+        except BaseException:
+            # Preserve the operation's original exception. A dispatcher which
+            # can no longer reach the owning thread cannot be repaired here.
+            pass
+        raise

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -36,7 +36,7 @@ from VibeCADModelingSurface import resolve_modeling_surface
 from VibeCADNativeBackground import NativeBackgroundManager
 from VibeCADNativeAnalyzeContext import AnalyzeContextCoordinator
 from VibeCADNativeDrawingContext import DrawingSourceCatalogCoordinator
-from VibeCADNativeState import NativeDocumentStateStore
+from VibeCADNativeState import NativeDocumentStateStore, is_structural_property
 from VibeCADNativeUndo import NativeAssistantUndoLedger
 from VibeCADNativeStatePersistence import (
     native_state_path,
@@ -237,6 +237,8 @@ class VibeCADService:
         self._vibescript_reference_snapshots: dict[
             tuple[str, str], dict[str, Any]
         ] = {}
+        self._document_change_batch_lock = threading.RLock()
+        self._deferred_document_changes: dict[str, dict[str, Any]] = {}
         self._register_core_tools()
 
     @staticmethod
@@ -374,14 +376,29 @@ class VibeCADService:
     def invalidate_vibescript_reference_snapshots(self, obj: Any) -> None:
         """Invalidate every cached source that depends on ``obj`` exactly."""
 
-        identity = self._vibescript_object_identity(obj)
-        if not all(identity):
+        self.invalidate_vibescript_reference_snapshots_many((obj,))
+
+    def invalidate_vibescript_reference_snapshots_many(
+        self,
+        objects: Any,
+    ) -> None:
+        """Invalidate snapshots for many changed sources under one cache lock."""
+
+        identities = {
+            identity
+            for identity in (
+                self._vibescript_object_identity(obj)
+                for obj in tuple(objects or ())
+            )
+            if all(identity)
+        }
+        if not identities:
             return
         with self._vibescript_reference_cache_lock:
             stale = [
                 key
                 for key, entry in self._vibescript_reference_snapshots.items()
-                if identity in entry.get("dependencies", ())
+                if identities.intersection(entry.get("dependencies", ()))
             ]
             for key in stale:
                 self._vibescript_reference_snapshots.pop(key, None)
@@ -698,6 +715,13 @@ class VibeCADService:
 
     def note_native_object_created(self, obj: Any) -> int | None:
         uid = self._object_document_uid(obj)
+        deferred, revision = self._defer_document_change(
+            uid,
+            structural=True,
+            invalidate=True,
+        )
+        if deferred:
+            return revision
         revision = (
             self._native_document_states.note_structural_change(uid) if uid else None
         )
@@ -708,6 +732,13 @@ class VibeCADService:
 
     def note_native_object_deleted(self, obj: Any) -> int | None:
         uid = self._object_document_uid(obj)
+        deferred, revision = self._defer_document_change(
+            uid,
+            structural=True,
+            invalidate=True,
+        )
+        if deferred:
+            return revision
         revision = (
             self._native_document_states.note_structural_change(uid) if uid else None
         )
@@ -737,6 +768,14 @@ class VibeCADService:
                     return self._native_document_states.current_revision(uid)
             except (ImportError, AttributeError, ReferenceError, RuntimeError, TypeError):
                 pass
+        structural = is_structural_property(property_name)
+        deferred, revision = self._defer_document_change(
+            uid,
+            structural=structural,
+            invalidate=(str(property_name or "") == "Visibility" or structural),
+        )
+        if deferred:
+            return revision
         previous_revision = self._native_document_states.current_revision(uid)
         revision = self._native_document_states.note_object_property_change(
             uid,
@@ -748,6 +787,125 @@ class VibeCADService:
         if revision_changed:
             self._sync_native_authority_metadata_if_active(uid)
         return revision
+
+    def begin_document_change_batch(
+        self,
+        document_uid: str,
+        *,
+        origin_program_id: str = "",
+        origin_domain: str = "",
+    ) -> None:
+        """Coalesce observer bookkeeping for one atomic document operation."""
+
+        from VibeCADDocumentChangeBatch import begin_document_change_batch
+
+        uid = str(document_uid or "").strip()
+        if not uid:
+            raise ValueError("A document change batch requires a document UID.")
+        begin_document_change_batch(
+            uid,
+            origin_program_id=origin_program_id,
+            origin_domain=origin_domain,
+        )
+        lock, changes = self._document_change_batch_storage()
+        with lock:
+            state = changes.setdefault(
+                uid,
+                {
+                    "depth": 0,
+                    "structural": False,
+                    "invalidate": False,
+                    "commit": True,
+                },
+            )
+            state["depth"] = int(state["depth"]) + 1
+
+    def end_document_change_batch(
+        self,
+        document_uid: str,
+        *,
+        commit: bool = True,
+    ) -> int | None:
+        """Flush one outer atomic operation as one structural revision."""
+
+        from VibeCADDocumentChangeBatch import end_document_change_batch
+
+        uid = str(document_uid or "").strip()
+        if type(commit) is not bool:
+            raise TypeError("commit must be a boolean")
+        lock, changes = self._document_change_batch_storage()
+        with lock:
+            state = changes.get(uid)
+            if state is None or int(state.get("depth") or 0) < 1:
+                raise RuntimeError(f"Document {uid!r} has no active change batch.")
+            state["commit"] = bool(state.get("commit", True)) and commit
+            state["depth"] = int(state["depth"]) - 1
+            outermost = int(state["depth"]) == 0
+            structural = bool(state.get("structural"))
+            invalidate = bool(state.get("invalidate"))
+            committed = bool(state.get("commit", True))
+            if outermost:
+                # Keep the record active while metadata synchronization emits
+                # its own FreeCAD property notification.
+                state["depth"] = 1
+        revision = self._native_document_states.current_revision(uid)
+        try:
+            if outermost and committed:
+                if structural:
+                    revision = self._native_document_states.note_structural_change(uid)
+                if invalidate:
+                    self._invalidate_native_read_contexts(uid)
+                if structural:
+                    self._sync_native_authority_metadata_if_active(uid)
+        finally:
+            if outermost:
+                with lock:
+                    changes.pop(uid, None)
+            end_document_change_batch(uid, commit=committed)
+        return revision
+
+    def document_change_batch_active(self, document_uid: str) -> bool:
+        """Return whether this service is coalescing one document's changes."""
+
+        uid = str(document_uid or "").strip()
+        lock, changes = self._document_change_batch_storage()
+        with lock:
+            state = changes.get(uid)
+            return bool(state and int(state.get("depth") or 0) > 0)
+
+    def _document_change_batch_storage(
+        self,
+    ) -> tuple[Any, dict[str, dict[str, Any]]]:
+        """Lazily support lightweight services constructed by integrations."""
+
+        lock = getattr(self, "_document_change_batch_lock", None)
+        if lock is None:
+            lock = threading.RLock()
+            self._document_change_batch_lock = lock
+        changes = getattr(self, "_deferred_document_changes", None)
+        if changes is None:
+            changes = {}
+            self._deferred_document_changes = changes
+        return lock, changes
+
+    def _defer_document_change(
+        self,
+        document_uid: str,
+        *,
+        structural: bool,
+        invalidate: bool,
+    ) -> tuple[bool, int | None]:
+        uid = str(document_uid or "").strip()
+        if not uid:
+            return False, None
+        lock, changes = self._document_change_batch_storage()
+        with lock:
+            state = changes.get(uid)
+            if state is None or int(state.get("depth") or 0) < 1:
+                return False, None
+            state["structural"] = bool(state.get("structural")) or structural
+            state["invalidate"] = bool(state.get("invalidate")) or invalidate
+        return True, self._native_document_states.current_revision(uid)
 
     def _invalidate_native_read_contexts(self, document_uid: str) -> None:
         """Invalidate revision-scoped detached read state for one document."""

--- a/src/Mod/VibeCAD/VibeCADDocumentChangeBatch.py
+++ b/src/Mod/VibeCAD/VibeCADDocumentChangeBatch.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Process-wide coordination for atomic live-document change batches.
+
+FreeCAD reports every property assignment through its document observers. A
+single logical publication can therefore produce thousands of callbacks. This
+small registry lets independent service and GUI layers defer aggregate work
+until the outermost atomic document change has finished.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Callable
+
+_lock = threading.RLock()
+_depth_by_document: dict[str, int] = {}
+_commit_by_document: dict[str, bool] = {}
+_origins_by_document: dict[str, set[tuple[str, str]]] = {}
+_completed_listeners: list[Callable[[str], None]] = []
+_finished_listeners: list[Callable[[str, bool], None]] = []
+_flush_listeners: list[Callable[[str], None]] = []
+
+
+def begin_document_change_batch(
+    document_uid: str,
+    *,
+    origin_program_id: str = "",
+    origin_domain: str = "",
+) -> None:
+    """Enter a nested atomic change batch for one document."""
+
+    uid = str(document_uid or "").strip()
+    if not uid:
+        raise ValueError("A document change batch requires a document UID.")
+    program_id = str(origin_program_id or "").strip()
+    domain = str(origin_domain or "").strip()
+    if bool(program_id) != bool(domain):
+        raise ValueError("A document change batch origin needs both program ID and domain.")
+    with _lock:
+        depth = _depth_by_document.get(uid, 0)
+        if depth == 0:
+            _commit_by_document[uid] = True
+            _origins_by_document[uid] = set()
+        _depth_by_document[uid] = depth + 1
+        if program_id:
+            _origins_by_document[uid].add((program_id, domain))
+
+
+def end_document_change_batch(document_uid: str, *, commit: bool = True) -> bool:
+    """Leave a batch and notify listeners after its outermost scope closes."""
+
+    uid = str(document_uid or "").strip()
+    if not uid:
+        raise ValueError("A document change batch requires a document UID.")
+    if type(commit) is not bool:
+        raise TypeError("commit must be a boolean")
+    with _lock:
+        depth = _depth_by_document.get(uid, 0)
+        if depth < 1:
+            raise RuntimeError(f"Document {uid!r} has no active change batch.")
+        _commit_by_document[uid] = _commit_by_document.get(uid, True) and commit
+        if depth > 1:
+            _depth_by_document[uid] = depth - 1
+            return False
+        _depth_by_document.pop(uid, None)
+        committed = _commit_by_document.pop(uid, True)
+        _origins_by_document.pop(uid, None)
+        listeners = tuple(_completed_listeners)
+        finished_listeners = tuple(_finished_listeners)
+    for listener in listeners:
+        try:
+            listener(uid)
+        except Exception:
+            # An observer refresh is advisory and must never corrupt or mask a
+            # successfully completed CAD transaction.
+            continue
+    for listener in finished_listeners:
+        try:
+            listener(uid, committed)
+        except Exception:
+            # Deferred observers are advisory. Their failure must not mask the
+            # transaction outcome that has already been established.
+            continue
+    return True
+
+
+def document_change_batch_active(document_uid: str) -> bool:
+    """Return whether one document is inside an atomic change batch."""
+
+    uid = str(document_uid or "").strip()
+    if not uid:
+        return False
+    with _lock:
+        return _depth_by_document.get(uid, 0) > 0
+
+
+def document_change_batch_origins(document_uid: str) -> frozenset[tuple[str, str]]:
+    """Return program identities responsible for the active nested batch."""
+
+    uid = str(document_uid or "").strip()
+    if not uid:
+        return frozenset()
+    with _lock:
+        return frozenset(_origins_by_document.get(uid, ()))
+
+
+def flush_document_change_batch(document_uid: str) -> None:
+    """Flush aggregate observers while the caller's transaction is still open."""
+
+    uid = str(document_uid or "").strip()
+    if not uid:
+        raise ValueError("A document change batch requires a document UID.")
+    with _lock:
+        if _depth_by_document.get(uid, 0) < 1:
+            return
+        listeners = tuple(_flush_listeners)
+    for listener in listeners:
+        listener(uid)
+
+
+def register_document_change_batch_completed(
+    listener: Callable[[str], None],
+) -> None:
+    """Register an idempotent callback for outermost batch completion."""
+
+    if not callable(listener):
+        raise TypeError("A document change batch listener must be callable.")
+    with _lock:
+        if listener not in _completed_listeners:
+            _completed_listeners.append(listener)
+
+
+def register_document_change_batch_finished(
+    listener: Callable[[str, bool], None],
+) -> None:
+    """Register an idempotent callback with the outermost commit outcome."""
+
+    if not callable(listener):
+        raise TypeError("A document change batch listener must be callable.")
+    with _lock:
+        if listener not in _finished_listeners:
+            _finished_listeners.append(listener)
+
+
+def register_document_change_batch_flush(listener: Callable[[str], None]) -> None:
+    """Register work which must run once before an atomic transaction commits."""
+
+    if not callable(listener):
+        raise TypeError("A document change batch listener must be callable.")
+    with _lock:
+        if listener not in _flush_listeners:
+            _flush_listeners.append(listener)

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -26,6 +26,13 @@ import FreeCADGui as Gui
 
 from VibeCADCore import get_service
 from VibeCADDebug import list_provider_request_captures
+from VibeCADDocumentChangeBatch import (
+    document_change_batch_active,
+    document_change_batch_origins,
+    register_document_change_batch_completed,
+    register_document_change_batch_finished,
+    register_document_change_batch_flush,
+)
 from VibeCADEditState import active_edit_object, active_edit_state
 from VibeCADPromptStarters import (
     BUILTIN_PROMPT_STARTERS,
@@ -77,6 +84,8 @@ _session_recovery_persist_lock = threading.RLock()
 _session_recovery_instance_id = uuid.uuid4().hex
 _active_session_recovery: dict[str, str] | None = None
 _assistant_document_refresh_scheduled = False
+_native_authority_selector_refresh_scheduled = False
+_deferred_vibescript_dependency_changes: dict[str, dict[str, Any]] = {}
 _legacy_architecture_warning_documents: set[str] = set()
 _pending_document_render_refreshes: set[str] = set()
 _analyze_context_prewarm_thread: threading.Thread | None = None
@@ -2352,6 +2361,17 @@ def _format_progress_event(event: dict[str, Any]) -> str:
                 message += f" - about {minutes} {unit} remaining"
             return message
         return f"VibeScript {phase.replace('_', ' ')}..."
+    if name == "vibescript_domain_publication_progress":
+        completed = max(0, int(event.get("completed") or 0))
+        total = max(0, int(event.get("total") or 0))
+        phase = str(event.get("phase") or "publishing")
+        if phase == "completed":
+            return f"Published {total} CAD objects."
+        if phase == "failed":
+            return f"VibeScript publication stopped after {completed} of {total} objects."
+        current = str(event.get("current_output") or "").strip()
+        detail = f": {current}" if current else ""
+        return f"Publishing CAD objects {completed} of {total}{detail}"
     if name == "vibescript_domain_deferred_recompute_completed":
         count = int(event.get("target_count", 0) or 0)
         elapsed = float(event.get("elapsed_seconds", 0.0) or 0.0)
@@ -2405,6 +2425,7 @@ _PROGRESS_STATUS_ONLY_EVENTS: set[str] = {
     "vibescript_domain_deferred_recompute_completed",
     "vibescript_domain_phase_completed",
     "vibescript_domain_phase_started",
+    "vibescript_domain_publication_progress",
     "vibescript_domain_worker_progress",
 }
 
@@ -3873,7 +3894,13 @@ def _document_recompute_active(document: Any) -> bool:
 def _document_render_refresh_blocked(document: Any) -> bool:
     """Return whether restored-document presentation work must be deferred."""
 
-    return _document_restore_active(document) or _document_recompute_active(document)
+    if _document_restore_active(document) or _document_recompute_active(document):
+        return True
+    try:
+        document_uid = str(getattr(document, "Uid", "") or "").strip()
+    except (ReferenceError, RuntimeError):
+        return False
+    return bool(document_uid and document_change_batch_active(document_uid))
 
 
 def _live_document_for_storage_key(
@@ -4309,7 +4336,16 @@ def _schedule_assistant_document_refresh() -> None:
 
         def refresh_when_restored() -> None:
             global _assistant_document_refresh_scheduled
-            if _document_restore_active():
+            try:
+                active_document = App.ActiveDocument
+                document_uid = str(
+                    getattr(active_document, "Uid", "") or ""
+                ).strip()
+            except (AttributeError, ReferenceError, RuntimeError):
+                document_uid = ""
+            if _document_restore_active() or (
+                document_uid and document_change_batch_active(document_uid)
+            ):
                 QtCore.QTimer.singleShot(100, refresh_when_restored)
                 return
             _assistant_document_refresh_scheduled = False
@@ -4598,13 +4634,114 @@ def _move_saved_document_conversation(doc: Any, filepath: str) -> None:
             _warn(f"VibeCAD saved-document project relocation failed: {exc}")
 
 
-class _VibeCADDocumentObserver:
-    @staticmethod
-    def _refresh_native_authority_selector() -> None:
+def _queue_zero_delay_callback(callback: Any) -> None:
+    """Queue one callback on Qt without making document observers block."""
+
+    try:
+        from PySide import QtCore
+    except ImportError:
+        callback()
+        return
+
+    QtCore.QTimer.singleShot(0, callback)
+
+
+def _schedule_native_authority_selector_refresh(document_uid: str = "") -> None:
+    """Coalesce document-event storms into one post-transaction UI refresh."""
+
+    uid = str(document_uid or "").strip()
+    if uid and document_change_batch_active(uid):
+        return
+    global _native_authority_selector_refresh_scheduled
+    if _native_authority_selector_refresh_scheduled:
+        return
+    _native_authority_selector_refresh_scheduled = True
+
+    def refresh() -> None:
+        global _native_authority_selector_refresh_scheduled
+        _native_authority_selector_refresh_scheduled = False
         state = get_service().native_document_state()
         authority = state.get("native_authority")
         if isinstance(authority, dict) and authority.get("active"):
             _refresh_authoring_mode_selector()
+
+    _queue_zero_delay_callback(refresh)
+
+
+def _defer_vibescript_dependency_change(
+    document_uid: str,
+    obj: Any,
+    property_name: str,
+) -> None:
+    """Record one semantic source delta without scanning dependents yet."""
+
+    uid = str(document_uid or "").strip()
+    if not uid:
+        return
+    state = _deferred_vibescript_dependency_changes.setdefault(
+        uid,
+        {"changes": {}, "excluded_programs": set()},
+    )
+    name = str(getattr(obj, "Name", "") or "")
+    identity = name or f"@{id(obj)}"
+    state["changes"][(identity, str(property_name or ""))] = (
+        obj,
+        str(property_name or ""),
+    )
+    state["excluded_programs"].update(
+        (uid, program_id, domain)
+        for program_id, domain in document_change_batch_origins(uid)
+    )
+
+
+def _finish_vibescript_dependency_batch(
+    document_uid: str,
+    committed: bool,
+) -> None:
+    """Apply one cache invalidation and one dependency scan after commit."""
+
+    uid = str(document_uid or "").strip()
+    state = _deferred_vibescript_dependency_changes.pop(uid, None)
+    if not state or not committed:
+        return
+    changes = tuple(state["changes"].values())
+    if not changes:
+        return
+    unique_objects = {}
+    for obj, _property_name in changes:
+        name = str(getattr(obj, "Name", "") or "")
+        unique_objects[name or f"@{id(obj)}"] = obj
+    service = get_service()
+    invalidate_many = getattr(
+        service,
+        "invalidate_vibescript_reference_snapshots_many",
+        None,
+    )
+    if callable(invalidate_many):
+        invalidate_many(tuple(unique_objects.values()))
+    else:
+        for obj in unique_objects.values():
+            service.invalidate_vibescript_reference_snapshots(obj)
+    try:
+        from VibeCADVibeScriptDomainPublication import (
+            mark_programs_stale_from_sources,
+        )
+
+        marked = mark_programs_stale_from_sources(
+            changes,
+            excluded_programs=frozenset(state["excluded_programs"]),
+        )
+    except Exception as exc:
+        _warn(f"VibeCAD VibeScript dependency batch failed: {exc}")
+        return
+    if marked:
+        _schedule_assistant_document_refresh()
+
+
+class _VibeCADDocumentObserver:
+    @staticmethod
+    def _refresh_native_authority_selector(document_uid: str = "") -> None:
+        _schedule_native_authority_selector_refresh(document_uid)
 
     def slotCreatedDocument(self, doc) -> None:
         get_service().ensure_native_document_state(
@@ -4636,7 +4773,9 @@ class _VibeCADDocumentObserver:
                 obj,
                 str(property_name or ""),
             )
-            self._refresh_native_authority_selector()
+            self._refresh_native_authority_selector(
+                str(getattr(document, "Uid", "") or "")
+            )
         try:
             from VibeCADVibeScriptDomainPublication import (
                 source_property_affects_vibescript_snapshot,
@@ -4646,6 +4785,14 @@ class _VibeCADDocumentObserver:
                 return
         except Exception as exc:
             _warn(f"VibeCAD VibeScript dependency filter failed: {exc}")
+            return
+        document_uid = str(getattr(document, "Uid", "") or "").strip()
+        if document_uid and document_change_batch_active(document_uid):
+            _defer_vibescript_dependency_change(
+                document_uid,
+                obj,
+                str(property_name or ""),
+            )
             return
         # Reference snapshots are valid only while the source and every native
         # dependency remain unchanged. Invalidate before stale propagation so a
@@ -4670,7 +4817,9 @@ class _VibeCADDocumentObserver:
         if document is not None and bool(getattr(document, "Restoring", False)):
             return
         get_service().note_native_object_created(obj)
-        self._refresh_native_authority_selector()
+        self._refresh_native_authority_selector(
+            str(getattr(document, "Uid", "") or "")
+        )
 
     def slotDeletedObject(self, obj) -> None:
         is_restoring = getattr(App, "isRestoring", None)
@@ -4680,7 +4829,9 @@ class _VibeCADDocumentObserver:
         if document is not None and bool(getattr(document, "Restoring", False)):
             return
         get_service().note_native_object_deleted(obj)
-        self._refresh_native_authority_selector()
+        self._refresh_native_authority_selector(
+            str(getattr(document, "Uid", "") or "")
+        )
 
     def slotStartSaveDocument(self, doc, filepath) -> None:
         try:
@@ -4719,6 +4870,13 @@ class _VibeCADDocumentObserver:
         _document_save_conversations.pop(document_key, None)
         _document_save_references.pop(document_key, None)
         _schedule_assistant_document_refresh()
+
+
+register_document_change_batch_completed(_schedule_native_authority_selector_refresh)
+register_document_change_batch_finished(_finish_vibescript_dependency_batch)
+register_document_change_batch_flush(
+    lambda document_uid: _finish_vibescript_dependency_batch(document_uid, True)
+)
 
 
 def _schedule_sketch_close_continuation(event: dict[str, Any]) -> None:

--- a/src/Mod/VibeCAD/VibeCADNativeBackground.py
+++ b/src/Mod/VibeCAD/VibeCADNativeBackground.py
@@ -12,6 +12,11 @@ import threading
 import time
 from typing import Any, Callable, Mapping
 
+from VibeCADCooperativeExecution import (
+    CooperativeExecutionCancelled,
+    run_document_thread_steps,
+)
+
 
 MAX_BACKGROUND_JOBS = 32
 MAX_BACKGROUND_RESULT_BYTES = 32 * 1024
@@ -75,6 +80,7 @@ class _Job:
 ProgressReporter = Callable[[int, str], None]
 PrepareHandler = Callable[[Callable[[], bool], ProgressReporter], Any]
 CommitHandler = Callable[[Any], Mapping[str, Any]]
+CooperativeCommitHandler = Callable[[Any], Any]
 DocumentThreadDispatcher = Callable[[Callable[[], Any]], Any]
 CommitValidator = Callable[[], Any]
 DiagnosticSink = Callable[[str, Exception], str | None]
@@ -178,6 +184,7 @@ class NativeBackgroundManager:
         changes_document: bool = False,
         document_change_resolver: DocumentChangeResolver | None = None,
         resource_scope: str = "document",
+        cooperative_commit: CooperativeCommitHandler | None = None,
     ) -> NativeBackgroundSnapshot:
         uid = str(document_uid or "").strip()
         capability = str(capability_name or "").strip()
@@ -202,6 +209,8 @@ class NativeBackgroundManager:
             raise TypeError("Native background callbacks must be callable")
         if cleanup is not None and not callable(cleanup):
             raise TypeError("Native background cleanup must be callable")
+        if cooperative_commit is not None and not callable(cooperative_commit):
+            raise TypeError("cooperative_commit must be callable or None")
         if type(changes_document) is not bool:
             raise TypeError("changes_document must be a boolean")
         if document_change_resolver is not None and not callable(document_change_resolver):
@@ -271,6 +280,7 @@ class NativeBackgroundManager:
                 clean_finalize_message,
                 cleanup,
                 document_change_resolver,
+                cooperative_commit,
             ),
             name=f"VibeCADNative-{job.job_id[:8]}",
             daemon=True,
@@ -288,6 +298,7 @@ class NativeBackgroundManager:
         finalize_message: str,
         cleanup: CleanupHandler | None,
         document_change_resolver: DocumentChangeResolver | None,
+        cooperative_commit: CooperativeCommitHandler | None,
     ) -> None:
         prepared = None
         try:
@@ -326,7 +337,48 @@ class NativeBackgroundManager:
                 )
                 return commit(prepared)
 
-            result = dispatch_to_document_thread(apply)
+            if cooperative_commit is None:
+                result = dispatch_to_document_thread(apply)
+            else:
+                def commit_steps():
+                    if job.cancellation.is_set():
+                        raise NativeBackgroundCancelled()
+                    validate_before_commit()
+                    if job.cancellation.is_set():
+                        raise NativeBackgroundCancelled()
+                    self._set_progress(
+                        job,
+                        "finalizing" if finalize_message else "committing",
+                        91,
+                        finalize_message or "Committing document change",
+                    )
+                    return (yield from cooperative_commit(prepared))
+
+                def report_commit_progress(event: Mapping[str, Any]) -> None:
+                    raw_percent = event.get("progress_percent", 95)
+                    percent = (
+                        raw_percent
+                        if type(raw_percent) is int and 91 <= raw_percent <= 99
+                        else 95
+                    )
+                    with self._lock:
+                        percent = max(job.progress_percent, percent)
+                    self._set_progress(
+                        job,
+                        "finalizing" if finalize_message else "committing",
+                        percent,
+                        str(event.get("message") or finalize_message or "Committing document change"),
+                    )
+
+                try:
+                    result = run_document_thread_steps(
+                        commit_steps(),
+                        dispatch=dispatch_to_document_thread,
+                        cancellation_check=job.cancellation.is_set,
+                        progress_callback=report_commit_progress,
+                    )
+                except CooperativeExecutionCancelled as exc:
+                    raise NativeBackgroundCancelled() from exc
             if document_change_resolver is not None:
                 resolved_change = document_change_resolver(result)
                 if type(resolved_change) is not bool:

--- a/src/Mod/VibeCAD/VibeCADPublicationProgress.py
+++ b/src/Mod/VibeCAD/VibeCADPublicationProgress.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Bounded publication progress for cooperative document mutation slices."""
+
+from __future__ import annotations
+
+import time
+from typing import Any, Callable
+
+
+class PublicationProgress:
+    """Report monotonic output progress and bound GUI event-loop starvation."""
+
+    def __init__(
+        self,
+        *,
+        domain: str,
+        total: int,
+        callback: Callable[[dict[str, Any]], None] | None = None,
+        event_yield: Callable[[], None] | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        yield_interval_seconds: float = 0.05,
+    ) -> None:
+        self._domain = str(domain or "")
+        self._total = max(0, int(total))
+        self._callback = callback
+        # Cooperative callers return to Qt between document slices.  Keep the
+        # explicit hook for compatible headless tests and legacy callers, but
+        # never enter a nested Qt event loop implicitly.
+        self._event_yield = event_yield
+        self._clock = clock
+        self._yield_interval = max(0.01, float(yield_interval_seconds))
+        self._last_completed = 0
+        self._last_yield = 0.0
+
+    def _emit(
+        self,
+        *,
+        completed: int,
+        phase: str,
+        name: str = "",
+        output_type: str = "",
+    ) -> None:
+        if self._callback is None:
+            return
+        self._callback(
+            {
+                "event": "vibescript_domain_publication_progress",
+                "domain": self._domain,
+                "phase": phase,
+                "completed": completed,
+                "total": self._total,
+                "current_output": str(name or ""),
+                "output_type": str(output_type or ""),
+            }
+        )
+
+    def _yield_if_due(self, now: float) -> None:
+        if self._event_yield is None:
+            return
+        if now - self._last_yield < self._yield_interval:
+            return
+        self._event_yield()
+        # A Qt pass can itself take measurable time. Measure the next interval
+        # from the completed pass so one slow callback cannot make every
+        # following output immediately re-enter the event loop.
+        self._last_yield = self._clock()
+
+    def start(self) -> None:
+        now = self._clock()
+        self._last_yield = now
+        self._emit(completed=0, phase="publishing")
+
+    def checkpoint(self, completed: int, *, name: str, output_type: str) -> None:
+        now = self._clock()
+        bounded = min(self._total, max(0, int(completed)))
+        if bounded > self._last_completed:
+            self._last_completed = bounded
+            self._emit(
+                completed=bounded,
+                phase="publishing",
+                name=name,
+                output_type=output_type,
+            )
+        self._yield_if_due(now)
+
+    def finish(self) -> None:
+        now = self._clock()
+        self._last_completed = self._total
+        self._emit(completed=self._total, phase="completed")
+        self._yield_if_due(now)
+
+    def fail(self) -> None:
+        now = self._clock()
+        self._emit(completed=self._last_completed, phase="failed")
+        self._yield_if_due(now)

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -2694,13 +2694,39 @@ def _run_domain_vibescript_tool(
             )
         retain_candidate(prepared, status="validated")
         try:
-            publication = run_phase(
-                "publish",
-                lambda: _on_document_thread(
-                    document_thread_dispatch,
-                    lambda: adapter.publish(service, prepared, validated),
-                ),
-            )
+            publish_cooperatively = getattr(adapter, "publish_cooperatively", None)
+            publish_with_progress = getattr(adapter, "publish_with_progress", None)
+
+            def publish_candidate_synchronously() -> dict[str, Any]:
+                if callable(publish_with_progress):
+                    return publish_with_progress(
+                        service,
+                        prepared,
+                        validated,
+                        progress_callback=progress_callback,
+                    )
+                return adapter.publish(service, prepared, validated)
+
+            if callable(publish_cooperatively) and document_thread_dispatch is not None:
+                publication = run_phase(
+                    "publish",
+                    lambda: publish_cooperatively(
+                        service,
+                        prepared,
+                        validated,
+                        document_thread_dispatch=document_thread_dispatch,
+                        cancellation_check=cancellation_check,
+                        progress_callback=progress_callback,
+                    ),
+                )
+            else:
+                publication = run_phase(
+                    "publish",
+                    lambda: _on_document_thread(
+                        document_thread_dispatch,
+                        publish_candidate_synchronously,
+                    ),
+                )
         except Exception as exc:
             failure = tool_failure(
                 tool_name,

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainPublication.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainPublication.py
@@ -10,16 +10,18 @@ from io import BytesIO
 import json
 import math
 import re
-from typing import Any, Mapping
+from typing import Any, Iterator, Mapping
 import zipfile
 
 from VibeCADDocumentReferences import (
     DocumentReferenceError,
     resolve_reference_target,
 )
+from VibeCADDocumentChangeBatch import flush_document_change_batch
 import VibeCADReferenceContracts as reference_contracts
 import VibeCADScriptedPublication as scripted_publication
 import VibeCADVibeScriptDomains as contracts
+from VibeCADPublicationProgress import PublicationProgress
 
 PROP_DEFINITION = "VibeCADVibeScriptDefinition"
 PROP_OUTPUT_TYPE = "VibeCADVibeScriptOutputType"
@@ -1421,6 +1423,137 @@ def mark_programs_stale_from_source(source: Any, property_name: str) -> list[str
                 _freeze_object(output, "Assembly BOM")
             if not already_stale:
                 marked.append(str(getattr(output, "Name", "") or ""))
+    return sorted(set(marked))
+
+
+def mark_programs_stale_from_sources(
+    changes: Any,
+    *,
+    excluded_programs: frozenset[tuple[str, str, str]] = frozenset(),
+) -> list[str]:
+    """Mark dependents of many source deltas with one scan per document.
+
+    The single-source entry point remains unchanged for existing callers.
+    Cooperative publications use this aggregate path so hundreds of property
+    notifications cannot repeatedly scan every object in the same document.
+    ``excluded_programs`` identifies the publication which produced the
+    notifications; its downstream consumers still become stale, but it cannot
+    invalidate itself while accepting its own revision.
+    """
+
+    excluded = set(excluded_programs)
+    affected: dict[tuple[str, str, str], tuple[Any, Any, str]] = {}
+    for source, property_name in tuple(changes or ()):
+        changed_property = str(property_name or "")
+        if not source_property_affects_vibescript_snapshot(changed_property):
+            continue
+        label_only = changed_property == "Label"
+        for output in list(getattr(source, "InList", []) or []):
+            properties = _properties(output)
+            if not ({PROP_INPUT_OBJECTS, PROP_NESTED_INPUT_OBJECTS} & properties):
+                continue
+            inputs = [
+                *list(getattr(output, PROP_INPUT_OBJECTS, []) or []),
+                *list(getattr(output, PROP_NESTED_INPUT_OBJECTS, []) or []),
+            ]
+            if not any(item is source for item in inputs):
+                continue
+            document = getattr(output, "Document", None)
+            document_uid = str(getattr(document, "Uid", "") or "")
+            program_id = str(getattr(output, contracts.PROP_PROGRAM_ID, "") or "")
+            domain = str(getattr(output, contracts.PROP_PROGRAM_DOMAIN, "") or "")
+            key = (document_uid, program_id, domain)
+            if (
+                document is None
+                or not document_uid
+                or not program_id
+                or not domain
+                or key in excluded
+                or (label_only and domain != "assembly")
+            ):
+                continue
+            affected.setdefault(key, (document, source, changed_property))
+
+    if not affected:
+        return []
+
+    keys_by_document: dict[int, tuple[Any, set[tuple[str, str, str]]]] = {}
+    for key, (document, _source, _property_name) in affected.items():
+        entry = keys_by_document.setdefault(id(document), (document, set()))
+        entry[1].add(key)
+
+    outputs_by_program: dict[tuple[str, str, str], list[Any]] = {
+        key: [] for key in affected
+    }
+    for document, target_keys in keys_by_document.values():
+        document_uid = str(getattr(document, "Uid", "") or "")
+        for output in list(getattr(document, "Objects", []) or []):
+            properties = _properties(output)
+            if not {
+                contracts.PROP_PROGRAM_ID,
+                contracts.PROP_PROGRAM_DOMAIN,
+            } <= properties:
+                continue
+            key = (
+                document_uid,
+                str(getattr(output, contracts.PROP_PROGRAM_ID, "") or ""),
+                str(getattr(output, contracts.PROP_PROGRAM_DOMAIN, "") or ""),
+            )
+            if key in target_keys:
+                outputs_by_program[key].append(output)
+
+    marked: list[str] = []
+    for key, outputs in outputs_by_program.items():
+        _document, source, changed_property = affected[key]
+        domain = key[2]
+        for output in outputs:
+            inspection_feature = (
+                domain == "inspection"
+                and str(getattr(output, "TypeId", "") or "")
+                == "Inspection::Feature"
+            )
+            assembly_bom = (
+                domain == "assembly"
+                and str(getattr(output, "TypeId", "") or "")
+                == "Assembly::BomObject"
+            )
+            already_stale = (
+                str(
+                    getattr(
+                        output,
+                        reference_contracts.PROP_DERIVED_STATE,
+                        "",
+                    )
+                    or ""
+                )
+                == "stale"
+            )
+            if not already_stale:
+                if inspection_feature:
+                    _unfreeze_inspection_feature(output)
+                elif assembly_bom:
+                    _unfreeze_object(output, "Assembly BOM")
+                revision = str(
+                    getattr(output, contracts.PROP_PROGRAM_REVISION, "") or ""
+                )
+                try:
+                    reference_contracts.mark_stale(
+                        output,
+                        revision,
+                        f"Input object {getattr(source, 'Name', '<object>')}."
+                        f"{changed_property} changed after this VibeScript snapshot; "
+                        "regenerate the program.",
+                    )
+                finally:
+                    if inspection_feature:
+                        _freeze_inspection_feature(output)
+                    elif assembly_bom:
+                        _freeze_object(output, "Assembly BOM")
+                marked.append(str(getattr(output, "Name", "") or ""))
+            elif inspection_feature and not _inspection_feature_is_frozen(output):
+                _freeze_inspection_feature(output)
+            elif assembly_bom and not _object_is_frozen(output, "Assembly BOM"):
+                _freeze_object(output, "Assembly BOM")
     return sorted(set(marked))
 
 
@@ -9763,6 +9896,7 @@ def _publish_material_candidate(
         )
         removed = _remove_timeline_deletion(doc, retired_deletion)
         if hasattr(doc, "commitTransaction") and transaction_open:
+            _flush_publication_observers(prepared)
             doc.commitTransaction()
             transaction_open = False
     except Exception as publication_error:
@@ -11217,6 +11351,7 @@ def _publish_cam_candidate(
             revision=str(prepared["revision"]),
         )
         if hasattr(doc, "commitTransaction") and transaction_open:
+            _flush_publication_observers(prepared)
             doc.commitTransaction()
             transaction_open = False
     except Exception as publication_error:
@@ -12370,6 +12505,7 @@ def _publish_techdraw_candidate(
             _techdraw_publication_checkpoint("before_freeze", output_key, obj)
             _freeze_object(obj, "TechDraw")
         if hasattr(doc, "commitTransaction") and transaction_open:
+            _flush_publication_observers(prepared)
             doc.commitTransaction()
             transaction_open = False
     except Exception as publication_error:
@@ -15863,6 +15999,7 @@ def _publish_partdesign_design_candidate(
             doc.removeObject(target_name)
             removed.append(target_name)
         if hasattr(doc, "commitTransaction") and transaction_open:
+            _flush_publication_observers(prepared)
             doc.commitTransaction()
             transaction_open = False
     except Exception as publication_error:
@@ -16291,6 +16428,7 @@ def _publish_partdesign_legacy_candidate(
             native_history,
         )
         if hasattr(doc, "commitTransaction") and transaction_open:
+            _flush_publication_observers(prepared)
             doc.commitTransaction()
             transaction_open = False
     except Exception as publication_error:
@@ -16402,11 +16540,157 @@ def _publish_partdesign_candidate(
     )
 
 
+def _assert_publication_document_intact(
+    service: Any,
+    prepared: Mapping[str, Any],
+    doc: Any,
+    targets: Any = (),
+) -> None:
+    """Reject a slice if its exact live document targets were replaced."""
+
+    try:
+        active = service._active_document()
+        identity_matches = (
+            active is doc
+            and str(getattr(doc, "Name", "") or "")
+            == str(prepared.get("document_name") or "")
+            and str(getattr(doc, "Uid", "") or "")
+            == str(prepared.get("document_uid") or "")
+        )
+    except (AttributeError, ReferenceError, RuntimeError):
+        identity_matches = False
+    if not identity_matches:
+        raise RuntimeError(
+            "The active document changed between publication slices; the "
+            "candidate was rolled back."
+        )
+    resolve = getattr(doc, "getObject", None)
+    if not callable(resolve):
+        return
+    for target in tuple(targets or ()):
+        try:
+            name = str(getattr(target, "Name", "") or "")
+            attached = not name or resolve(name) is target
+        except (ReferenceError, RuntimeError):
+            attached = False
+        if not attached:
+            raise RuntimeError(
+                "A live document target changed between publication slices; "
+                "the candidate was rolled back."
+            )
+
+
+def _flush_publication_observers(prepared: Mapping[str, Any]) -> None:
+    """Apply deferred dependency work inside the publication transaction."""
+
+    document_uid = str(prepared.get("document_uid") or "").strip()
+    if document_uid:
+        flush_document_change_batch(document_uid)
+
+
+def iter_publish_candidate(
+    service: Any,
+    prepared: dict[str, Any],
+    validated: dict[str, Any],
+    *,
+    progress_callback: Any | None = None,
+) -> Iterator[Any]:
+    """Yield between bounded live-document publication slices."""
+
+    document_uid = str(prepared.get("document_uid") or "").strip()
+    begin_batch = getattr(service, "begin_document_change_batch", None)
+    end_batch = getattr(service, "end_document_change_batch", None)
+    batch_supported = bool(document_uid and callable(begin_batch) and callable(end_batch))
+    active_document = getattr(service, "_active_document", lambda: None)()
+    begin_mutation = getattr(active_document, "beginCooperativeMutation", None)
+    end_mutation = getattr(active_document, "endCooperativeMutation", None)
+    mutation_supported = bool(callable(begin_mutation) and callable(end_mutation))
+    total = len(list(validated.get("outputs") or []))
+    if str(getattr(prepared.get("pack"), "domain", "")) == "assembly":
+        total += len(list(validated.get("assembly_members") or []))
+    progress = PublicationProgress(
+        domain=str(getattr(prepared.get("pack"), "domain", "")),
+        total=total,
+        callback=progress_callback,
+    )
+    origin_program_id = str(prepared.get("program_id") or "")
+    origin_domain = (
+        str(getattr(prepared.get("pack"), "domain", "") or "")
+        if origin_program_id
+        else ""
+    )
+    mutation_started = False
+    batch_started = False
+    try:
+        if mutation_supported:
+            begin_mutation()
+            mutation_started = True
+        if batch_supported:
+            begin_batch(
+                document_uid,
+                origin_program_id=origin_program_id,
+                origin_domain=origin_domain,
+            )
+            batch_started = True
+        succeeded = False
+        try:
+            progress.start()
+            try:
+                result = yield from _iter_publish_candidate_unbatched(
+                    service,
+                    prepared,
+                    validated,
+                    publication_progress=progress,
+                )
+            except Exception:
+                progress.fail()
+                raise
+            else:
+                progress.finish()
+                succeeded = True
+                return result
+        finally:
+            if batch_started:
+                end_batch(document_uid, commit=succeeded)
+    finally:
+        if mutation_started:
+            end_mutation()
+
+
+def _drain_publication_steps(steps: Iterator[Any]) -> dict[str, Any]:
+    while True:
+        try:
+            next(steps)
+        except StopIteration as completed:
+            return completed.value
+
+
 def publish_candidate(
     service: Any,
     prepared: dict[str, Any],
     validated: dict[str, Any],
+    *,
+    progress_callback: Any | None = None,
 ) -> dict[str, Any]:
+    """Preserve the synchronous publication API for existing direct callers."""
+
+    return _drain_publication_steps(
+        iter_publish_candidate(
+            service,
+            prepared,
+            validated,
+            progress_callback=progress_callback,
+        )
+    )
+
+
+def _iter_publish_candidate_unbatched(
+    service: Any,
+    prepared: dict[str, Any],
+    validated: dict[str, Any],
+    *,
+    publication_progress: PublicationProgress,
+) -> Iterator[Any]:
     """Apply detached, validated values without process waits or artifact I/O."""
 
     _surface_still_matches(service, prepared)
@@ -16432,6 +16716,12 @@ def publish_candidate(
             f"VibeScript domain {domain!r} has no semantic History publication "
             "strategy."
         )
+    yield {
+        "progress_percent": 91,
+        "message": f"Validated {prepared['pack'].title} publication target",
+        "phase": "publication_preflight",
+    }
+    _assert_publication_document_intact(service, prepared, doc)
     if domain == "partdesign":
         return _publish_partdesign_candidate(service, prepared, validated, doc)
     if domain == "material":
@@ -16483,6 +16773,12 @@ def publish_candidate(
             "human-created or foreign document objects still reference them",
             retired_uses,
         )
+    yield {
+        "progress_percent": 91,
+        "message": f"Indexed {prepared['pack'].title} publication graph",
+        "phase": "publication_preflight",
+    }
+    _assert_publication_document_intact(service, prepared, doc)
     updated_objects = [
         existing[str(item["name"])]
         for item in validated["outputs"]
@@ -16551,6 +16847,12 @@ def publish_candidate(
         updated_objects,
         internal_objects,
     )
+    yield {
+        "progress_percent": 91,
+        "message": f"Prepared {prepared['pack'].title} rollback state",
+        "phase": "publication_preflight",
+    }
+    _assert_publication_document_intact(service, prepared, doc)
     outputs: dict[str, Any] = {}
     created: list[Any] = []
     removed: list[str] = []
@@ -16705,7 +17007,34 @@ def publish_candidate(
             configure_order.sort(
                 key=lambda item: priority.get(str(item["type"]), 7)
             )
-        for item in configure_order:
+
+        yield {
+            "progress_percent": 92,
+            "message": f"Publishing {prepared['pack'].title} document objects",
+            "phase": "publication_objects",
+        }
+        _assert_publication_document_intact(service, prepared, doc)
+
+        def complete_output_slice(
+            output_index: int,
+            *,
+            output_name: str,
+            output_type: str,
+        ) -> None:
+            publication_progress.checkpoint(
+                output_index + 1,
+                name=output_name,
+                output_type=output_type,
+            )
+
+        for output_index, item in enumerate(configure_order):
+            if output_index:
+                _assert_publication_document_intact(
+                    service,
+                    prepared,
+                    doc,
+                    tuple(outputs.values()),
+                )
             output_name = str(item["name"])
             output_type = str(item["type"])
             adopted_occurrence = False
@@ -16856,6 +17185,11 @@ def publish_candidate(
                         obj,
                         f"{prepared['pack'].title} output {output_name!r}",
                     )
+                yield complete_output_slice(
+                    output_index,
+                    output_name=output_name,
+                    output_type=output_type,
+                )
                 continue
 
             if output_type == "assembly":
@@ -16899,6 +17233,11 @@ def publish_candidate(
                             context="Assembly dependency resource graph",
                         )
                     )
+                yield complete_output_slice(
+                    output_index,
+                    output_name=output_name,
+                    output_type=output_type,
+                )
                 continue
 
             if output_type == "component_link":
@@ -16930,6 +17269,11 @@ def publish_candidate(
                                     f"Assembly grounding operation for {output_name!r}"
                                 ),
                             )
+                    yield complete_output_slice(
+                        output_index,
+                        output_name=output_name,
+                        output_type=output_type,
+                    )
                     continue
 
                 fastener_source = assembly_fastener_sources.get(output_name)
@@ -17068,6 +17412,11 @@ def publish_candidate(
                                 f"{output_name!r}"
                             ),
                         )
+                yield complete_output_slice(
+                    output_index,
+                    output_name=output_name,
+                    output_type=output_type,
+                )
                 continue
 
             _mark_timeline_operation(
@@ -17126,6 +17475,11 @@ def publish_candidate(
                     # checks are standalone History operations. Their native
                     # properties—including intentional suppression changes—
                     # update normally and require no resource reconciliation.
+                    yield complete_output_slice(
+                        output_index,
+                        output_name=output_name,
+                        output_type=output_type,
+                    )
                     continue
                 released = _finalize_timeline_resource_reconciliation(
                     doc,
@@ -17141,6 +17495,17 @@ def publish_candidate(
                         context=f"Assembly output {output_name!r} resource graph",
                     )
                 )
+            yield complete_output_slice(
+                output_index,
+                output_name=output_name,
+                output_type=output_type,
+            )
+        _assert_publication_document_intact(
+            service,
+            prepared,
+            doc,
+            tuple(outputs.values()),
+        )
         if prepared["pack"].domain != "assembly":
             # Configure the complete output graph before publishing any new
             # operation.  Native proxies may update a dependency's
@@ -17175,6 +17540,17 @@ def publish_candidate(
                     "creation order: "
                     + ", ".join(str(obj.Name) for obj in missing_publications)
                 )
+        yield {
+            "progress_percent": 98,
+            "message": f"Finalizing {prepared['pack'].title} History",
+            "phase": "publication_history",
+        }
+        _assert_publication_document_intact(
+            service,
+            prepared,
+            doc,
+            tuple(outputs.values()),
+        )
         if assembly_dependency_anchor is not None and assembly_item is not None:
             # Publish the anchor with the Assembly root in creation order, but
             # install its source links only after every occurrence has finished
@@ -17193,6 +17569,17 @@ def publish_candidate(
                 assembly_dependency_anchor,
                 assembly_adoptions,
             )
+        yield {
+            "progress_percent": 98,
+            "message": f"Reconciling {prepared['pack'].title} presentation",
+            "phase": "publication_reconciliation",
+        }
+        _assert_publication_document_intact(
+            service,
+            prepared,
+            doc,
+            tuple(outputs.values()),
+        )
         if assembly is not None and any(obj is assembly for obj in created):
             _configure_new_assembly_presentation(
                 assembly,
@@ -17217,10 +17604,22 @@ def publish_candidate(
             downstream_uses,
             revision=str(prepared["revision"]),
         )
+        yield {
+            "progress_percent": 99,
+            "message": f"Committing {prepared['pack'].title} publication",
+            "phase": "publication_commit",
+        }
+        _assert_publication_document_intact(
+            service,
+            prepared,
+            doc,
+            tuple(outputs.values()),
+        )
         if prepared["pack"].domain == "robot":
             retired_robot_trajectories = _extract_robot_trajectories(retired)
         removed = _remove_timeline_deletion(doc, retired_deletion)
         if hasattr(doc, "commitTransaction") and transaction_open:
+            _flush_publication_observers(prepared)
             doc.commitTransaction()
             transaction_open = False
     except Exception as publication_error:

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
@@ -36,6 +36,7 @@ from VibeCADDocumentReferences import (
     normalize_document_reference,
     resolve_reference_target,
 )
+from VibeCADCooperativeExecution import run_document_thread_steps
 from VibeCADMechanismEngine import (
     MECHANISM_SCENARIO_SCHEMA,
     MECHANISM_SOLVE_REPORT_SCHEMA,
@@ -17428,6 +17429,47 @@ class DeclarativeDomainAdapter:
     ) -> dict[str, Any]:
         return publish_candidate(service, prepared, validated)
 
+    def publish_with_progress(
+        self,
+        service: Any,
+        prepared: dict[str, Any],
+        validated: dict[str, Any],
+        *,
+        progress_callback: Callable[[dict[str, Any]], None] | None,
+    ) -> dict[str, Any]:
+        """Publish with item progress while preserving the legacy entry point."""
+
+        return publish_candidate(
+            service,
+            prepared,
+            validated,
+            progress_callback=progress_callback,
+        )
+
+    def publish_cooperatively(
+        self,
+        service: Any,
+        prepared: dict[str, Any],
+        validated: dict[str, Any],
+        *,
+        document_thread_dispatch: Callable[[Callable[[], Any]], Any] | None,
+        cancellation_check: Callable[[], bool] | None,
+        progress_callback: Callable[[dict[str, Any]], None] | None,
+    ) -> dict[str, Any]:
+        """Publish in bounded document slices while preserving legacy APIs."""
+
+        return run_document_thread_steps(
+            iter_publish_candidate(
+                service,
+                prepared,
+                validated,
+                progress_callback=progress_callback,
+            ),
+            dispatch=document_thread_dispatch,
+            cancellation_check=cancellation_check,
+            progress_callback=progress_callback,
+        )
+
     def inspect(
         self, captured: dict[str, Any], contract: dict[str, Any]
     ) -> dict[str, Any]:
@@ -24262,5 +24304,6 @@ def install_builtin_adapters() -> None:
 # Publication helpers are imported late to keep worker-side imports FreeCADGui-free.
 from VibeCADVibeScriptDomainPublication import (  # noqa: E402
     delete_live_program,
+    iter_publish_candidate,
     publish_candidate,
 )

--- a/src/Mod/VibeCAD/vibecad_tests/test_cooperative_document_execution.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_cooperative_document_execution.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Contracts for bounded, cooperative document-thread execution."""
+
+from __future__ import annotations
+
+import pytest
+
+from VibeCADCooperativeExecution import (
+    CooperativeExecutionCancelled,
+    run_document_thread_steps,
+)
+
+
+def test_document_steps_return_to_dispatcher_between_every_slice() -> None:
+    dispatches = []
+    progress = []
+
+    def steps():
+        yield {"completed": 1, "total": 3}
+        yield {"completed": 2, "total": 3}
+        yield {"completed": 3, "total": 3}
+        return {"ok": True, "published": 3}
+
+    def dispatch(operation):
+        dispatches.append(operation)
+        return operation()
+
+    result = run_document_thread_steps(
+        steps(),
+        dispatch=dispatch,
+        progress_callback=progress.append,
+    )
+
+    assert result == {"ok": True, "published": 3}
+    assert len(dispatches) == 4
+    assert [event["completed"] for event in progress] == [1, 2, 3]
+
+
+def test_document_steps_cancel_by_throwing_on_the_document_thread() -> None:
+    dispatches = []
+    finalized = []
+    cancellation_checks = 0
+
+    def steps():
+        try:
+            yield {"completed": 1, "total": 2}
+            yield {"completed": 2, "total": 2}
+            return {"ok": True}
+        finally:
+            finalized.append(True)
+
+    def dispatch(operation):
+        dispatches.append(operation)
+        return operation()
+
+    def cancelled() -> bool:
+        nonlocal cancellation_checks
+        cancellation_checks += 1
+        return cancellation_checks > 2
+
+    with pytest.raises(CooperativeExecutionCancelled):
+        run_document_thread_steps(
+            steps(),
+            dispatch=dispatch,
+            cancellation_check=cancelled,
+        )
+
+    assert finalized == [True]
+    assert len(dispatches) == 2
+
+
+def test_document_steps_report_any_slice_that_exceeds_its_budget() -> None:
+    now = iter((0.0, 0.08, 0.08, 0.09))
+    progress = []
+
+    def steps():
+        yield {"completed": 1, "total": 1}
+        return {"ok": True}
+
+    result = run_document_thread_steps(
+        steps(),
+        dispatch=lambda operation: operation(),
+        progress_callback=progress.append,
+        clock=lambda: next(now),
+        slice_budget_seconds=0.05,
+    )
+
+    assert result == {"ok": True}
+    assert progress[0]["event"] == "document_thread_slice_over_budget"
+    assert progress[0]["elapsed_seconds"] == 0.08
+    assert progress[1]["completed"] == 1
+
+
+def test_progress_failure_closes_steps_on_the_document_thread() -> None:
+    dispatch_active = False
+    finalized = []
+
+    def steps():
+        try:
+            yield {"completed": 1, "total": 2}
+            yield {"completed": 2, "total": 2}
+        finally:
+            finalized.append(dispatch_active)
+
+    def dispatch(operation):
+        nonlocal dispatch_active
+        assert dispatch_active is False
+        dispatch_active = True
+        try:
+            return operation()
+        finally:
+            dispatch_active = False
+
+    def reject_progress(_event) -> None:
+        raise RuntimeError("progress callback failed")
+
+    with pytest.raises(RuntimeError, match="progress callback failed"):
+        run_document_thread_steps(
+            steps(),
+            dispatch=dispatch,
+            progress_callback=reject_progress,
+        )
+
+    assert finalized == [True]

--- a/src/Mod/VibeCAD/vibecad_tests/test_document_restore_rendering.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_document_restore_rendering.py
@@ -405,6 +405,101 @@ def test_open_scheduler_waits_for_restore_then_makes_document_render_ready(
     assert document.Uid not in gui._pending_document_render_refreshes
 
 
+def test_open_scheduler_defers_render_during_atomic_document_change(
+    monkeypatch,
+) -> None:
+    document = _Document([_Object("PendingFeature", ["Touched"])])
+    _install_gui_document(monkeypatch, document)
+    callbacks: list[tuple[int, object]] = []
+    batch_active = [True]
+
+    class _Timer:
+        @staticmethod
+        def singleShot(delay: int, callback) -> None:
+            callbacks.append((delay, callback))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "PySide",
+        SimpleNamespace(QtCore=SimpleNamespace(QTimer=_Timer)),
+    )
+    monkeypatch.setattr(gui.App, "isRestoring", lambda: False, raising=False)
+    monkeypatch.setattr(
+        gui.App,
+        "listDocuments",
+        lambda: {document.Name: document},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        gui,
+        "document_change_batch_active",
+        lambda uid: batch_active[0] and uid == document.Uid,
+    )
+    gui._pending_document_render_refreshes.discard(document.Uid)
+
+    gui._schedule_document_render_after_restore(document)
+    callbacks.pop(0)[1]()
+
+    assert document.recompute_calls == 0
+    assert callbacks[0][0] == 100
+
+    batch_active[0] = False
+    callbacks.pop(0)[1]()
+    assert document.recompute_calls == 1
+
+
+def test_assistant_refresh_defers_context_prewarm_during_atomic_document_change(
+    monkeypatch,
+) -> None:
+    document = _Document([])
+    callbacks: list[tuple[int, object]] = []
+    refreshed = []
+    prewarmed = []
+    batch_active = [True]
+
+    class _Timer:
+        @staticmethod
+        def singleShot(delay: int, callback) -> None:
+            callbacks.append((delay, callback))
+
+    monkeypatch.setitem(
+        sys.modules,
+        "PySide",
+        SimpleNamespace(QtCore=SimpleNamespace(QTimer=_Timer)),
+    )
+    monkeypatch.setattr(gui.App, "ActiveDocument", document, raising=False)
+    monkeypatch.setattr(gui, "_document_restore_active", lambda *_args: False)
+    monkeypatch.setattr(
+        gui,
+        "document_change_batch_active",
+        lambda uid: batch_active[0] and uid == document.Uid,
+    )
+    monkeypatch.setattr(
+        gui,
+        "_refresh_assistant_for_document_change",
+        lambda: refreshed.append(True),
+    )
+    monkeypatch.setattr(
+        gui,
+        "_schedule_analyze_context_prewarm",
+        lambda: prewarmed.append(True),
+    )
+    gui._assistant_document_refresh_scheduled = False
+
+    gui._schedule_assistant_document_refresh()
+    callbacks.pop(0)[1]()
+
+    assert refreshed == []
+    assert prewarmed == []
+    assert callbacks[0][0] == 100
+
+    batch_active[0] = False
+    callbacks.pop(0)[1]()
+
+    assert refreshed == [True]
+    assert prewarmed == [True]
+
+
 def test_open_scheduler_redraws_restored_partdesign_history(monkeypatch) -> None:
     document = _Document([_Object("CleanFeature", ["Up-to-date"])])
     view = _install_gui_document(monkeypatch, document)

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_background.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_background.py
@@ -177,6 +177,72 @@ def test_cancel_while_waiting_for_document_thread_skips_commit() -> None:
     assert commits == []
 
 
+def test_cooperative_commit_returns_to_document_dispatcher_between_slices() -> None:
+    manager = NativeBackgroundManager()
+    dispatches = []
+    committed = []
+
+    def commit_steps(prepared):
+        committed.append(("begin", prepared))
+        yield {"progress_percent": 93, "message": "Adding first result"}
+        committed.append(("middle", prepared))
+        yield {"progress_percent": 97, "message": "Adding second result"}
+        committed.append(("end", prepared))
+        return {"created": 2}
+
+    submitted = manager.submit(
+        document_uid="document-a",
+        capability_name="drawing.create",
+        prepare=lambda _cancelled, _progress: {"detached": True},
+        validate_before_commit=lambda: None,
+        commit=lambda _prepared: pytest.fail("legacy commit must not run"),
+        cooperative_commit=commit_steps,
+        dispatch_to_document_thread=lambda callback: (
+            dispatches.append(callback), callback()
+        )[1],
+    )
+    completed = manager.wait(submitted.job_id, 2.0)
+
+    assert completed.phase == "completed"
+    assert completed.result == {"created": 2}
+    assert len(dispatches) == 3
+    assert [name for name, _prepared in committed] == ["begin", "middle", "end"]
+
+
+def test_cooperative_commit_observes_cancel_after_dispatch_was_queued() -> None:
+    manager = NativeBackgroundManager()
+    dispatcher_entered = threading.Event()
+    allow_dispatch = threading.Event()
+    commits = []
+
+    def dispatch(callback):
+        dispatcher_entered.set()
+        assert allow_dispatch.wait(1.0)
+        return callback()
+
+    def commit_steps(_prepared):
+        commits.append("must not run")
+        yield {"progress_percent": 95, "message": "Committing"}
+        return {"created": 1}
+
+    submitted = manager.submit(
+        document_uid="document-a",
+        capability_name="mesh.convert",
+        prepare=lambda _cancelled, _progress: {"detached": True},
+        validate_before_commit=lambda: None,
+        commit=lambda _prepared: pytest.fail("legacy commit must not run"),
+        cooperative_commit=commit_steps,
+        dispatch_to_document_thread=dispatch,
+    )
+    assert dispatcher_entered.wait(1.0)
+    assert manager.cancel(submitted.job_id) is True
+    allow_dispatch.set()
+    cancelled = manager.wait(submitted.job_id, 2.0)
+
+    assert cancelled.phase == "cancelled"
+    assert commits == []
+
+
 def test_surface_or_document_validation_failure_prevents_commit() -> None:
     class SurfaceChanged(RuntimeError):
         def failure(self):

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_state.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_state.py
@@ -503,6 +503,334 @@ def test_document_observer_counts_create_and_delete(monkeypatch) -> None:
     assert store.current_revision("document-a") == 2
 
 
+def test_document_observer_coalesces_authority_selector_refreshes(monkeypatch) -> None:
+    import VibeCADGui as gui
+
+    scheduled = []
+    refreshed = []
+
+    class Service:
+        @staticmethod
+        def note_native_object_property_change(_obj, _property_name):
+            return None
+
+        @staticmethod
+        def native_document_state():
+            return {"native_authority": {"active": True}}
+
+    monkeypatch.setattr(gui, "get_service", lambda: Service())
+    monkeypatch.setattr(gui.App, "isRestoring", lambda: False, raising=False)
+    monkeypatch.setattr(
+        gui,
+        "_queue_zero_delay_callback",
+        lambda callback: scheduled.append(callback),
+    )
+    monkeypatch.setattr(
+        gui,
+        "_refresh_authoring_mode_selector",
+        lambda: refreshed.append(True),
+    )
+    monkeypatch.setattr(gui, "_native_authority_selector_refresh_scheduled", False)
+    obj = SimpleNamespace(
+        Document=SimpleNamespace(Uid="document-a", Restoring=False),
+    )
+    observer = gui._VibeCADDocumentObserver()
+
+    observer.slotChangedObject(obj, "_LinkTouched")
+    observer.slotChangedObject(obj, "_LinkTouched")
+
+    assert len(scheduled) == 1
+    assert refreshed == []
+    scheduled.pop()()
+    assert refreshed == [True]
+
+
+def test_service_coalesces_atomic_document_change_bookkeeping(monkeypatch) -> None:
+    import threading
+
+    from VibeCADCore import VibeCADService
+
+    service = object.__new__(VibeCADService)
+    service._native_document_states = NativeDocumentStateStore()
+    service._document_change_batch_lock = threading.RLock()
+    service._deferred_document_changes = {}
+    invalidations = []
+    metadata_syncs = []
+    monkeypatch.setattr(
+        service,
+        "_invalidate_native_read_contexts",
+        lambda uid: invalidations.append(uid),
+    )
+    monkeypatch.setattr(
+        service,
+        "_sync_native_authority_metadata_if_active",
+        lambda uid: metadata_syncs.append(uid),
+    )
+    document = SimpleNamespace(Uid="document-a")
+    obj = SimpleNamespace(Document=document)
+
+    service.begin_document_change_batch("document-a")
+    for _index in range(100):
+        service.note_native_object_created(obj)
+        service.note_native_object_property_change(obj, "Shape")
+    assert service._native_document_states.current_revision("document-a") == 0
+    service.end_document_change_batch("document-a")
+
+    assert service._native_document_states.current_revision("document-a") == 1
+    assert invalidations == ["document-a"]
+    assert metadata_syncs == ["document-a"]
+
+
+def test_service_document_change_batches_are_nested_and_exception_safe(
+    monkeypatch,
+) -> None:
+    import threading
+
+    from VibeCADCore import VibeCADService
+    from VibeCADDocumentChangeBatch import document_change_batch_active
+
+    service = object.__new__(VibeCADService)
+    service._native_document_states = NativeDocumentStateStore()
+    service._document_change_batch_lock = threading.RLock()
+    service._deferred_document_changes = {}
+    monkeypatch.setattr(service, "_invalidate_native_read_contexts", lambda _uid: None)
+    monkeypatch.setattr(
+        service,
+        "_sync_native_authority_metadata_if_active",
+        lambda _uid: (_ for _ in ()).throw(RuntimeError("metadata failed")),
+    )
+    obj = SimpleNamespace(Document=SimpleNamespace(Uid="document-b"))
+
+    service.begin_document_change_batch("document-b")
+    service.begin_document_change_batch("document-b")
+    service.note_native_object_created(obj)
+    service.end_document_change_batch("document-b")
+    assert document_change_batch_active("document-b") is True
+    assert service._native_document_states.current_revision("document-b") == 0
+
+    with pytest.raises(RuntimeError, match="metadata failed"):
+        service.end_document_change_batch("document-b")
+
+    assert document_change_batch_active("document-b") is False
+    assert service.document_change_batch_active("document-b") is False
+    assert service._native_document_states.current_revision("document-b") == 1
+
+
+def test_service_discards_bookkeeping_for_rolled_back_document_batch(
+    monkeypatch,
+) -> None:
+    import threading
+
+    from VibeCADCore import VibeCADService
+    from VibeCADDocumentChangeBatch import document_change_batch_active
+
+    service = object.__new__(VibeCADService)
+    service._native_document_states = NativeDocumentStateStore()
+    service._document_change_batch_lock = threading.RLock()
+    service._deferred_document_changes = {}
+    invalidations = []
+    metadata_syncs = []
+    monkeypatch.setattr(
+        service,
+        "_invalidate_native_read_contexts",
+        lambda uid: invalidations.append(uid),
+    )
+    monkeypatch.setattr(
+        service,
+        "_sync_native_authority_metadata_if_active",
+        lambda uid: metadata_syncs.append(uid),
+    )
+    obj = SimpleNamespace(Document=SimpleNamespace(Uid="document-c"))
+
+    service.begin_document_change_batch("document-c")
+    service.note_native_object_created(obj)
+    service.note_native_object_property_change(obj, "Shape")
+    service.end_document_change_batch("document-c", commit=False)
+
+    assert document_change_batch_active("document-c") is False
+    assert service.document_change_batch_active("document-c") is False
+    assert service._native_document_states.current_revision("document-c") == 0
+    assert invalidations == []
+    assert metadata_syncs == []
+
+
+def test_document_change_batch_reports_the_outermost_commit_outcome() -> None:
+    from VibeCADDocumentChangeBatch import (
+        begin_document_change_batch,
+        end_document_change_batch,
+        register_document_change_batch_finished,
+    )
+
+    outcomes = []
+    register_document_change_batch_finished(
+        lambda uid, committed: outcomes.append((uid, committed))
+        if uid == "document-outcome"
+        else None
+    )
+
+    begin_document_change_batch("document-outcome")
+    begin_document_change_batch("document-outcome")
+    assert end_document_change_batch("document-outcome", commit=False) is False
+    assert outcomes == []
+    assert end_document_change_batch("document-outcome") is True
+
+    assert outcomes == [("document-outcome", False)]
+
+
+def test_document_observer_batches_dependency_invalidation_and_stale_scans(
+    monkeypatch,
+) -> None:
+    import VibeCADGui as gui
+    import VibeCADVibeScriptDomainPublication as publication
+
+    class Source:
+        Document = SimpleNamespace(Uid="document-batched", Restoring=False)
+
+    source = Source()
+    batch_active = [True]
+    invalidated = []
+    stale_scans = []
+    refreshed = []
+
+    class Service:
+        @staticmethod
+        def note_native_object_property_change(_obj, _property_name):
+            return None
+
+        @staticmethod
+        def invalidate_vibescript_reference_snapshots_many(objects):
+            invalidated.append(tuple(objects))
+
+    monkeypatch.setattr(gui, "get_service", lambda: Service())
+    monkeypatch.setattr(gui.App, "isRestoring", lambda: False, raising=False)
+    monkeypatch.setattr(
+        gui,
+        "document_change_batch_active",
+        lambda uid: batch_active[0] and uid == "document-batched",
+    )
+    monkeypatch.setattr(
+        publication,
+        "mark_programs_stale_from_sources",
+        lambda changes, **_kwargs: stale_scans.append(tuple(changes))
+        or ["DependentOutput"],
+    )
+    monkeypatch.setattr(
+        gui,
+        "_schedule_assistant_document_refresh",
+        lambda: refreshed.append(True),
+    )
+    gui._deferred_vibescript_dependency_changes.clear()
+    observer = gui._VibeCADDocumentObserver()
+
+    for _index in range(100):
+        observer.slotChangedObject(source, "Shape")
+
+    assert invalidated == []
+    assert stale_scans == []
+
+    batch_active[0] = False
+    gui._finish_vibescript_dependency_batch("document-batched", True)
+
+    assert invalidated == [(source,)]
+    assert stale_scans == [((source, "Shape"),)]
+    assert refreshed == [True]
+
+
+def test_document_observer_discards_dependency_work_after_rollback(
+    monkeypatch,
+) -> None:
+    import VibeCADGui as gui
+    import VibeCADVibeScriptDomainPublication as publication
+
+    class Source:
+        Document = SimpleNamespace(Uid="document-rollback", Restoring=False)
+
+    source = Source()
+    invalidated = []
+    stale_scans = []
+
+    class Service:
+        @staticmethod
+        def note_native_object_property_change(_obj, _property_name):
+            return None
+
+        @staticmethod
+        def invalidate_vibescript_reference_snapshots_many(objects):
+            invalidated.append(tuple(objects))
+
+    monkeypatch.setattr(gui, "get_service", lambda: Service())
+    monkeypatch.setattr(gui.App, "isRestoring", lambda: False, raising=False)
+    monkeypatch.setattr(gui, "document_change_batch_active", lambda _uid: True)
+    monkeypatch.setattr(
+        publication,
+        "mark_programs_stale_from_sources",
+        lambda changes, **_kwargs: stale_scans.append(tuple(changes)) or [],
+    )
+    gui._deferred_vibescript_dependency_changes.clear()
+
+    gui._VibeCADDocumentObserver().slotChangedObject(source, "Shape")
+    gui._finish_vibescript_dependency_batch("document-rollback", False)
+
+    assert invalidated == []
+    assert stale_scans == []
+
+
+def test_bulk_stale_propagation_scans_each_document_once(monkeypatch) -> None:
+    import VibeCADVibeScriptDomainPublication as publication
+
+    class Document:
+        Uid = "document-bulk-stale"
+
+        def __init__(self) -> None:
+            self.object_reads = 0
+            self.outputs = []
+
+        @property
+        def Objects(self):
+            self.object_reads += 1
+            return list(self.outputs)
+
+    document = Document()
+    first_source = SimpleNamespace(Name="SourceA", InList=[])
+    second_source = SimpleNamespace(Name="SourceB", InList=[])
+    output = SimpleNamespace(
+        Name="DependentOutput",
+        TypeId="Part::Feature",
+        Document=document,
+        PropertiesList=[
+            publication.PROP_INPUT_OBJECTS,
+            publication.contracts.PROP_PROGRAM_ID,
+            publication.contracts.PROP_PROGRAM_DOMAIN,
+            publication.contracts.PROP_PROGRAM_REVISION,
+            publication.reference_contracts.PROP_DERIVED_STATE,
+        ],
+        VibeCADVibeScriptInputObjects=[first_source, second_source],
+        VibeCADVibeScriptNestedInputObjects=[],
+        VibeCADVibeScriptProgramId="program-a",
+        VibeCADVibeScriptDomain="part",
+        VibeCADVibeScriptRevision="revision-a",
+        VibeCADVibeScriptDerivedState="accepted",
+    )
+    first_source.InList = [output]
+    second_source.InList = [output]
+    document.outputs = [output]
+    marked = []
+    monkeypatch.setattr(
+        publication.reference_contracts,
+        "mark_stale",
+        lambda obj, revision, reason: marked.append((obj, revision, reason)),
+    )
+
+    result = publication.mark_programs_stale_from_sources(
+        ((first_source, "Shape"), (second_source, "Placement"))
+    )
+
+    assert result == ["DependentOutput"]
+    assert document.object_reads == 1
+    assert len(marked) == 1
+    assert marked[0][0] is output
+
+
 def test_state_module_has_no_ui_activation_or_tool_execution_api() -> None:
     public_names = {name for name in vars(state_module) if not name.startswith("_")}
     forbidden = ("activate", "switch", "run_command", "execute")

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py
@@ -1,0 +1,368 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Unit contracts for responsive, observable VibeScript publication."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from VibeCADPublicationProgress import PublicationProgress
+
+
+def test_publication_progress_reports_items_and_bounds_ui_yields() -> None:
+    events = []
+    yields = []
+    clock_values = iter((0.0, 0.01, 0.06, 0.07, 0.08, 0.13, 0.14))
+    progress = PublicationProgress(
+        domain="assembly",
+        total=3,
+        callback=events.append,
+        event_yield=lambda: yields.append(True),
+        clock=lambda: next(clock_values),
+        yield_interval_seconds=0.05,
+    )
+
+    progress.start()
+    progress.checkpoint(0, name="Model", output_type="assembly")
+    progress.checkpoint(1, name="Part001", output_type="component_link")
+    progress.checkpoint(2, name="Joint001", output_type="joint")
+    progress.finish()
+
+    assert [event["completed"] for event in events] == [0, 1, 2, 3]
+    assert all(event["total"] == 3 for event in events)
+    assert events[2]["current_output"] == "Joint001"
+    assert events[2]["output_type"] == "joint"
+    assert events[-1]["phase"] == "completed"
+    assert len(yields) == 2
+
+
+def test_publication_throttle_measures_from_completed_event_yield() -> None:
+    now = [0.0]
+    yields = []
+
+    def event_yield() -> None:
+        yields.append(now[0])
+        now[0] += 0.20
+
+    progress = PublicationProgress(
+        domain="assembly",
+        total=2,
+        event_yield=event_yield,
+        clock=lambda: now[0],
+        yield_interval_seconds=0.05,
+    )
+
+    progress.start()
+    now[0] = 0.06
+    progress.checkpoint(1, name="Part001", output_type="component_link")
+    now[0] = 0.27
+    progress.checkpoint(2, name="Part002", output_type="component_link")
+
+    assert yields == [0.06]
+
+
+def test_publication_releases_document_batch_when_progress_reporting_fails() -> None:
+    from VibeCADVibeScriptDomainPublication import publish_candidate
+
+    calls = []
+
+    class Service:
+        @staticmethod
+        def begin_document_change_batch(uid, **_kwargs):
+            calls.append(("begin", uid))
+
+        @staticmethod
+        def end_document_change_batch(uid, *, commit=True):
+            calls.append(("end", uid, commit))
+
+    def reject_progress(_event):
+        raise RuntimeError("progress failed")
+
+    with pytest.raises(RuntimeError, match="progress failed"):
+        publish_candidate(
+            Service(),
+            {
+                "document_uid": "document-a",
+                "pack": SimpleNamespace(domain="assembly"),
+            },
+            {"outputs": [], "assembly_members": []},
+            progress_callback=reject_progress,
+        )
+
+    assert calls == [("begin", "document-a"), ("end", "document-a", False)]
+
+
+@pytest.mark.parametrize("fails", [False, True])
+def test_publication_holds_document_cooperative_mutation_for_its_full_lifetime(
+    monkeypatch,
+    fails: bool,
+) -> None:
+    import VibeCADVibeScriptDomainPublication as publication
+
+    calls = []
+
+    class Document:
+        @staticmethod
+        def beginCooperativeMutation():
+            calls.append("mutation-begin")
+
+        @staticmethod
+        def endCooperativeMutation():
+            calls.append("mutation-end")
+
+    class Service:
+        @staticmethod
+        def _active_document():
+            return Document()
+
+        @staticmethod
+        def begin_document_change_batch(uid, **_kwargs):
+            calls.append(("batch-begin", uid))
+
+        @staticmethod
+        def end_document_change_batch(uid, *, commit=True):
+            calls.append(("batch-end", uid, commit))
+
+    def publication_steps(*_args, **_kwargs):
+        calls.append("publication-start")
+        yield {"event": "publication-slice"}
+        if fails:
+            raise RuntimeError("publication failed")
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        publication,
+        "_iter_publish_candidate_unbatched",
+        publication_steps,
+    )
+    inputs = (
+        Service(),
+        {
+            "document_uid": "document-a",
+            "pack": SimpleNamespace(domain="assembly"),
+        },
+        {"outputs": [], "assembly_members": []},
+    )
+
+    if fails:
+        with pytest.raises(RuntimeError, match="publication failed"):
+            publication.publish_candidate(*inputs)
+    else:
+        assert publication.publish_candidate(*inputs) == {"ok": True}
+
+    assert calls == [
+        "mutation-begin",
+        ("batch-begin", "document-a"),
+        "publication-start",
+        ("batch-end", "document-a", not fails),
+        "mutation-end",
+    ]
+
+
+def test_publication_releases_cooperative_mutation_when_batch_setup_fails() -> None:
+    from VibeCADVibeScriptDomainPublication import publish_candidate
+
+    calls = []
+
+    class Document:
+        @staticmethod
+        def beginCooperativeMutation():
+            calls.append("mutation-begin")
+
+        @staticmethod
+        def endCooperativeMutation():
+            calls.append("mutation-end")
+
+    class Service:
+        @staticmethod
+        def _active_document():
+            return Document()
+
+        @staticmethod
+        def begin_document_change_batch(_uid, **_kwargs):
+            calls.append("batch-begin")
+            raise RuntimeError("batch setup failed")
+
+        @staticmethod
+        def end_document_change_batch(_uid, *, commit=True):
+            calls.append(("batch-end", commit))
+
+    with pytest.raises(RuntimeError, match="batch setup failed"):
+        publish_candidate(
+            Service(),
+            {
+                "document_uid": "document-a",
+                "pack": SimpleNamespace(domain="assembly"),
+            },
+            {"outputs": [], "assembly_members": []},
+        )
+
+    assert calls == ["mutation-begin", "batch-begin", "mutation-end"]
+
+
+def test_domain_adapter_cooperatively_dispatches_each_publication_step(
+    monkeypatch,
+) -> None:
+    import VibeCADVibeScriptDomainRuntime as runtime
+
+    dispatches = []
+    events = []
+
+    def publication_steps(*_args, **_kwargs):
+        yield {"event": "publication_slice", "completed": 1, "total": 2}
+        yield {"event": "publication_slice", "completed": 2, "total": 2}
+        return {"ok": True, "outputs": ["Model"]}
+
+    monkeypatch.setattr(runtime, "iter_publish_candidate", publication_steps)
+    adapter = runtime.DeclarativeDomainAdapter(
+        SimpleNamespace(domain="assembly", workbench="Assembly")
+    )
+
+    result = adapter.publish_cooperatively(
+        object(),
+        {},
+        {},
+        document_thread_dispatch=lambda operation: (dispatches.append(operation), operation())[1],
+        cancellation_check=lambda: False,
+        progress_callback=events.append,
+    )
+
+    assert result == {"ok": True, "outputs": ["Model"]}
+    assert len(dispatches) == 3
+    assert [event["completed"] for event in events] == [1, 2]
+
+
+def test_large_assembly_publication_dispatches_all_307_members(
+    monkeypatch,
+) -> None:
+    import VibeCADVibeScriptDomainPublication as publication
+    import VibeCADVibeScriptDomainRuntime as runtime
+
+    dispatches = 0
+    progress_events = []
+    document = SimpleNamespace(
+        beginCooperativeMutation=lambda: None,
+        endCooperativeMutation=lambda: None,
+    )
+
+    class Service:
+        @staticmethod
+        def _active_document():
+            return document
+
+        @staticmethod
+        def begin_document_change_batch(_uid, **_kwargs):
+            return None
+
+        @staticmethod
+        def end_document_change_batch(_uid, *, commit=True):
+            return commit
+
+    public_outputs = [
+        {"name": "Model", "type": "assembly"},
+        {"name": "Diagnostics", "type": "solver_diagnostics"},
+    ]
+    assembly_members = [
+        {"name": f"Member{index:03d}", "type": "component_link"} for index in range(307)
+    ]
+
+    def publication_steps(
+        _service,
+        _prepared,
+        validated,
+        *,
+        publication_progress,
+    ):
+        items = [
+            *list(validated["outputs"]),
+            *list(validated["assembly_members"]),
+        ]
+        for index, item in enumerate(items, start=1):
+            publication_progress.checkpoint(
+                index,
+                name=item["name"],
+                output_type=item["type"],
+            )
+            yield {"phase": "publication_item"}
+        return {"ok": True, "published": len(items)}
+
+    monkeypatch.setattr(
+        publication,
+        "_iter_publish_candidate_unbatched",
+        publication_steps,
+    )
+    # Runtime imports the generator function directly, so bind the patched
+    # production wrapper rather than replacing its lifecycle behavior.
+    monkeypatch.setattr(
+        runtime,
+        "iter_publish_candidate",
+        publication.iter_publish_candidate,
+    )
+    adapter = runtime.DeclarativeDomainAdapter(
+        SimpleNamespace(domain="assembly", workbench="Assembly")
+    )
+
+    def dispatch(operation):
+        nonlocal dispatches
+        dispatches += 1
+        return operation()
+
+    result = adapter.publish_cooperatively(
+        Service(),
+        {
+            "document_uid": "large-assembly",
+            "program_id": "program-a",
+            "pack": SimpleNamespace(domain="assembly"),
+        },
+        {
+            "outputs": public_outputs,
+            "assembly_members": assembly_members,
+        },
+        document_thread_dispatch=dispatch,
+        cancellation_check=lambda: False,
+        progress_callback=progress_events.append,
+    )
+
+    assert result == {"ok": True, "published": 309}
+    assert dispatches == 310
+    publication_events = [
+        event
+        for event in progress_events
+        if event.get("event") == "vibescript_domain_publication_progress"
+    ]
+    assert publication_events[-1]["phase"] == "completed"
+    assert publication_events[-1]["completed"] == 309
+    assert all(event["total"] == 309 for event in publication_events)
+
+
+def test_publication_slice_validation_rejects_replaced_targets() -> None:
+    from VibeCADVibeScriptDomainPublication import (
+        _assert_publication_document_intact,
+    )
+
+    original = SimpleNamespace(Name="Member001")
+    replacement = SimpleNamespace(Name="Member001")
+
+    class Document:
+        Name = "AssemblyDocument"
+        Uid = "document-a"
+
+        @staticmethod
+        def getObject(name):
+            return replacement if name == "Member001" else None
+
+    document = Document()
+    service = SimpleNamespace(_active_document=lambda: document)
+
+    with pytest.raises(RuntimeError, match="changed between publication slices"):
+        _assert_publication_document_intact(
+            service,
+            {
+                "document_name": document.Name,
+                "document_uid": document.Uid,
+            },
+            document,
+            (original,),
+        )

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -7,6 +7,7 @@ add_subdirectory(propertyeditor)
 add_executable(Gui_tests_run
         Assistant.cpp
         Camera.cpp
+        DocumentProjection.cpp
         ExactTransaction.cpp
         FileDialog.cpp
         StyleParameters/StyleParametersApplicationTest.cpp
@@ -26,7 +27,6 @@ setup_qt_test(MacroTaskAcceptance)
 setup_qt_test(QuantitySpinBox)
 
 target_link_libraries(Gui_tests_run PRIVATE
-    GTest::gtest_main
     GTest::gmock_main
     FreeCADApp
     FreeCADGui

--- a/tests/src/Gui/DocumentProjection.cpp
+++ b/tests/src/Gui/DocumentProjection.cpp
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <gtest/gtest.h>
+
+#include "App/Application.h"
+#include "App/Document.h"
+#include "Gui/Document.h"
+#include <src/App/InitApplication.h>
+
+class DocumentProjectionTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
+    void SetUp() override
+    {
+        _documentName = App::GetApplication().getUniqueDocumentName("projection_refresh");
+        _document = App::GetApplication().newDocument(_documentName.c_str(), "testUser");
+    }
+
+    void TearDown() override
+    {
+        if (_document && App::GetApplication().getDocument(_documentName.c_str())) {
+            App::GetApplication().closeDocument(_documentName.c_str());
+        }
+    }
+
+    std::string _documentName;
+    App::Document* _document {};
+};
+
+TEST_F(DocumentProjectionTest, NormalTransactionKeepsIncrementalProjectionLive)
+{
+    ASSERT_NE(_document, nullptr);
+    EXPECT_FALSE(Gui::Document::projectionRefreshBlocked(_document));
+    EXPECT_FALSE(Gui::Document::historyMutationBlocked(_document));
+
+    _document->openTransaction("test projection batching");
+    EXPECT_FALSE(Gui::Document::projectionRefreshBlocked(_document));
+    EXPECT_TRUE(Gui::Document::historyMutationBlocked(_document));
+
+    _document->commitTransaction();
+    EXPECT_FALSE(Gui::Document::projectionRefreshBlocked(_document));
+    EXPECT_FALSE(Gui::Document::historyMutationBlocked(_document));
+}
+
+TEST_F(DocumentProjectionTest, NormalEditLockKeepsIncrementalProjectionLive)
+{
+    ASSERT_NE(_document, nullptr);
+    _document->lockTransaction();
+    EXPECT_FALSE(Gui::Document::projectionRefreshBlocked(_document));
+    EXPECT_TRUE(Gui::Document::historyMutationBlocked(_document));
+
+    _document->unlockTransaction();
+    EXPECT_FALSE(Gui::Document::projectionRefreshBlocked(_document));
+    EXPECT_FALSE(Gui::Document::historyMutationBlocked(_document));
+}
+
+TEST_F(DocumentProjectionTest, CooperativeMutationDefersProjectionUntilOutermostEnd)
+{
+    ASSERT_NE(_document, nullptr);
+    int transitions = 0;
+    bool lastActive = false;
+    auto connection = _document->signalCooperativeMutationChanged.connect(
+        [&transitions, &lastActive](const App::Document&, bool active) {
+            ++transitions;
+            lastActive = active;
+        }
+    );
+
+    _document->beginCooperativeMutation();
+    _document->beginCooperativeMutation();
+    EXPECT_TRUE(_document->isCooperativeMutationActive());
+    EXPECT_TRUE(Gui::Document::projectionRefreshBlocked(_document));
+    EXPECT_TRUE(Gui::Document::historyMutationBlocked(_document));
+    EXPECT_FALSE(_document->isClosable());
+    EXPECT_EQ(transitions, 1);
+    EXPECT_TRUE(lastActive);
+
+    _document->endCooperativeMutation();
+    EXPECT_TRUE(_document->isCooperativeMutationActive());
+    EXPECT_EQ(transitions, 1);
+
+    _document->endCooperativeMutation();
+    EXPECT_FALSE(_document->isCooperativeMutationActive());
+    EXPECT_FALSE(Gui::Document::projectionRefreshBlocked(_document));
+    EXPECT_TRUE(_document->isClosable());
+    EXPECT_EQ(transitions, 2);
+    EXPECT_FALSE(lastActive);
+}
+
+TEST_F(DocumentProjectionTest, CooperativeMutationRefusesDocumentClose)
+{
+    ASSERT_NE(_document, nullptr);
+    _document->beginCooperativeMutation();
+
+    EXPECT_FALSE(App::GetApplication().closeDocument(_documentName.c_str()));
+    EXPECT_EQ(App::GetApplication().getDocument(_documentName.c_str()), _document);
+
+    _document->endCooperativeMutation();
+}
+
+TEST_F(DocumentProjectionTest, CooperativeMutationRefusesUndoUntilPublicationEnds)
+{
+    ASSERT_NE(_document, nullptr);
+    _document->setUndoMode(1);
+    _document->openTransaction("create protected object");
+    auto* protectedObject = _document->addObject("App::FeaturePython", "ProtectedObject");
+    ASSERT_NE(protectedObject, nullptr);
+    _document->commitTransaction();
+    ASSERT_GT(_document->getAvailableUndos(), 0);
+
+    _document->beginCooperativeMutation();
+    EXPECT_FALSE(_document->undo());
+    EXPECT_EQ(_document->getObject("ProtectedObject"), protectedObject);
+    EXPECT_GT(_document->getAvailableUndos(), 0);
+
+    _document->endCooperativeMutation();
+    EXPECT_TRUE(_document->undo());
+    EXPECT_EQ(_document->getObject("ProtectedObject"), nullptr);
+}


### PR DESCRIPTION
## User-visible outcome

Large VibeScript publication no longer runs as one monolithic FreeCAD/Qt callback. The captured 307-member Assembly is published one member per bounded document-thread dispatch, with progress and cancellation between slices, while Tree/Timeline and VibeCAD observer work are coalesced once for the logical operation.

Closes #167

## Why

The old path held the GUI thread through publication and triggered redundant whole-document projection and observer work for per-object notifications. Merely yielding inside the existing transaction was unsafe because Undo, Redo, Recompute, document close, or another command could alter the document between slices.

This change adds an explicit nested cooperative-mutation state to `App::Document`, separates bulk-projection blocking from ordinary edit/history guards, and makes the publication transaction both cooperative and atomic.

## What changed

- Added a shared cooperative document-thread step runner with cancellation, item-level progress, slice telemetry, and document-thread generator teardown.
- Added additive generator-based VibeScript publication while preserving the existing synchronous publication entry point.
- Added nested document-change batching with commit/rollback outcomes.
- Coalesced selector refresh, reference-snapshot invalidation, dependency-staleness scans, recompute, redraw, Tree refresh, and Feature Timeline refresh.
- Added `App::Document` cooperative-mutation state and Python bindings.
- Disabled/refused Undo, Redo, Recompute, and document close while cooperative publication is active; restored them on the outermost end.
- Kept ordinary Part Design/task-panel transactions incrementally visible by separating the narrow projection predicate from the wider history-mutation predicate.
- Added exact target/document revalidation between publication slices.
- Merged all 307 Assembly members into publication progress rather than treating the Assembly container as one opaque item.
- Fixed cancellation/error teardown so a suspended publication generator is finalized on the document thread, never the worker thread.

## Red/green development

RED cases were added before implementation for:

- cooperative cancellation between document-thread slices;
- generator finalization on the document thread after worker-side progress failure;
- rollback discarding batched observer work;
- normal open transaction/edit lock preserving incremental Tree projection;
- nested cooperative mutation deferring one authoritative projection refresh;
- close/Undo refusal during cooperative publication;
- 307-member Assembly item-level publication and dispatch count.

Observed RED for the teardown regression:

```text
assert finalized == [True]
E assert [False] == [True]
```

GREEN verification:

```text
C:\Users\robit\vibecad\.pixi\envs\default\python.exe -m pytest src\Mod\VibeCAD\vibecad_tests -q
4380 passed, 9 skipped in 84.80s
```

```text
ctest --test-dir build -C Release -R ^Gui_tests_run$ --output-on-failure
138/138 tests passed
```

Focused cooperative/publication suite:

```text
C:\Users\robit\vibecad\.pixi\envs\default\python.exe -m pytest src\Mod\VibeCAD\vibecad_tests\test_cooperative_document_execution.py src\Mod\VibeCAD\vibecad_tests\test_vibescript_publication_progress.py -q
13 passed
```

Full Windows build through the repository's normal Rattler/Pixi path:

```text
cd package\rattler-build
C:\Users\robit\.pixi\bin\pixi.exe reinstall --frozen -e default vibecad
```

Result: exit 0; `vibecad-26.3.1RC6-h3c70cbc_1.conda` produced; default environment reinstalled.

Packaged runtime smoke:

```text
VibeCAD 26.3.1-RC6 (Build 1)
COOP_METHODS True True
COOP_INITIAL False
COOP_ACTIVE True
COOP_ENDED False
```

The packaged Windows GUI is currently running in normal (non-safe) mode for owner acceptance testing.

## Risk and mitigation

The principal risk is changing document transaction/projection behavior. The implementation uses a new explicit cooperative state only for bulk cooperative mutation; existing normal transactions and edit locks retain incremental Tree behavior. Native tests cover nesting, normal edit compatibility, close refusal, and Undo refusal/recovery. Exact live document/object validation protects every inter-slice continuation.

## Deliberate non-goals

- No public tool/schema/preference names changed.
- No provider or capability was removed.
- No unrelated UI or packaging behavior was refactored.
- This PR establishes the shared cooperative mechanism and applies it to the reproduced VibeScript publication path; remaining long-running Native capabilities can adopt the additive `cooperative_commit` adapter independently.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults preserve previous behavior for callers that do not use cooperative publication.
- [x] Existing synchronous publication is retained through an additive adapter.
- [x] No breaking changes are included.