### PR TITLE
Bound Anthropic stream retries to one transport budget

### DIFF
--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import base64
 from contextlib import ExitStack, contextmanager
 from dataclasses import dataclass
+from email.utils import mktime_tz, parsedate_tz
 import hashlib
 import json
 import multiprocessing
@@ -4732,6 +4733,43 @@ def _is_retryable_anthropic_stream_error(
     return any(token in text for token in retry_tokens)
 
 
+def _is_retryable_anthropic_request_error(
+    exc: BaseException, anthropic_module: Any
+) -> bool:
+    status_error = getattr(anthropic_module, "APIStatusError", ())
+    if isinstance(exc, status_error):
+        directive = exc.response.headers.get("x-should-retry")
+        if directive in {"true", "false"}:
+            return directive == "true"
+        return exc.status_code in {408, 409, 429} or exc.status_code >= 500
+    return _is_retryable_anthropic_stream_error(exc, anthropic_module)
+
+
+def _anthropic_request_retry_delay(exc: BaseException, attempt: int) -> float:
+    response = getattr(exc, "response", None)
+    if response is None:
+        return min(2.0, 0.25 * attempt)
+
+    headers = response.headers
+    delay = None
+    for name, scale in (("retry-after-ms", 0.001), ("retry-after", 1.0)):
+        try:
+            delay = float(headers[name]) * scale
+            break
+        except (KeyError, TypeError, ValueError):
+            continue
+    if delay is None and headers.get("retry-after"):
+        try:
+            parsed = parsedate_tz(headers["retry-after"])
+            if parsed is not None:
+                delay = mktime_tz(parsed) - time.time()
+        except (TypeError, ValueError, OverflowError):
+            pass
+    if delay is not None and 0 < delay <= 60:
+        return delay
+    return min(8.0, 0.5 * 2 ** min(attempt - 1, 4))
+
+
 def _bounded_compaction_text(value: Any, limit: int) -> str:
     text = str(value or "").strip()
     if len(text) <= limit:
@@ -5887,6 +5925,10 @@ def _anthropic_child_main(
             )
         )
 
+        # Stream retries belong to the outer loop, including failures after
+        # headers. Keep metadata and separate compaction SDK retries intact.
+        client.max_retries = 0
+
         request_kwargs: dict[str, Any] = {
             "model": model,
             "max_tokens": max_tokens,
@@ -5900,7 +5942,11 @@ def _anthropic_child_main(
                 "effort": _anthropic_adaptive_effort(reasoning_effort)
             }
 
+        response_content_observed = False
+
         def _stream_response(turn: int, attempt: int) -> Any:
+            nonlocal response_content_observed
+            response_content_observed = False
             # The SDK rejects non-streaming requests that could exceed ten
             # minutes (large max_tokens plus thinking budgets), so always
             # stream and accumulate the final message.
@@ -5969,6 +6015,8 @@ def _anthropic_child_main(
                     event_count += 1
                     summary = _anthropic_stream_event_summary(stream_event)
                     stream_event_type = summary.get("stream_event_type")
+                    if stream_event_type in {"content_block_start", "content_block_delta"}:
+                        response_content_observed = True
                     delta_type = summary.get("delta_type")
                     text_delta = summary.get("text_delta")
                     if text_delta:
@@ -6044,15 +6092,22 @@ def _anthropic_child_main(
                 return stream.get_final_message()
 
         def _stream_response_with_retries(turn: int) -> Any:
+            status_failures = 0
             for attempt in range(1, ANTHROPIC_STREAM_MAX_ATTEMPTS + 1):
                 try:
                     return _stream_response(turn, attempt)
                 except anthropic.BadRequestError:
                     raise
                 except Exception as exc:
+                    is_status_error = isinstance(
+                        exc, getattr(anthropic, "APIStatusError", ())
+                    )
+                    if is_status_error:
+                        status_failures += 1
                     if (
                         attempt >= ANTHROPIC_STREAM_MAX_ATTEMPTS
-                        or not _is_retryable_anthropic_stream_error(exc, anthropic)
+                        or status_failures >= client_kwargs["max_retries"] + 1
+                        or not _is_retryable_anthropic_request_error(exc, anthropic)
                     ):
                         raise
                     _send_child_progress(
@@ -6062,11 +6117,17 @@ def _anthropic_child_main(
                             "turn": turn,
                             "attempt": attempt,
                             "next_attempt": attempt + 1,
+                            "transport_attempt_count": attempt,
+                            "response_content_observed": response_content_observed,
                             "max_attempts": ANTHROPIC_STREAM_MAX_ATTEMPTS,
                             "error": _short_provider_error(exc),
                         },
                     )
-                    time.sleep(min(2.0, 0.25 * attempt))
+                    time.sleep(
+                        _anthropic_request_retry_delay(
+                            exc, status_failures if is_status_error else attempt
+                        )
+                    )
             raise RuntimeError("Anthropic stream retry loop exited unexpectedly.")
 
         turn = 1

--- a/src/Mod/VibeCAD/vibecad_tests/test_anthropic_retry_budget.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_anthropic_retry_budget.py
@@ -1,0 +1,195 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Count real SDK transport attempts without contacting Anthropic."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import VibeCADProvider as provider
+
+anthropic = pytest.importorskip("anthropic")
+httpx = pytest.importorskip("httpx")
+
+
+def _event(kind, **fields):
+    return f"event: {kind}\ndata: {json.dumps({'type': kind, **fields})}\n\n".encode()
+
+
+def _response_events():
+    return [
+        _event("message_start", message={
+            "id": "msg_test", "type": "message", "role": "assistant",
+            "model": "test-model", "content": [], "stop_reason": None,
+            "stop_sequence": None, "usage": {"input_tokens": 1, "output_tokens": 0},
+        }),
+        _event("content_block_start", index=0,
+               content_block={"type": "text", "text": ""}),
+        _event("content_block_delta", index=0,
+               delta={"type": "text_delta", "text": "Recovered."}),
+        _event("content_block_stop", index=0),
+        _event("message_delta", delta={"stop_reason": "end_turn", "stop_sequence": None},
+               usage={"output_tokens": 1}),
+        _event("message_stop"),
+    ]
+
+
+@pytest.fixture
+def run_transport(monkeypatch):
+    real_client = anthropic.Anthropic
+    clients = []
+
+    def run(outcomes, *, metadata_failures=0):
+        requests = []
+        metadata = []
+        sleeps = []
+        messages = []
+
+        class InterruptedStream(httpx.SyncByteStream):
+            def __iter__(self):
+                yield b"".join(_response_events()[:3])
+                raise httpx.ReadError("peer closed connection")
+
+        def handle(request):
+            if request.method == "GET":
+                metadata.append(request)
+                if len(metadata) <= metadata_failures:
+                    return httpx.Response(503, json={
+                        "type": "error", "error": {
+                            "type": "overloaded_error", "message": "Temporary"
+                        },
+                    })
+                return httpx.Response(200, json={
+                    "id": "test-model", "type": "model",
+                    "display_name": "Test", "created_at": "2026-01-01T00:00:00Z",
+                    "max_tokens": 8192,
+                })
+            requests.append(request)
+            outcome = outcomes[min(len(requests) - 1, len(outcomes) - 1)]
+            if outcome == "timeout":
+                raise httpx.ReadTimeout("read timed out", request=request)
+            if outcome == "connect":
+                raise httpx.ConnectError("connection failed", request=request)
+            if outcome == "broken":
+                return httpx.Response(200, headers={"content-type": "text/event-stream"},
+                                      stream=InterruptedStream())
+            if outcome == "ok":
+                return httpx.Response(200, headers={"content-type": "text/event-stream"},
+                                      content=b"".join(_response_events()))
+            status, headers = outcome if isinstance(outcome, tuple) else (outcome, {})
+            return httpx.Response(status, headers=headers, json={
+                "type": "error", "error": {"type": "api_error", "message": "Temporary"},
+            })
+
+        def make_client(**kwargs):
+            client = real_client(
+                **kwargs, http_client=httpx.Client(transport=httpx.MockTransport(handle))
+            )
+            clients.append(client)
+            return client
+
+        class Connection:
+            def send(self, message):
+                messages.append(message)
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(anthropic, "Anthropic", make_client)
+        monkeypatch.setattr(provider, "_validate_provider_wire_surface", lambda _: None)
+        monkeypatch.setattr(provider.time, "sleep", sleeps.append)
+        provider._anthropic_child_main(
+            Connection(), "Inspect the model.", {"provider_tool_schemas": []},
+            "test-model", "fake-key", None, 1.0, 1, False,
+        )
+        return requests, metadata, messages, sleeps
+
+    yield run
+    for client in clients:
+        client.close()
+
+
+@pytest.mark.parametrize("failure", ["timeout", "connect", "broken", 408, 409, 429, 503])
+def test_stream_total_transport_attempts_are_bounded(run_transport, failure):
+    requests, _, messages, _ = run_transport([failure])
+    expected_attempts = 3 if isinstance(failure, int) else 6
+    assert len(requests) == expected_attempts
+    assert messages[-1]["type"] == "error"
+    retries = [
+        message["event"] for message in messages
+        if message.get("event", {}).get("event") == "anthropic_stream_retrying"
+    ]
+    assert [event["next_attempt"] for event in retries] == list(
+        range(2, expected_attempts + 1)
+    )
+    assert [event["transport_attempt_count"] for event in retries] == list(
+        range(1, expected_attempts)
+    )
+    assert all(event["response_content_observed"] == (failure == "broken")
+               for event in retries)
+    assert not any(message["type"] == "tool" for message in messages)
+
+
+def test_stream_mixed_failures_can_recover_on_last_attempt(run_transport):
+    requests, _, messages, _ = run_transport(
+        ["timeout", 503, "broken", 429, "connect", "ok"]
+    )
+    assert len(requests) == 6
+    assert messages[-1] == {
+        "type": "done", "final_output": "Recovered.", "raw": None
+    }
+
+
+@pytest.mark.parametrize("status", [400, 401, 403, 422])
+def test_stream_permanent_errors_are_not_retried(run_transport, status):
+    requests, _, messages, sleeps = run_transport([status])
+    assert len(requests) == 1
+    assert messages[-1]["type"] == "error"
+    assert sleeps == []
+
+
+def test_stream_obeys_explicit_do_not_retry(run_transport):
+    requests, _, messages, sleeps = run_transport([(503, {"x-should-retry": "false"})])
+    assert len(requests) == 1
+    assert messages[-1]["type"] == "error"
+    assert sleeps == []
+
+
+@pytest.mark.parametrize("headers,delay", [
+    ({"retry-after": "2"}, 2.0),
+    ({"retry-after-ms": "1250", "retry-after": "2"}, 1.25),
+    ({"retry-after": "Thu, 01 Jan 1970 00:16:43 GMT"}, 3.0),
+])
+def test_stream_respects_server_retry_delay(run_transport, monkeypatch, headers, delay):
+    monkeypatch.setattr(provider.time, "time", lambda: 1000.0)
+    requests, _, messages, sleeps = run_transport([(429, headers), "ok"])
+    assert len(requests) == 2
+    assert messages[-1]["type"] == "done"
+    assert sleeps == [delay]
+
+
+def test_metadata_retains_sdk_retries(run_transport):
+    requests, metadata, messages, _ = run_transport(["ok"], metadata_failures=2)
+    assert len(metadata) == 3
+    assert len(requests) == 1
+    assert messages[-1]["type"] == "done"
+
+
+@pytest.mark.parametrize("value", ["invalid", "NaN", "Infinity", "-1", "61"])
+def test_stream_invalid_retry_delay_uses_bounded_backoff(run_transport, value):
+    requests, _, messages, sleeps = run_transport(
+        [(429, {"retry-after": value}), "ok"]
+    )
+    assert len(requests) == 2
+    assert messages[-1]["type"] == "done"
+    assert sleeps == [0.5]
+
+
+def test_stream_status_retry_limit_survives_mixed_failures(run_transport):
+    requests, _, messages, _ = run_transport(
+        [503, "timeout", 429, "broken", 503, "ok"]
+    )
+    assert len(requests) == 5
+    assert messages[-1]["type"] == "error"

--- a/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
@@ -676,6 +676,7 @@ def test_anthropic_thinking_only_max_tokens_compacts_and_continues(
     assert len(compaction_calls) == 1
     assert compaction_calls[0]["model"] == "memory-model"
     assert compaction_calls[0]["max_tokens"] == 128_000
+    assert compaction_calls[0]["client_kwargs"]["max_retries"] == 2
     assert model_requests == ["interactive-model", "memory-model"]
     assert messages.requests[0]["max_tokens"] == 128_000
     recovery_request = messages.requests[1]
@@ -2691,3 +2692,51 @@ def test_partdesign_does_not_inject_a_model_manifest_at_turn_start(
     assert "partdesign" not in context
     assert "vibescript" not in context
     assert context["editable_sources"]["domain"] == "partdesign"
+
+
+@pytest.mark.parametrize("stop", ["cancel", "deadline"])
+def test_retry_wait_is_terminated_by_parent_stop(monkeypatch, stop) -> None:
+    now = [0.0]
+
+    class RetryWaitProcess(_ExitedProcess):
+        terminated = False
+
+        def is_alive(self):
+            return not self.terminated
+
+        def terminate(self):
+            self.terminated = True
+
+    class RetryWaitPipe(_DelayedPipeMessage):
+        notified = False
+
+        def poll(self, timeout):
+            assert not self.notified, "Parent continued waiting after stop"
+            return True
+
+        def recv(self):
+            self.notified = True
+            now[0] = 2.0
+            return {
+                "type": "progress",
+                "event": {"event": "anthropic_stream_retrying", "attempt": 1},
+            }
+
+    context = _FakeMultiprocessingContext()
+    context.process = RetryWaitProcess()
+    context.parent_conn = RetryWaitPipe()
+    monkeypatch.setattr(
+        provider, "_provider_multiprocessing_context", lambda **kwargs: context
+    )
+    monkeypatch.setattr(provider.time, "monotonic", lambda: now[0])
+    error = provider.ProviderUnavailable if stop == "cancel" else TimeoutError
+    with pytest.raises(error):
+        provider._run_provider_subprocess(
+            prompt="Inspect", context={}, tool_runner=None, model="test-model",
+            api_key=None, reasoning_effort=None,
+            timeout_seconds=1.0 if stop == "deadline" else None,
+            cancellation_check=lambda: stop == "cancel" and context.parent_conn.notified,
+            child_main=_unused_child, clear_inherited_modules=False,
+        )
+    assert context.process.terminated
+    assert context.parent_conn.closed


### PR DESCRIPTION
Repeated Anthropic connection/read failures could submit one streamed generation 18 times: three SDK transport attempts inside each of six application attempts. This change makes the existing application loop own stream retries, limiting a generation to six actual transport attempts.

SDK retries are disabled on the streaming client only after model capability retrieval. Metadata retrieval and the separate compaction client retain their existing SDK retry policy. HTTP status failures retain a three-failure allowance within the six-attempt total; transient 408/409/429/5xx responses and explicit server retry directives are handled by the outer loop. Retry-After seconds, milliseconds, and HTTP dates are honored within the SDK's existing 60-second range.

Retry progress now includes the transport attempt count and whether response content was observed, alongside the existing turn/attempt fields. Connection/read failures retain the existing short backoff; HTTP failures use bounded exponential backoff. Retries do not execute partially received CAD tool calls.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
- [x] The PR lists the exact build and test commands and their results.

Test environment: Windows, the repository-pinned Anthropic SDK 0.116.0, and httpx.MockTransport. The full provider child executes against the actual SDK; no HTTP request reaches the network. In the commands below, `$python` and `$git` denote the absolute executable paths used; machine-specific paths are omitted.

Red baseline:
```powershell
& $python -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_anthropic_retry_budget.py --tb=line
```
**6 failed, 11 passed**. Connection/read failures produced 18 transport attempts instead of 6; SDK-internal status retries were absent from the application retry events.

Additional telemetry red tests:
```powershell
& $python -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_anthropic_retry_budget.py src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py -k 'total_transport or retry_wait' --tb=line
```
**7 failed, 2 passed, 68 deselected** before adding the telemetry fields. Parent cancellation/deadline termination tests already passed.

Final green:
```powershell
& $python -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_anthropic_retry_budget.py src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py --tb=short
& $python -m py_compile src/Mod/VibeCAD/VibeCADProvider.py src/Mod/VibeCAD/vibecad_tests/test_anthropic_retry_budget.py src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py
& $git diff --cached --check
```
**85 passed, 1 skipped**; compilation and whitespace checks passed. The skip is Linux-specific.

Coverage includes persistent and mixed failures, recovery on the sixth attempt, interruption after streamed content, permanent errors, server backoff and malformed headers, and unchanged metadata/compaction retry policies. Parent cancellation/deadline tests use a simulated waiting child and verify termination before the parent continues waiting.

No paid model requests or full GUI/C++ build were performed. This is a Python provider orchestration change. Fewer failed transport attempts do not imply that every avoided attempt would have been billable.

## Issues

Closes #177.

## Before and After Images

Not applicable: no GUI layout changes. Under persistent connection/read failures, the observed request count changes from 18 to 6.

## Compatibility

- [x] Existing public functions/APIs remain present.
- [x] No preference keys, tool names, or schema fields renamed or removed.
- [x] Model selection, reasoning/output limits, CAD tool contracts, and provider turn limits remain unchanged.
- [x] Existing six-attempt stream recovery remains available.
- [x] Metadata and compaction SDK retries remain unchanged.
- [x] No dependency or packaging changes; no deprecations.

The deliberate behavior change is removal of nested transport retries. Status errors share the overall budget while retaining their existing three-failure ceiling. This PR is independent of the Gemini fix in #180.
