### PR TITLE
Fix unit preference changes for open documents

### DIFF
--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -171,19 +171,23 @@ void DlgSettingsGeneral::saveUnitSystemSettings()
     // Set the actual format value
     UnitsApi::setDenominator(FracInch);
 
+    const int selectedSchema = ui->comboBox_UnitSystem->currentIndex();
+
     // Set and save the Unit System
     if (ui->checkBox_projectUnitSystemIgnore->isChecked()) {
-        // currently selected View System (unit system)
-        int viewSystemIndex = ui->comboBox_UnitSystem->currentIndex();
-        UnitsApi::setSchema(viewSystemIndex);
+        // Use the preference for the current view without changing the
+        // document's own unit system.
+        UnitsApi::setSchema(selectedSchema);
     }
-    else if (App::Document* doc = App::GetApplication().getActiveDocument()) {
-        UnitsApi::setSchema(doc->UnitSystem.getValue());
+    else if (App::GetApplication().getActiveDocument()) {
+        // A preference change with a project open must also update that
+        // project's unit system. Otherwise the old project schema is restored
+        // immediately and the model appears to break when units are changed.
+        getMainWindow()->setUserSchema(selectedSchema);
     }
     else {
         // if there is no existing document then the unit must still be set
-        int viewSystemIndex = ui->comboBox_UnitSystem->currentIndex();
-        UnitsApi::setSchema(viewSystemIndex);
+        UnitsApi::setSchema(selectedSchema);
     }
 
     ui->SubstituteDecimal->onSave();

--- a/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+++ b/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
@@ -150,7 +150,9 @@ void DlgSettingsGeneral::saveUnitSystemSettings()
     ParameterGrp::handle hGrpu = App::GetApplication().GetParameterGroupByPath(
         "User parameter:BaseApp/Preferences/Units"
     );
-    hGrpu->SetInt("UserSchema", ui->comboBox_UnitSystem->currentIndex());
+    const int selectedSchema = ui->comboBox_UnitSystem->currentIndex();
+    const bool schemaChanged = selectedSchema != hGrpu->GetInt("UserSchema", 0);
+    hGrpu->SetInt("UserSchema", selectedSchema);
     hGrpu->SetInt("Decimals", ui->spinBoxDecimals->value());
     hGrpu->SetBool("IgnoreProjectSchema", ui->checkBox_projectUnitSystemIgnore->isChecked());
 
@@ -171,19 +173,21 @@ void DlgSettingsGeneral::saveUnitSystemSettings()
     // Set the actual format value
     UnitsApi::setDenominator(FracInch);
 
-    const int selectedSchema = ui->comboBox_UnitSystem->currentIndex();
-
     // Set and save the Unit System
     if (ui->checkBox_projectUnitSystemIgnore->isChecked()) {
         // Use the preference for the current view without changing the
         // document's own unit system.
         UnitsApi::setSchema(selectedSchema);
     }
-    else if (App::GetApplication().getActiveDocument()) {
-        // A preference change with a project open must also update that
-        // project's unit system. Otherwise the old project schema is restored
-        // immediately and the model appears to break when units are changed.
-        getMainWindow()->setUserSchema(selectedSchema);
+    else if (App::Document* doc = App::GetApplication().getActiveDocument()) {
+        if (schemaChanged) {
+            getMainWindow()->setUserSchema(selectedSchema);
+        }
+        else {
+            // Applying unrelated preferences or restoring project units must
+            // preserve the document's own schema.
+            UnitsApi::setSchema(doc->UnitSystem.getValue());
+        }
     }
     else {
         // if there is no existing document then the unit must still be set

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -109,6 +109,12 @@ if(WIN32)
     elseif(EXISTS "${CMAKE_PREFIX_PATH}/bin")
         list(APPEND _test_env_mod "PATH=path_list_prepend:${CMAKE_PREFIX_PATH}/bin")
     endif()
+    set(_qt_platform_plugin_path "${CMAKE_PREFIX_PATH}/lib/qt6/plugins/platforms")
+    if(EXISTS "${_qt_platform_plugin_path}")
+        list(APPEND _test_env_mod
+            "QT_QPA_PLATFORM_PLUGIN_PATH=set:${_qt_platform_plugin_path}"
+        )
+    endif()
     file(GLOB _mod_dirs LIST_DIRECTORIES true "${CMAKE_BINARY_DIR}/Mod/*")
     foreach(_mod_dir ${_mod_dirs})
         if(IS_DIRECTORY "${_mod_dir}")

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -25,6 +25,11 @@ add_executable(Gui_tests_run
 setup_qt_test(DockLayoutState)
 setup_qt_test(MacroTaskAcceptance)
 setup_qt_test(QuantitySpinBox)
+setup_qt_test(UnitSettings)
+
+target_sources(UnitSettings_Tests_run PRIVATE
+    ${CMAKE_SOURCE_DIR}/src/Gui/PreferencePages/DlgSettingsGeneral.cpp
+)
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main

--- a/tests/src/Gui/UnitSettings.cpp
+++ b/tests/src/Gui/UnitSettings.cpp
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 
+#include <QCheckBox>
 #include <QComboBox>
 #include <QTest>
 
@@ -50,37 +51,75 @@ private Q_SLOTS:
         guiApplication.release();
     }
 
-    void changingDefaultUnitsUpdatesAnOpenDocument()
+    void savingUnitPreferences_data()
     {
+        QTest::addColumn<int>("projectSchema");
+        QTest::addColumn<int>("selectedSchema");
+        QTest::addColumn<bool>("initialIgnore");
+        QTest::addColumn<bool>("ignoreProject");
+        QTest::addColumn<int>("expectedProjectSchema");
+        QTest::addColumn<int>("expectedViewSchema");
+
+        QTest::newRow("change-open-document") << 0 << 3 << false << false << 3 << 3;
+        QTest::newRow("unchanged-preference") << 3 << 0 << false << false << 3 << 3;
+        QTest::newRow("ignore-project") << 0 << 3 << false << true << 0 << 3;
+        QTest::newRow("ignore-project-unchanged") << 3 << 0 << true << true << 3 << 0;
+        QTest::newRow("restore-project-units") << 3 << 0 << true << false << 3 << 3;
+        QTest::newRow("change-and-restore-project-units") << 0 << 3 << true << false << 3 << 3;
+        QTest::newRow("no-document") << -1 << 3 << false << false << -1 << 3;
+    }
+
+    void savingUnitPreferences()
+    {
+        QFETCH(int, projectSchema);
+        QFETCH(int, selectedSchema);
+        QFETCH(bool, initialIgnore);
+        QFETCH(bool, ignoreProject);
+        QFETCH(int, expectedProjectSchema);
+        QFETCH(int, expectedViewSchema);
         auto units = preferences();
         originalSchema = units->GetInt("UserSchema", 0);
         originalIgnoreProjectSchema = units->GetBool("IgnoreProjectSchema", false);
         units->SetInt("UserSchema", 0);
-        units->SetBool("IgnoreProjectSchema", false);
+        units->SetBool("IgnoreProjectSchema", initialIgnore);
         Base::UnitsApi::setSchema(0);
 
-        documentName = App::GetApplication().getUniqueDocumentName("unit_settings_test");
-        auto* document = App::GetApplication().newDocument(documentName.c_str());
-        QVERIFY(document != nullptr);
-        document->UnitSystem.setValue(0L);
+        App::Document* document = nullptr;
+        if (projectSchema >= 0) {
+            documentName = App::GetApplication().getUniqueDocumentName("unit_settings_test");
+            document = App::GetApplication().newDocument(documentName.c_str());
+            QVERIFY(document != nullptr);
+            document->UnitSystem.setValue(static_cast<long>(projectSchema));
 
-        auto* guiDocument = guiApplication->getDocument(document);
-        QVERIFY(guiDocument != nullptr);
-        guiApplication->setActiveDocument(guiDocument);
+            auto* guiDocument = guiApplication->getDocument(document);
+            QVERIFY(guiDocument != nullptr);
+            guiApplication->setActiveDocument(guiDocument);
+        }
 
         Gui::Dialog::DlgSettingsGeneral dialog;
         dialog.loadSettings();
         auto* unitSystem = dialog.findChild<QComboBox*>(QStringLiteral("comboBox_UnitSystem"));
         QVERIFY(unitSystem != nullptr);
-        QVERIFY(unitSystem->count() > 1);
-        unitSystem->setCurrentIndex(3);
+        QVERIFY(unitSystem->count() > selectedSchema);
+        unitSystem->setCurrentIndex(selectedSchema);
+        auto* ignore = dialog.findChild<QCheckBox*>(
+            QStringLiteral("checkBox_projectUnitSystemIgnore")
+        );
+        QVERIFY(ignore != nullptr);
+        ignore->setChecked(ignoreProject);
 
         dialog.saveSettings();
 
-        QCOMPARE(document->UnitSystem.getValue(), 3);
-        QCOMPARE(units->GetInt("UserSchema", 0), 3);
+        if (document) {
+            QCOMPARE(document->UnitSystem.getValue(), expectedProjectSchema);
+        }
+        QCOMPARE(units->GetInt("UserSchema", 0), selectedSchema);
+        QCOMPARE(units->GetBool("IgnoreProjectSchema", false), ignoreProject);
         const auto translated = Base::UnitsApi::schemaTranslate(Base::Quantity(25.4, "mm"));
-        QVERIFY(QString::fromStdString(translated).contains(QStringLiteral("in")));
+        QCOMPARE(
+            QString::fromStdString(translated).contains(QStringLiteral("in")),
+            expectedViewSchema == 3
+        );
     }
 
 private:

--- a/tests/src/Gui/UnitSettings.cpp
+++ b/tests/src/Gui/UnitSettings.cpp
@@ -1,0 +1,103 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <memory>
+#include <string>
+
+#include <QComboBox>
+#include <QTest>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <Base/Parameter.h>
+#include <Base/UnitsApi.h>
+#include <Gui/Application.h>
+#include <Gui/MainWindow.h>
+#include <src/App/InitApplication.h>
+
+#include <Gui/PreferencePages/DlgSettingsGeneral.h>
+
+class UnitSettingsTest: public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        tests::initApplication();
+        Gui::Application::initApplication();
+        Gui::Application::initOpenInventor();
+        guiApplication = std::make_unique<Gui::Application>(true);
+        mainWindow = std::make_unique<Gui::MainWindow>();
+    }
+
+    void cleanup()
+    {
+        if (!documentName.empty()
+            && App::GetApplication().getDocument(documentName.c_str())) {
+            App::GetApplication().closeDocument(documentName.c_str());
+            documentName.clear();
+        }
+        preferences()->SetInt("UserSchema", originalSchema);
+        preferences()->SetBool("IgnoreProjectSchema", originalIgnoreProjectSchema);
+        Base::UnitsApi::setSchema(originalSchema);
+    }
+
+    void cleanupTestCase()
+    {
+        // FreeCAD's GUI singleton is process-scoped; leave it alive until the
+        // test process exits rather than tearing it down after QTest.
+        mainWindow.release();
+        guiApplication.release();
+    }
+
+    void changingDefaultUnitsUpdatesAnOpenDocument()
+    {
+        auto units = preferences();
+        originalSchema = units->GetInt("UserSchema", 0);
+        originalIgnoreProjectSchema = units->GetBool("IgnoreProjectSchema", false);
+        units->SetInt("UserSchema", 0);
+        units->SetBool("IgnoreProjectSchema", false);
+        Base::UnitsApi::setSchema(0);
+
+        documentName = App::GetApplication().getUniqueDocumentName("unit_settings_test");
+        auto* document = App::GetApplication().newDocument(documentName.c_str());
+        QVERIFY(document != nullptr);
+        document->UnitSystem.setValue(0L);
+
+        auto* guiDocument = guiApplication->getDocument(document);
+        QVERIFY(guiDocument != nullptr);
+        guiApplication->setActiveDocument(guiDocument);
+
+        Gui::Dialog::DlgSettingsGeneral dialog;
+        dialog.loadSettings();
+        auto* unitSystem = dialog.findChild<QComboBox*>(QStringLiteral("comboBox_UnitSystem"));
+        QVERIFY(unitSystem != nullptr);
+        QVERIFY(unitSystem->count() > 1);
+        unitSystem->setCurrentIndex(3);
+
+        dialog.saveSettings();
+
+        QCOMPARE(document->UnitSystem.getValue(), 3);
+        QCOMPARE(units->GetInt("UserSchema", 0), 3);
+        const auto translated = Base::UnitsApi::schemaTranslate(Base::Quantity(25.4, "mm"));
+        QVERIFY(QString::fromStdString(translated).contains(QStringLiteral("in")));
+    }
+
+private:
+    ParameterGrp::handle preferences() const
+    {
+        return App::GetApplication().GetParameterGroupByPath(
+            "User parameter:BaseApp/Preferences/Units"
+        );
+    }
+
+    std::unique_ptr<Gui::Application> guiApplication;
+    std::unique_ptr<Gui::MainWindow> mainWindow;
+    std::string documentName;
+    int originalSchema {0};
+    bool originalIgnoreProjectSchema {false};
+};
+
+QTEST_MAIN(UnitSettingsTest)
+
+#include "UnitSettings.moc"


### PR DESCRIPTION
The unit preference change now updates the active document's unit system when project units are not being ignored, while preserving the view-only behavior when "Ignore project unit system" is enabled. A regression test covers changing units with an open document.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
- [x] The PR lists the exact build and test commands and their results.

The focused regression test failed against the pre-fix implementation and passes afterward:

- pixi run cmake --build build/debug --target UnitSettings_Tests_run --parallel 8
- pixi run ctest --test-dir build/debug -R UnitSettings_Tests_run --output-on-failure

Also verified the existing QuantitySpinBox_Tests_run test passes.

<!--
The FreeCAD community thanks you for your contribution.
By creating a Pull Request you agree to the contributing policy. The complete policy can be found in the root of the source tree (CONTRIBUTING.md) or at https://github.com/FreeCAD/FreeCAD/blob/main/CONTRIBUTING.md

This template provides guidance on creating a PR that can be reviewed and approved as quickly as possible. Comments may be safely deleted.

Unless you know exactly what you're doing, please leave the checkbox 'Allow edits by maintainers' enabled. This will allow maintainers to help you.
-->

## Issues

Fixes #182

<!-- link to individual issues this PR closes by referencing the issue number (e.g., fixes #1234, closes #4321). -->

## Before and After Images

No visual changes; screenshots are not applicable.

<!-- If your proposed changes affect the FreeCAD GUI, add before and after screenshots -->



<!--  Notes on the PR Review Process

The following section describes what the maintainers consider when reviewing your Pull Request. The following items may not require you to take any action. This information is provided for context. Understanding this information can help you prepare your request for speedy approval.

Alignment (Does the PR align with the goals and interests of the project?)
  - Does the PR have at least one issue linked, which this PR closes?
  - Has the conversation on the PR and related issue(s) reached consensus?
  - If the PR affects the GUI, is the Design Working Group (DWG) aware and have they had time to review and comment?
  - If the PR affects the GUI, did the contributor include before/after images?
  - If the PR affects standards and workflow, is the CAD Working Group (CWG) aware and have they had time to review/comment?

Impact (Does the change affect other parts of the project?)
  - Has the impact on documentation been considered and appropriate action taken?
  - Has the impact on translation been considered appropriate action taken?
  - Will the change affect existing user documents?

Code Quality (Is code well-written and maintainable?)
  - Does the PR warrant a review by the Code Quality Working Group (CQWG)?
  - Does the change include tests?
  - Is the PR rebased on the current main branch with unnecessary commits squashed?

Release (Are there considerations related to release timing?)
  - Has the PR been considered for backporting to the latest release branch?
  - Have the release notes been considered/updated?
  -->