### PR TITLE
Fix Gemini replay of unchanged CAD state

### DIFF
--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -5706,6 +5706,7 @@ def _gemini_child_main(
             )
 
             for tool_call in assistant_tool_calls:
+                previous_context = live_context
                 function = tool_call["function"]
                 function_name = str(function["name"])
                 tool_name = tools_by_name.get(function_name)
@@ -5750,6 +5751,7 @@ def _gemini_child_main(
                 state_after = _provider_state_after_tool(
                     live_context,
                     result if isinstance(result, dict) else None,
+                    previous_context=previous_context,
                 )
                 if isinstance(result, dict) and state_after:
                     result["vibecad_state_after"] = state_after

--- a/src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py
@@ -4,10 +4,13 @@
 
 from __future__ import annotations
 
+import copy
 import json
 from pathlib import Path
 import sys
 from types import SimpleNamespace
+
+import pytest
 
 import VibeCADAuth as auth
 import VibeCADDesignReview as design_review
@@ -497,3 +500,116 @@ def test_gemini_stream_preserves_thought_signatures_and_repairs_tool_arguments(
         "raw": None,
     }
     assert connection.closed
+
+
+@pytest.mark.parametrize("change", ["revision", "surface", "workbench", "native"])
+def test_gemini_only_sends_changed_state_after_tools(monkeypatch, change) -> None:
+    initial = {
+        "workbench": "Model",
+        "modeling_surface": {
+            "engine": "native" if change == "native" else "vibescript",
+            "workbench": "Model",
+            "domain": "partdesign",
+            "surface_id": "surface-1",
+        },
+        "native_state": {"revision": 1, "inventory": "x" * 8192},
+        "provider_tool_schemas": [_state_read_schema()],
+    }
+    changed = copy.deepcopy(initial)
+    if change in {"revision", "native"}:
+        changed["native_state"]["revision"] = 2
+    elif change == "surface":
+        changed["modeling_surface"]["surface_id"] = "surface-2"
+    else:
+        changed["workbench"] = "Assembly"
+        changed["modeling_surface"]["workbench"] = "Assembly"
+
+    updates = [initial, changed, changed, changed]
+    requests = []
+
+    class _Connection(_GeminiConnection):
+        def recv(self):
+            return {
+                "type": "tool_result",
+                "result": {"ok": True, "objects": ["Body"]},
+                "context": copy.deepcopy(updates.pop(0)),
+            }
+
+    def tool_delta(index, call_id):
+        return SimpleNamespace(
+            index=index,
+            id=call_id,
+            type="function",
+            function=SimpleNamespace(
+                name="state_read", arguments='{"target":"Body"}'
+            ),
+            extra_content={"google": {"thought_signature": call_id}},
+        )
+
+    streams = [
+        iter([_chunk(
+            tool_calls=[tool_delta(0, "call-1"), tool_delta(1, "call-2")],
+            finish_reason="tool_calls",
+        )]),
+        iter([_chunk(
+            tool_calls=[tool_delta(0, "call-3"), tool_delta(1, "call-4")],
+            finish_reason="tool_calls",
+        )]),
+        iter([_chunk(content="Inspection complete.", finish_reason="stop")]),
+    ]
+
+    class _OpenAI:
+        def __init__(self, **_kwargs):
+            self.chat = SimpleNamespace(
+                completions=SimpleNamespace(create=self._create)
+            )
+
+        @staticmethod
+        def _create(**kwargs):
+            requests.append(copy.deepcopy(kwargs))
+            return streams.pop(0)
+
+        @staticmethod
+        def close():
+            pass
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=_OpenAI))
+    monkeypatch.setattr(
+        provider, "_validate_provider_wire_surface", lambda _context: None
+    )
+    connection = _Connection()
+    provider._gemini_child_main(
+        connection, "Inspect Body.", copy.deepcopy(initial),
+        "gemini-flash-latest", "gemini-test-key", "high", 10.0, 3, False,
+        provider.DEFAULT_GEMINI_API_BASE,
+    )
+
+    assert connection.messages[-1] == {
+        "type": "done", "final_output": "Inspection complete.", "raw": None
+    }
+    assert len(requests) == 3
+    results = [
+        message for message in requests[-1]["messages"]
+        if message["role"] == "tool"
+    ]
+    assert [result["tool_call_id"] for result in results] == [
+        "call-1", "call-2", "call-3", "call-4"
+    ]
+    for index, result in enumerate(results):
+        expected = {"ok": True, "objects": ["Body"]}
+        if index == 1 and change != "native":
+            expected["vibecad_state_after"] = {
+                "surface": changed["modeling_surface"],
+                "active_domain": changed["native_state"],
+            }
+        assert json.loads(result["content"]) == expected
+
+    assistant_messages = [
+        message for message in requests[-1]["messages"]
+        if message["role"] == "assistant"
+    ]
+    for message in assistant_messages:
+        for call in message["tool_calls"]:
+            assert call["extra_content"] == {
+                "google": {"thought_signature": call["id"]}
+            }


### PR DESCRIPTION
Gemini previously attached the complete VibeScript state after every tool call, including reads that left it unchanged. This two-line fix passes the pre-tool context to the existing comparison helper, so unchanged state is omitted and changed state is delivered once.

Regression tests cover document revision, surface and workbench changes, native-engine state omission, and multiple calls within one model response. Tool results, call IDs, and Gemini thought signatures are preserved.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
- [x] The PR lists the exact build and test commands and their results.

Tests ran on Windows using the bundled Python interpreter and isolated pytest/jsonschema dependencies. In the commands below, `$python` and `$git` stand for the absolute executable paths used during verification; machine-specific paths are omitted.

Before the implementation:
```powershell
& $python -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py -k only_sends_changed_state --tb=short
```
Result: **3 failed, 1 passed, 9 deselected**. The three VibeScript cases reproduced redundant state; the native-engine case already passed.

After the implementation:
```powershell
& $python -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py --tb=short
```
Result: **64 passed, 1 skipped**.

Additional checks:
```powershell
& $python -m py_compile src/Mod/VibeCAD/VibeCADProvider.py src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py
& $git diff --check
```
Both passed.

No paid model requests were made. Provider streams and the CAD bridge were mocked. No full C++ build or live GUI test was run; the production change is limited to Python request construction.

## Issues

Fixes #175.

Follow-up to the provider payload optimization in #130.

## Before and After Images

Not applicable: no GUI changes. Previously each unchanged read added another state block to the model conversation; afterward unchanged reads preserve the useful tool result without that redundant block.

## Compatibility

- [x] Existing public functions and APIs remain present.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Existing model settings and productive tool execution remain unchanged.
- [x] Changed CAD state, tool results, call IDs, and thought signatures remain available.
- [x] No deprecations, dependency changes, packaging changes, or public API breaks.
