### PR TITLE
perf: reuse projection icons during stable refresh

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -268,6 +268,28 @@ raster-transforming equivalent Timeline icons once per operation. Optimize
 those measured repetitions before changing projection architecture. Remaining
 Qt item construction must then be applied in bounded event-loop batches.
 
+The first measured optimization checkpoint reuses exact rendered icons during
+one projection refresh and caches named SVG rendering by resolved path, device-
+pixel size, and color map. It does not add persistent projection state or alter
+any public API. The same fixture and command produced:
+
+| Measurement | Baseline | Reuse checkpoint | Change |
+|---|---:|---:|---:|
+| Correct publication | passed | passed | unchanged |
+| Longest cooperative apply unit | 93.518 ms | 93.870 ms | +0.4% |
+| GUI heartbeat maximum | 1,863.733 ms | 644.622 ms | -65.4% |
+| Final Tree stable refresh | 963.229 ms | 326.063 ms | -66.1% |
+| Model-browser rebuild | 473.543 ms | 12.956 ms | -97.3% |
+| Browser item creation | 463.308 ms / 321 | 4.273 ms / 321 | -99.1% |
+| Tree status-icon generation | 912.865 ms / 642 | 287.627 ms / 321 | -68.5% |
+| Final Feature Timeline rebuild | 842.690 ms | 261.887 ms | -68.9% |
+| Timeline item construction | 834.236 ms / 312 | 256.264 ms / 312 | -69.3% |
+| Timeline icon transformation | 393.617 ms / 312 | 2.351 ms / 6 | -99.4% |
+
+This is a successful reduction, not completion: the 645 ms final gap still
+fails the 100 ms watchdog. The remaining measured Tree and Timeline widget work
+must be cooperatively batched without moving Qt widgets off the GUI thread.
+
 ## Work plan and ledger
 
 Status values are `DONE`, `IN PROGRESS`, `NOT STARTED`, `BLOCKED`, and
@@ -288,7 +310,7 @@ Status values are `DONE`, `IN PROGRESS`, `NOT STARTED`, `BLOCKED`, and
 | P10 | Bound publication commit/rollback/final-stabilization phases | IN PROGRESS | B07 final Tree + Timeline tail isolated at 1.806 s; optimization and B26 remain |
 | P11 | Coalesce Tree, Timeline, cache, and observer notifications | NOT STARTED | One logical refresh per operation |
 | P12 | Eliminate full-object stable refresh when exact changed identities exist | NOT STARTED | B05/B07 traversal and allocation evidence |
-| P13 | Measure and optimize Tree projection and Feature Timeline rebuild | IN PROGRESS | Representative B07 native trace isolates Tree status-icon generation (912.865 ms) and Timeline icon transformation (393.617 ms); optimization remains |
+| P13 | Measure and optimize Tree projection and Feature Timeline rebuild | IN PROGRESS | B07 exact-icon/SVG reuse cuts the final gap 65.4% (1,863.733 to 644.622 ms), browser item creation 99.1%, and Timeline icon transforms 99.4%; bounded widget batching remains |
 | P14 | Implement persistent startup worker runtime and bounded queues | NOT STARTED | Startup, reuse, fairness, shutdown, and crash tests |
 | P15 | Implement per-document actor ownership and revision-safe result application | NOT STARTED | B26/B27 stress evidence |
 | P16 | Standardize human/AI progress, cancellation, and diagnostics contract | REVALIDATE | VibeScript direct progress exists; audit every other long operation |

--- a/src/Gui/BitmapFactory.cpp
+++ b/src/Gui/BitmapFactory.cpp
@@ -35,6 +35,7 @@
 #include <QStyleOption>
 
 #include <string>
+#include <tuple>
 #include <Inventor/fields/SoSFImage.h>
 
 #include <App/Application.h>
@@ -47,10 +48,13 @@ using namespace Gui;
 
 namespace Gui
 {
+using SvgPixmapCacheKey = std::tuple<QString, int, int, ColorMap>;
+
 class BitmapFactoryInstP
 {
 public:
     QMap<std::string, QPixmap> xpmCache;
+    std::map<SvgPixmapCacheKey, QPixmap> svgCache;
 
     bool useIconTheme;
 };
@@ -319,15 +323,26 @@ QPixmap BitmapFactoryInst::pixmapFromSvg(
     }
 
     if (!iconPath.isEmpty()) {
+        const QSize renderSize = (size * dpr).toSize();
+        SvgPixmapCacheKey cacheKey {
+            iconPath,
+            renderSize.width(),
+            renderSize.height(),
+            colorMapping,
+        };
+        if (const auto cached = d->svgCache.find(cacheKey); cached != d->svgCache.end()) {
+            return cached->second;
+        }
         QFile file(iconPath);
         if (file.open(QFile::ReadOnly | QFile::Text)) {
             QByteArray content = file.readAll();
-            icon = pixmapFromSvg(content, size * dpr, colorMapping);
+            icon = pixmapFromSvg(content, renderSize, colorMapping);
         }
-    }
 
-    if (!icon.isNull()) {
-        icon.setDevicePixelRatio(dpr);
+        if (!icon.isNull()) {
+            icon.setDevicePixelRatio(dpr);
+            d->svgCache.emplace(std::move(cacheKey), icon);
+        }
     }
 
     return icon;

--- a/src/Gui/FeatureTimeline.cpp
+++ b/src/Gui/FeatureTimeline.cpp
@@ -6,6 +6,7 @@
 #include <functional>
 #include <iterator>
 #include <limits>
+#include <map>
 #include <optional>
 #include <sstream>
 #include <string_view>
@@ -1305,6 +1306,7 @@ void FeatureTimeline::rebuild()
     std::vector<VisibleSemanticBlock> visibleBlocks;
     visibleBlocks.reserve(operations.size());
     int lastActiveVisible = -1;
+    std::map<std::pair<qint64, unsigned int>, QIcon> iconCache;
     for (std::size_t index = 0; index < operations.size(); ++index) {
         if (!isVisibleTimelineOperation(operations[index], internalTransformations, projection)) {
             continue;
@@ -1433,14 +1435,21 @@ void FeatureTimeline::rebuild()
                     Gui::Application::Instance->getViewProvider(iconObject)
                 )) {
                 const QIcon icon = viewProvider->getIcon();
-                item->setIcon(
-                    timelineObjectIcon(
-                        icon,
-                        object,
-                        afterPosition,
-                        presentationVisible
-                    )
-                );
+                const unsigned int iconState =
+                    (afterPosition ? 1U : 0U)
+                    | (presentationVisible.has_value() ? 2U : 0U)
+                    | (presentationVisible.value_or(false) ? 4U : 0U)
+                    | (object->isError() ? 8U : 0U)
+                    | ((object->isTouched() || object->mustExecute() == 1) ? 16U : 0U);
+                const auto key = std::make_pair(icon.cacheKey(), iconState);
+                auto cached = iconCache.find(key);
+                if (cached == iconCache.end()) {
+                    cached = iconCache.emplace(
+                        key,
+                        timelineObjectIcon(icon, object, afterPosition, presentationVisible)
+                    ).first;
+                }
+                item->setIcon(cached->second);
             }
         }
 

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -5555,7 +5555,19 @@ DocumentObjectItem* DocumentItem::createBrowserObjectItem(
     );
     item->populated = true;
     item->setChildIndicatorPolicy(QTreeWidgetItem::DontShowIndicator);
-    item->testStatus(true);
+    QIcon normalIcon;
+    QIcon disabledIcon;
+    const bool visible = object->Visibility.getValue();
+    for (auto* existingItem : data->items) {
+        if (existingItem == item || existingItem->isBrowserProxy()
+            || TreeWidget::objectItemVisibility(existingItem) != visible) {
+            continue;
+        }
+        QIcon& existingIcon = visible ? normalIcon : disabledIcon;
+        existingIcon = existingItem->icon(0);
+        break;
+    }
+    item->testStatus(true, normalIcon, disabledIcon);
     return item;
 }
 


### PR DESCRIPTION
## Outcome

Eliminates measured duplicate icon work during the Tree and Feature Timeline refresh at the end of large publications.

- Cache named SVG rasterization by resolved path, rendered pixel size, and exact color map.
- Reuse the already-correct legacy Tree icon when the semantic browser renders the same document object with the same effective visibility.
- Reuse exact Timeline icon variants within one rebuild using the Qt icon identity and complete visual-state bits.
- Keep cache lifetime and ownership narrow; no persistent projection state was added.

## Why

The representative 307-member Assembly trace proved that the final 1.864-second UI stall was dominated by duplicate Tree and Timeline icon generation, not semantic classification or tessellation.

## Red / green evidence

Red baseline (`build/run_vibescript_publication_307_native_trace.ps1`):

- Correct 307-member publication, but maximum GUI heartbeat gap: **1,863.733 ms** (100 ms contract failed).
- Browser item creation: **463.308 ms / 321**.
- Tree icon generation: **912.865 ms / 642**.
- Timeline icon transformation: **393.617 ms / 312**.

Green, same fixture and command against the exact rebuilt Rattler/MSVC DLL:

- Correct publication: **307 members / 322 objects**.
- Maximum GUI heartbeat gap: **644.622 ms** (**65.4% lower**; remaining batching work is explicitly not claimed complete).
- Browser item creation: **4.273 ms / 321** (**99.1% lower**).
- Tree icon generation: **287.627 ms / 321** (**68.5% lower**).
- Timeline icon transformation: **2.351 ms / 6** (**99.4% lower**).
- Longest cooperative publication unit: **93.870 ms**.

Focused test:

```powershell
.pixi\envs\default\python.exe -m pytest src\Mod\VibeCAD\vibecad_tests\test_performance.py -q
```

Result: **12 passed**.

Exact native build:

```powershell
cmake --build <rattler-work-build> --target FreeCADGui --parallel 8
```

Result: **passed with MSVC**, followed by the native benchmark above. A red compile caught an incorrect `QIcon`/`QPixmap` argument during simplification; the corrected target rebuilt and linked cleanly before measurement.

## Risk and non-goals

Risk is limited to icon caching/reuse. Failed SVG loads are not cached. Keys include every input that changes rendered output. This PR deliberately does not claim to solve the remaining 645 ms final projection stall; bounded GUI-thread widget batching is the next measured step.

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed or removed.
- [x] Defaults and visible behavior are unchanged.
- [x] No deprecations.
- [x] No breaking changes.