### PR TITLE
Establish performance proof and coalesce tree visibility updates

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,397 @@
+# VibeCAD Performance Program
+
+Status: ACTIVE  
+Owner: VibeCAD engineering  
+Last updated: 2026-09-04  
+Tracking issue: [#167](https://github.com/10-X-eng/vibecad/issues/167)  
+Foundation PR: [#168](https://github.com/10-X-eng/vibecad/pull/168)
+
+## Mission
+
+VibeCAD must remain responsive while opening, inspecting, modifying, analyzing,
+solving, publishing, rendering, importing, exporting, or saving complicated CAD
+documents. Upstream synchronous behavior is not an acceptable product constraint.
+If a FreeCAD or third-party operation cannot safely run concurrently in the UI
+process, VibeCAD must isolate it in a worker process, stream its progress, and
+apply its result without starving the interface.
+
+This document is the authoritative plan and completion ledger for that work. A
+performance item is not complete because the code looks asynchronous or because
+one manual test felt faster. It is complete only when the required measurements,
+correctness tests, stress tests, and packaged-build acceptance evidence are
+recorded here.
+
+## Non-negotiable outcomes
+
+1. The GUI event loop never performs unbounded computation, filesystem I/O,
+   network I/O, process waits, or repeated whole-document traversal.
+2. Every operation that can take noticeable time returns control to the GUI,
+   displays a truthful phase and progress state, and supports cancellation at a
+   safe checkpoint.
+3. Expensive results are cached by the exact inputs and document revision that
+   produced them. Expensive work is not repeated without a relevant change.
+4. Independent, thread-safe computation uses up to approximately 75% of the
+   machine's logical CPUs by default, leaving capacity for the UI and operating
+   system.
+5. Live FreeCAD and Qt objects are never accessed from an unsafe thread. Work that
+   cannot satisfy this rule runs in an isolated process and returns immutable
+   data.
+6. Performance improvements preserve document correctness, undo/redo behavior,
+   saved-file compatibility, public APIs, tool schemas, and existing defaults.
+7. No optimization is accepted without a failing regression test or benchmark
+   first and a measured before/after result afterward.
+
+## Responsiveness contract
+
+These are engineering gates, not aspirational observations.
+
+| Signal | Target | Failure threshold |
+|---|---:|---:|
+| Direct UI event handler, p95 | <= 8 ms | > 16 ms |
+| One GUI-thread apply unit, target | <= 1 ms | > 16 ms without an explicit measured exception |
+| GUI heartbeat gap during background work, p99 | <= 50 ms | > 100 ms |
+| Visible acknowledgement of a command | <= 50 ms | > 100 ms |
+| First truthful progress state | <= 100 ms | > 250 ms |
+| Progress heartbeat while active | <= 1 s | > 2 s without a declared uninterruptible phase |
+| Cancellation acknowledgement | <= 100 ms | > 250 ms |
+| Cancellation checkpoint | <= 1 s | > 2 s except a documented external atomic call |
+| Synchronous disk/network/process wait on GUI thread | 0 | Any occurrence |
+| Redundant full-document scans per logical operation | 0 | Any occurrence |
+
+An unavoidable third-party atomic call longer than 16 ms must be named in the
+trace, have progress painted before entry, and have a plan for isolation or
+replacement. Merely recording that a slice exceeded its budget does not satisfy
+this contract.
+
+## Correct execution architecture
+
+### UI process
+
+The UI process owns Qt widgets, the Coin scene graph, live `App::Document`
+presentation, selection, and lightweight command orchestration. It may apply
+small, measured document changes, but it must not construct or validate complex
+geometry, wait on workers, tessellate hundreds of solids serially, or rebuild the
+same projection once per object.
+
+### Persistent runtime
+
+VibeCAD will initialize a host-owned runtime during application startup:
+
+- an I/O pool for filesystem, network, subprocess communication, and downloads;
+- a native CPU pool for explicitly thread-safe C++ and OpenCASCADE algorithms;
+- persistent isolated processes for Python CPU work and unsafe FreeCAD work;
+- a single-writer document actor/queue for each open document;
+- a bounded GUI apply queue for thread-affine document and presentation changes;
+- one progress, cancellation, diagnostics, and back-pressure contract shared by
+  human commands and AI tools.
+
+The default CPU concurrency is `max(1, floor(logical_cpu_count * 0.75))` for
+parallelizable CPU work. The runtime must cap queued work, avoid oversubscription
+with libraries that already parallelize internally, and lower worker priority
+when necessary to preserve input and rendering latency.
+
+### Data boundaries
+
+- Workers receive immutable snapshots, authenticated artifact paths, revisions,
+  and explicit settings.
+- Workers return immutable geometry, render meshes, metadata, diagnostics, and a
+  deterministic publication plan.
+- No `DocumentObject`, `ViewObject`, Qt object, Coin node, or borrowed OpenCASCADE
+  pointer crosses a worker boundary.
+- Each result carries its source document UID, revision, input fingerprints, and
+  settings fingerprint. Stale results are rejected before apply.
+- Modeling BREP remains authoritative. A worker-generated display mesh is a
+  cacheable presentation artifact and never replaces modeling geometry.
+
+### GUI apply
+
+- A document-scoped mutation lease prevents conflicting undo, redo, close,
+  recompute, refresh, or mutation while an apply operation is active.
+- Apply work is divided into independently measured units.
+- Cheap units may be adaptively batched until the current frame-time budget is
+  reached. The scheduler returns to the event loop before the next batch.
+- A single slow unit cannot be repaired by batching. Its expensive preparation
+  must move to a worker or be subdivided below the thread-affine boundary.
+- Observers, Tree updates, Timeline updates, cache invalidations, and visibility
+  changes are coalesced once per logical operation.
+- Terminal success or failure is emitted only after commit or rollback and all
+  required stabilization work has completed.
+
+## Measurement and proof infrastructure
+
+### Cross-language trace
+
+Add one low-overhead trace format shared by C++ and Python. Each span records:
+
+- operation and phase name;
+- document UID and revision, without document contents;
+- thread and process identity;
+- start time, duration, item count, and byte count where relevant;
+- GUI-thread classification;
+- cache hit/miss;
+- cancellation and outcome;
+- parent operation ID.
+
+Development builds write bounded Chrome Trace Event JSON so Windows Performance
+Analyzer, Perfetto, or Chromium tracing can show C++, Python, process, and GUI
+events on one timeline. Release builds keep only aggregate counters and slow-span
+diagnostics unless detailed tracing is explicitly enabled.
+
+### GUI watchdog
+
+Add a Qt event-loop watchdog that records heartbeat gaps without calling
+`processEvents()` re-entrantly. Test mode fails the benchmark when the applicable
+threshold is crossed. Diagnostics name the active operation and most recent GUI
+span so a freeze is never reported only as "not responding."
+
+### Required native spans
+
+- `Document::recompute` and async recompute handoff
+- document transaction open, commit, abort, undo, and redo
+- document object creation/removal and property application
+- `ViewProviderPartExt::updateVisual`
+- BREP tessellation and Coin geometry construction
+- Tree visibility mutation and folder-status traversal
+- Tree stable refresh and model rebuild
+- Feature Timeline scheduling and rebuild
+- selection updates and 3D-view fit/redraw
+- file open, restore, save, and autosave
+
+### Required VibeCAD spans
+
+- provider request/stream/tool dispatch
+- context capture and cache lookup
+- Analyze and Drawing source discovery
+- VibeScript worker startup, import, execution, validation, and artifact I/O
+- VibeScript publication per output/member and final stabilization
+- Assembly joint construction, solve, collision sweep, and publication
+- FEM/CFD mesh generation, deck preparation, solver, parsing, and presentation
+- Drawing generation, redraw, screenshot, and publication
+- manufacturing, slicer discovery, slicing, post-processing, and preview
+- import/export and McMaster catalog/browser operations
+
+### Benchmark evidence
+
+Each benchmark produces a small summary containing:
+
+- commit and build identity;
+- hardware and operating-system summary;
+- fixture identity and size;
+- cold and warm results;
+- wall time, CPU time, peak memory, GUI heartbeat percentiles, longest GUI span,
+  cache behavior, and cancellation latency;
+- correctness result and output fingerprint.
+
+Do not commit customer documents or machine-specific paths. Add deterministic
+synthetic fixtures for CI and use a separately configured local private benchmark
+set for representative large documents.
+
+## Benchmark matrix
+
+| ID | Scenario | Required scale | Primary proof |
+|---|---|---:|---|
+| B01 | Cold application launch | packaged build | first usable input, heartbeat, memory |
+| B02 | Open and restore document | 2,000+ objects | GUI gaps, restore spans, visual readiness |
+| B03 | Save and autosave | 2,000+ objects | GUI gaps, bytes, atomic-save behavior |
+| B04 | Workbench/ribbon switch | every VibeCAD surface | activation p95 and maximum |
+| B05 | Tree expand/filter/selection | 2,000+ objects | handler time and traversal count |
+| B06 | Bulk visibility | 150+ joints and 2,000+ mixed objects | one refresh/invalidation cycle |
+| B07 | VibeScript publication | 300+ solids/members | per-item cost, tessellation, final tail |
+| B08 | Assembly construction | 150+ joints | CPU utilization, progress, cancellation |
+| B09 | Assembly drag/edit | 150+ joints | no visibility storm, interactive latency |
+| B10 | Motion/collision sweep | 150+ joints, 100+ frames | parallel efficiency and progress ETA |
+| B11 | Analyze context capture | 2,000+ objects, mostly hidden | hidden-object pruning and cache reuse |
+| B12 | FEM mesh/deck/solve | 100k+ nodes | background execution and stage progress |
+| B13 | CFD preparation/solve | representative multi-body model | background execution and cancellation |
+| B14 | Drawing source discovery | 2,000+ objects, mostly hidden | pruning, cache reuse, heartbeat |
+| B15 | Drawing generation/redraw | multi-page drawing | background preparation and UI apply |
+| B16 | Screenshot/render export | multiple pages/views | no GUI wait and exact requested output |
+| B17 | Sketch edit/recompute | constrained production sketch | interaction and dependent update latency |
+| B18 | Part/PartDesign operations | complex bodies/history | worker/recompute use and GUI gaps |
+| B19 | Mesh operations | large STL/mesh | CPU scaling, memory, cancellation |
+| B20 | Import | STEP, STL, and Fusion archives | deduplication, progress, visual readiness |
+| B21 | Export | STEP, STL, drawing, and manufacturing outputs | no GUI I/O wait |
+| B22 | Manufacturing/3D printing | production mesh and slicer | no console, background work, progress |
+| B23 | McMaster catalog/browser | cold and authenticated warm session | launch/search/import latency |
+| B24 | Assistant conversation | long conversation plus CAD tools | stream latency and responsive controls |
+| B25 | Preferences/start/update UI | cold and warm | interaction latency and no blocking I/O |
+| B26 | Cancel/close/undo stress | every long-running class | integrity, no deadlock, bounded response |
+| B27 | Multi-document load | three active documents/jobs | fairness, memory, document isolation |
+
+## Work plan and ledger
+
+Status values are `DONE`, `IN PROGRESS`, `NOT STARTED`, `BLOCKED`, and
+`REVALIDATE`. `DONE` requires linked evidence in the final column.
+
+| ID | Work item | Status | Completion evidence |
+|---|---|---|---|
+| P00 | Establish cooperative mutation lease and block conflicting document mutations | DONE | PR #168; native GUI tests 138/138 |
+| P01 | Yield VibeScript publication between output/member apply steps | DONE | PR #168; Python suite 4,380 passed, 9 skipped; large Assembly became interactively usable |
+| P02 | Add publication phase/item progress | DONE | PR #168; direct VibeScript progress callback tests |
+| P03 | Instrument cross-language spans and GUI watchdog | NOT STARTED | Required before optimization claims |
+| P04 | Capture cold/warm baseline for B02, B06, B07, B09, and B24 | NOT STARTED | Trace and benchmark summaries |
+| P05 | Remove Assembly drag/bulk-visibility refresh storm | NOT STARTED | Red test, traversal count of one, B06/B09 pass |
+| P06 | Measure BREP assignment, tessellation, and Coin construction independently | NOT STARTED | Native trace identifies per-solid costs |
+| P07 | Pre-tessellate eligible solids in isolated workers and cache render meshes | NOT STARTED | Same visual/correct BREP output; B07 comparison |
+| P08 | Drive ordinary per-object GUI apply cost toward <= 1 ms | NOT STARTED | B07 per-item distribution and longest span |
+| P09 | Add adaptive batching for proven-cheap apply units | NOT STARTED | Higher throughput without heartbeat regression |
+| P10 | Bound publication commit/rollback/final-stabilization phases | NOT STARTED | No unnamed GUI span > 16 ms in B07/B26 |
+| P11 | Coalesce Tree, Timeline, cache, and observer notifications | NOT STARTED | One logical refresh per operation |
+| P12 | Eliminate full-object stable refresh when exact changed identities exist | NOT STARTED | B05/B07 traversal and allocation evidence |
+| P13 | Measure and optimize Tree projection and Feature Timeline rebuild | NOT STARTED | B05 and B07 final-tail evidence |
+| P14 | Implement persistent startup worker runtime and bounded queues | NOT STARTED | Startup, reuse, fairness, shutdown, and crash tests |
+| P15 | Implement per-document actor ownership and revision-safe result application | NOT STARTED | B26/B27 stress evidence |
+| P16 | Standardize human/AI progress, cancellation, and diagnostics contract | REVALIDATE | VibeScript direct progress exists; audit every other long operation |
+| P17 | Audit and eliminate synchronous filesystem/network/process waits in UI callbacks | NOT STARTED | Static audit plus runtime trace shows zero occurrences |
+| P18 | Validate and optimize application startup and document restore | NOT STARTED | B01/B02 cold/warm evidence |
+| P19 | Validate and optimize Analyze/FEM/CFD workflows | NOT STARTED | B11-B13 evidence |
+| P20 | Validate and optimize Drawing/TechDraw workflows | NOT STARTED | B14-B16 evidence |
+| P21 | Validate and optimize Assembly edit, solve, motion, and collision workflows | NOT STARTED | B08-B10 evidence |
+| P22 | Validate and optimize Sketcher, Part, PartDesign, Mesh, and import/export | NOT STARTED | B17-B21 evidence |
+| P23 | Validate and optimize manufacturing, 3D printing, and external tools | NOT STARTED | B22 evidence |
+| P24 | Validate and optimize McMaster and embedded browser behavior | NOT STARTED | B23 evidence |
+| P25 | Validate and optimize assistant, conversation, context, and persistence UI | NOT STARTED | B24 evidence |
+| P26 | Validate preferences, start page, updates, ribbon, and workbench switching | NOT STARTED | B04/B25 evidence |
+| P27 | Run multi-document, cancellation, rollback, autosave, undo, close, and shutdown stress | NOT STARTED | B26/B27 evidence with no corruption/deadlock |
+| P28 | Run full unit/integration/native suites and actual Windows portable packaging | NOT STARTED | Exact commands and results recorded below |
+| P29 | Run packaged interactive acceptance across the entire benchmark matrix | NOT STARTED | Signed-off result for B01-B27 |
+
+## Immediate implementation sequence
+
+### Phase 1: measurement foundation
+
+1. Add failing tests for the GUI watchdog and nested performance spans.
+2. Add C++ RAII and Python context-manager spans with the same trace schema.
+3. Instrument the confirmed publication, tessellation, Tree, Timeline, and bulk
+   visibility paths.
+4. Capture cold and warm baselines before changing those paths.
+5. Record the results in this document.
+
+### Phase 2: confirmed event storms
+
+1. Add a failing test proving bulk visibility currently triggers repeated folder
+   refreshes.
+2. Add an additive batch/coalescing scope used by Assembly drag and general bulk
+   visibility commands.
+3. Emit one browser refresh, one cache invalidation, and one selection update at
+   the end of the logical command.
+4. Verify rollback and single-object behavior remain compatible.
+5. Re-run B05, B06, and B09 and record the before/after result.
+
+### Phase 3: rendering and tessellation
+
+1. Separate timings for BREP load, `Shape` assignment, view-provider attachment,
+   OpenCASCADE tessellation, and Coin node construction.
+2. If tessellation dominates, prototype worker-side meshing with the exact active
+   deviation/angular-deflection settings.
+3. Determine the safest transport after measurement: BREP with retained
+   triangulation or a companion indexed render mesh keyed by shape/settings
+   fingerprints.
+4. Preserve authoritative BREP, face/edge selection mapping, colors, normals,
+   transparency, and saved-document behavior.
+5. Prove that cached worker output prevents host re-tessellation and produces the
+   same visible and selectable model.
+6. Re-run B02 and B07 cold and warm.
+
+### Phase 4: publication and projections
+
+1. Reduce each GUI apply unit below the responsiveness contract.
+2. Add adaptive batching only after individual unit cost is bounded.
+3. Carry exact changed-object identities through commit and rollback.
+4. Remove whole-document Tree invalidation when exact identities are available.
+5. Coalesce Feature Timeline and other projection refreshes.
+6. Move only pointer-free computation off-thread; final Qt model application
+   remains on the GUI thread.
+7. Ensure progress is painted before any measured atomic phase and remains
+   truthful through stabilization.
+
+### Phase 5: persistent runtime
+
+1. Measure current per-operation process startup/import overhead.
+2. Add the startup-owned runtime without removing existing entry points.
+3. Route new work through persistent pools while preserving a compatible legacy
+   adapter during rollout.
+4. Add per-document serialization, global back-pressure, CPU budgeting, crash
+   replacement, clean shutdown, and stale-result rejection.
+5. Stress multiple documents and simultaneous human/AI requests.
+
+### Phase 6: interface-wide audit
+
+For each P18-P26 area:
+
+1. Capture an interaction trace.
+2. Add a regression benchmark for every slow or blocking path.
+3. Move computation/I/O to the correct executor.
+4. remove redundant work and add revision-aware caching;
+5. coalesce resulting UI changes;
+6. verify progress and cancellation;
+7. record cold/warm before-and-after evidence.
+
+The audit is complete only after every action reachable from VibeCAD's ribbons,
+menus, assistant tools, document lifecycle, and primary workbenches has either a
+passing trace or an explicit benchmark entry.
+
+### Phase 7: release proof
+
+1. Run all Python, C++, GUI, provider, and packaging tests applicable to the
+   touched code.
+2. Produce the actual Windows portable package through the repository's Rattler
+   workflow; do not substitute an installed development tree.
+3. Run B01-B27 against that package.
+4. Verify document fingerprints and expected outputs against the baseline.
+5. Record exact commands, durations, test counts, artifact identity, and known
+   platform limitations below.
+6. Do not mark the performance program complete while any row remains
+   `NOT STARTED`, `IN PROGRESS`, `BLOCKED`, or `REVALIDATE`.
+
+## Test and build record
+
+Append evidence; do not overwrite prior measurements. Each record must include
+the commit under test.
+
+### 2026-09-04 — PR #168 foundation
+
+- Commit: `fcf47b46cd7c6dd5cdf80094196923ec0a30f8bc`
+- Merge commit: `7289751459ceace471ac771f3a0ec39b972d1949`
+- Python tests: 4,380 passed, 9 skipped.
+- Focused cooperative publication tests: 13 passed.
+- Native GUI tests: 138 passed out of 138.
+- Windows Rattler build: completed successfully; package
+  `vibecad-26.3.1RC6-h3c70cbc_1.conda`.
+- Interactive result: large Assembly publication became substantially more
+  usable, but measurable freezes remained during final publication and bulk
+  visibility. This is foundation evidence, not completion evidence.
+
+## PR discipline
+
+This program may require multiple small PRs, but they all track this one plan.
+Every code PR must:
+
+1. solve one measured bottleneck or add one coherent piece of proof
+   infrastructure;
+2. include the failing test/benchmark observed before implementation;
+3. preserve public APIs and existing behavior unless the owner explicitly
+   approves a break;
+4. report exact commands and before/after results;
+5. update the applicable ledger rows and test record in this document;
+6. avoid unrelated cleanup, generated noise, local paths, credentials, and test
+   documents.
+
+## Completion definition
+
+The performance program is complete only when all of the following are true:
+
+- Every P00-P29 ledger row is `DONE`.
+- Every B01-B27 scenario has cold and warm evidence from a packaged build.
+- No benchmark contains an unexplained GUI heartbeat failure.
+- No expensive UI callback performs synchronous I/O, process waiting, repeated
+  whole-document traversal, or unbounded geometry work.
+- Human and AI paths use the same background execution, progress, cancellation,
+  caching, and document-integrity contracts.
+- Large-document stress tests show no deadlock, corruption, stale apply, lost
+  rollback, or unsafe cross-thread object access.
+- The repository's full required test and packaging gates pass.
+- The remaining measured latency is attributable only to bounded UI application
+  or external operations that are isolated, cancellable where possible, and
+  truthfully visible to the user.
+

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -121,7 +121,11 @@ when necessary to preserve input and rendering latency.
 
 ### Cross-language trace
 
-Add one low-overhead trace format shared by C++ and Python. Each span records:
+Reuse the repository's existing Tracy integration (`Base/Profiler.h` and
+`BUILD_TRACY_FRAME_PROFILER`) for native spans. Use one bounded Python Chrome
+Trace recorder for Python and process-level spans, then correlate the two by
+wall time, process/thread identity, and operation ID. Do not add a second native
+profiler or a parallel batching/dispatch framework. Each span records:
 
 - operation and phase name;
 - document UID and revision, without document contents;
@@ -132,17 +136,18 @@ Add one low-overhead trace format shared by C++ and Python. Each span records:
 - cancellation and outcome;
 - parent operation ID.
 
-Development builds write bounded Chrome Trace Event JSON so Windows Performance
-Analyzer, Perfetto, or Chromium tracing can show C++, Python, process, and GUI
-events on one timeline. Release builds keep only aggregate counters and slow-span
-diagnostics unless detailed tracing is explicitly enabled.
+Detailed tracing is opt-in through `VIBECAD_PERFORMANCE_TRACE`; normal startup
+does not import the Python tracing modules or install a heartbeat timer. An
+instrumented run can export bounded Chrome Trace Event JSON for Perfetto or
+Chromium tracing and capture the native Tracy timeline. Release operation has
+zero periodic tracing work unless detailed tracing is explicitly enabled.
 
 ### GUI watchdog
 
-Add a Qt event-loop watchdog that records heartbeat gaps without calling
+The opt-in Qt event-loop watchdog records heartbeat gaps without calling
 `processEvents()` re-entrantly. Test mode fails the benchmark when the applicable
-threshold is crossed. Diagnostics name the active operation and most recent GUI
-span so a freeze is never reported only as "not responding."
+threshold is crossed. Named operation and span context will be added only at
+measured entry points; there is no always-on activity registry.
 
 ### Required native spans
 
@@ -228,9 +233,9 @@ Status values are `DONE`, `IN PROGRESS`, `NOT STARTED`, `BLOCKED`, and
 | P00 | Establish cooperative mutation lease and block conflicting document mutations | DONE | PR #168; native GUI tests 138/138 |
 | P01 | Yield VibeScript publication between output/member apply steps | DONE | PR #168; Python suite 4,380 passed, 9 skipped; large Assembly became interactively usable |
 | P02 | Add publication phase/item progress | DONE | PR #168; direct VibeScript progress callback tests |
-| P03 | Instrument cross-language spans and GUI watchdog | NOT STARTED | Required before optimization claims |
+| P03 | Instrument cross-language spans and GUI watchdog | IN PROGRESS | Bounded Python trace recorder and opt-in Qt watchdog added in `ac9eec72`; native instrumentation will reuse the existing Tracy integration |
 | P04 | Capture cold/warm baseline for B02, B06, B07, B09, and B24 | NOT STARTED | Trace and benchmark summaries |
-| P05 | Remove Assembly drag/bulk-visibility refresh storm | NOT STARTED | Red test, traversal count of one, B06/B09 pass |
+| P05 | Remove Assembly drag/bulk-visibility refresh storm | DONE | Packaged red tests proved duplicate deferred traversal and synchronous per-selection traversal across 153 visibility changes; packaged green test proved direct, standard multi-selection, and folder-toggle paths each converge in exactly one delayed refresh |
 | P06 | Measure BREP assignment, tessellation, and Coin construction independently | NOT STARTED | Native trace identifies per-solid costs |
 | P07 | Pre-tessellate eligible solids in isolated workers and cache render meshes | NOT STARTED | Same visual/correct BREP output; B07 comparison |
 | P08 | Drive ordinary per-object GUI apply cost toward <= 1 ms | NOT STARTED | B07 per-item distribution and longest span |
@@ -261,7 +266,8 @@ Status values are `DONE`, `IN PROGRESS`, `NOT STARTED`, `BLOCKED`, and
 ### Phase 1: measurement foundation
 
 1. Add failing tests for the GUI watchdog and nested performance spans.
-2. Add C++ RAII and Python context-manager spans with the same trace schema.
+2. Add Python context-manager spans and reuse the existing Tracy RAII macros for
+   native spans; correlate them without adding another profiler.
 3. Instrument the confirmed publication, tessellation, Tree, Timeline, and bulk
    visibility paths.
 4. Capture cold and warm baselines before changing those paths.
@@ -271,12 +277,15 @@ Status values are `DONE`, `IN PROGRESS`, `NOT STARTED`, `BLOCKED`, and
 
 1. Add a failing test proving bulk visibility currently triggers repeated folder
    refreshes.
-2. Add an additive batch/coalescing scope used by Assembly drag and general bulk
-   visibility commands.
-3. Emit one browser refresh, one cache invalidation, and one selection update at
+2. Remove synchronous and duplicate deferred folder traversals; rely on the
+   Tree's existing coalescing status timer for incidental visibility bursts.
+3. For declared bulk operations that span projections, reuse the existing
+   cooperative-mutation scope and its single stable refresh. Do not add another
+   batching abstraction.
+4. Emit one browser refresh, one cache invalidation, and one selection update at
    the end of the logical command.
-4. Verify rollback and single-object behavior remain compatible.
-5. Re-run B05, B06, and B09 and record the before/after result.
+5. Verify rollback and single-object behavior remain compatible.
+6. Re-run B05, B06, and B09 and record the before/after result.
 
 ### Phase 3: rendering and tessellation
 
@@ -362,6 +371,31 @@ the commit under test.
   usable, but measurable freezes remained during final publication and bulk
   visibility. This is foundation evidence, not completion evidence.
 
+### 2026-09-04 — Tree visibility coalescing
+
+- Base: `7289751459ceace471ac771f3a0ec39b972d1949`.
+- Foundation: `4daa8d06`.
+- Red, direct property path: 153 visibility changes produced two delayed
+  browser-folder traversals.
+- Red, standard command path: multi-selection Hide traversed browser folders
+  synchronously before its deferred refresh.
+- Implementation: removed the per-object synchronous traversals and duplicate
+  deferred traversal; all visibility paths reuse the existing Tree status timer.
+  No new batching mechanism was added, and the native implementation has fewer
+  executable lines than before.
+- Focused Python command:
+  `python -m pytest src/Mod/VibeCAD/vibecad_tests/test_performance.py src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py src/Mod/VibeCAD/vibecad_tests/test_aero_ribbon_install.py -q`.
+  Result: 53 passed, 6 skipped.
+- Windows package command from `package/rattler-build`:
+  `pixi install -e default --frozen`. Result: success in 16 minutes; package
+  `vibecad-26.3.1RC6-h3c70cbc_1.conda`.
+- Packaged GUI command: `pixi run --as-is --environment default --executable
+  freecad.exe --user-cfg <isolated>/User.cfg --system-cfg
+  <isolated>/System.cfg ../../src/Mod/VibeCAD/vibecad_tests/tree_visibility_coalescing_gui_integration.py`.
+  Result: `VIBECAD_TREE_VISIBILITY_COALESCING_OK`; each of direct property,
+  standard multi-selection Hide, and folder Space-toggle produced zero
+  synchronous traversals and exactly one stable delayed traversal.
+
 ## PR discipline
 
 This program may require multiple small PRs, but they all track this one plan.
@@ -394,4 +428,3 @@ The performance program is complete only when all of the following are true:
 - The remaining measured latency is attributable only to bounded UI application
   or external operations that are isolated, cancellable where possible, and
   truthfully visible to the user.
-

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -233,7 +233,7 @@ Status values are `DONE`, `IN PROGRESS`, `NOT STARTED`, `BLOCKED`, and
 | P00 | Establish cooperative mutation lease and block conflicting document mutations | DONE | PR #168; native GUI tests 138/138 |
 | P01 | Yield VibeScript publication between output/member apply steps | DONE | PR #168; Python suite 4,380 passed, 9 skipped; large Assembly became interactively usable |
 | P02 | Add publication phase/item progress | DONE | PR #168; direct VibeScript progress callback tests |
-| P03 | Instrument cross-language spans and GUI watchdog | IN PROGRESS | Bounded Python trace recorder and opt-in Qt watchdog added in `ac9eec72`; native instrumentation will reuse the existing Tracy integration |
+| P03 | Instrument cross-language spans and GUI watchdog | IN PROGRESS | Bounded Python trace recorder and opt-in Qt watchdog added in `4daa8d06`; native instrumentation will reuse the existing Tracy integration |
 | P04 | Capture cold/warm baseline for B02, B06, B07, B09, and B24 | NOT STARTED | Trace and benchmark summaries |
 | P05 | Remove Assembly drag/bulk-visibility refresh storm | DONE | Packaged red tests proved duplicate deferred traversal and synchronous per-selection traversal across 153 visibility changes; packaged green test proved direct, standard multi-selection, and folder-toggle paths each converge in exactly one delayed refresh |
 | P06 | Measure BREP assignment, tessellation, and Coin construction independently | NOT STARTED | Native trace identifies per-solid costs |
@@ -375,6 +375,7 @@ the commit under test.
 
 - Base: `7289751459ceace471ac771f3a0ec39b972d1949`.
 - Foundation: `4daa8d06`.
+- Commit under test: `0a9a3781`.
 - Red, direct property path: 153 visibility changes produced two delayed
   browser-folder traversals.
 - Red, standard command path: multi-selection Hide traversed browser folders

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -507,7 +507,6 @@ public:
         for (auto* item : items) {
             TreeWidget::setObjectItemVisibility(item, visible);
         }
-        owner->updateBrowserFolderStatus();
     }
 
     void toggleVisibility()
@@ -2445,9 +2444,6 @@ void TreeWidget::keyPressEvent(QKeyEvent* event)
                 appObj->getNameInDocument()
             );
         }
-        for (const auto& entry : DocumentMap) {
-            entry.second->updateBrowserFolderStatus();
-        }
         setFocus();
         event->accept();
         return;
@@ -2558,6 +2554,11 @@ TreeWidget::resolveModelBrowserVisibilityTarget(App::DocumentObject* object)
     return target;
 }
 
+qulonglong TreeWidget::browserFolderStatusUpdateCount() const
+{
+    return browserFolderStatusUpdates;
+}
+
 bool TreeWidget::applyModelBrowserVisibility(
     App::DocumentObject* object,
     int requestedVisibility,
@@ -2617,18 +2618,6 @@ bool TreeWidget::applyModelBrowserVisibility(
     }
     resultingVisibility = viewProvider->isShow();
 
-    // Do not retain item pointers across show()/hide(): those calls can emit
-    // document changes and rebuild a browser. Resolve each document item
-    // afresh solely to update aggregate folder indicators.
-    for (auto* tree : Instances) {
-        if (!tree || !guiDocument) {
-            continue;
-        }
-        const auto documentIt = tree->DocumentMap.find(guiDocument);
-        if (documentIt != tree->DocumentMap.end() && documentIt->second) {
-            documentIt->second->updateBrowserFolderStatus();
-        }
-    }
     return true;
 }
 
@@ -2675,9 +2664,6 @@ void TreeWidget::mousePressEvent(QMouseEvent* event)
                             objectItem,
                             !objectItemVisibility(objectItem)
                         );
-                        if (auto* owner = objectItem->getOwnerDocument()) {
-                            owner->updateBrowserFolderStatus();
-                        }
                     }
                     else {
                         auto* object = objectItem->object()->getObject();
@@ -4494,7 +4480,6 @@ void TreeWidget::onUpdateStatus()
     FC_LOG("update item status");
     for (auto pos = DocumentMap.begin(); pos != DocumentMap.end(); ++pos) {
         pos->second->testStatus();
-        pos->second->updateBrowserFolderStatus();
     }
 
     // Checking for just restored documents
@@ -5657,6 +5642,10 @@ void DocumentItem::updateBrowserFolderStatus()
 {
     if (!modelBrowserActive) {
         return;
+    }
+
+    if (auto* tree = getTree()) {
+        ++tree->browserFolderStatusUpdates;
     }
 
     std::vector<BrowserFolderItem*> folders;
@@ -7748,15 +7737,10 @@ void TreeWidget::slotChangeObject(const Gui::ViewProviderDocumentObject& view, c
     _updateStatus();
 
     if (&prop == &obj->Visibility) {
-        std::set<DocumentItem*> documents;
-        for (const auto& data : itEntry->second) {
-            if (data && data->docItem) {
-                documents.insert(data->docItem);
-            }
-        }
-        for (auto* document : documents) {
-            document->updateBrowserFolderStatus();
-        }
+        // _updateStatus() already coalesces a burst of object notifications and
+        // refreshes each document's folder state once. Traversing every folder
+        // synchronously for every Visibility property produced quadratic work
+        // during Assembly drag setup and other bulk-visibility operations.
         return;
     }
 

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -62,6 +62,10 @@ GuiExport bool isTreeViewDragging();
 class TreeWidget: public QTreeWidget, public SelectionObserver
 {
     Q_OBJECT
+    Q_PROPERTY(
+        qulonglong VibeCADBrowserFolderStatusUpdateCount
+            READ browserFolderStatusUpdateCount
+    )
 
 public:
     explicit TreeWidget(const char* name, QWidget* parent = nullptr);
@@ -80,6 +84,8 @@ public:
 
     int itemSpacing() const;
     void setItemSpacing(int);
+
+    qulonglong browserFolderStatusUpdateCount() const;
 
     bool eventFilter(QObject*, QEvent* ev) override;
 
@@ -342,6 +348,7 @@ private:
 
     std::string myName;  // for debugging purpose
     int updateBlocked = 0;
+    qulonglong browserFolderStatusUpdates = 0;
 
     // State tracking for the two-stage "Select All" operation
     bool lastSelectAllParent = false;   // true if last select was group-level, used for double-tap

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -1308,6 +1308,7 @@ if(BUILD_TEST AND BUILD_GUI)
         vibecad_tests/grid_gui_integration.py
         vibecad_tests/section_view_gui_integration.py
         vibecad_tests/link_override_visibility_gui_integration.py
+        vibecad_tests/tree_visibility_coalescing_gui_integration.py
         vibecad_tests/mcp_gui_integration.py
         vibecad_tests/session_recovery_gui_integration.py
         vibecad_tests/test_session_recovery.py

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -1212,6 +1212,8 @@ set(VibeCAD_Scripts
     VibeCADRibbonSurface.py
     VibeCADProject.py
     VibeCADPublicationProgress.py
+    VibeCADPerformance.py
+    VibeCADPerformanceGui.py
     VibeCADSession.py
     VibeCADSessionRecovery.py
     VibeCADScriptedEditor.py

--- a/src/Mod/VibeCAD/InitGui.py
+++ b/src/Mod/VibeCAD/InitGui.py
@@ -379,6 +379,34 @@ try:
             except Exception:
                 pass
 
+    def _setup_performance_watchdog() -> None:
+        try:
+            import os
+
+            trace_setting = str(
+                os.environ.get("VIBECAD_PERFORMANCE_TRACE") or ""
+            ).strip().lower()
+            # Mirror VibeCADPerformance without importing its tracing machinery
+            # during normal startup.
+            if trace_setting not in {"1", "on", "true", "yes"}:
+                return
+
+            import FreeCADGui as Gui
+            import VibeCADPerformanceGui
+
+            VibeCADPerformanceGui.install_event_loop_watchdog(
+                parent=Gui.getMainWindow()
+            )
+        except Exception as exc:
+            try:
+                import FreeCAD as _App
+
+                _App.Console.PrintWarning(
+                    f"VibeCAD UI performance watchdog failed to start: {exc}\n"
+                )
+            except Exception:
+                pass
+
     def _setup_aero_ribbon() -> None:
         try:
             import VibeCADAeroRibbon
@@ -397,6 +425,7 @@ try:
     QtCore.QTimer.singleShot(0, _setup_development_identity)
     QtCore.QTimer.singleShot(0, _setup_always_on_grid)
     QtCore.QTimer.singleShot(0, _setup_agent_control)
+    QtCore.QTimer.singleShot(0, _setup_performance_watchdog)
     QtCore.QTimer.singleShot(0, _setup_aero_ribbon)
 except Exception as exc:
     _warn(f"VibeCAD GUI bootstrap failed: {exc}")

--- a/src/Mod/VibeCAD/VibeCADPerformance.py
+++ b/src/Mod/VibeCAD/VibeCADPerformance.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Bounded performance tracing primitives shared by VibeCAD host code.
+
+Recording is memory-only. Export is an explicit operation so an instrumented
+GUI callback never performs trace-file I/O on the document thread.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections import deque
+from contextlib import contextmanager
+import json
+import os
+from pathlib import Path
+import threading
+import time
+from typing import Any, Callable, Iterator, Mapping
+
+DEFAULT_TRACE_CAPACITY = 50_000
+DEFAULT_HEARTBEAT_HISTORY_CAPACITY = 4_096
+
+
+def _environment_enabled() -> bool:
+    value = str(os.environ.get("VIBECAD_PERFORMANCE_TRACE") or "").strip().lower()
+    return value in {"1", "on", "true", "yes"}
+
+
+class PerformanceRecorder:
+    """Keep a bounded, thread-safe stream of Chrome Trace Event records."""
+
+    def __init__(
+        self,
+        *,
+        enabled: bool | None = None,
+        capacity: int = DEFAULT_TRACE_CAPACITY,
+        monotonic_ns: Callable[[], int] = time.perf_counter_ns,
+        wall_time_ns: Callable[[], int] = time.time_ns,
+        process_id: Callable[[], int] = os.getpid,
+        thread_id: Callable[[], int] = threading.get_native_id,
+    ) -> None:
+        if type(capacity) is not int or capacity < 1:
+            raise ValueError("Performance trace capacity must be a positive integer.")
+        self._enabled = _environment_enabled() if enabled is None else bool(enabled)
+        self._capacity = capacity
+        self._monotonic_ns = monotonic_ns
+        self._wall_time_ns = wall_time_ns
+        self._process_id = process_id
+        self._thread_id = thread_id
+        self._events: deque[dict[str, Any]] = deque(maxlen=capacity)
+        self._dropped_event_count = 0
+        self._lock = threading.RLock()
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def dropped_event_count(self) -> int:
+        with self._lock:
+            return self._dropped_event_count
+
+    def _append(self, event: dict[str, Any]) -> None:
+        with self._lock:
+            if len(self._events) == self._capacity:
+                self._dropped_event_count += 1
+            self._events.append(event)
+
+    @contextmanager
+    def span(
+        self,
+        name: str,
+        *,
+        category: str = "vibecad",
+        gui_thread: bool = False,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> Iterator[None]:
+        """Measure one scope without changing its exception behavior."""
+
+        if not self._enabled:
+            yield
+            return
+
+        start_monotonic_ns = self._monotonic_ns()
+        start_wall_us = self._wall_time_ns() / 1_000.0
+        process_id = self._process_id()
+        thread_id = self._thread_id()
+        outcome = "completed"
+        exception_type = ""
+        try:
+            yield
+        except BaseException as exc:
+            outcome = "failed"
+            exception_type = exc.__class__.__name__
+            raise
+        finally:
+            end_monotonic_ns = self._monotonic_ns()
+            details = dict(attributes or {})
+            details["gui_thread"] = bool(gui_thread)
+            details["outcome"] = outcome
+            if exception_type:
+                details["exception_type"] = exception_type
+            self.record_complete(
+                name,
+                category=category,
+                start_wall_us=start_wall_us,
+                duration_us=max(0.0, (end_monotonic_ns - start_monotonic_ns) / 1_000.0),
+                process_id=process_id,
+                thread_id=thread_id,
+                gui_thread=gui_thread,
+                attributes=details,
+            )
+
+    def record_complete(
+        self,
+        name: str,
+        *,
+        category: str = "vibecad",
+        start_wall_us: float | None = None,
+        duration_us: float,
+        process_id: int | None = None,
+        thread_id: int | None = None,
+        gui_thread: bool = False,
+        attributes: Mapping[str, Any] | None = None,
+    ) -> None:
+        if not self._enabled:
+            return
+        details = dict(attributes or {})
+        details.setdefault("gui_thread", bool(gui_thread))
+        details.setdefault("outcome", "completed")
+        duration = max(0.0, float(duration_us))
+        start = (
+            self._wall_time_ns() / 1_000.0 - duration
+            if start_wall_us is None
+            else float(start_wall_us)
+        )
+        event = {
+            "name": str(name),
+            "cat": str(category),
+            "ph": "X",
+            "ts": start,
+            "dur": duration,
+            "pid": self._process_id() if process_id is None else int(process_id),
+            "tid": self._thread_id() if thread_id is None else int(thread_id),
+            "args": details,
+        }
+        self._append(event)
+
+    def record_instant(
+        self,
+        name: str,
+        *,
+        category: str = "vibecad",
+        attributes: Mapping[str, Any] | None = None,
+    ) -> None:
+        if not self._enabled:
+            return
+        self._append(
+            {
+                "name": str(name),
+                "cat": str(category),
+                "ph": "i",
+                "s": "t",
+                "ts": self._wall_time_ns() / 1_000.0,
+                "pid": self._process_id(),
+                "tid": self._thread_id(),
+                "args": dict(attributes or {}),
+            }
+        )
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        with self._lock:
+            events = list(self._events)
+        return copy.deepcopy(events)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._events.clear()
+            self._dropped_event_count = 0
+
+    def export_chrome_trace(self, path: str | os.PathLike[str]) -> dict[str, Any]:
+        """Write a snapshot explicitly; callers must keep this off the GUI thread."""
+
+        target = Path(path)
+        with self._lock:
+            events = list(self._events)
+            dropped = self._dropped_event_count
+        events = copy.deepcopy(events)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "traceEvents": events,
+            "metadata": {"dropped_event_count": dropped},
+        }
+        target.write_text(
+            json.dumps(payload, ensure_ascii=False, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        return {
+            "event_count": len(events),
+            "dropped_event_count": dropped,
+            "path": str(target),
+        }
+
+
+class EventLoopWatchdog:
+    """Measure event-loop heartbeat gaps without entering a nested event loop."""
+
+    def __init__(
+        self,
+        *,
+        expected_interval_ms: float,
+        failure_threshold_ms: float,
+        history_capacity: int = DEFAULT_HEARTBEAT_HISTORY_CAPACITY,
+        recorder: PerformanceRecorder | None = None,
+        monotonic_ns: Callable[[], int] = time.perf_counter_ns,
+    ) -> None:
+        if expected_interval_ms <= 0:
+            raise ValueError("The expected heartbeat interval must be positive.")
+        if failure_threshold_ms < expected_interval_ms:
+            raise ValueError(
+                "The heartbeat failure threshold cannot be shorter than its interval."
+            )
+        if type(history_capacity) is not int or history_capacity < 1:
+            raise ValueError("Heartbeat history capacity must be a positive integer.")
+        self._expected_interval_ms = float(expected_interval_ms)
+        self._failure_threshold_ms = float(failure_threshold_ms)
+        self._recorder = recorder
+        self._monotonic_ns = monotonic_ns
+        self._last_tick_ns: int | None = None
+        self._gaps_ms: deque[float] = deque(maxlen=history_capacity)
+        self._sample_count = 0
+        self._violation_count = 0
+        self._maximum_gap_ms = 0.0
+        self._lock = threading.RLock()
+
+    def tick(self) -> dict[str, Any] | None:
+        now_ns = self._monotonic_ns()
+        with self._lock:
+            previous_ns = self._last_tick_ns
+            self._last_tick_ns = now_ns
+            if previous_ns is None:
+                return None
+            gap_ms = max(0.0, (now_ns - previous_ns) / 1_000_000.0)
+            self._gaps_ms.append(gap_ms)
+            self._sample_count += 1
+            self._maximum_gap_ms = max(self._maximum_gap_ms, gap_ms)
+            if gap_ms <= self._failure_threshold_ms:
+                return None
+            self._violation_count += 1
+            violation = {
+                "gap_ms": gap_ms,
+                "threshold_ms": self._failure_threshold_ms,
+            }
+        if self._recorder is not None:
+            self._recorder.record_instant(
+                "gui.heartbeat_gap",
+                category="ui",
+                attributes=violation,
+            )
+        return violation
+
+    def summary(self) -> dict[str, Any]:
+        with self._lock:
+            ordered_gaps = sorted(self._gaps_ms)
+            p99_gap_ms = (
+                ordered_gaps[(99 * len(ordered_gaps) - 1) // 100]
+                if ordered_gaps
+                else 0.0
+            )
+            return {
+                "expected_interval_ms": self._expected_interval_ms,
+                "failure_threshold_ms": self._failure_threshold_ms,
+                "sample_count": self._sample_count,
+                "retained_gap_count": len(self._gaps_ms),
+                "violation_count": self._violation_count,
+                "maximum_gap_ms": self._maximum_gap_ms,
+                "p99_gap_ms": p99_gap_ms,
+            }
+
+
+_global_recorder = PerformanceRecorder()
+
+
+def get_performance_recorder() -> PerformanceRecorder:
+    return _global_recorder

--- a/src/Mod/VibeCAD/VibeCADPerformanceGui.py
+++ b/src/Mod/VibeCAD/VibeCADPerformanceGui.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Qt event-loop heartbeat measurement for VibeCAD.
+
+The timer deliberately does not enter a nested event loop or perform file I/O.
+When Qt is starved, its next ordinary timeout measures the entire starvation gap.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from VibeCADPerformance import (
+    EventLoopWatchdog,
+    get_performance_recorder,
+)
+
+HEARTBEAT_INTERVAL_MS = 25
+HEARTBEAT_FAILURE_THRESHOLD_MS = 100
+
+_event_loop_timer: Any | None = None
+_event_loop_watchdog: Any | None = None
+
+
+def install_event_loop_watchdog(
+    *,
+    parent: Any | None = None,
+    timer_factory: Callable[[Any], Any] | None = None,
+    watchdog: Any | None = None,
+) -> Any:
+    """Install exactly one low-overhead heartbeat on FreeCAD's Qt loop."""
+
+    global _event_loop_timer, _event_loop_watchdog
+    if _event_loop_timer is not None:
+        return _event_loop_timer
+
+    recorder = get_performance_recorder()
+    if watchdog is None and not recorder.enabled:
+        return None
+
+    if parent is None:
+        import FreeCADGui as Gui
+
+        parent = Gui.getMainWindow()
+    if parent is None:
+        raise RuntimeError("FreeCAD's main window is unavailable for the UI watchdog.")
+
+    if timer_factory is None:
+        from PySide import QtCore
+
+        timer_factory = QtCore.QTimer
+    if watchdog is None:
+        watchdog = EventLoopWatchdog(
+            expected_interval_ms=HEARTBEAT_INTERVAL_MS,
+            failure_threshold_ms=HEARTBEAT_FAILURE_THRESHOLD_MS,
+            recorder=recorder,
+        )
+
+    timer = timer_factory(parent)
+    timer.setInterval(HEARTBEAT_INTERVAL_MS)
+    timer.timeout.connect(watchdog.tick)
+    timer.start()
+    _event_loop_watchdog = watchdog
+    _event_loop_timer = timer
+    return timer
+
+
+def event_loop_watchdog_summary() -> dict[str, Any]:
+    if _event_loop_watchdog is None:
+        return {
+            "installed": False,
+            "sample_count": 0,
+        }
+    return dict(_event_loop_watchdog.summary())
+
+
+def _reset_event_loop_watchdog_for_tests() -> None:
+    global _event_loop_timer, _event_loop_watchdog
+    timer = _event_loop_timer
+    _event_loop_timer = None
+    _event_loop_watchdog = None
+    stop = getattr(timer, "stop", None)
+    if callable(stop):
+        stop()

--- a/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_branding_contract.py
@@ -1284,7 +1284,7 @@ def test_vibecad_migrates_its_obsolete_background_autoload_before_use() -> None:
     assert 'general->RemoveASCII("BackgroundAutoloadModules");' in migration
 
 
-def test_vibecad_bootstrap_repairs_only_vibecad_disabled_lists(monkeypatch) -> None:
+def test_vibecad_bootstrap_repairs_disabled_lists_and_gates_profiling(monkeypatch) -> None:
     class ParameterGroup:
         def __init__(self, disabled: str) -> None:
             self.disabled = disabled
@@ -1332,8 +1332,31 @@ def test_vibecad_bootstrap_repairs_only_vibecad_disabled_lists(monkeypatch) -> N
         "scheduled:_setup_development_identity",
         "scheduled:_setup_always_on_grid",
         "scheduled:_setup_agent_control",
+        "scheduled:_setup_performance_watchdog",
         "scheduled:_setup_aero_ribbon",
     ]
+
+    watchdog_installs: list[object] = []
+    monkeypatch.delenv("VIBECAD_PERFORMANCE_TRACE", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "FreeCADGui",
+        SimpleNamespace(getMainWindow=lambda: "main-window"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "VibeCADPerformanceGui",
+        SimpleNamespace(
+            install_event_loop_watchdog=lambda **kwargs: watchdog_installs.append(
+                kwargs["parent"]
+            )
+        ),
+    )
+    namespace["_setup_performance_watchdog"]()
+    assert watchdog_installs == []
+    monkeypatch.setenv("VIBECAD_PERFORMANCE_TRACE", "1")
+    namespace["_setup_performance_watchdog"]()
+    assert watchdog_installs == ["main-window"]
 
     preferences.disabled = (
         "MaterialWorkbench,TestWorkbench,NoneWorkbench,CustomWorkbench"
@@ -1522,6 +1545,7 @@ def test_vibecad_bootstrap_isolates_optional_command_registration_failures(
         "scheduled:_setup_development_identity",
         "scheduled:_setup_always_on_grid",
         "scheduled:_setup_agent_control",
+        "scheduled:_setup_performance_watchdog",
         "scheduled:_setup_aero_ribbon",
     ]
     assert any(

--- a/src/Mod/VibeCAD/vibecad_tests/test_performance.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_performance.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from __future__ import annotations
+
+import json
+
+from VibeCADPerformance import EventLoopWatchdog, PerformanceRecorder
+import VibeCADPerformanceGui
+
+
+class _Clock:
+    def __init__(self, values: list[int]):
+        self._values = iter(values)
+
+    def __call__(self) -> int:
+        return next(self._values)
+
+
+def test_performance_span_records_chrome_trace_fields():
+    recorder = PerformanceRecorder(
+        enabled=True,
+        capacity=8,
+        monotonic_ns=_Clock([1_000, 6_000]),
+        wall_time_ns=lambda: 2_000_000,
+        process_id=lambda: 17,
+        thread_id=lambda: 23,
+    )
+
+    with recorder.span(
+        "publication.apply",
+        category="vibescript",
+        gui_thread=True,
+        attributes={"item_count": 3, "document_revision": "revision-a"},
+    ):
+        pass
+
+    assert recorder.snapshot() == [
+        {
+            "name": "publication.apply",
+            "cat": "vibescript",
+            "ph": "X",
+            "ts": 2_000.0,
+            "dur": 5.0,
+            "pid": 17,
+            "tid": 23,
+            "args": {
+                "document_revision": "revision-a",
+                "gui_thread": True,
+                "item_count": 3,
+                "outcome": "completed",
+            },
+        }
+    ]
+
+
+def test_performance_span_records_failure_without_hiding_exception():
+    recorder = PerformanceRecorder(
+        enabled=True,
+        monotonic_ns=_Clock([10_000, 20_000]),
+        wall_time_ns=lambda: 5_000_000,
+    )
+
+    try:
+        with recorder.span("publication.commit", gui_thread=True):
+            raise RuntimeError("commit failed")
+    except RuntimeError as exc:
+        assert str(exc) == "commit failed"
+    else:  # pragma: no cover - this is an assertion guard
+        raise AssertionError("The measured exception was swallowed.")
+
+    event = recorder.snapshot()[0]
+    assert event["args"]["outcome"] == "failed"
+    assert event["args"]["exception_type"] == "RuntimeError"
+
+
+def test_performance_recorder_is_bounded_and_reports_drops():
+    recorder = PerformanceRecorder(enabled=True, capacity=2)
+    recorder.record_complete("first", start_wall_us=1.0, duration_us=1.0)
+    recorder.record_complete("second", start_wall_us=2.0, duration_us=1.0)
+    recorder.record_complete("third", start_wall_us=3.0, duration_us=1.0)
+
+    assert [event["name"] for event in recorder.snapshot()] == ["second", "third"]
+    assert recorder.dropped_event_count == 1
+
+
+def test_record_complete_derives_start_time_from_duration():
+    recorder = PerformanceRecorder(
+        enabled=True,
+        wall_time_ns=lambda: 10_000_000,
+    )
+
+    recorder.record_complete("completed", duration_us=2_500.0)
+
+    assert recorder.snapshot()[0]["ts"] == 7_500.0
+
+
+def test_disabled_recorder_does_not_call_clocks_or_store_events():
+    def fail_clock() -> int:
+        raise AssertionError("A disabled recorder evaluated a clock.")
+
+    recorder = PerformanceRecorder(
+        enabled=False,
+        monotonic_ns=fail_clock,
+        wall_time_ns=fail_clock,
+    )
+
+    with recorder.span("disabled"):
+        pass
+    recorder.record_complete("disabled", start_wall_us=1.0, duration_us=2.0)
+
+    assert recorder.snapshot() == []
+
+
+def test_chrome_trace_export_is_explicit_and_valid(tmp_path):
+    recorder = PerformanceRecorder(enabled=True)
+    recorder.record_complete(
+        "tree.folder_status",
+        category="tree",
+        start_wall_us=10.0,
+        duration_us=4.5,
+        process_id=7,
+        thread_id=8,
+        gui_thread=True,
+        attributes={"folder_count": 12},
+    )
+    target = tmp_path / "trace.json"
+
+    summary = recorder.export_chrome_trace(target)
+
+    payload = json.loads(target.read_text(encoding="utf-8"))
+    assert payload["traceEvents"] == recorder.snapshot()
+    assert payload["metadata"]["dropped_event_count"] == 0
+    assert summary == {"event_count": 1, "dropped_event_count": 0, "path": str(target)}
+
+
+def test_event_loop_watchdog_records_only_threshold_violations():
+    recorder = PerformanceRecorder(enabled=True)
+    watchdog = EventLoopWatchdog(
+        expected_interval_ms=25.0,
+        failure_threshold_ms=100.0,
+        recorder=recorder,
+        monotonic_ns=_Clock([0, 25_000_000, 175_000_000, 200_000_000]),
+    )
+
+    assert watchdog.tick() is None
+    assert watchdog.tick() is None
+    violation = watchdog.tick()
+    assert violation == {
+        "gap_ms": 150.0,
+        "threshold_ms": 100.0,
+    }
+    assert watchdog.tick() is None
+
+    summary = watchdog.summary()
+    assert summary["sample_count"] == 3
+    assert summary["violation_count"] == 1
+    assert summary["maximum_gap_ms"] == 150.0
+    event = recorder.snapshot()[0]
+    assert event["name"] == "gui.heartbeat_gap"
+    assert event["ph"] == "i"
+    assert event["args"] == violation
+
+
+def test_event_loop_watchdog_keeps_bounded_gap_history():
+    watchdog = EventLoopWatchdog(
+        expected_interval_ms=10.0,
+        failure_threshold_ms=50.0,
+        history_capacity=2,
+        monotonic_ns=_Clock([0, 10_000_000, 30_000_000, 60_000_000]),
+    )
+
+    for _ in range(4):
+        watchdog.tick()
+
+    summary = watchdog.summary()
+    assert summary["sample_count"] == 3
+    assert summary["retained_gap_count"] == 2
+    assert summary["maximum_gap_ms"] == 30.0
+    assert summary["p99_gap_ms"] == 30.0
+
+
+class _Signal:
+    def __init__(self):
+        self.callback = None
+
+    def connect(self, callback):
+        self.callback = callback
+
+
+class _Timer:
+    def __init__(self, parent):
+        self.parent = parent
+        self.timeout = _Signal()
+        self.interval_ms = None
+        self.started = False
+
+    def setInterval(self, interval_ms):
+        self.interval_ms = interval_ms
+
+    def start(self):
+        self.started = True
+
+
+class _Watchdog:
+    def __init__(self):
+        self.ticks = 0
+
+    def tick(self):
+        self.ticks += 1
+
+    def summary(self):
+        return {"sample_count": self.ticks}
+
+
+def test_gui_watchdog_is_not_installed_when_tracing_is_disabled(monkeypatch):
+    class _DisabledRecorder:
+        enabled = False
+
+    VibeCADPerformanceGui._reset_event_loop_watchdog_for_tests()
+    monkeypatch.setattr(
+        VibeCADPerformanceGui,
+        "get_performance_recorder",
+        lambda: _DisabledRecorder(),
+    )
+
+    def fail_timer_factory(_parent):
+        raise AssertionError("A disabled watchdog allocated a timer.")
+
+    assert (
+        VibeCADPerformanceGui.install_event_loop_watchdog(
+            parent="main-window",
+            timer_factory=fail_timer_factory,
+        )
+        is None
+    )
+    assert VibeCADPerformanceGui.event_loop_watchdog_summary() == {
+        "installed": False,
+        "sample_count": 0,
+    }
+
+
+def test_gui_watchdog_installation_is_idempotent():
+    VibeCADPerformanceGui._reset_event_loop_watchdog_for_tests()
+    watchdog = _Watchdog()
+    created = []
+
+    def timer_factory(parent):
+        timer = _Timer(parent)
+        created.append(timer)
+        return timer
+
+    first = VibeCADPerformanceGui.install_event_loop_watchdog(
+        parent="main-window",
+        timer_factory=timer_factory,
+        watchdog=watchdog,
+    )
+    second = VibeCADPerformanceGui.install_event_loop_watchdog(
+        parent="ignored",
+        timer_factory=timer_factory,
+        watchdog=_Watchdog(),
+    )
+
+    assert first is second
+    assert len(created) == 1
+    assert first.parent == "main-window"
+    assert first.interval_ms == 25
+    assert first.started is True
+    first.timeout.callback()
+    assert watchdog.ticks == 1
+    assert VibeCADPerformanceGui.event_loop_watchdog_summary() == {"sample_count": 1}
+    VibeCADPerformanceGui._reset_event_loop_watchdog_for_tests()

--- a/src/Mod/VibeCAD/vibecad_tests/tree_visibility_coalescing_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/tree_visibility_coalescing_gui_integration.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Prove one browser-folder refresh for a burst of visibility changes."""
+
+from __future__ import annotations
+
+import sys
+import time
+import traceback
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from PySide import QtCore, QtWidgets
+from PySide6 import QtTest
+
+
+def _first_populated_browser_folder(tree: QtWidgets.QTreeWidget):
+    pending = [tree.topLevelItem(index) for index in range(tree.topLevelItemCount())]
+    retained = list(pending)
+    while pending:
+        parent = pending.pop()
+        for index in range(parent.childCount()):
+            child = parent.child(index)
+            retained.append(child)
+            if child.type() == 1002 and child.childCount() > 0:
+                return child, retained
+            pending.append(child)
+    raise AssertionError("The model browser did not create a populated folder.")
+
+
+def _instrumented_tree(main_window):
+    tree_dock = main_window.findChild(QtWidgets.QDockWidget, "Std_TreeView")
+    assert tree_dock is not None
+    for tree in tree_dock.findChildren(QtWidgets.QTreeWidget):
+        if tree.property("VibeCADBrowserFolderStatusUpdateCount") is not None:
+            return tree
+    raise AssertionError("The Tree does not expose its browser-folder refresh counter.")
+
+
+def _run() -> None:
+    application = QtWidgets.QApplication.instance()
+    document = None
+    tree_preferences = None
+    original_organize_by_type = True
+    original_status_timeout = 100
+
+    def finish(code: int) -> None:
+        if tree_preferences is not None:
+            tree_preferences.SetBool("OrganizeModelByType", original_organize_by_type)
+            tree_preferences.SetInt("StatusTimeout", original_status_timeout)
+        if document is not None and document.Name in App.listDocuments():
+            App.closeDocument(document.Name)
+        application.exit(code)
+
+    try:
+        tree_preferences = App.ParamGet("User parameter:BaseApp/Preferences/TreeView")
+        original_organize_by_type = tree_preferences.GetBool(
+            "OrganizeModelByType", True
+        )
+        original_status_timeout = tree_preferences.GetInt("StatusTimeout", 100)
+        tree_preferences.SetBool("OrganizeModelByType", True)
+        tree_preferences.SetInt("StatusTimeout", 25)
+        document = App.newDocument("TreeVisibilityCoalescing")
+        objects = [
+            document.addObject("App::FeaturePython", f"VisibleObject{index:03d}")
+            for index in range(153)
+        ]
+        document.recompute()
+        assert set(App.listDocuments()) == {
+            document.Name
+        }, "The visibility coalescing test requires one isolated document."
+
+        def exercise() -> None:
+            try:
+                tree = _instrumented_tree(Gui.getMainWindow())
+                counter_name = "VibeCADBrowserFolderStatusUpdateCount"
+                before = int(tree.property(counter_name))
+                folder, retained_tree_items = _first_populated_browser_folder(tree)
+                visible_brush_style = folder.foreground(0).style()
+
+                def wait_for_one_refresh(previous: int, continuation) -> None:
+                    deadline = time.monotonic() + 2.0
+                    settled_since = None
+
+                    def poll() -> None:
+                        nonlocal settled_since
+                        try:
+                            count = int(tree.property(counter_name)) - previous
+                            if count == 1:
+                                settled_since = settled_since or time.monotonic()
+                                if time.monotonic() - settled_since >= 0.1:
+                                    continuation()
+                                    return
+                            else:
+                                settled_since = None
+                                assert count == 0, (
+                                    "Expected one coalesced browser-folder refresh, "
+                                    f"got {count}."
+                                )
+                            assert (
+                                time.monotonic() < deadline
+                            ), "The coalesced browser-folder refresh did not run."
+                            QtCore.QTimer.singleShot(10, poll)
+                        except Exception:
+                            traceback.print_exc(file=sys.__stderr__)
+                            finish(1)
+
+                    poll()
+
+                def restore_after_direct_change() -> None:
+                    try:
+                        assert retained_tree_items
+                        assert all(not obj.ViewObject.Visibility for obj in objects)
+                        assert (
+                            folder.foreground(0).style() != visible_brush_style
+                        ), "The coalesced refresh did not update the folder's hidden state."
+                        restore_before = int(tree.property(counter_name))
+                        for obj in objects:
+                            obj.ViewObject.Visibility = True
+                        assert int(tree.property(counter_name)) == restore_before
+                        wait_for_one_refresh(restore_before, exercise_selection_hide)
+                    except Exception:
+                        traceback.print_exc(file=sys.__stderr__)
+                        finish(1)
+
+                def exercise_selection_hide() -> None:
+                    try:
+                        Gui.Selection.clearSelection()
+                        for obj in objects:
+                            Gui.Selection.addSelection(obj)
+                        selection_before = int(tree.property(counter_name))
+                        Gui.Selection.setVisible(False)
+                        assert (
+                            int(tree.property(counter_name)) == selection_before
+                        ), "Std Hide traversed browser folders synchronously per selection."
+                        Gui.Selection.clearSelection()
+                        wait_for_one_refresh(
+                            selection_before, restore_after_selection_hide
+                        )
+                    except Exception:
+                        traceback.print_exc(file=sys.__stderr__)
+                        finish(1)
+
+                def restore_after_selection_hide() -> None:
+                    try:
+                        restore_before = int(tree.property(counter_name))
+                        for obj in objects:
+                            obj.ViewObject.Visibility = True
+                        assert int(tree.property(counter_name)) == restore_before
+                        wait_for_one_refresh(restore_before, exercise_folder_toggle)
+                    except Exception:
+                        traceback.print_exc(file=sys.__stderr__)
+                        finish(1)
+
+                def exercise_folder_toggle() -> None:
+                    try:
+                        current_folder, current_tree_items = (
+                            _first_populated_browser_folder(tree)
+                        )
+                        assert current_tree_items
+                        tree.clearSelection()
+                        tree.setCurrentItem(current_folder)
+                        current_folder.setSelected(True)
+                        tree.setFocus()
+                        folder_before = int(tree.property(counter_name))
+                        QtTest.QTest.keyClick(tree, QtCore.Qt.Key_Space)
+                        assert (
+                            int(tree.property(counter_name)) == folder_before
+                        ), "A folder visibility toggle traversed browser folders synchronously."
+                        wait_for_one_refresh(folder_before, verify_complete)
+                    except Exception:
+                        traceback.print_exc(file=sys.__stderr__)
+                        finish(1)
+
+                def verify_complete() -> None:
+                    try:
+                        assert all(not obj.ViewObject.Visibility for obj in objects)
+                        print("VIBECAD_TREE_VISIBILITY_COALESCING_OK", flush=True)
+                        finish(0)
+                    except Exception:
+                        traceback.print_exc(file=sys.__stderr__)
+                        finish(1)
+
+                for obj in objects:
+                    obj.ViewObject.Visibility = False
+                assert (
+                    int(tree.property(counter_name)) == before
+                ), "A visibility notification traversed browser folders synchronously."
+                wait_for_one_refresh(before, restore_after_direct_change)
+            except Exception:
+                traceback.print_exc(file=sys.__stderr__)
+                finish(1)
+
+        QtCore.QTimer.singleShot(1000, exercise)
+        QtCore.QTimer.singleShot(10000, lambda: finish(1))
+    except Exception:
+        traceback.print_exc(file=sys.__stderr__)
+        finish(1)
+
+
+QtCore.QTimer.singleShot(1000, _run)


### PR DESCRIPTION
## Summary

Establishes the measured foundation for the system-wide responsiveness program and removes the confirmed O(N²)-shaped browser-folder work from bulk visibility changes.

- Adds PERFORMANCE.md as the authoritative benchmark/implementation ledger.
- Adds bounded, opt-in Python tracing and a Qt event-loop watchdog. Normal startup does not import either module or create a timer unless VIBECAD_PERFORMANCE_TRACE is enabled.
- Reuses TreeWidget's existing deferred status timer instead of adding another batching framework.
- Removes synchronous per-object and duplicate deferred browser-folder traversals from direct Visibility changes, Std Show/Hide, folder Space toggles, and model-browser eye toggles.
- Adds a cheap diagnostic counter and a packaged GUI regression covering 153 objects.

The native visibility path has fewer executable lines than before. This is a follow-up to #167 and does not close the broader performance program.

## Root cause and behavior

Each Visibility event recursively traversed browser folders immediately, while the existing Tree status timer also scheduled stabilization work. A 150-object command therefore paid repeated whole-tree work and could then pay it again after the command.

The corrected path records the object changes normally and lets the existing zero-delay Tree refresh converge once after the logical burst. Single-object and bulk behavior remain compatible; only redundant refresh timing is coalesced.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
- [x] The PR lists the exact build and test commands and their results.

Red evidence from the packaged GUI regression before implementation:

- 153 direct Visibility changes caused two delayed browser-folder traversals.
- Std Hide over a multi-selection traversed browser folders synchronously before its delayed traversal.

Focused Python tests:

    C:\Users\robit\vibecad\.pixi\envs\default\python.exe -m pytest src\Mod\VibeCAD\vibecad_tests\test_performance.py src\Mod\VibeCAD\vibecad_tests\test_branding_contract.py src\Mod\VibeCAD\vibecad_tests\test_aero_ribbon_install.py -q

Result: 53 passed, 6 skipped in 1.72 seconds.

Formatting:

    C:\Users\robit\vibecad\.pixi\envs\default\python.exe -m black --check src\Mod\VibeCAD\VibeCADPerformance.py src\Mod\VibeCAD\VibeCADPerformanceGui.py src\Mod\VibeCAD\vibecad_tests\test_performance.py src\Mod\VibeCAD\vibecad_tests\tree_visibility_coalescing_gui_integration.py

Result: 4 files unchanged.

Full Windows Rattler package build, from package/rattler-build:

    pixi install -e default --frozen

Result: success in 16 minutes; vibecad-26.3.1RC6-h3c70cbc_1.conda.

Packaged GUI regression:

    pixi run --as-is --environment default --executable freecad.exe --user-cfg <isolated>/User.cfg --system-cfg <isolated>/System.cfg ../../src/Mod/VibeCAD/vibecad_tests/tree_visibility_coalescing_gui_integration.py

Result: VIBECAD_TREE_VISIBILITY_COALESCING_OK. Direct property changes, Std multi-selection Hide, and folder Space toggling each caused zero synchronous traversals and exactly one delayed traversal that remained stable.

The installed InitGui.py, VibeCADPerformance.py, and VibeCADPerformanceGui.py SHA-256 hashes exactly match commit 0a9a3781's sources. The final evidence-only commit changes PERFORMANCE.md only.

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults preserve previous behavior; tracing is disabled unless explicitly enabled by environment.
- [x] No deprecations or breaking changes.

## Risk and non-goals

Risk is limited to Tree refresh scheduling after visibility changes. The package test covers the human command paths and the direct property path used by automation, including final folder presentation state.

This PR does not attempt tessellation, persistent workers, Timeline optimization, or release-level B01-B27 acceptance. Those remain explicitly tracked in PERFORMANCE.md and will be delivered as measured, focused follow-ups rather than bundled into this change.

## Issues

Follow-up to #167.

## Before and After Images

Not applicable: presentation is unchanged. The regression is event-count and responsiveness behavior verified in the packaged GUI.