### PR TITLE
Bound Gemini no-progress tool loops

### DIFF
--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -1887,9 +1887,11 @@ class GeminiProvider(BaseProvider):
         api_key: str | None = None,
         reasoning_effort: str = "high",
         timeout_seconds: float | None = None,
-        max_turns: int | None = None,
+        max_turns: int | None = 64,
         base_url: str | None = None,
+        no_progress_limit: int = 3,
     ) -> None:
+        self.no_progress_limit = max(0, int(no_progress_limit))
         self.model = model
         self.api_key = api_key
         self.reasoning_effort = reasoning_effort
@@ -1906,6 +1908,10 @@ class GeminiProvider(BaseProvider):
         progress_callback: ProgressCallback | None = None,
     ) -> ProviderResult:
         try:
+            context = dict(context)
+            options = dict(context.get("_vibecad_provider_options") or {})
+            options["gemini_no_progress_limit"] = self.no_progress_limit
+            context["_vibecad_provider_options"] = options
             return _run_provider_subprocess(
                 prompt=prompt,
                 context=context,
@@ -5460,6 +5466,27 @@ def _gemini_forced_tool_completion(
     return _json_safe(arguments)
 
 
+def _gemini_pending_poll(tool_name: str, result: Any) -> bool:
+    """Allow explicit reads of a still-running operation within the turn ceiling."""
+    if not isinstance(result, dict) or result.get("ok") is False:
+        return False
+    if not (
+        tool_name.endswith((".read_operation", ".read_job"))
+        or tool_name.endswith(".inspect")
+        or tool_name == "manufacture.read_setup"
+    ):
+        return False
+    for key in ("operation", "job"):
+        job = result.get(key)
+        if (
+            isinstance(job, dict)
+            and (job.get("operation_id") or job.get("job_id") or job.get("id"))
+            and job.get("status") in {"queued", "pending", "running"}
+        ):
+            return True
+    return False
+
+
 def _gemini_child_main(
     conn,
     prompt: str,
@@ -5540,6 +5567,11 @@ def _gemini_child_main(
             client_kwargs["timeout"] = timeout_seconds
         client = openai.OpenAI(**client_kwargs)
 
+        no_progress_limit = _provider_option_value(
+            live_context, "gemini_no_progress_limit"
+        )
+        no_progress_limit = 3 if no_progress_limit is None else max(0, int(no_progress_limit))
+        unchanged_calls: dict[str, int] = {}
         turn = 1
         while max_turns is None or max_turns <= 0 or turn <= max_turns:
             sdk_request: dict[str, Any] = {
@@ -5706,6 +5738,7 @@ def _gemini_child_main(
             )
 
             for tool_call in assistant_tool_calls:
+                before_state = _anthropic_progress_state_fingerprint(live_context)
                 function = tool_call["function"]
                 function_name = str(function["name"])
                 tool_name = tools_by_name.get(function_name)
@@ -5758,6 +5791,33 @@ def _gemini_child_main(
                     if isinstance(result, dict)
                     else result
                 )
+                after_state = _anthropic_progress_state_fingerprint(live_context)
+                if before_state != after_state:
+                    unchanged_calls.clear()
+                elif no_progress_limit and not _gemini_pending_poll(
+                    tool_name or function_name, result
+                ):
+                    try:
+                        arguments = json.loads(str(function["arguments"]))
+                    except (TypeError, ValueError):
+                        arguments = str(function["arguments"])
+                    fingerprint = _anthropic_progress_fingerprint(
+                        [function_name, arguments, after_state, visible_result]
+                    )
+                    if fingerprint not in unchanged_calls and len(unchanged_calls) >= 128:
+                        unchanged_calls.pop(next(iter(unchanged_calls)))
+                    unchanged_calls[fingerprint] = unchanged_calls.get(fingerprint, 0) + 1
+                    if unchanged_calls[fingerprint] >= no_progress_limit:
+                        conn.send({
+                            "type": "done",
+                            "final_output": (
+                                f"I stopped after repeated unchanged results from {tool_name or function_name}. "
+                                "The work already completed is retained. Inspect the current CAD state "
+                                "and resolve the tool's blocker or revise the request before continuing."
+                            ),
+                            "raw": {"stalled": True, "reason": "no_progress"},
+                        })
+                        return
                 messages.append(
                     {
                         "role": "tool",
@@ -5769,8 +5829,12 @@ def _gemini_child_main(
             turn += 1
         conn.send(
             {
-                "type": "error",
-                "error": "Google Gemini provider turn limit reached.",
+                "type": "done",
+                "final_output": (
+                    "I reached the Gemini turn limit. Completed work is retained; "
+                    "inspect the current result or running job before continuing."
+                ),
+                "raw": {"stalled": True, "reason": "turn_limit"},
             }
         )
     except BaseException as exc:

--- a/src/Mod/VibeCAD/VibeCADProvider.py
+++ b/src/Mod/VibeCAD/VibeCADProvider.py
@@ -1888,7 +1888,7 @@ class GeminiProvider(BaseProvider):
         api_key: str | None = None,
         reasoning_effort: str = "high",
         timeout_seconds: float | None = None,
-        max_turns: int | None = 64,
+        max_turns: int | None = None,
         base_url: str | None = None,
         no_progress_limit: int = 3,
     ) -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py
@@ -9,6 +9,8 @@ from pathlib import Path
 import sys
 from types import SimpleNamespace
 
+import pytest
+
 import VibeCADAuth as auth
 import VibeCADDesignReview as design_review
 import VibeCADIntentMemoryCompiler as intent_compiler
@@ -497,3 +499,74 @@ def test_gemini_stream_preserves_thought_signatures_and_repairs_tool_arguments(
         "raw": None,
     }
     assert connection.closed
+
+
+def test_gemini_has_finite_default_turn_limit():
+    assert provider.GeminiProvider().max_turns == 64
+    assert provider.GeminiProvider(max_turns=None).max_turns is None
+
+
+@pytest.mark.parametrize("case,expected_calls", [
+    ("same", 3), ("failure", 3), ("unknown", 3),
+    ("alternating", 5), ("revision", 6), ("poll", 6), ("disabled", 6),
+])
+def test_gemini_stalled_calls_are_bounded(monkeypatch, case, expected_calls):
+    requests = []
+    context = {
+        "modeling_surface": {"engine": "native"},
+        "native_state": {"revision": 1},
+        "provider_tool_schemas": [_state_read_schema()],
+        "_vibecad_provider_options": {
+            "gemini_no_progress_limit": 0 if case == "disabled" else 3
+        },
+    }
+    if case == "poll":
+        context["provider_tool_schemas"][0]["name"] = "vibescript.read_operation"
+
+    class Connection(_GeminiConnection):
+        def recv(self):
+            state = json.loads(json.dumps(context))
+            if case == "revision":
+                state["native_state"]["revision"] = len(requests) + 1
+            result = {"ok": case != "failure", "value": "unchanged"}
+            if case == "poll":
+                result = {"ok": True, "operation": {"operation_id": "job-1", "status": "running"}}
+            return {"type": "tool_result", "result": result, "context": state}
+
+    class Client:
+        def __init__(self, **kwargs):
+            self.chat = SimpleNamespace(completions=SimpleNamespace(create=self.create))
+
+        def close(self):
+            pass
+
+        def create(self, **kwargs):
+            requests.append(kwargs)
+            if len(requests) > 6:
+                return iter([_chunk(content="Done.", finish_reason="stop")])
+            name = "missing" if case == "unknown" else (
+                "vibescript_read_operation" if case == "poll" else "state_read"
+            )
+            arguments = {"operation_id": "job-1"} if case == "poll" else {
+                "target": "A" if case != "alternating" or len(requests) % 2 else "B"
+            }
+            call = SimpleNamespace(
+                index=0, id=f"call-{len(requests)}", type="function",
+                function=SimpleNamespace(name=name, arguments=json.dumps(arguments)),
+            )
+            return iter([_chunk(tool_calls=[call], finish_reason="tool_calls")])
+
+    monkeypatch.setitem(sys.modules, "openai", SimpleNamespace(OpenAI=Client))
+    monkeypatch.setattr(provider, "_validate_provider_wire_surface", lambda _: None)
+    connection = Connection()
+    provider._gemini_child_main(
+        connection, "Inspect.", context, "mock", "fake", None, 1.0, 8, False,
+    )
+    terminal = connection.messages[-1]
+    assert terminal["type"] == "done"
+    if expected_calls < 6:
+        assert len(requests) == expected_calls
+        assert terminal["raw"]["reason"] == "no_progress"
+    else:
+        assert len(requests) == 7
+        assert terminal["final_output"] == "Done."

--- a/src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py
@@ -502,14 +502,15 @@ def test_gemini_stream_preserves_thought_signatures_and_repairs_tool_arguments(
     assert connection.closed
 
 
-def test_gemini_has_finite_default_turn_limit():
-    assert provider.GeminiProvider().max_turns == 64
+def test_gemini_preserves_autonomous_default_with_explicit_turn_limit():
+    assert provider.GeminiProvider().max_turns is None
+    assert provider.GeminiProvider(max_turns=64).max_turns == 64
     assert provider.GeminiProvider(max_turns=None).max_turns is None
 
 
 @pytest.mark.parametrize("case,expected_calls", [
     ("same", 3), ("failure", 3), ("unknown", 3),
-    ("alternating", 5), ("revision", 6), ("poll", 6), ("disabled", 6),
+    ("alternating", 5), ("revision", 70), ("poll", 70), ("disabled", 6),
 ])
 def test_gemini_stalled_calls_are_bounded(monkeypatch, case, expected_calls):
     requests = []
@@ -543,7 +544,7 @@ def test_gemini_stalled_calls_are_bounded(monkeypatch, case, expected_calls):
 
         def create(self, **kwargs):
             requests.append(kwargs)
-            if len(requests) > 6:
+            if len(requests) > (70 if case in {"revision", "poll"} else 6):
                 return iter([_chunk(content="Done.", finish_reason="stop")])
             name = "missing" if case == "unknown" else (
                 "vibescript_read_operation" if case == "poll" else "state_read"
@@ -561,7 +562,8 @@ def test_gemini_stalled_calls_are_bounded(monkeypatch, case, expected_calls):
     monkeypatch.setattr(provider, "_validate_provider_wire_surface", lambda _: None)
     connection = Connection()
     provider._gemini_child_main(
-        connection, "Inspect.", context, "mock", "fake", None, 1.0, 8, False,
+        connection, "Inspect.", context, "mock", "fake", None, 1.0,
+        provider.GeminiProvider().max_turns, False,
     )
     terminal = connection.messages[-1]
     assert terminal["type"] == "done"
@@ -569,7 +571,7 @@ def test_gemini_stalled_calls_are_bounded(monkeypatch, case, expected_calls):
         assert len(requests) == expected_calls
         assert terminal["raw"]["reason"] == "no_progress"
     else:
-        assert len(requests) == 7
+        assert len(requests) == expected_calls + 1
         assert terminal["final_output"] == "Done."
 
 @pytest.mark.parametrize("change", ["revision", "surface", "workbench", "native"])


### PR DESCRIPTION
Gemini now stops repeated identical tool observations when CAD state is unchanged, instead of wasting requests indefinitely. Productive work and explicit pending-job polls continue without a default turn ceiling; callers can still set `max_turns` explicitly. The stalled-observation guard defaults to three repeats and can be disabled with `no_progress_limit=0`.

The observation cache is bounded to 128 entries. Completed work is preserved, and a stopped run receives an actionable explanation. This integrates the provider changes already merged in #180, #181, #184, and #185.

## Validation

Red/green tests for the autonomy adjustment: three tests failed with the proposed 64-turn default. After preserving the unlimited default, tests cover 70 productive turns and 70 pending-job polls, alongside stalled successes, errors, alternating calls, and explicit limits.

```sh
PYTHONPATH=src/Mod/VibeCAD /tmp/vibecad-pr-review-env/bin/python -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_gemini_provider.py src/Mod/VibeCAD/vibecad_tests/test_provider_history_budget.py src/Mod/VibeCAD/vibecad_tests/test_provider_subprocess.py src/Mod/VibeCAD/vibecad_tests/test_anthropic_retry_budget.py src/Mod/VibeCAD/vibecad_tests/test_provider_research_review.py --tb=short
# 151 passed in 3.65s
git diff --check
# Passed
```

Tests use mocked provider responses; no paid Gemini API calls were made. Local debug captures contained no Gemini requests. This is Python-only and does not require a C++ rebuild.

## Compatibility

- [x] Existing public functions/APIs remain present.
- [x] No preference keys, tool names, or schema fields renamed or removed.
- [x] Productive workflows preserve the existing unlimited default.
- [x] No deprecations.
- [x] The requested stalled-loop behavior is enabled by default, with an explicit opt-out.

Closes #176.
