### PR TITLE
Make Section View cut as a hatched solid with a movable plane

### DIFF
--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -550,6 +550,8 @@ SET(Part_SRCS
     BRepMesh.h
     RenderMesh.cpp
     RenderMesh.h
+    SectionGeometry.cpp
+    SectionGeometry.h
     BRepOffsetAPI_MakeOffsetFix.cpp
     BRepOffsetAPI_MakeOffsetFix.h
     BSplineCurveBiArcs.cpp

--- a/src/Mod/Part/App/RenderMesh.cpp
+++ b/src/Mod/Part/App/RenderMesh.cpp
@@ -131,6 +131,25 @@ Part::RenderMesh Part::prepareRenderMesh(
     TopTools_MapOfShape faceEdges;
     TopTools_IndexedMapOfShape faceMap;
     TopExp::MapShapes(shape, TopAbs_FACE, faceMap);
+    TopTools_IndexedMapOfShape solidMap;
+    TopExp::MapShapes(shape, TopAbs_SOLID, solidMap);
+    result.solidFaceIndices.reserve(solidMap.Extent());
+    for (int solidIndex = 1; solidIndex <= solidMap.Extent(); ++solidIndex) {
+        checkCancellation(stopToken);
+        TopTools_IndexedMapOfShape solidFaces;
+        TopExp::MapShapes(solidMap(solidIndex), TopAbs_FACE, solidFaces);
+        auto& indices = result.solidFaceIndices.emplace_back();
+        indices.reserve(solidFaces.Extent());
+        for (int i = 1; i <= solidFaces.Extent(); ++i) {
+            checkCancellation(stopToken);
+            const int faceIndex = faceMap.FindIndex(solidFaces(i));
+            if (faceIndex == 0) {
+                throw std::logic_error("Solid face missing from render mesh topology");
+            }
+            indices.push_back(faceIndex - 1);
+        }
+    }
+
     TopTools_IndexedMapOfShape edgeMap;
     TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
     struct FaceInput

--- a/src/Mod/Part/App/RenderMesh.h
+++ b/src/Mod/Part/App/RenderMesh.h
@@ -36,6 +36,10 @@ struct PartExport RenderMesh
     // and thousands of individual Coin field updates during adoption.
     std::vector<std::int32_t> lineMaterialIndices {0};
     std::int32_t vertexStart {0};
+    // Face indices (into faceTriangleCounts) belonging to each solid. Section
+    // preparation keeps touching solids separate without copying mesh buffers.
+    // Empty preserves the unpartitioned path for caller-supplied meshes.
+    std::vector<std::vector<std::int32_t>> solidFaceIndices;
 
     [[nodiscard]] std::size_t vertexCount() const
     {

--- a/src/Mod/Part/App/SectionGeometry.cpp
+++ b/src/Mod/Part/App/SectionGeometry.cpp
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include "SectionGeometry.h"
+
+#include <stdexcept>
+#include <BRepBuilderAPI_Copy.hxx>
+#include <BRep_Tool.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Wire.hxx>
+#include <gp.hxx>
+
+#include "FaceMakerBullseye.h"
+#include "TopoShape.h"
+
+namespace
+{
+void checkCancellation(std::stop_token stop)
+{
+    if (stop.stop_requested()) {
+        throw std::runtime_error("Section face preparation cancelled");
+    }
+}
+}
+
+TopoDS_Shape Part::prepareSectionFaces(
+    const TopoDS_Shape& source, const Base::Matrix4D& displayedTransform,
+    const Base::Vector3d& origin, const Base::Vector3d& normal, std::stop_token stop)
+{
+    checkCancellation(stop);
+    if (source.IsNull() || !TopExp_Explorer(source, TopAbs_SOLID).More()) {
+        return {};
+    }
+    if (normal.Length() <= gp::Resolution()) {
+        throw std::invalid_argument("Section plane requires a nonzero normal");
+    }
+    auto direction = normal;
+    direction.Normalize();
+    const double distance = direction.Dot(origin);
+
+    // Do all copying and kernel work on the compute worker. Only root location
+    // is replaced: locations of children in a compound remain part of geometry.
+    auto local = BRepBuilderAPI_Copy(source, Standard_True, Standard_False).Shape();
+    local.Location(TopLoc_Location());
+    checkCancellation(stop);
+    TopoShape world(local);
+    // Preserve analytic surfaces for rigid placements; use a general transform
+    // only when instance scaling actually requires one.
+    world.transformShape(displayedTransform, false, true);
+
+    for (const double offset : {0.0, 1e-4, -1e-4}) {
+        checkCancellation(stop);
+        const auto section = world.makeElementSlice(direction, distance + offset);
+        FaceMakerBullseye maker;
+        maker.MyElementMapPolicy = ElementMapPolicy::Drop;
+        bool hasWire = false;
+        for (TopExp_Explorer wires(section.getShape(), TopAbs_WIRE); wires.More(); wires.Next()) {
+            checkCancellation(stop);
+            const auto wire = TopoDS::Wire(wires.Current());
+            if (BRep_Tool::IsClosed(wire)) {
+                maker.addWire(wire);
+                hasWire = true;
+            }
+        }
+        if (hasWire) {
+            maker.Build();
+            checkCancellation(stop);
+            return maker.Shape();
+        }
+    }
+    return {};
+}

--- a/src/Mod/Part/App/SectionGeometry.cpp
+++ b/src/Mod/Part/App/SectionGeometry.cpp
@@ -8,6 +8,8 @@
 #include <map>
 #include <set>
 #include <BRepBuilderAPI_MakePolygon.hxx>
+#include <BRep_Builder.hxx>
+#include <TopoDS_Compound.hxx>
 #include <BRepAdaptor_CompCurve.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <GCPnts_UniformDeflection.hxx>
@@ -72,116 +74,159 @@ TopoDS_Shape Part::prepareSectionMeshFaces(
     const double tolerance = std::max(1e-7, scale * 4 * std::numeric_limits<float>::epsilon());
     if (low > tolerance || high < -tolerance || vertices.empty()) { return {}; }
 
-    using Cell = std::array<std::int64_t, 3>;
-    using Edge = std::pair<std::size_t, std::size_t>;
-    std::map<Cell, std::vector<std::size_t>> cells;
-    std::vector<Base::Vector3d> points;
-    std::set<Edge> edges;
-    const auto vertexId = [&](const Base::Vector3d& point) {
-        Cell cell {static_cast<std::int64_t>(std::floor(point.x / tolerance)),
-                   static_cast<std::int64_t>(std::floor(point.y / tolerance)),
-                   static_cast<std::int64_t>(std::floor(point.z / tolerance))};
-        // Search adjacent buckets too: rounding alone splits coincident seams
-        // at bucket boundaries and leaves otherwise closed contours open.
-        for (int x = -1; x <= 1; ++x) {
-            for (int y = -1; y <= 1; ++y) {
-                for (int z = -1; z <= 1; ++z) {
-                    const auto found = cells.find({cell[0]+x, cell[1]+y, cell[2]+z});
-                    if (found == cells.end()) { continue; }
-                    for (const auto index : found->second) {
-                        if ((points[index] - point).Length() <= tolerance) { return index; }
+    using TriangleRange = std::pair<std::size_t, std::size_t>;
+    const auto prepareGroup = [&](const std::vector<TriangleRange>& ranges) -> TopoDS_Shape {
+        using Cell = std::array<std::int64_t, 3>;
+        using Edge = std::pair<std::size_t, std::size_t>;
+        std::map<Cell, std::vector<std::size_t>> cells;
+        std::vector<Base::Vector3d> points;
+        std::set<Edge> edges;
+        const auto vertexId = [&](const Base::Vector3d& point) {
+            Cell cell {static_cast<std::int64_t>(std::floor(point.x / tolerance)),
+                       static_cast<std::int64_t>(std::floor(point.y / tolerance)),
+                       static_cast<std::int64_t>(std::floor(point.z / tolerance))};
+            // Search adjacent buckets too: rounding alone splits coincident seams
+            // at bucket boundaries and leaves otherwise closed contours open.
+            for (int x = -1; x <= 1; ++x) {
+                for (int y = -1; y <= 1; ++y) {
+                    for (int z = -1; z <= 1; ++z) {
+                        const auto found = cells.find({cell[0]+x, cell[1]+y, cell[2]+z});
+                        if (found == cells.end()) { continue; }
+                        for (const auto index : found->second) {
+                            if ((points[index] - point).Length() <= tolerance) { return index; }
+                        }
                     }
                 }
             }
-        }
-        const auto index = points.size();
-        points.push_back(point);
-        cells[cell].push_back(index);
-        return index;
-    };
-    for (std::size_t i = 0; i < mesh.triangleIndices.size(); i += 4) {
-        if (i % 1024 == 0) { checkCancellation(stop); }
-        if (mesh.triangleIndices[i+3] != -1) {
-            throw std::invalid_argument("Section mesh requires triangle delimiters");
-        }
-        std::array<std::size_t, 3> ids;
-        std::array<double, 3> signedDistance;
-        for (std::size_t j = 0; j < 3; ++j) {
-            const auto index = mesh.triangleIndices[i+j];
-            if (index < 0 || static_cast<std::size_t>(index) >= vertices.size()) {
-                throw std::invalid_argument("Invalid section triangle index");
-            }
-            ids[j] = static_cast<std::size_t>(index);
-            signedDistance[j] = std::abs(distances[ids[j]]) <= tolerance ? 0 : distances[ids[j]];
-        }
-        if (signedDistance[0] == 0 && signedDistance[1] == 0 && signedDistance[2] == 0) {
-            continue; // Adjacent non-coplanar triangles supply the perimeter.
-        }
-        // At a step or seam exactly on the plane, the two neighboring
-        // surfaces can have different outlines. Only the positive (kept)
-        // half-space supplies an on-plane edge; combining both outlines
-        // creates spurious branches or hatches the removed side's footprint.
-        if (std::count(signedDistance.begin(), signedDistance.end(), 0.0) == 2
-            && *std::min_element(signedDistance.begin(), signedDistance.end()) < 0.0) {
-            continue;
-        }
-        std::set<std::size_t> cut;
-        for (std::size_t j = 0; j < 3; ++j) {
-            const auto next = (j+1) % 3;
-            if (signedDistance[j] == 0) {
-                const auto point = vertices[ids[j]] - direction * distances[ids[j]];
-                cut.insert(vertexId(point));
-            }
-            else if ((signedDistance[j] < 0 && signedDistance[next] > 0)
-                     || (signedDistance[j] > 0 && signedDistance[next] < 0)) {
-                const double ratio = signedDistance[j] / (signedDistance[j] - signedDistance[next]);
-                cut.insert(vertexId(vertices[ids[j]] + (vertices[ids[next]] - vertices[ids[j]]) * ratio));
-            }
-        }
-        if (cut.size() == 2) { edges.emplace(*cut.begin(), *cut.rbegin()); }
-    }
-    if (edges.empty()) { return {}; }
-    std::vector<std::vector<std::size_t>> adjacent(points.size());
-    for (const auto& [a, b] : edges) {
-        adjacent[a].push_back(b);
-        adjacent[b].push_back(a);
-    }
-    for (const auto& neighbors : adjacent) {
-        if (!neighbors.empty() && neighbors.size() != 2) {
-            throw std::runtime_error("Section mesh contains an open or branching contour");
-        }
-    }
-    FaceMakerBullseye maker;
-    maker.MyElementMapPolicy = ElementMapPolicy::Drop;
-    while (!edges.empty()) {
-        checkCancellation(stop);
-        auto [first, current] = *edges.begin();
-        auto previous = first;
-        edges.erase(edges.begin());
-        BRepBuilderAPI_MakePolygon polygon;
-        const auto add = [&](std::size_t index) {
-            const auto point = points[index] + origin;
-            polygon.Add(gp_Pnt(point.x, point.y, point.z));
+            const auto index = points.size();
+            points.push_back(point);
+            cells[cell].push_back(index);
+            return index;
         };
-        add(first);
-        while (current != first) {
-            checkCancellation(stop);
-            add(current);
-            const auto& neighbors = adjacent[current];
-            const auto next = neighbors[0] == previous ? neighbors[1] : neighbors[0];
-            if (!edges.erase(std::minmax(current, next))) {
-                throw std::runtime_error("Section mesh contour cannot be closed");
+        for (const auto& [first, last] : ranges) {
+            for (std::size_t i = first; i < last; i += 4) {
+                if (i % 1024 == 0) { checkCancellation(stop); }
+                if (mesh.triangleIndices[i+3] != -1) {
+                    throw std::invalid_argument("Section mesh requires triangle delimiters");
+                }
+                std::array<std::size_t, 3> ids;
+                std::array<double, 3> signedDistance;
+                for (std::size_t j = 0; j < 3; ++j) {
+                    const auto index = mesh.triangleIndices[i+j];
+                    if (index < 0 || static_cast<std::size_t>(index) >= vertices.size()) {
+                        throw std::invalid_argument("Invalid section triangle index");
+                    }
+                    ids[j] = static_cast<std::size_t>(index);
+                    signedDistance[j] = std::abs(distances[ids[j]]) <= tolerance ? 0 : distances[ids[j]];
+                }
+                if (signedDistance[0] == 0 && signedDistance[1] == 0 && signedDistance[2] == 0) {
+                    continue; // Adjacent non-coplanar triangles supply the perimeter.
+                }
+                // At a step or seam exactly on the plane, the two neighboring
+                // surfaces can have different outlines. Only the positive (kept)
+                // half-space supplies an on-plane edge; combining both outlines
+                // creates spurious branches or hatches the removed side's footprint.
+                if (std::count(signedDistance.begin(), signedDistance.end(), 0.0) == 2
+                    && *std::min_element(signedDistance.begin(), signedDistance.end()) < 0.0) {
+                    continue;
+                }
+                std::set<std::size_t> cut;
+                for (std::size_t j = 0; j < 3; ++j) {
+                    const auto next = (j+1) % 3;
+                    if (signedDistance[j] == 0) {
+                        const auto point = vertices[ids[j]] - direction * distances[ids[j]];
+                        cut.insert(vertexId(point));
+                    }
+                    else if ((signedDistance[j] < 0 && signedDistance[next] > 0)
+                             || (signedDistance[j] > 0 && signedDistance[next] < 0)) {
+                        const double ratio = signedDistance[j] / (signedDistance[j] - signedDistance[next]);
+                        cut.insert(vertexId(vertices[ids[j]] + (vertices[ids[next]] - vertices[ids[j]]) * ratio));
+                    }
+                }
+                if (cut.size() == 2) { edges.emplace(*cut.begin(), *cut.rbegin()); }
             }
-            previous = current;
-            current = next;
         }
-        polygon.Close();
-        if (!polygon.IsDone()) { throw std::runtime_error("Invalid section mesh polygon"); }
-        maker.addWire(polygon.Wire());
+        if (edges.empty()) { return {}; }
+        std::vector<std::vector<std::size_t>> adjacent(points.size());
+        for (const auto& [a, b] : edges) {
+            adjacent[a].push_back(b);
+            adjacent[b].push_back(a);
+        }
+        for (const auto& neighbors : adjacent) {
+            if (!neighbors.empty() && neighbors.size() != 2) {
+                throw std::runtime_error("Section mesh contains an open or branching contour");
+            }
+        }
+        FaceMakerBullseye maker;
+        maker.MyElementMapPolicy = ElementMapPolicy::Drop;
+        while (!edges.empty()) {
+            checkCancellation(stop);
+            auto [first, current] = *edges.begin();
+            auto previous = first;
+            edges.erase(edges.begin());
+            BRepBuilderAPI_MakePolygon polygon;
+            const auto add = [&](std::size_t index) {
+                const auto point = points[index] + origin;
+                polygon.Add(gp_Pnt(point.x, point.y, point.z));
+            };
+            add(first);
+            while (current != first) {
+                checkCancellation(stop);
+                add(current);
+                const auto& neighbors = adjacent[current];
+                const auto next = neighbors[0] == previous ? neighbors[1] : neighbors[0];
+                if (!edges.erase(std::minmax(current, next))) {
+                    throw std::runtime_error("Section mesh contour cannot be closed");
+                }
+                previous = current;
+                current = next;
+            }
+            polygon.Close();
+            if (!polygon.IsDone()) { throw std::runtime_error("Invalid section mesh polygon"); }
+            maker.addWire(polygon.Wire());
+        }
+        maker.Build();
+        checkCancellation(stop);
+        return maker.Shape();
+    };
+    if (mesh.solidFaceIndices.empty()) {
+        return prepareGroup({{0, mesh.triangleIndices.size()}});
     }
-    maker.Build();
-    checkCancellation(stop);
-    return maker.Shape();
+
+    // Transform each vertex once, then assemble independent solid contours.
+    // Welding different solids together invents branches at valid contacts.
+    std::vector<std::size_t> offsets {0};
+    for (const auto count : mesh.faceTriangleCounts) {
+        if (count < 0 || static_cast<std::size_t>(count) > (mesh.triangleIndices.size() - offsets.back()) / 4) {
+            throw std::invalid_argument("Invalid section face triangle counts");
+        }
+        offsets.push_back(offsets.back() + static_cast<std::size_t>(count) * 4);
+    }
+    if (offsets.back() != mesh.triangleIndices.size()) {
+        throw std::invalid_argument("Incomplete section face triangle counts");
+    }
+    BRep_Builder builder;
+    TopoDS_Compound combined;
+    builder.MakeCompound(combined);
+    bool haveFaces = false;
+    for (const auto& faces : mesh.solidFaceIndices) {
+        checkCancellation(stop);
+        std::vector<TriangleRange> ranges;
+        ranges.reserve(faces.size());
+        for (const auto index : faces) {
+            if (index < 0 || static_cast<std::size_t>(index) >= mesh.faceTriangleCounts.size()) {
+                throw std::invalid_argument("Invalid section solid face index");
+            }
+            ranges.emplace_back(offsets[index], offsets[index + 1]);
+        }
+        auto prepared = prepareGroup(ranges);
+        if (mesh.solidFaceIndices.size() == 1) { return prepared; }
+        if (!prepared.IsNull()) {
+            builder.Add(combined, prepared);
+            haveFaces = true;
+        }
+    }
+    return haveFaces ? TopoDS_Shape(combined) : TopoDS_Shape();
 }
 
 TopoDS_Shape Part::prepareSectionFaces(

--- a/src/Mod/Part/App/SectionGeometry.cpp
+++ b/src/Mod/Part/App/SectionGeometry.cpp
@@ -5,6 +5,9 @@
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <map>
+#include <set>
+#include <BRepBuilderAPI_MakePolygon.hxx>
 #include <BRepAdaptor_CompCurve.hxx>
 #include <BRepMesh_IncrementalMesh.hxx>
 #include <GCPnts_UniformDeflection.hxx>
@@ -19,6 +22,7 @@
 
 #include "FaceMakerBullseye.h"
 #include "TopoShape.h"
+#include "RenderMesh.h"
 
 namespace
 {
@@ -28,6 +32,156 @@ void checkCancellation(std::stop_token stop)
         throw std::runtime_error("Section face preparation cancelled");
     }
 }
+}
+
+TopoDS_Shape Part::prepareSectionMeshFaces(
+    const RenderMesh& mesh, const Base::Matrix4D& transform,
+    const Base::Vector3d& origin, const Base::Vector3d& normal, std::stop_token stop)
+{
+    checkCancellation(stop);
+    auto direction = normal;
+    if (!std::isfinite(direction.Length()) || direction.Length() <= gp::Resolution()) {
+        throw std::invalid_argument("Section plane requires a finite nonzero normal");
+    }
+    direction.Normalize();
+    if (mesh.vertices.size() % 3 || mesh.triangleIndices.size() % 4) {
+        throw std::invalid_argument("Malformed section mesh buffers");
+    }
+    std::vector<Base::Vector3d> vertices;
+    std::vector<double> distances;
+    vertices.reserve(mesh.vertexCount());
+    distances.reserve(mesh.vertexCount());
+    double low = std::numeric_limits<double>::infinity();
+    double high = -low;
+    double scale = 1.0;
+    for (std::size_t i = 0; i < mesh.vertexCount(); ++i) {
+        if (i % 256 == 0) { checkCancellation(stop); }
+        Base::Vector3d point;
+        transform.multVec(Base::Vector3d(mesh.vertices[3*i], mesh.vertices[3*i+1], mesh.vertices[3*i+2]), point);
+        point -= origin;
+        if (!std::isfinite(point.Length())) {
+            throw std::invalid_argument("Section mesh requires finite coordinates");
+        }
+        scale = std::max(scale, point.Length());
+        const double distance = point.Dot(direction);
+        low = std::min(low, distance);
+        high = std::max(high, distance);
+        vertices.push_back(point);
+        distances.push_back(distance);
+    }
+    const double tolerance = std::max(1e-7, scale * 4 * std::numeric_limits<float>::epsilon());
+    if (low > tolerance || high < -tolerance || vertices.empty()) { return {}; }
+
+    using Cell = std::array<std::int64_t, 3>;
+    using Edge = std::pair<std::size_t, std::size_t>;
+    std::map<Cell, std::vector<std::size_t>> cells;
+    std::vector<Base::Vector3d> points;
+    std::set<Edge> edges;
+    const auto vertexId = [&](const Base::Vector3d& point) {
+        Cell cell {static_cast<std::int64_t>(std::floor(point.x / tolerance)),
+                   static_cast<std::int64_t>(std::floor(point.y / tolerance)),
+                   static_cast<std::int64_t>(std::floor(point.z / tolerance))};
+        // Search adjacent buckets too: rounding alone splits coincident seams
+        // at bucket boundaries and leaves otherwise closed contours open.
+        for (int x = -1; x <= 1; ++x) {
+            for (int y = -1; y <= 1; ++y) {
+                for (int z = -1; z <= 1; ++z) {
+                    const auto found = cells.find({cell[0]+x, cell[1]+y, cell[2]+z});
+                    if (found == cells.end()) { continue; }
+                    for (const auto index : found->second) {
+                        if ((points[index] - point).Length() <= tolerance) { return index; }
+                    }
+                }
+            }
+        }
+        const auto index = points.size();
+        points.push_back(point);
+        cells[cell].push_back(index);
+        return index;
+    };
+    for (std::size_t i = 0; i < mesh.triangleIndices.size(); i += 4) {
+        if (i % 1024 == 0) { checkCancellation(stop); }
+        if (mesh.triangleIndices[i+3] != -1) {
+            throw std::invalid_argument("Section mesh requires triangle delimiters");
+        }
+        std::array<std::size_t, 3> ids;
+        std::array<double, 3> signedDistance;
+        for (std::size_t j = 0; j < 3; ++j) {
+            const auto index = mesh.triangleIndices[i+j];
+            if (index < 0 || static_cast<std::size_t>(index) >= vertices.size()) {
+                throw std::invalid_argument("Invalid section triangle index");
+            }
+            ids[j] = static_cast<std::size_t>(index);
+            signedDistance[j] = std::abs(distances[ids[j]]) <= tolerance ? 0 : distances[ids[j]];
+        }
+        if (signedDistance[0] == 0 && signedDistance[1] == 0 && signedDistance[2] == 0) {
+            continue; // Adjacent non-coplanar triangles supply the perimeter.
+        }
+        // At a step or seam exactly on the plane, the two neighboring
+        // surfaces can have different outlines. Only the positive (kept)
+        // half-space supplies an on-plane edge; combining both outlines
+        // creates spurious branches or hatches the removed side's footprint.
+        if (std::count(signedDistance.begin(), signedDistance.end(), 0.0) == 2
+            && *std::min_element(signedDistance.begin(), signedDistance.end()) < 0.0) {
+            continue;
+        }
+        std::set<std::size_t> cut;
+        for (std::size_t j = 0; j < 3; ++j) {
+            const auto next = (j+1) % 3;
+            if (signedDistance[j] == 0) {
+                const auto point = vertices[ids[j]] - direction * distances[ids[j]];
+                cut.insert(vertexId(point));
+            }
+            else if ((signedDistance[j] < 0 && signedDistance[next] > 0)
+                     || (signedDistance[j] > 0 && signedDistance[next] < 0)) {
+                const double ratio = signedDistance[j] / (signedDistance[j] - signedDistance[next]);
+                cut.insert(vertexId(vertices[ids[j]] + (vertices[ids[next]] - vertices[ids[j]]) * ratio));
+            }
+        }
+        if (cut.size() == 2) { edges.emplace(*cut.begin(), *cut.rbegin()); }
+    }
+    if (edges.empty()) { return {}; }
+    std::vector<std::vector<std::size_t>> adjacent(points.size());
+    for (const auto& [a, b] : edges) {
+        adjacent[a].push_back(b);
+        adjacent[b].push_back(a);
+    }
+    for (const auto& neighbors : adjacent) {
+        if (!neighbors.empty() && neighbors.size() != 2) {
+            throw std::runtime_error("Section mesh contains an open or branching contour");
+        }
+    }
+    FaceMakerBullseye maker;
+    maker.MyElementMapPolicy = ElementMapPolicy::Drop;
+    while (!edges.empty()) {
+        checkCancellation(stop);
+        auto [first, current] = *edges.begin();
+        auto previous = first;
+        edges.erase(edges.begin());
+        BRepBuilderAPI_MakePolygon polygon;
+        const auto add = [&](std::size_t index) {
+            const auto point = points[index] + origin;
+            polygon.Add(gp_Pnt(point.x, point.y, point.z));
+        };
+        add(first);
+        while (current != first) {
+            checkCancellation(stop);
+            add(current);
+            const auto& neighbors = adjacent[current];
+            const auto next = neighbors[0] == previous ? neighbors[1] : neighbors[0];
+            if (!edges.erase(std::minmax(current, next))) {
+                throw std::runtime_error("Section mesh contour cannot be closed");
+            }
+            previous = current;
+            current = next;
+        }
+        polygon.Close();
+        if (!polygon.IsDone()) { throw std::runtime_error("Invalid section mesh polygon"); }
+        maker.addWire(polygon.Wire());
+    }
+    maker.Build();
+    checkCancellation(stop);
+    return maker.Shape();
 }
 
 TopoDS_Shape Part::prepareSectionFaces(

--- a/src/Mod/Part/App/SectionGeometry.cpp
+++ b/src/Mod/Part/App/SectionGeometry.cpp
@@ -2,6 +2,14 @@
 #include "SectionGeometry.h"
 
 #include <stdexcept>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <BRepAdaptor_CompCurve.hxx>
+#include <BRepMesh_IncrementalMesh.hxx>
+#include <GCPnts_UniformDeflection.hxx>
+#include <Poly_Triangulation.hxx>
+#include <TopoDS_Face.hxx>
 #include <BRepBuilderAPI_Copy.hxx>
 #include <BRep_Tool.hxx>
 #include <TopExp_Explorer.hxx>
@@ -68,4 +76,125 @@ TopoDS_Shape Part::prepareSectionFaces(
         }
     }
     return {};
+}
+
+Part::SectionDisplayGeometry Part::prepareSectionDisplay(
+    const TopoDS_Shape& faces, const Base::Vector3d& origin,
+    const Base::Vector3d& normal, double spacing, std::stop_token stop)
+{
+    checkCancellation(stop);
+    if (!std::isfinite(spacing) || spacing <= 0.0) {
+        throw std::invalid_argument("Hatch spacing must be finite and positive");
+    }
+    auto direction = normal;
+    if (!std::isfinite(direction.Length()) || direction.Length() <= gp::Resolution()) {
+        throw std::invalid_argument("Section plane requires a finite nonzero normal");
+    }
+    direction.Normalize();
+    const auto helper = std::abs(direction.z) < 0.9 ? Base::Vector3d(0, 0, 1)
+                                                   : Base::Vector3d(0, 1, 0);
+    auto u = direction.Cross(helper);
+    u.Normalize();
+    auto v = direction.Cross(u);
+    v.Normalize();
+    const auto offset = direction * -0.05;
+    SectionDisplayGeometry result;
+    if (faces.IsNull()) { return result; }
+
+    // Triangulation modifies topology caches. Give it private topology while
+    // sharing the read-only analytic curves/surfaces of these detached faces.
+    const auto display = BRepBuilderAPI_Copy(faces, Standard_False, Standard_False).Shape();
+    BRepMesh_IncrementalMesh mesher(display, 0.25);
+    using Point2 = std::array<double, 2>;
+    std::vector<std::vector<Point2>> rings;
+    const auto point3 = [](const gp_Pnt& point) {
+        return Base::Vector3d(point.X(), point.Y(), point.Z());
+    };
+    for (TopExp_Explorer faceIterator(display, TopAbs_FACE); faceIterator.More(); faceIterator.Next()) {
+        checkCancellation(stop);
+        const auto face = TopoDS::Face(faceIterator.Current());
+        TopLoc_Location location;
+        const auto triangulation = BRep_Tool::Triangulation(face, location);
+        if (!triangulation.IsNull()) {
+            for (int index = 1; index <= triangulation->NbTriangles(); ++index) {
+                checkCancellation(stop);
+                int a, b, c;
+                triangulation->Triangle(index).Get(a, b, c);
+                if (face.Orientation() == TopAbs_REVERSED) { std::swap(b, c); }
+                result.triangles.push_back({
+                    point3(triangulation->Node(a).Transformed(location.Transformation())) + offset,
+                    point3(triangulation->Node(b).Transformed(location.Transformation())) + offset,
+                    point3(triangulation->Node(c).Transformed(location.Transformation())) + offset
+                });
+            }
+        }
+        for (TopExp_Explorer wires(face, TopAbs_WIRE); wires.More(); wires.Next()) {
+            checkCancellation(stop);
+            BRepAdaptor_CompCurve curve(TopoDS::Wire(wires.Current()));
+            GCPnts_UniformDeflection discretizer(curve, 0.25, curve.FirstParameter(), curve.LastParameter());
+            if (!discretizer.IsDone()) {
+                throw std::runtime_error("Section outline discretization failed");
+            }
+            std::vector<Base::Vector3d> points;
+            for (int index = 1; index <= discretizer.NbPoints(); ++index) {
+                points.push_back(point3(discretizer.Value(index)));
+            }
+            if (points.size() > 1 && (points.front() - points.back()).Length() < 1e-9) {
+                points.pop_back();
+            }
+            if (points.size() < 3) { continue; }
+            std::vector<Point2> ring;
+            for (std::size_t index = 0; index < points.size(); ++index) {
+                const auto relative = points[index] - origin;
+                ring.push_back({relative.Dot(u), relative.Dot(v)});
+                result.outlines.push_back({points[index] + offset,
+                                           points[(index + 1) % points.size()] + offset});
+            }
+            rings.push_back(std::move(ring));
+        }
+    }
+    if (rings.empty()) { return result; }
+
+    // Rotate plane coordinates into 45-degree hatch coordinates, then pair
+    // crossings with an even/odd fill rule. Half-open edges handle vertices
+    // shared by adjacent segments without filling holes or tangent contacts.
+    constexpr double diagonal = 0.70710678118654752440;
+    double minimum = std::numeric_limits<double>::infinity();
+    double maximum = -minimum;
+    for (auto& ring : rings) {
+        for (auto& point : ring) {
+            point = {(point[0] + point[1]) * diagonal, (-point[0] + point[1]) * diagonal};
+            minimum = std::min(minimum, point[1]);
+            maximum = std::max(maximum, point[1]);
+        }
+    }
+    double across = std::floor(minimum / spacing) * spacing;
+    if (!std::isfinite(across)) { throw std::invalid_argument("Hatch spacing is too small"); }
+    while (across <= maximum + 1e-9) {
+        checkCancellation(stop);
+        std::vector<double> hits;
+        for (const auto& ring : rings) {
+            for (std::size_t index = 0; index < ring.size(); ++index) {
+                const auto& a = ring[index];
+                const auto& b = ring[(index + 1) % ring.size()];
+                if ((a[1] <= across && across < b[1]) || (b[1] <= across && across < a[1])) {
+                    hits.push_back(a[0] + (b[0] - a[0]) * (across - a[1]) / (b[1] - a[1]));
+                }
+            }
+        }
+        std::sort(hits.begin(), hits.end());
+        const auto unproject = [&](double along) {
+            return origin + u * ((along - across) * diagonal)
+                          + v * ((along + across) * diagonal) + offset;
+        };
+        for (std::size_t index = 1; index < hits.size(); index += 2) {
+            if (hits[index] - hits[index - 1] > 1e-9) {
+                result.hatch.push_back({unproject(hits[index - 1]), unproject(hits[index])});
+            }
+        }
+        const double next = across + spacing;
+        if (!(next > across)) { throw std::invalid_argument("Hatch spacing is too small"); }
+        across = next;
+    }
+    return result;
 }

--- a/src/Mod/Part/App/SectionGeometry.h
+++ b/src/Mod/Part/App/SectionGeometry.h
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+
+#include <stop_token>
+#include <TopoDS_Shape.hxx>
+#include <Base/Matrix.h>
+#include <Base/Vector3D.h>
+#include <Mod/Part/PartGlobal.h>
+
+namespace Part
+{
+/** Prepare exact section faces from a cached rendered shape on a compute worker.
+ * The root location is replaced by the displayed instance transform, matching
+ * render-mesh placement. Source geometry is never mutated. No GUI/Python access.
+ */
+PartExport TopoDS_Shape prepareSectionFaces(
+    const TopoDS_Shape& source,
+    const Base::Matrix4D& displayedTransform,
+    const Base::Vector3d& origin,
+    const Base::Vector3d& normal,
+    std::stop_token stopToken = {}
+);
+}

--- a/src/Mod/Part/App/SectionGeometry.h
+++ b/src/Mod/Part/App/SectionGeometry.h
@@ -11,6 +11,18 @@
 
 namespace Part
 {
+struct RenderMesh;
+
+/** Prepare visual section faces from immutable, already displayed triangles.
+ * Curved boundaries follow display tessellation; exact CAD callers retain
+ * prepareSectionFaces. No source buffers or document geometry are modified.
+ */
+PartExport TopoDS_Shape prepareSectionMeshFaces(
+    const RenderMesh& mesh, const Base::Matrix4D& displayedTransform,
+    const Base::Vector3d& origin, const Base::Vector3d& normal,
+    std::stop_token stopToken = {}
+);
+
 /** Prepare exact section faces from a cached rendered shape on a compute worker.
  * The root location is replaced by the displayed instance transform, matching
  * render-mesh placement. Source geometry is never mutated. No GUI/Python access.

--- a/src/Mod/Part/App/SectionGeometry.h
+++ b/src/Mod/Part/App/SectionGeometry.h
@@ -2,6 +2,8 @@
 #pragma once
 
 #include <stop_token>
+#include <array>
+#include <vector>
 #include <TopoDS_Shape.hxx>
 #include <Base/Matrix.h>
 #include <Base/Vector3D.h>
@@ -19,5 +21,18 @@ PartExport TopoDS_Shape prepareSectionFaces(
     const Base::Vector3d& origin,
     const Base::Vector3d& normal,
     std::stop_token stopToken = {}
+);
+
+struct SectionDisplayGeometry
+{
+    std::vector<std::array<Base::Vector3d, 3>> triangles;
+    std::vector<std::array<Base::Vector3d, 2>> hatch;
+    std::vector<std::array<Base::Vector3d, 2>> outlines;
+};
+
+/** Prepare renderer-neutral cap triangles and lines on a compute worker. */
+PartExport SectionDisplayGeometry prepareSectionDisplay(
+    const TopoDS_Shape& faces, const Base::Vector3d& origin,
+    const Base::Vector3d& normal, double spacing, std::stop_token stopToken = {}
 );
 }

--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -181,6 +181,8 @@ public:
                            "Prepare native section faces asynchronously; callback(faces, error) runs on the GUI owner.");
         add_varargs_method("cancelSectionFaces", &Module::cancelSectionFaces,
                            "cancelSectionFaces(handle)\nCancel requests and release callbacks on the GUI owner.");
+        add_varargs_method("requestSectionMeshDisplay", &Module::requestSectionMeshDisplay,
+                           "Prepare section display from immutable mesh snapshots off the GUI thread.");
         add_varargs_method("requestSectionDisplay", &Module::requestSectionDisplay,
                            "requestSectionDisplay(handle, instances, origin, normal, spacing, callback)\n"
                            "Prepare cap display data on native workers; callback receives a geometry handle and error.");
@@ -307,8 +309,9 @@ private:
 
     Py::Object requestSectionFaces(const Py::Tuple& args) { return requestSection(args, false); }
     Py::Object requestSectionDisplay(const Py::Tuple& args) { return requestSection(args, true); }
+    Py::Object requestSectionMeshDisplay(const Py::Tuple& args) { return requestSection(args, true, true); }
 
-    Py::Object requestSection(const Py::Tuple& args, bool display)
+    Py::Object requestSection(const Py::Tuple& args, bool display, bool mesh = false)
     {
         PyObject *controller, *pythonInstances, *origin, *normal, *callback;
         double spacing = 0.0;
@@ -331,6 +334,16 @@ private:
             if (pair.size() != 2) { throw Py::TypeError("each instance requires a shape and matrix"); }
             Py::Object shape = pair[0];
             Py::Object matrix = pair[1];
+            if (mesh) {
+                if (!PyObject_TypeCheck(matrix.ptr(), &Base::MatrixPy::Type)) {
+                    throw Py::TypeError("each mesh instance requires a Base matrix");
+                }
+                using MeshOwner = std::shared_ptr<const Part::RenderMesh>;
+                auto* snapshot = static_cast<MeshOwner*>(PyCapsule_GetPointer(shape.ptr(), "PartGui.RenderMesh"));
+                if (!snapshot) { throw Py::Exception(); }
+                instances.push_back({{}, *static_cast<Base::MatrixPy*>(matrix.ptr())->getMatrixPtr(), *snapshot});
+                continue;
+            }
             if (!PyObject_TypeCheck(shape.ptr(), &Part::TopoShapePy::Type)
                 || !PyObject_TypeCheck(matrix.ptr(), &Base::MatrixPy::Type)) {
                 throw Py::TypeError("each instance requires a Part shape and Base matrix");

--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -23,7 +23,15 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <algorithm>
+#include <QApplication>
+#include <QThread>
+#include <Gui/FrameBudget.h>
 #include <Base/Console.h>
+#include <Base/MatrixPy.h>
+#include <Base/VectorPy.h>
+#include <Mod/Part/App/TopoShapePy.h>
+#include "SectionFaceController.h"
 #include <Base/Interpreter.h>
 #include <Base/PyObjectBase.h>
 #include <Base/ServiceProvider.h>
@@ -166,10 +174,226 @@ public:
             "Return whether a retained Part task can safely own the active "
             "document transaction."
         );
+        add_varargs_method("createSectionFaceController", &Module::createSectionFaceController,
+                           "createSectionFaceController() -> handle\nCreate an owner-held native section controller.");
+        add_varargs_method("requestSectionFaces", &Module::requestSectionFaces,
+                           "requestSectionFaces(handle, instances, origin, normal, callback)\n"
+                           "Prepare native section faces asynchronously; callback(faces, error) runs on the GUI owner.");
+        add_varargs_method("cancelSectionFaces", &Module::cancelSectionFaces,
+                           "cancelSectionFaces(handle)\nCancel requests and release callbacks on the GUI owner.");
+        add_varargs_method("requestSectionDisplay", &Module::requestSectionDisplay,
+                           "requestSectionDisplay(handle, instances, origin, normal, spacing, callback)\n"
+                           "Prepare cap display data on native workers; callback receives a geometry handle and error.");
+        add_varargs_method("sectionDisplaySizes", &Module::sectionDisplaySizes,
+                           "sectionDisplaySizes(handle) -> triangle, hatch, outline counts");
+        add_varargs_method("readSectionDisplay", &Module::readSectionDisplay,
+                           "readSectionDisplay(handle, kind, first, count) -> tuple\nRead at most 256 primitives.");
+        add_varargs_method("_deferSectionDisplay", &Module::deferSectionDisplay,
+                           "Queue a section presentation step through the GUI frame dispatcher.");
         initialize("This module is the PartGui module.");  // register with Python
     }
 
 private:
+    using GeometryOwner = std::shared_ptr<const Part::SectionDisplayGeometry>;
+
+    static const GeometryOwner& sectionGeometry(PyObject* object)
+    {
+        auto* geometry = static_cast<GeometryOwner*>(
+            PyCapsule_GetPointer(object, "PartGui.SectionDisplayGeometry"));
+        if (!geometry) { throw Py::Exception(); }
+        return *geometry;
+    }
+
+    Py::Object sectionDisplaySizes(const Py::Tuple& args)
+    {
+        PyObject* handle;
+        if (!PyArg_ParseTuple(args.ptr(), "O", &handle)) { throw Py::Exception(); }
+        const auto& geometry = sectionGeometry(handle);
+        Py::Tuple sizes(3);
+        sizes.setItem(0, Py::Long(geometry ? geometry->triangles.size() : 0));
+        sizes.setItem(1, Py::Long(geometry ? geometry->hatch.size() : 0));
+        sizes.setItem(2, Py::Long(geometry ? geometry->outlines.size() : 0));
+        return sizes;
+    }
+
+    Py::Object readSectionDisplay(const Py::Tuple& args)
+    {
+        PyObject* handle;
+        const char* kind;
+        Py_ssize_t first, count;
+        if (!PyArg_ParseTuple(args.ptr(), "Osnn", &handle, &kind, &first, &count)) {
+            throw Py::Exception();
+        }
+        if (first < 0 || count < 0) { throw Py::ValueError("chunk indices must be nonnegative"); }
+        const auto& geometry = sectionGeometry(handle);
+        if (!geometry) { return Py::Tuple(); }
+        const auto read = [&](const auto& values) {
+            const auto begin = static_cast<std::size_t>(first);
+            const auto length = begin < values.size()
+                ? std::min({static_cast<std::size_t>(count), std::size_t(256), values.size() - begin})
+                : 0;
+            Py::Tuple result(length);
+            for (std::size_t index = 0; index < length; ++index) {
+                const auto& primitive = values[begin + index];
+                Py::Tuple points(primitive.size());
+                for (std::size_t point = 0; point < primitive.size(); ++point) {
+                    Py::Tuple xyz(3);
+                    xyz.setItem(0, Py::Float(primitive[point].x));
+                    xyz.setItem(1, Py::Float(primitive[point].y));
+                    xyz.setItem(2, Py::Float(primitive[point].z));
+                    points.setItem(point, xyz);
+                }
+                result.setItem(index, points);
+            }
+            return result;
+        };
+        if (strcmp(kind, "triangles") == 0) { return read(geometry->triangles); }
+        if (strcmp(kind, "hatch") == 0) { return read(geometry->hatch); }
+        if (strcmp(kind, "outlines") == 0) { return read(geometry->outlines); }
+        throw Py::ValueError("unknown section primitive kind");
+    }
+
+    Py::Object deferSectionDisplay(const Py::Tuple& args)
+    {
+        PyObject* callback;
+        if (!PyArg_ParseTuple(args.ptr(), "O", &callback)) { throw Py::Exception(); }
+        if (!qApp || QThread::currentThread() != qApp->thread()) {
+            throw Py::RuntimeError("Section display must be queued on the GUI owner");
+        }
+        if (!PyCallable_Check(callback)) { throw Py::TypeError("callback must be callable"); }
+        struct Callback
+        {
+            PyObject* object;
+            explicit Callback(PyObject* object) : object(object) { Py_INCREF(object); }
+            ~Callback() { Base::PyGILStateLocker lock; Py_DECREF(object); }
+        };
+        auto retained = std::make_shared<Callback>(callback);
+        return Py::Boolean(Gui::dispatchToGuiFrame([retained] {
+            Base::PyGILStateLocker lock;
+            try { Py::Callable(retained->object).apply(Py::Tuple()); }
+            catch (Py::Exception&) { PyErr_Print(); }
+        }));
+    }
+
+    static SectionFaceController* sectionController(PyObject* object)
+    {
+        auto* result = static_cast<SectionFaceController*>(
+            PyCapsule_GetPointer(object, "PartGui.SectionFaceController"));
+        if (!result) { throw Py::Exception(); }
+        return result;
+    }
+
+    Py::Object createSectionFaceController(const Py::Tuple& args)
+    {
+        if (!PyArg_ParseTuple(args.ptr(), "")) { throw Py::Exception(); }
+        auto controller = std::make_unique<SectionFaceController>();
+        auto* capsule = PyCapsule_New(controller.get(), "PartGui.SectionFaceController", [](PyObject* object) {
+            delete static_cast<SectionFaceController*>(
+                PyCapsule_GetPointer(object, "PartGui.SectionFaceController"));
+        });
+        if (!capsule) { throw Py::Exception(); }
+        controller.release();
+        return Py::asObject(capsule);
+    }
+
+    Py::Object cancelSectionFaces(const Py::Tuple& args)
+    {
+        PyObject* controller;
+        if (!PyArg_ParseTuple(args.ptr(), "O", &controller)) { throw Py::Exception(); }
+        try { sectionController(controller)->cancel(); }
+        catch (const std::exception& error) { throw Py::RuntimeError(error.what()); }
+        return Py::None();
+    }
+
+    Py::Object requestSectionFaces(const Py::Tuple& args) { return requestSection(args, false); }
+    Py::Object requestSectionDisplay(const Py::Tuple& args) { return requestSection(args, true); }
+
+    Py::Object requestSection(const Py::Tuple& args, bool display)
+    {
+        PyObject *controller, *pythonInstances, *origin, *normal, *callback;
+        double spacing = 0.0;
+        const int parsed = display
+            ? PyArg_ParseTuple(args.ptr(), "OOO!O!dO", &controller, &pythonInstances,
+                               &Base::VectorPy::Type, &origin, &Base::VectorPy::Type, &normal,
+                               &spacing, &callback)
+            : PyArg_ParseTuple(args.ptr(), "OOO!O!O", &controller, &pythonInstances,
+                               &Base::VectorPy::Type, &origin, &Base::VectorPy::Type, &normal, &callback);
+        if (!parsed) {
+            throw Py::Exception();
+        }
+        auto* target = sectionController(controller);
+        if (!PyCallable_Check(callback)) { throw Py::TypeError("callback must be callable"); }
+        std::vector<SectionInstance> instances;
+        Py::Sequence sequence(pythonInstances);
+        instances.reserve(sequence.size());
+        for (auto iterator = sequence.begin(); iterator != sequence.end(); ++iterator) {
+            Py::Tuple pair(*iterator);
+            if (pair.size() != 2) { throw Py::TypeError("each instance requires a shape and matrix"); }
+            Py::Object shape = pair[0];
+            Py::Object matrix = pair[1];
+            if (!PyObject_TypeCheck(shape.ptr(), &Part::TopoShapePy::Type)
+                || !PyObject_TypeCheck(matrix.ptr(), &Base::MatrixPy::Type)) {
+                throw Py::TypeError("each instance requires a Part shape and Base matrix");
+            }
+            instances.push_back({
+                static_cast<Part::TopoShapePy*>(shape.ptr())->getTopoShapePtr()->getShape(),
+                *static_cast<Base::MatrixPy*>(matrix.ptr())->getMatrixPtr()
+            });
+        }
+        struct OwnerCallback
+        {
+            PyObject* object;
+            bool display;
+            OwnerCallback(PyObject* object, bool display) : object(object), display(display) { Py_INCREF(object); }
+            ~OwnerCallback() { Base::PyGILStateLocker lock; Py_DECREF(object); }
+            void deliver(SectionFaceResult result)
+            {
+                Base::PyGILStateLocker lock;
+                try {
+                    Py::Object payload;
+                    if (display) {
+                        auto geometry = std::make_unique<GeometryOwner>(std::move(result.geometry));
+                        auto* capsule = PyCapsule_New(geometry.get(), "PartGui.SectionDisplayGeometry", [](PyObject* object) {
+                            delete static_cast<GeometryOwner*>(PyCapsule_GetPointer(object, "PartGui.SectionDisplayGeometry"));
+                        });
+                        if (!capsule) { throw Py::Exception(); }
+                        geometry.release();
+                        payload = Py::asObject(capsule);
+                    }
+                    else {
+                        Py::Tuple faces(result.faces.size());
+                        for (std::size_t index = 0; index < result.faces.size(); ++index) {
+                            faces.setItem(index, Py::asObject(new Part::TopoShapePy(
+                                new Part::TopoShape(std::move(result.faces[index])))));
+                        }
+                        payload = faces;
+                    }
+                    Py::Tuple args(2);
+                    args.setItem(0, payload);
+                    args.setItem(1, Py::String(result.error));
+                    Py::Callable(object).apply(args);
+                }
+                catch (Py::Exception&) {
+                    PyErr_Print();
+                }
+            }
+        };
+        auto retained = std::make_shared<OwnerCallback>(callback, display);
+        try {
+            auto completion = [retained](SectionFaceResult result) { retained->deliver(std::move(result)); };
+            const auto originValue = *static_cast<Base::VectorPy*>(origin)->getVectorPtr();
+            const auto normalValue = *static_cast<Base::VectorPy*>(normal)->getVectorPtr();
+            if (display) {
+                target->requestDisplay(std::move(instances), originValue, normalValue, spacing, std::move(completion));
+            }
+            else {
+                target->request(std::move(instances), originValue, normalValue, std::move(completion));
+            }
+        }
+        catch (const std::exception& error) { throw Py::RuntimeError(error.what()); }
+        return Py::None();
+    }
+
     Py::Object isModelingObjectActive(const Py::Tuple& args)
     {
         PyObject* pythonObject = nullptr;

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -149,6 +149,8 @@ SET(PartGui_SRCS
     PreviewUpdateScheduler.h
     RenderMeshController.cpp
     RenderMeshController.h
+    SectionFaceController.cpp
+    SectionFaceController.h
     PropertyEnumAttacherItem.cpp
     PropertyEnumAttacherItem.h
     SoFCShapeObject.cpp

--- a/src/Mod/Part/Gui/SectionFaceController.cpp
+++ b/src/Mod/Part/Gui/SectionFaceController.cpp
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include "SectionFaceController.h"
+
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <QApplication>
+#include <QThread>
+#include <Standard_Failure.hxx>
+#include <App/Application.h>
+#include <App/HostRuntime.h>
+#include <Base/Exception.h>
+#include <Gui/FrameBudget.h>
+
+using namespace PartGui;
+
+namespace
+{
+void requireOwner()
+{
+    if (!qApp || QThread::currentThread() != qApp->thread()) {
+        throw std::logic_error("Section requests must originate on the GUI owner");
+    }
+}
+}
+
+struct SectionFaceController::State: std::enable_shared_from_this<State>
+{
+    struct Request
+    {
+        std::uint64_t generation;
+        std::vector<SectionInstance> instances;
+        Base::Vector3d origin;
+        Base::Vector3d normal;
+        Completion completion;
+    };
+
+    std::uint64_t generation {0};
+    bool active {false};
+    std::optional<Request> pending;
+    Completion completion;
+    std::shared_ptr<std::stop_source> cancellation;
+
+    void request(std::vector<SectionInstance> instances,
+                 Base::Vector3d origin, Base::Vector3d normal, Completion callback)
+    {
+        if (!callback) {
+            throw std::invalid_argument("Section request requires a completion callback");
+        }
+        Request next {++generation, std::move(instances), origin, normal, std::move(callback)};
+        if (active) {
+            // Commit state before releasing callbacks: their destructors can
+            // submit a replacement request on this owner.
+            auto replaced = std::exchange(pending, std::move(next));
+            auto oldCallback = std::move(completion);
+            cancellation->request_stop();
+            return;
+        }
+        start(std::move(next));
+    }
+
+    void cancel()
+    {
+        ++generation;
+        auto discarded = std::exchange(pending, {});
+        auto oldCallback = std::move(completion);
+        if (cancellation) {
+            cancellation->request_stop();
+        }
+    }
+
+    void start(Request request)
+    {
+        active = true;
+        completion = std::move(request.completion);
+        cancellation = std::make_shared<std::stop_source>();
+        auto stop = cancellation;
+        auto weak = weak_from_this();
+        const auto requestedGeneration = request.generation;
+        auto deliver = [weak, requestedGeneration](SectionFaceResult result) {
+            Gui::dispatchToGuiFrame([weak, requestedGeneration, result = std::move(result)]() mutable {
+                if (auto owner = weak.lock()) {
+                    owner->finish(requestedGeneration, std::move(result));
+                }
+            });
+        };
+        try {
+            App::GetApplication().hostRuntime().submitWithCompletion(
+                App::HostRuntime::Lane::Compute,
+                [instances = std::move(request.instances), origin = request.origin,
+                 normal = request.normal, stop](std::stop_token runtimeStop) {
+                    std::stop_callback stopped(runtimeStop, [stop] { stop->request_stop(); });
+                    SectionFaceResult result;
+                    for (const auto& instance : instances) {
+                        if (stop->stop_requested()) {
+                            break;
+                        }
+                        try {
+                            auto face = Part::prepareSectionFaces(
+                                instance.shape, instance.transform, origin, normal, stop->get_token());
+                            if (!face.IsNull()) {
+                                result.faces.push_back(std::move(face));
+                            }
+                        }
+                        catch (const Standard_Failure& error) {
+                            if (result.error.empty()) {
+                                result.error = error.GetMessageString() ? error.GetMessageString()
+                                                                        : "Section kernel failure";
+                            }
+                        }
+                        catch (const Base::Exception& error) {
+                            if (result.error.empty()) { result.error = error.what(); }
+                        }
+                        catch (const std::exception& error) {
+                            if (result.error.empty()) { result.error = error.what(); }
+                        }
+                    }
+                    return result;
+                },
+                [deliver](std::future<SectionFaceResult> future) {
+                    SectionFaceResult result;
+                    try { result = future.get(); }
+                    catch (const std::exception& error) { result.error = error.what(); }
+                    catch (...) { result.error = "Section request cancelled or failed"; }
+                    deliver(std::move(result));
+                });
+        }
+        catch (const std::exception& error) {
+            deliver(SectionFaceResult {{}, error.what()});
+        }
+    }
+
+    void finish(std::uint64_t requestedGeneration, SectionFaceResult result)
+    {
+        active = false;
+        cancellation.reset();
+        auto notify = std::move(completion);
+        auto next = std::exchange(pending, {});
+        if (next) {
+            start(std::move(*next));
+        }
+        else if (requestedGeneration == generation && notify) {
+            notify(std::move(result));
+        }
+    }
+};
+
+SectionFaceController::SectionFaceController() : state(std::make_shared<State>()) {}
+SectionFaceController::~SectionFaceController() { state->cancel(); }
+
+void SectionFaceController::request(std::vector<SectionInstance> instances,
+                                   Base::Vector3d origin, Base::Vector3d normal, Completion completion)
+{
+    requireOwner();
+    const auto owner = state;
+    owner->request(std::move(instances), origin, normal, std::move(completion));
+}
+
+void SectionFaceController::cancel()
+{
+    requireOwner();
+    const auto owner = state;
+    owner->cancel();
+}

--- a/src/Mod/Part/Gui/SectionFaceController.cpp
+++ b/src/Mod/Part/Gui/SectionFaceController.cpp
@@ -2,6 +2,7 @@
 #include "SectionFaceController.h"
 
 #include <cstdint>
+#include <iterator>
 #include <optional>
 #include <stdexcept>
 #include <utility>
@@ -34,6 +35,7 @@ struct SectionFaceController::State: std::enable_shared_from_this<State>
         Base::Vector3d origin;
         Base::Vector3d normal;
         Completion completion;
+        std::optional<double> spacing;
     };
 
     std::uint64_t generation {0};
@@ -43,12 +45,13 @@ struct SectionFaceController::State: std::enable_shared_from_this<State>
     std::shared_ptr<std::stop_source> cancellation;
 
     void request(std::vector<SectionInstance> instances,
-                 Base::Vector3d origin, Base::Vector3d normal, Completion callback)
+                 Base::Vector3d origin, Base::Vector3d normal, Completion callback,
+                 std::optional<double> spacing = {})
     {
         if (!callback) {
             throw std::invalid_argument("Section request requires a completion callback");
         }
-        Request next {++generation, std::move(instances), origin, normal, std::move(callback)};
+        Request next {++generation, std::move(instances), origin, normal, std::move(callback), spacing};
         if (active) {
             // Commit state before releasing callbacks: their destructors can
             // submit a replacement request on this owner.
@@ -89,9 +92,10 @@ struct SectionFaceController::State: std::enable_shared_from_this<State>
             App::GetApplication().hostRuntime().submitWithCompletion(
                 App::HostRuntime::Lane::Compute,
                 [instances = std::move(request.instances), origin = request.origin,
-                 normal = request.normal, stop](std::stop_token runtimeStop) {
+                 normal = request.normal, spacing = request.spacing, stop](std::stop_token runtimeStop) {
                     std::stop_callback stopped(runtimeStop, [stop] { stop->request_stop(); });
                     SectionFaceResult result;
+                    auto geometry = spacing ? std::make_shared<Part::SectionDisplayGeometry>() : nullptr;
                     for (const auto& instance : instances) {
                         if (stop->stop_requested()) {
                             break;
@@ -100,7 +104,20 @@ struct SectionFaceController::State: std::enable_shared_from_this<State>
                             auto face = Part::prepareSectionFaces(
                                 instance.shape, instance.transform, origin, normal, stop->get_token());
                             if (!face.IsNull()) {
-                                result.faces.push_back(std::move(face));
+                                if (geometry) {
+                                    auto prepared = Part::prepareSectionDisplay(
+                                        face, origin, normal, *spacing, stop->get_token());
+                                    const auto append = [](auto& target, auto& source) {
+                                        target.insert(target.end(), std::make_move_iterator(source.begin()),
+                                                      std::make_move_iterator(source.end()));
+                                    };
+                                    append(geometry->triangles, prepared.triangles);
+                                    append(geometry->hatch, prepared.hatch);
+                                    append(geometry->outlines, prepared.outlines);
+                                }
+                                else {
+                                    result.faces.push_back(std::move(face));
+                                }
                             }
                         }
                         catch (const Standard_Failure& error) {
@@ -116,6 +133,13 @@ struct SectionFaceController::State: std::enable_shared_from_this<State>
                             if (result.error.empty()) { result.error = error.what(); }
                         }
                     }
+                    if (stop->stop_requested()) {
+                        result.faces.clear();
+                        result.error = "Section request cancelled";
+                    }
+                    else {
+                        result.geometry = std::move(geometry);
+                    }
                     return result;
                 },
                 [deliver](std::future<SectionFaceResult> future) {
@@ -127,7 +151,9 @@ struct SectionFaceController::State: std::enable_shared_from_this<State>
                 });
         }
         catch (const std::exception& error) {
-            deliver(SectionFaceResult {{}, error.what()});
+            SectionFaceResult result;
+            result.error = error.what();
+            deliver(std::move(result));
         }
     }
 
@@ -162,4 +188,13 @@ void SectionFaceController::cancel()
     requireOwner();
     const auto owner = state;
     owner->cancel();
+}
+
+void SectionFaceController::requestDisplay(std::vector<SectionInstance> instances,
+                                         Base::Vector3d origin, Base::Vector3d normal,
+                                         double spacing, Completion completion)
+{
+    requireOwner();
+    const auto owner = state;
+    owner->request(std::move(instances), origin, normal, std::move(completion), spacing);
 }

--- a/src/Mod/Part/Gui/SectionFaceController.cpp
+++ b/src/Mod/Part/Gui/SectionFaceController.cpp
@@ -101,8 +101,11 @@ struct SectionFaceController::State: std::enable_shared_from_this<State>
                             break;
                         }
                         try {
-                            auto face = Part::prepareSectionFaces(
-                                instance.shape, instance.transform, origin, normal, stop->get_token());
+                            auto face = instance.mesh
+                                ? Part::prepareSectionMeshFaces(*instance.mesh, instance.transform,
+                                                                origin, normal, stop->get_token())
+                                : Part::prepareSectionFaces(instance.shape, instance.transform,
+                                                           origin, normal, stop->get_token());
                             if (!face.IsNull()) {
                                 if (geometry) {
                                     auto prepared = Part::prepareSectionDisplay(

--- a/src/Mod/Part/Gui/SectionFaceController.h
+++ b/src/Mod/Part/Gui/SectionFaceController.h
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+#include <Mod/Part/App/SectionGeometry.h>
+
+namespace PartGui
+{
+struct SectionInstance
+{
+    TopoDS_Shape shape;
+    Base::Matrix4D transform;
+};
+
+struct SectionFaceResult
+{
+    std::vector<TopoDS_Shape> faces;
+    std::string error;
+};
+
+/** One active calculation and one replaceable pending section request.
+ * Requests, cancellation, and callback destruction belong to the GUI owner.
+ * Workers retain only native geometry, transforms, and cancellation tokens.
+ */
+class PartGuiExport SectionFaceController
+{
+public:
+    using Completion = std::function<void(SectionFaceResult)>;
+    SectionFaceController();
+    ~SectionFaceController();
+    SectionFaceController(const SectionFaceController&) = delete;
+    SectionFaceController& operator=(const SectionFaceController&) = delete;
+
+    void request(std::vector<SectionInstance> instances,
+                 Base::Vector3d origin, Base::Vector3d normal, Completion completion);
+    void cancel();
+
+private:
+    struct State;
+    std::shared_ptr<State> state;
+};
+}

--- a/src/Mod/Part/Gui/SectionFaceController.h
+++ b/src/Mod/Part/Gui/SectionFaceController.h
@@ -13,6 +13,7 @@ struct SectionInstance
 {
     TopoDS_Shape shape;
     Base::Matrix4D transform;
+    std::shared_ptr<const Part::RenderMesh> mesh;
 };
 
 struct SectionFaceResult

--- a/src/Mod/Part/Gui/SectionFaceController.h
+++ b/src/Mod/Part/Gui/SectionFaceController.h
@@ -19,6 +19,7 @@ struct SectionFaceResult
 {
     std::vector<TopoDS_Shape> faces;
     std::string error;
+    std::shared_ptr<const Part::SectionDisplayGeometry> geometry;
 };
 
 /** One active calculation and one replaceable pending section request.
@@ -36,6 +37,9 @@ public:
 
     void request(std::vector<SectionInstance> instances,
                  Base::Vector3d origin, Base::Vector3d normal, Completion completion);
+    void requestDisplay(std::vector<SectionInstance> instances,
+                        Base::Vector3d origin, Base::Vector3d normal,
+                        double spacing, Completion completion);
     void cancel();
 
 private:

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -148,6 +148,16 @@ public:
         );
     }
 
+    /** Capture the installed native geometry on the GUI owner, without reading
+     * document properties. The reference survives view removal. Treat shared
+     * geometry as read-only and make a private copy before kernel mutation.
+     * Returns a null shape until a rendered generation is available.
+     */
+    TopoDS_Shape getRenderedShapeSnapshot() const
+    {
+        return lastRenderedShape;
+    }
+
     /** @name Highlight handling
      * This group of methods do the highlighting of elements.
      */

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -153,6 +153,11 @@ public:
      * geometry as read-only and make a private copy before kernel mutation.
      * Returns a null shape until a rendered generation is available.
      */
+    std::shared_ptr<const Part::RenderMesh> getRenderedMeshSnapshot() const
+    {
+        return installedRenderMesh;
+    }
+
     TopoDS_Shape getRenderedShapeSnapshot() const
     {
         return lastRenderedShape;

--- a/src/Mod/Part/Gui/ViewProviderPartExt.pyi
+++ b/src/Mod/Part/Gui/ViewProviderPartExt.pyi
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from Base.Metadata import export
+from Base.Metadata import export, no_args
 from Gui.ViewProviderGeometryObject import ViewProviderGeometryObject
 
 @export(
@@ -17,4 +17,12 @@ class ViewProviderPartExt(ViewProviderGeometryObject):
     Licence: LGPL
     """
 
-    ...
+    @no_args
+    def getRenderedShapeSnapshot(self) -> object:
+        """Return the cached native shape without reading document geometry.
+
+        Call on the GUI thread. The snapshot retains geometry after the view
+        closes; treat it as read-only and copy before modifying it. An empty
+        shape means that no cached rendered generation is available yet.
+        """
+        ...

--- a/src/Mod/Part/Gui/ViewProviderPartExt.pyi
+++ b/src/Mod/Part/Gui/ViewProviderPartExt.pyi
@@ -18,6 +18,15 @@ class ViewProviderPartExt(ViewProviderGeometryObject):
     """
 
     @no_args
+    def getRenderedMeshSnapshot(self) -> object:
+        """Retain the immutable displayed mesh, or None before it is available.
+
+        Call on the GUI thread. Pass the opaque snapshot to
+        PartGui.requestSectionMeshDisplay; it remains valid after view closure.
+        """
+        ...
+
+    @no_args
     def getRenderedShapeSnapshot(self) -> object:
         """Return the cached native shape without reading document geometry.
 

--- a/src/Mod/Part/Gui/ViewProviderPartExtPyImp.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPartExtPyImp.cpp
@@ -44,6 +44,19 @@ std::string ViewProviderPartExtPy::representation() const
     return str.str();
 }
 
+PyObject* ViewProviderPartExtPy::getRenderedMeshSnapshot()
+{
+    using Owner = std::shared_ptr<const Part::RenderMesh>;
+    auto snapshot = getViewProviderPartExtPtr()->getRenderedMeshSnapshot();
+    if (!snapshot) { Py_RETURN_NONE; }
+    auto owner = std::make_unique<Owner>(std::move(snapshot));
+    auto* capsule = PyCapsule_New(owner.get(), "PartGui.RenderMesh", [](PyObject* object) {
+        delete static_cast<Owner*>(PyCapsule_GetPointer(object, "PartGui.RenderMesh"));
+    });
+    if (capsule) { owner.release(); }
+    return capsule;
+}
+
 PyObject* ViewProviderPartExtPy::getRenderedShapeSnapshot()
 {
     return new Part::TopoShapePy(

--- a/src/Mod/Part/Gui/ViewProviderPartExtPyImp.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPartExtPyImp.cpp
@@ -27,6 +27,7 @@
 
 #include <App/GeoFeature.h>
 #include <App/PropertyStandard.h>
+#include <Mod/Part/App/TopoShapePy.h>
 
 #include "ViewProviderPartExtPy.h"
 #include "ViewProviderPartExtPy.cpp"
@@ -41,6 +42,13 @@ std::string ViewProviderPartExtPy::representation() const
     str << "<View provider geometry object at " << getViewProviderPartExtPtr() << ">";
 
     return str.str();
+}
+
+PyObject* ViewProviderPartExtPy::getRenderedShapeSnapshot()
+{
+    return new Part::TopoShapePy(
+        new Part::TopoShape(getViewProviderPartExtPtr()->getRenderedShapeSnapshot())
+    );
 }
 
 PyObject* ViewProviderPartExtPy::getCustomAttributes(const char* attr) const

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -133,6 +133,8 @@ _dragger_node: Any | None = None
 _dragger_view: Any | None = None
 _dragger_document: Any | None = None
 _section_document_observer: Any | None = None
+_bounds_view: Any | None = None
+_section_bounds: ModelBounds | None = None
 _dragger_busy = False
 _drag_start_settings: SectionViewSettings | None = None
 _drag_start_origin: tuple[float, float, float] | None = None
@@ -1392,10 +1394,20 @@ def section_view_placement(
         raise RuntimeError("FreeCAD is unavailable.")
     active = settings if settings is not None else _settings
     bounds = model_bounds(_document_objects(document))
+    return _placement_from_bounds(active, bounds)
+
+
+def _placement_from_bounds(settings: SectionViewSettings, bounds: ModelBounds | None) -> Any:
     center = bounds.center if bounds is not None else (0.0, 0.0, 0.0)
-    origin, normal = clip_plane_from_settings(active, center)
+    origin, normal = clip_plane_from_settings(settings, center)
     rotation = App.Rotation(App.Vector(0.0, 0.0, -1.0), App.Vector(*normal))
     return App.Placement(App.Vector(*origin), rotation)
+
+
+def _bounds_for_view(view: Any, document: Any | None) -> ModelBounds | None:
+    if view is not None and view == _bounds_view:
+        return _section_bounds
+    return model_bounds(_document_objects(document))
 
 
 def is_section_view_active(view: Any | None = None) -> bool:
@@ -1564,7 +1576,7 @@ def _observe_section_document(view: Any, document: Any | None) -> None:
 
 def _remove_dragger(view: Any) -> None:
     global _dragger_node, _dragger_busy, _drag_start_settings
-    global _dragger_view, _dragger_document
+    global _dragger_view, _dragger_document, _bounds_view, _section_bounds
     global _drag_start_origin, _drag_start_axes, _drag_start_rot_counts, _triad_parts
     scene = _scene_from_view(view)
     _stop_dragger_poll()
@@ -1572,6 +1584,8 @@ def _remove_dragger(view: Any) -> None:
     _dragger_node = None
     _dragger_view = None
     _dragger_document = None
+    _bounds_view = None
+    _section_bounds = None
     _dragger_busy = False
     _drag_start_settings = None
     _drag_start_origin = None
@@ -1615,7 +1629,7 @@ def _sync_overlay(
     if scene is None:
         return
     objects = _document_objects(document)
-    bounds = model_bounds(objects)
+    bounds = _bounds_for_view(view, document)
     center = bounds.center if bounds is not None else (0.0, 0.0, 0.0)
     origin, normal = clip_plane_from_settings(settings, center)
     if settings.show_plane:
@@ -2011,7 +2025,11 @@ def _set_dragger_pose(
 
 
 def _dragger_center(document: Any | None) -> tuple[float, float, float]:
-    bounds = model_bounds(_document_objects(document))
+    bounds = (
+        _bounds_for_view(_dragger_view, document)
+        if document is None or document is _dragger_document
+        else model_bounds(_document_objects(document))
+    )
     if bounds is None:
         return (0.0, 0.0, 0.0)
     return bounds.center
@@ -2305,7 +2323,7 @@ def _autoscale_dragger(view: Any, origin: tuple[float, float, float]) -> None:
         return
     scale = world_scale_for_ndc(view, origin, _DRAGGER_NDC_SIZE)
     if scale is None or scale <= 0.0:
-        bounds = model_bounds(_document_objects(None))
+        bounds = _bounds_for_view(view, None)
         if bounds is None:
             scale = 20.0
         else:
@@ -2563,7 +2581,7 @@ def _sync_dragger(
     scene = _scene_from_view(view)
     if scene is None:
         return
-    bounds = model_bounds(_document_objects(document))
+    bounds = _bounds_for_view(view, document)
     center = bounds.center if bounds is not None else (0.0, 0.0, 0.0)
     origin, _normal = clip_plane_from_settings(settings, center)
     axes = section_cs_axes(
@@ -2642,11 +2660,15 @@ def _apply_clip(
     preview: bool = False,
     sync_dragger: bool = True,
 ) -> None:
+    global _bounds_view, _section_bounds
     if _dragger_view is not None and view != _dragger_view:
         # The section editor owns one scene. Transfer it before attaching new
         # nodes, rather than leaving the previous view with dangling wrappers.
         set_section_view(False, view=_dragger_view, document=_dragger_document)
-    placement = section_view_placement(document, settings)
+    if not preview or view != _bounds_view:
+        _section_bounds = model_bounds(_document_objects(document))
+        _bounds_view = view
+    placement = _placement_from_bounds(settings, _section_bounds)
     if is_section_view_active(view):
         if not _update_clip_plane(view, placement):
             view.toggleClippingPlane(toggle=0)

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -130,6 +130,9 @@ _settings = SectionViewSettings()
 _overlay_node: Any | None = None
 _cap_node: Any | None = None
 _dragger_node: Any | None = None
+_dragger_view: Any | None = None
+_dragger_document: Any | None = None
+_section_document_observer: Any | None = None
 _dragger_busy = False
 _drag_start_settings: SectionViewSettings | None = None
 _drag_start_origin: tuple[float, float, float] | None = None
@@ -1523,13 +1526,52 @@ def _remove_overlay(view: Any) -> None:
     _cap_node = None
 
 
+class _SectionViewDocumentObserver:
+    def slotActivateDocument(self, gui_document: Any) -> None:
+        if _dragger_node is None:
+            return
+        if getattr(gui_document, "Document", None) is _dragger_document:
+            _start_dragger_poll()
+        else:
+            _stop_dragger_poll()
+
+    def slotDeletedDocument(self, gui_document: Any) -> None:
+        global _dragger_view, _dragger_document
+        if getattr(gui_document, "Document", None) is not _dragger_document:
+            return
+        # Gui's delete notification precedes scene destruction. Pivy wrappers
+        # must be released here, before the poll timer can see deleted nodes.
+        view = _dragger_view
+        _stop_selection_snap()
+        _remove_dragger(view)
+        _remove_overlay(view)
+        _dragger_view = None
+        _dragger_document = None
+        _close_ui()
+
+
+def _observe_section_document(view: Any, document: Any | None) -> None:
+    global _dragger_view, _dragger_document, _section_document_observer
+    import FreeCADGui as Gui
+
+    if _section_document_observer is None:
+        observer = _SectionViewDocumentObserver()
+        Gui.addDocumentObserver(observer)
+        _section_document_observer = observer
+    _dragger_view = view
+    _dragger_document = document if document is not None else _active_document()
+
+
 def _remove_dragger(view: Any) -> None:
     global _dragger_node, _dragger_busy, _drag_start_settings
+    global _dragger_view, _dragger_document
     global _drag_start_origin, _drag_start_axes, _drag_start_rot_counts, _triad_parts
     scene = _scene_from_view(view)
     _stop_dragger_poll()
     _detach_scene_node(scene, _dragger_node)
     _dragger_node = None
+    _dragger_view = None
+    _dragger_document = None
     _dragger_busy = False
     _drag_start_settings = None
     _drag_start_origin = None
@@ -2569,6 +2611,7 @@ def _sync_dragger(
             _triad_parts = None
             return
         _dragger_node = dragger
+        _observe_section_document(view, document)
         _start_dragger_poll()
     _set_dragger_pose(coin, _dragger_node, origin, axes)
     _autoscale_dragger(view, origin)
@@ -2599,6 +2642,10 @@ def _apply_clip(
     preview: bool = False,
     sync_dragger: bool = True,
 ) -> None:
+    if _dragger_view is not None and view != _dragger_view:
+        # The section editor owns one scene. Transfer it before attaching new
+        # nodes, rather than leaving the previous view with dangling wrappers.
+        set_section_view(False, view=_dragger_view, document=_dragger_document)
     placement = section_view_placement(document, settings)
     if is_section_view_active(view):
         if not _update_clip_plane(view, placement):

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -1549,10 +1549,12 @@ def _detach_scene_node(scene: Any, node: Any) -> None:
 
 
 def _scene_from_view(view: Any) -> Any | None:
-    get_scene = getattr(view, "getSceneGraph", None)
-    if not callable(get_scene):
-        return None
     try:
+        # FreeCAD wrappers can raise during attribute lookup after their view
+        # is deleted, before a bound method can even be obtained.
+        get_scene = getattr(view, "getSceneGraph", None)
+        if not callable(get_scene):
+            return None
         return get_scene()
     except Exception:
         return None
@@ -1742,8 +1744,8 @@ def _remove_dragger(view: Any) -> None:
     global _dragger_view, _dragger_document, _bounds_view, _section_bounds, _cap_dirty
     global _last_dragger_scale
     global _drag_start_origin, _drag_start_axes, _drag_start_rot_counts, _triad_parts
-    scene = _scene_from_view(view)
     _stop_dragger_poll()
+    scene = _scene_from_view(view)
     _detach_scene_node(scene, _dragger_node)
     _dragger_node = None
     _dragger_view = None

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -1418,7 +1418,7 @@ def _placement_from_bounds(settings: SectionViewSettings, bounds: ModelBounds | 
 
 
 def _render_bounds(view: Any) -> ModelBounds | None:
-    """Bound displayed BRep instances, excluding grids and editor decorations.
+    """Bound displayed model instances, excluding grids and editor decorations.
 
     Applying the action to each visible path preserves Link/display transforms
     without reading document compound shapes or modifying the scene.
@@ -1430,7 +1430,10 @@ def _render_bounds(view: Any) -> ModelBounds | None:
         from pivy import coin
 
         box = coin.SbBox3f()
-        for type_name in ("SoBrepFaceSet", "SoBrepEdgeSet", "SoBrepPointSet"):
+        for type_name in (
+            "SoBrepFaceSet", "SoBrepEdgeSet", "SoBrepPointSet",
+            "SoFCMeshObjectShape", "SoFCIndexedFaceSet",
+        ):
             shape_type = coin.SoType.fromName(type_name)
             if shape_type.isBad():
                 continue

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -59,6 +59,7 @@ class SectionViewSettings:
     yaw: float = 0.0
     pitch: float = 0.0
     roll: float = 0.0
+    show_handles: bool = True
 
     def __post_init__(self) -> None:
         plane = str(self.plane).strip().casefold()
@@ -71,6 +72,7 @@ class SectionViewSettings:
         object.__setattr__(self, "yaw", float(self.yaw))
         object.__setattr__(self, "pitch", float(self.pitch))
         object.__setattr__(self, "roll", float(self.roll))
+        object.__setattr__(self, "show_handles", bool(self.show_handles))
 
 
 @dataclass(frozen=True)
@@ -402,7 +404,7 @@ def section_plane_from_view_direction(
     toward_camera = (-look[0], -look[1], -look[2])
     plane = principal_plane_for_axis(toward_camera)
     principal = section_plane_normal(plane, flipped=False)
-    flipped = _dot(principal, toward_camera) < 0.0
+    flipped = _dot(principal, look) < 0.0
     return plane, flipped
 
 
@@ -577,6 +579,7 @@ def apply_feature_snap(
                 plane=plane,
                 flipped=flipped,
                 show_plane=settings.show_plane,
+                show_handles=settings.show_handles,
             )
     offset = offset_through_point(next_settings, model_center, point)
     return replace(next_settings, offset=offset)
@@ -1415,16 +1418,33 @@ def _placement_from_bounds(settings: SectionViewSettings, bounds: ModelBounds | 
 
 
 def _render_bounds(view: Any) -> ModelBounds | None:
-    """Use the displayed scene, without materializing document compound shapes."""
+    """Bound displayed BRep instances, excluding grids and editor decorations.
+
+    Applying the action to each visible path preserves Link/display transforms
+    without reading document compound shapes or modifying the scene.
+    """
     scene = _scene_from_view(view)
     if scene is None:
         return None
     try:
         from pivy import coin
 
-        action = coin.SoGetBoundingBoxAction(coin.SbViewportRegion(1, 1))
-        action.apply(scene)
-        box = action.getBoundingBox()
+        box = coin.SbBox3f()
+        for type_name in ("SoBrepFaceSet", "SoBrepEdgeSet", "SoBrepPointSet"):
+            shape_type = coin.SoType.fromName(type_name)
+            if shape_type.isBad():
+                continue
+            search = coin.SoSearchAction()
+            search.setType(shape_type)
+            search.setInterest(coin.SoSearchAction.ALL)
+            search.setSearchingAll(False)
+            search.apply(scene)
+            for path in search.getPaths():
+                action = coin.SoGetBoundingBoxAction(coin.SbViewportRegion(1, 1))
+                action.apply(path)
+                instance_box = action.getBoundingBox()
+                if not instance_box.isEmpty():
+                    box.extendBy(instance_box)
         if box.isEmpty():
             return None
         low, high = _vec3(box.getMin()), _vec3(box.getMax())
@@ -1623,7 +1643,7 @@ class _NativeSectionCapWorker:
         if not self._backend._deferSectionDisplay(run):
             self.cancel()
 
-    def request(self, snapshots, origin, normal, spacing, publish):
+    def request(self, snapshots, origin, normal, spacing, publish, *, mesh=False):
         from time import perf_counter
 
         self.cancel()
@@ -1662,7 +1682,9 @@ class _NativeSectionCapWorker:
                     instance = next(self._steps)
                 except StopIteration:
                     self._steps = None
-                    self._backend.requestSectionDisplay(
+                    request = (self._backend.requestSectionMeshDisplay if mesh
+                               else self._backend.requestSectionDisplay)
+                    request(
                         self._handle, instances, origin, normal, spacing, completed
                     )
                     return
@@ -1744,9 +1766,14 @@ def _remove_dragger(view: Any) -> None:
     global _dragger_view, _dragger_document, _bounds_view, _section_bounds, _cap_dirty
     global _last_dragger_scale
     global _drag_start_origin, _drag_start_axes, _drag_start_rot_counts, _triad_parts
+    _stop_plane_drag()
     _stop_dragger_poll()
     scene = _scene_from_view(view)
     _detach_scene_node(scene, _dragger_node)
+    if _dragger_node is not None:
+        unref = getattr(_dragger_node, "unref", None)
+        if callable(unref):
+            unref()
     _dragger_node = None
     _dragger_view = None
     _dragger_document = None
@@ -1796,23 +1823,38 @@ def _sync_overlay(
     scene = _scene_from_view(view)
     if scene is None:
         return
-    objects = _document_objects(document)
+    _sync_plane_guide(view, document, settings)
     bounds = _bounds_for_view(view, document)
     center = bounds.center if bounds is not None else (0.0, 0.0, 0.0)
     origin, normal = clip_plane_from_settings(settings, center)
+    if not rebuild_caps:
+        return
+    _schedule_cap_build(coin, view, document, origin, normal, hatch_spacing_for_bounds(bounds))
+
+
+def _sync_plane_guide(view, document, settings):
+    """Change guide visibility without cancelling or rebuilding cut faces."""
+    global _overlay_node
+    scene = _scene_from_view(view)
+    if scene is None:
+        return
+    _detach_scene_node(scene, _overlay_node)
+    _overlay_node = None
     if settings.show_plane:
+        from pivy import coin
+
+        bounds = _bounds_for_view(view, document)
+        center = bounds.center if bounds is not None else (0.0, 0.0, 0.0)
+        origin, normal = clip_plane_from_settings(settings, center)
         half_width, half_height = _overlay_size(bounds, normal)
         corners = section_plane_corners(origin, normal, half_width, half_height)
         try:
             _install_overlay_node(coin, scene, corners)
         except Exception:
             pass
-    if not rebuild_caps:
-        return
-    _schedule_cap_build(coin, view, document, origin, normal, hatch_spacing_for_bounds(bounds))
 
 
-def _rendered_section_snapshot_steps(view):
+def _rendered_section_snapshot_steps(view, *, mesh=False):
     """Capture displayed instances on the owner, yielding between providers.
 
     Only detached native shape references and matrices leave this generator.
@@ -1826,10 +1868,11 @@ def _rendered_section_snapshot_steps(view):
     for document in App.listDocuments().values():
         for obj in document.Objects:
             provider = obj.ViewObject
-            snapshot = getattr(provider, "getRenderedShapeSnapshot", None)
+            snapshot = getattr(provider, "getRenderedMeshSnapshot" if mesh else "getRenderedShapeSnapshot", None)
             if callable(snapshot):
                 shape = snapshot()
-                if not shape.isNull():
+                available = shape is not None if mesh else not shape.isNull()
+                if available:
                     search = coin.SoSearchAction()
                     search.setType(face_type)
                     search.setInterest(coin.SoSearchAction.FIRST)
@@ -1880,8 +1923,8 @@ def _schedule_cap_build(coin, view, document, origin, normal, spacing):
             return _install_cap_node_steps(coin, scene, caps)
 
     _cap_worker.request(
-        _rendered_section_snapshot_steps(view),
-        App.Vector(*origin), App.Vector(*normal), spacing, publish,
+        _rendered_section_snapshot_steps(view, mesh=True),
+        App.Vector(*origin), App.Vector(*normal), spacing, publish, mesh=True,
     )
 
 
@@ -2737,6 +2780,8 @@ def _poll_dragger() -> None:
     if (_cap_dirty and not _dragger_busy and view is not None
             and _dragger_document is not None and _dragger_document.isClosable()):
         _sync_overlay(view, _dragger_document, _settings)
+    if not _settings.show_handles:
+        return
     origin = _current_dragger_origin()
     if origin is not None and view is not None:
         _autoscale_dragger(view, origin)
@@ -2833,6 +2878,114 @@ def _poll_dragger() -> None:
     _refresh_dialog()
 
 
+_plane_drag_filter = None
+
+
+def _stop_plane_drag():
+    global _plane_drag_filter
+    handler, _plane_drag_filter = _plane_drag_filter, None
+    if handler is not None:
+        try:
+            handler.widget.removeEventFilter(handler)
+            handler.deleteLater()
+        except RuntimeError:
+            pass
+
+
+def _start_plane_drag(view):
+    """Handle guide drags on the owning Qt viewport, without Coin callbacks."""
+    global _plane_drag_filter
+    if _plane_drag_filter is not None or not callable(getattr(view, "graphicsView", None)):
+        return
+    from PySide import QtCore, QtGui
+
+    class PlaneDragFilter(QtCore.QObject):
+        def __init__(self, widget):
+            super().__init__(widget)
+            self.widget = widget
+            self.dragging = False
+
+        def eventFilter(self, watched, event):
+            if _active_3d_view() != view or _dragger_view != view:
+                self.dragging = False
+                return False
+            kind = event.type()
+            if kind == QtCore.QEvent.MouseButtonPress:
+                if (event.button() != QtCore.Qt.LeftButton
+                        or event.modifiers() != QtCore.Qt.NoModifier
+                        or not _settings.show_plane or _overlay_node is None):
+                    return False
+                bounds = _bounds_for_view(view, _dragger_document)
+                center = bounds.center if bounds else (0, 0, 0)
+                origin, normal = clip_plane_from_settings(_settings, center)
+                width, height = _overlay_size(bounds, normal)
+
+                def project(point):
+                    x, y = view.getPointOnScreen(App.Vector(*point))
+                    return QtCore.QPointF(x, watched.height() - 1 - y)
+
+                corners = section_plane_corners(origin, normal, width, height)
+                polygon = QtGui.QPolygonF([project(point) for point in corners])
+                position = event.position()
+                if not polygon.containsPoint(position, QtCore.Qt.OddEvenFill):
+                    return False
+                # The native gizmo keeps its own arrow/ring interaction when
+                # both the guide and a handle lie under the cursor.
+                from pivy import coin
+                pixel_x, pixel_y = int(position.x()), watched.height() - 1 - int(position.y())
+                ray_point = view.getPoint(pixel_x, pixel_y)
+                direction = view.getCameraOrientation().multVec(App.Vector(0, 0, -1))
+                camera = _view_camera(view)
+                if camera is not None:
+                    ray_point = ray_point - direction * float(camera.farDistance.getValue())
+                pick = coin.SoRayPickAction(coin.SbViewportRegion(watched.width(), watched.height()))
+                pick.setRay(_coin_vec3(coin, _vec3(ray_point)), _coin_vec3(coin, _vec3(direction)))
+                pick.setPickAll(True)
+                pick.apply(_scene_from_view(view))
+                if any(point.getPath().containsNode(_dragger_node) for point in pick.getPickedPointList()):
+                    return False
+                self.start_position = position
+                self.start_settings = _settings
+                self.normal = normal
+                self.center = center
+                self.bounds = bounds
+                self.axis = project(tuple(origin[i] + normal[i] for i in range(3))) - project(origin)
+                # Looking straight at the cut collapses its normal on screen;
+                # vertical dragging then uses the view's world-units-per-pixel.
+                a = view.getPoint(pixel_x, pixel_y)
+                b = view.getPoint(pixel_x, pixel_y + 1)
+                self.pixel_scale = (b - a).Length
+                self.dragging = True
+                return True
+            if not self.dragging:
+                return False
+            if kind == QtCore.QEvent.MouseMove:
+                delta = event.position() - self.start_position
+                length2 = self.axis.x() ** 2 + self.axis.y() ** 2
+                distance = ((delta.x() * self.axis.x() + delta.y() * self.axis.y()) / length2
+                            if length2 > 0.25 else -delta.y() * self.pixel_scale)
+                offset = self.start_settings.offset + distance
+                if self.bounds is not None:
+                    low, high = offset_range_along_normal(self.bounds, self.normal)
+                    offset = max(low, min(high, offset))
+                configure_section_view(offset=offset, view=view, document=_dragger_document,
+                                       preview=True, sync_dragger=False)
+                _sync_plane_guide(view, _dragger_document, _settings)
+                _refresh_dialog()
+                return True
+            if kind == QtCore.QEvent.MouseButtonRelease and event.button() == QtCore.Qt.LeftButton:
+                self.dragging = False
+                configure_section_view(view=view, document=_dragger_document)
+                _refresh_dialog()
+                return True
+            return False
+
+    widget = view.graphicsView().viewport()
+    handler = PlaneDragFilter(widget)
+    widget.installEventFilter(handler)
+    _plane_drag_filter = handler
+
+
 def _sync_dragger(
     view: Any,
     document: Any | None,
@@ -2895,12 +3048,21 @@ def _sync_dragger(
         except Exception:
             _triad_parts = None
             return
+        # Keep a native reference while the handles are detached. A Python
+        # wrapper alone does not keep a Coin node alive after removeChild.
+        dragger.ref()
         _dragger_node = dragger
         _observe_section_document(view, document)
         _start_dragger_poll()
     _set_dragger_pose(coin, _dragger_node, origin, axes)
     _autoscale_dragger(view, origin)
     _snapshot_polled_pose()
+    _start_plane_drag(view)
+    if settings.show_handles:
+        if scene.findChild(_dragger_node) < 0:
+            scene.insertChild(_dragger_node, 0)
+    else:
+        _detach_scene_node(scene, _dragger_node)
     touch = getattr(scene, "touch", None)
     if callable(touch):
         try:
@@ -3170,11 +3332,14 @@ def configure_section_view(
     document: Any | None = None,
     preview: bool = False,
     sync_dragger: bool = True,
+    show_handles: bool | None = None,
 ) -> dict[str, object]:
     """Update the live Front/Top/Right section without changing geometry."""
 
     global _settings
     updates: dict[str, object] = {}
+    if show_handles is not None:
+        updates["show_handles"] = show_handles
     if plane is not None:
         updates["plane"] = plane
     if offset is not None:
@@ -3192,18 +3357,25 @@ def configure_section_view(
     _settings = replace(_settings, **updates) if updates else _settings
     active = view if view is not None else _active_3d_view()
     if active is not None and is_section_view_active(active):
-        _apply_clip(
-            active,
-            document,
-            _settings,
-            preview=preview,
-            sync_dragger=sync_dragger,
-        )
+        if updates and updates.keys() <= {"show_plane", "show_handles"}:
+            if "show_plane" in updates:
+                _sync_plane_guide(active, document, _settings)
+            if "show_handles" in updates:
+                _sync_dragger(active, document, _settings)
+        else:
+            _apply_clip(
+                active,
+                document,
+                _settings,
+                preview=preview,
+                sync_dragger=sync_dragger,
+            )
     return {
         "plane": _settings.plane,
         "offset": _settings.offset,
         "flipped": _settings.flipped,
         "show_plane": _settings.show_plane,
+        "show_handles": _settings.show_handles,
         "yaw": _settings.yaw,
         "pitch": _settings.pitch,
         "roll": _settings.roll,

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -2,10 +2,12 @@
 
 """SolidWorks/Fusion-style 3D section view for VibeCAD.
 
-Cuts the active 3D view with a Front (XY), Top (XZ), or Right (YZ) plane
+Cuts the active 3D view with a Front (XZ), Top (XY), or Right (YZ) plane
 through the model. Offset slides the plane along its normal; Flip keeps the
-opposite half. The clip is a plain Inventor clipping plane, not the Coin
-manipulator, and does not change model geometry.
+opposite half. The GPU clip hides the discarded half without changing model
+geometry. Because displayed solids are tessellated shells, a clip plane alone
+leaves an open surface. This module also builds the planar cut faces and
+draws them as a filled, hatched cap so the remaining half reads as a solid.
 
 The native ``VibeCAD_SectionView`` command owns the View-ribbon action. This
 module inspects and applies the active Inventor view's clipping plane; when no
@@ -18,7 +20,8 @@ as linters and test collectors can load it.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from typing import Any, Iterable
+from math import atan2, cos, degrees, floor, hypot, radians, sin
+from typing import Any, Iterable, Sequence
 
 try:
     import FreeCAD as App
@@ -27,20 +30,35 @@ except ImportError:  # pragma: no cover - only outside FreeCAD (tooling/tests)
 
 
 SECTION_PLANES = ("front", "top", "right")
+# Z-up, matching VibeCAD's Top/Front/Right cameras: Top looks along -Z at XY,
+# Front looks along -Y at XZ, Right looks along -X at YZ.
 _PLANE_NORMALS = {
-    "front": (0.0, 0.0, 1.0),
-    "top": (0.0, 1.0, 0.0),
+    "front": (0.0, 1.0, 0.0),
+    "top": (0.0, 0.0, 1.0),
     "right": (1.0, 0.0, 0.0),
 }
 _OVERLAY_NAME = "VibeCADSectionPlaneOverlay"
+_CAP_OVERLAY_NAME = "VibeCADSectionCapOverlay"
+_DRAGGER_NAME = "VibeCADSectionDragger"
+SECTION_CAP_OFFSET = 0.05
+_HATCH_ANGLE_DEG = 45.0
+_DEFAULT_HATCH_SPACING = 2.5
+_PLANE_CS = {
+    "front": ((1.0, 0.0, 0.0), (0.0, 0.0, -1.0), (0.0, 1.0, 0.0)),
+    "top": ((1.0, 0.0, 0.0), (0.0, 1.0, 0.0), (0.0, 0.0, 1.0)),
+    "right": ((0.0, 1.0, 0.0), (0.0, 0.0, 1.0), (1.0, 0.0, 0.0)),
+}
 
 
 @dataclass(frozen=True)
 class SectionViewSettings:
-    plane: str = "front"
+    plane: str = "top"
     offset: float = 0.0
     flipped: bool = False
     show_plane: bool = True
+    yaw: float = 0.0
+    pitch: float = 0.0
+    roll: float = 0.0
 
     def __post_init__(self) -> None:
         plane = str(self.plane).strip().casefold()
@@ -50,6 +68,9 @@ class SectionViewSettings:
         object.__setattr__(self, "offset", float(self.offset))
         object.__setattr__(self, "flipped", bool(self.flipped))
         object.__setattr__(self, "show_plane", bool(self.show_plane))
+        object.__setattr__(self, "yaw", float(self.yaw))
+        object.__setattr__(self, "pitch", float(self.pitch))
+        object.__setattr__(self, "roll", float(self.roll))
 
 
 @dataclass(frozen=True)
@@ -72,16 +93,61 @@ class ModelBounds:
     def axis_half_extent(self, plane: str) -> float:
         name = str(plane).strip().casefold()
         if name == "front":
-            return abs(self.zmax - self.zmin) / 2.0
-        if name == "top":
             return abs(self.ymax - self.ymin) / 2.0
+        if name == "top":
+            return abs(self.zmax - self.zmin) / 2.0
         if name == "right":
             return abs(self.xmax - self.xmin) / 2.0
         raise ValueError("Section plane must be front, top, or right.")
 
 
+@dataclass(frozen=True)
+class SectionCapGeometry:
+    """Filled cut faces, hatch strokes, and outlines in world coordinates."""
+
+    triangles: tuple[
+        tuple[
+            tuple[float, float, float],
+            tuple[float, float, float],
+            tuple[float, float, float],
+        ],
+        ...,
+    ] = ()
+    hatch: tuple[
+        tuple[tuple[float, float, float], tuple[float, float, float]],
+        ...,
+    ] = ()
+    outlines: tuple[
+        tuple[tuple[float, float, float], tuple[float, float, float]],
+        ...,
+    ] = ()
+
+    def __bool__(self) -> bool:
+        return bool(self.triangles or self.hatch or self.outlines)
+
+
 _settings = SectionViewSettings()
 _overlay_node: Any | None = None
+_cap_node: Any | None = None
+_dragger_node: Any | None = None
+_dragger_busy = False
+_drag_start_settings: SectionViewSettings | None = None
+_drag_start_origin: tuple[float, float, float] | None = None
+_drag_start_axes: tuple[
+    tuple[float, float, float],
+    tuple[float, float, float],
+    tuple[float, float, float],
+] | None = None
+_drag_start_rot_counts: tuple[int, int, int] | None = None
+_triad_parts: dict[str, Any] | None = None
+_selection_observer: Any | None = None
+_poll_timer: Any | None = None
+_last_polled_origin: tuple[float, float, float] | None = None
+_last_polled_quat: tuple[float, float, float, float] | None = None
+_stable_ticks = 0
+_DRAGGER_NDC_SIZE = 0.03
+_POLL_MS = 50
+_STABLE_TICKS = 5
 
 
 def reset_section_view_settings() -> SectionViewSettings:
@@ -154,19 +220,453 @@ def bounds_center(objects: Any) -> tuple[float, float, float] | None:
     return bounds.center
 
 
-def section_plane_normal(plane: str, flipped: bool = False) -> tuple[float, float, float]:
+def _dot(
+    left: tuple[float, float, float],
+    right: tuple[float, float, float],
+) -> float:
+    return left[0] * right[0] + left[1] * right[1] + left[2] * right[2]
+
+
+def _sub(
+    left: tuple[float, float, float],
+    right: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    return (left[0] - right[0], left[1] - right[1], left[2] - right[2])
+
+
+def _rotate_vector(
+    vector: tuple[float, float, float],
+    axis: tuple[float, float, float],
+    degrees: float,
+) -> tuple[float, float, float]:
+    if abs(float(degrees)) < 1.0e-12:
+        return vector
+    angle = radians(float(degrees))
+    k = _unit(axis)
+    cosine = cos(angle)
+    sine = sin(angle)
+    kdotv = _dot(k, vector)
+    crossed = _cross(k, vector)
+    scale = 1.0 - cosine
+    return (
+        vector[0] * cosine + crossed[0] * sine + k[0] * kdotv * scale,
+        vector[1] * cosine + crossed[1] * sine + k[1] * kdotv * scale,
+        vector[2] * cosine + crossed[2] * sine + k[2] * kdotv * scale,
+    )
+
+
+def principal_cs(
+    plane: str,
+    flipped: bool = False,
+) -> tuple[
+    tuple[float, float, float],
+    tuple[float, float, float],
+    tuple[float, float, float],
+]:
     name = str(plane).strip().casefold()
-    normal = _PLANE_NORMALS.get(name)
-    if normal is None:
+    axes = _PLANE_CS.get(name)
+    if axes is None:
         raise ValueError("Section plane must be front, top, or right.")
+    u_axis, v_axis, normal = axes
     if flipped:
-        return (-normal[0], -normal[1], -normal[2])
-    return normal
+        u_axis = (-u_axis[0], -u_axis[1], -u_axis[2])
+        normal = (-normal[0], -normal[1], -normal[2])
+    return u_axis, v_axis, normal
 
 
-def section_offset_range(bounds: ModelBounds, plane: str) -> tuple[float, float]:
-    half = float(bounds.axis_half_extent(plane))
-    return (-half, half)
+def section_cs_axes(
+    plane: str,
+    flipped: bool = False,
+    yaw: float = 0.0,
+    pitch: float = 0.0,
+    roll: float = 0.0,
+) -> tuple[
+    tuple[float, float, float],
+    tuple[float, float, float],
+    tuple[float, float, float],
+]:
+    u_axis, v_axis, normal = principal_cs(plane, flipped)
+    if abs(float(pitch)) > 1.0e-12:
+        v_axis = _rotate_vector(v_axis, u_axis, pitch)
+        normal = _rotate_vector(normal, u_axis, pitch)
+    if abs(float(yaw)) > 1.0e-12:
+        u_axis = _rotate_vector(u_axis, v_axis, yaw)
+        normal = _rotate_vector(normal, v_axis, yaw)
+    normal = _unit(normal)
+    u_axis = _unit(_cross(v_axis, normal))
+    v_axis = _unit(_cross(normal, u_axis))
+    if abs(float(roll)) > 1.0e-12:
+        u_axis = _rotate_vector(u_axis, normal, roll)
+        v_axis = _rotate_vector(v_axis, normal, roll)
+    return u_axis, v_axis, normal
+
+
+def section_plane_normal(
+    plane: str,
+    flipped: bool = False,
+    yaw: float = 0.0,
+    pitch: float = 0.0,
+    roll: float = 0.0,
+) -> tuple[float, float, float]:
+    if abs(float(yaw)) < 1.0e-12 and abs(float(pitch)) < 1.0e-12:
+        _u_axis, _v_axis, normal = principal_cs(plane, flipped)
+        return normal
+    return section_cs_axes(plane, flipped, yaw, pitch, roll)[2]
+
+
+def wrap_degrees(value: float) -> float:
+    wrapped = float(value)
+    while wrapped > 180.0:
+        wrapped -= 360.0
+    while wrapped < -180.0:
+        wrapped += 360.0
+    return wrapped
+
+
+def orientation_from_axes(
+    plane: str,
+    flipped: bool,
+    u_axis: tuple[float, float, float],
+    normal: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    """Return (yaw, pitch, roll) that reproduces ``normal`` and ``u_axis``."""
+
+    u0, v0, n0 = principal_cs(plane, flipped)
+    direction = _unit(normal)
+    nx = _dot(direction, u0)
+    ny = _dot(direction, v0)
+    nz = _dot(direction, n0)
+    pitch = wrap_degrees(degrees(atan2(-ny, nz)))
+    yaw = wrap_degrees(degrees(atan2(nx, hypot(ny, nz))))
+    u_expected, v_expected, _n_expected = section_cs_axes(
+        plane, flipped, yaw, pitch, 0.0
+    )
+    roll = wrap_degrees(
+        degrees(atan2(_dot(u_axis, v_expected), _dot(u_axis, u_expected)))
+    )
+    return yaw, pitch, roll
+
+
+def apply_world_rotation(
+    settings: SectionViewSettings,
+    origin: tuple[float, float, float],
+    center: tuple[float, float, float],
+    quat: tuple[float, float, float, float],
+) -> SectionViewSettings:
+    """Map a datum rotation-ring pose onto yaw, pitch, and roll."""
+
+    normal = _unit(_quat_rotate(quat, (0.0, 0.0, 1.0)))
+    u_axis = _unit(_quat_rotate(quat, (1.0, 0.0, 0.0)))
+    start_normal = section_plane_normal(
+        settings.plane, settings.flipped, settings.yaw, settings.pitch, settings.roll
+    )
+    if _dot(normal, start_normal) < 0.0:
+        normal = (-normal[0], -normal[1], -normal[2])
+        u_axis = (-u_axis[0], -u_axis[1], -u_axis[2])
+    yaw, pitch, roll = orientation_from_axes(
+        settings.plane, settings.flipped, u_axis, normal
+    )
+    return replace(
+        settings,
+        yaw=yaw,
+        pitch=pitch,
+        roll=roll,
+        offset=_dot(_sub(origin, center), normal),
+    )
+
+
+def section_offset_label(settings: SectionViewSettings) -> str:
+    names = {"front": ("Front", "Y"), "top": ("Top", "Z"), "right": ("Right", "X")}
+    plane, axis = names[settings.plane]
+    tilted = abs(settings.yaw) > 0.5 or abs(settings.pitch) > 0.5
+    if tilted:
+        return f"{plane}  ·  offset along cut"
+    return f"{plane}  ·  offset along {axis}"
+
+
+def section_plane_from_view_direction(
+    direction: tuple[float, float, float],
+) -> tuple[str, bool]:
+    """Pick Front/Top/Right parallel to the screen, keeping the far half."""
+
+    look = _unit(direction)
+    toward_camera = (-look[0], -look[1], -look[2])
+    plane = principal_plane_for_axis(toward_camera)
+    principal = section_plane_normal(plane, flipped=False)
+    flipped = _dot(principal, toward_camera) < 0.0
+    return plane, flipped
+
+
+def initial_section_settings(
+    view_direction: tuple[float, float, float] | None = None,
+) -> SectionViewSettings:
+    if view_direction is None:
+        return SectionViewSettings()
+    plane, flipped = section_plane_from_view_direction(view_direction)
+    return SectionViewSettings(plane=plane, flipped=flipped)
+
+
+def principal_plane_for_axis(axis: tuple[float, float, float]) -> str:
+    direction = _unit(axis)
+    abs_x, abs_y, abs_z = abs(direction[0]), abs(direction[1]), abs(direction[2])
+    if abs_z >= abs_x and abs_z >= abs_y:
+        return "top"
+    if abs_y >= abs_x:
+        return "front"
+    return "right"
+
+
+def offset_through_point(
+    settings: SectionViewSettings,
+    model_center: tuple[float, float, float],
+    point: tuple[float, float, float],
+) -> float:
+    """Offset that puts the current section plane through ``point``."""
+
+    normal = section_plane_normal(
+        settings.plane, settings.flipped, settings.yaw, settings.pitch, settings.roll
+    )
+    return _dot(_sub(point, model_center), normal)
+
+
+def snap_point_from_shape(shape: Any) -> tuple[float, float, float] | None:
+    """Center of a hole, cylinder, circle, vertex, or other picked shape."""
+
+    if shape is None:
+        return None
+    shape_type = str(getattr(shape, "ShapeType", "") or "")
+    if shape_type == "Vertex":
+        point = getattr(shape, "Point", None)
+        if point is not None:
+            try:
+                return _vec3(point)
+            except Exception:
+                return None
+    # Cylindrical hole faces: CenterOfMass is the midpoint along the hole.
+    # Surface.Center/Location is the cylinder origin and often sits at one end.
+    if shape_type == "Face" and snap_axis_from_shape(shape) is not None:
+        com = getattr(shape, "CenterOfMass", None)
+        if com is not None:
+            try:
+                return _vec3(com)
+            except Exception:
+                pass
+    for owner_name in ("Curve", "Surface"):
+        try:
+            owner = getattr(shape, owner_name)
+        except Exception:
+            owner = None
+        if owner is None:
+            continue
+        for center_name in ("Center", "Location"):
+            center = getattr(owner, center_name, None)
+            if center is None:
+                continue
+            try:
+                return _vec3(center)
+            except Exception:
+                continue
+    com = getattr(shape, "CenterOfMass", None)
+    if com is None:
+        return None
+    try:
+        return _vec3(com)
+    except Exception:
+        return None
+
+
+def snap_axis_from_shape(shape: Any) -> tuple[float, float, float] | None:
+    """Axis of a hole, cylinder, or circular edge, if the shape has one."""
+
+    if shape is None:
+        return None
+    for owner_name in ("Curve", "Surface"):
+        try:
+            owner = getattr(shape, owner_name)
+        except Exception:
+            owner = None
+        if owner is None:
+            continue
+        axis = getattr(owner, "Axis", None)
+        if axis is None:
+            continue
+        try:
+            return _unit(_vec3(axis))
+        except Exception:
+            continue
+    return None
+
+
+def snap_geometry_from_shape(
+    shape: Any,
+) -> tuple[tuple[float, float, float] | None, tuple[float, float, float] | None]:
+    """Return (center, axis) for a picked hole or other feature."""
+
+    point = snap_point_from_shape(shape)
+    axis = snap_axis_from_shape(shape)
+    if axis is not None:
+        return point, axis
+    faces = tuple(getattr(shape, "Faces", ()) or ())
+    best: tuple[float, tuple[float, float, float] | None, tuple[float, float, float]] | None = None
+    for face in faces:
+        face_axis = snap_axis_from_shape(face)
+        if face_axis is None:
+            continue
+        face_point = snap_point_from_shape(face) or point
+        radius = getattr(getattr(face, "Surface", None), "Radius", None)
+        key = float(radius) if radius is not None else 1.0e9
+        if best is None or key < best[0]:
+            best = (key, face_point, face_axis)
+    if best is not None:
+        return best[1], best[2]
+    return point, None
+
+
+def plane_containing_axis(
+    axis: tuple[float, float, float],
+    view_direction: tuple[float, float, float] | None = None,
+) -> tuple[str, bool]:
+    """Principal plane that contains ``axis``, preferring one facing the camera."""
+
+    direction = _unit(axis)
+    look = _unit(view_direction) if view_direction is not None else (0.0, 0.0, -1.0)
+    toward_camera = (-look[0], -look[1], -look[2])
+    ranked: list[tuple[float, float, str, tuple[float, float, float]]] = []
+    for plane in SECTION_PLANES:
+        normal = section_plane_normal(plane, False)
+        contain = 1.0 - abs(_dot(normal, direction))
+        facing = abs(_dot(normal, look))
+        ranked.append((contain, facing, plane, normal))
+    ranked.sort(reverse=True)
+    _contain, _facing, plane, normal = ranked[0]
+    flipped = _dot(normal, toward_camera) < 0.0
+    return plane, flipped
+
+
+def apply_feature_snap(
+    settings: SectionViewSettings,
+    model_center: tuple[float, float, float],
+    point: tuple[float, float, float],
+    axis: tuple[float, float, float] | None = None,
+    view_direction: tuple[float, float, float] | None = None,
+) -> SectionViewSettings:
+    """Snap the section through a feature. Holes are cut along their depth."""
+
+    next_settings = settings
+    if axis is not None:
+        direction = _unit(axis)
+        current_normal = section_plane_normal(
+            settings.plane,
+            settings.flipped,
+            settings.yaw,
+            settings.pitch,
+            settings.roll,
+        )
+        if abs(_dot(current_normal, direction)) > 0.5:
+            plane, flipped = plane_containing_axis(direction, view_direction)
+            next_settings = SectionViewSettings(
+                plane=plane,
+                flipped=flipped,
+                show_plane=settings.show_plane,
+            )
+    offset = offset_through_point(next_settings, model_center, point)
+    return replace(next_settings, offset=offset)
+
+
+def offset_range_along_normal(
+    bounds: ModelBounds,
+    normal: tuple[float, float, float],
+) -> tuple[float, float]:
+    direction = _unit(normal)
+    center = bounds.center
+    values = []
+    for x in (bounds.xmin, bounds.xmax):
+        for y in (bounds.ymin, bounds.ymax):
+            for z in (bounds.zmin, bounds.zmax):
+                values.append(_dot(_sub((x, y, z), center), direction))
+    return (min(values), max(values))
+
+
+def section_offset_range(
+    bounds: ModelBounds,
+    plane: str,
+    yaw: float = 0.0,
+    pitch: float = 0.0,
+    flipped: bool = False,
+) -> tuple[float, float]:
+    if abs(float(yaw)) < 1.0e-12 and abs(float(pitch)) < 1.0e-12:
+        half = float(bounds.axis_half_extent(plane))
+        return (-half, half)
+    return offset_range_along_normal(
+        bounds, section_plane_normal(plane, flipped, yaw, pitch)
+    )
+
+
+def apply_dragger_translation(
+    settings: SectionViewSettings,
+    origin: tuple[float, float, float],
+    center: tuple[float, float, float],
+    translation_counts: tuple[int, int, int],
+) -> SectionViewSettings:
+    """Map a datum-origin arrow drag onto plane, offset, and cleared tilt."""
+
+    count_x, count_y, count_z = (int(value) for value in translation_counts)
+    abs_x, abs_y, abs_z = abs(count_x), abs(count_y), abs(count_z)
+    u_axis, v_axis, normal = section_cs_axes(
+        settings.plane, settings.flipped, settings.yaw, settings.pitch, settings.roll
+    )
+    switch_threshold = 20
+    if abs_x >= abs_y and abs_x > abs_z and abs_x >= switch_threshold:
+        plane = principal_plane_for_axis(u_axis)
+        principal = section_plane_normal(plane, settings.flipped)
+        return replace(
+            settings,
+            plane=plane,
+            offset=_dot(_sub(origin, center), principal),
+            yaw=0.0,
+            pitch=0.0,
+            roll=0.0,
+        )
+    if abs_y > abs_z and abs_y >= switch_threshold:
+        plane = principal_plane_for_axis(v_axis)
+        principal = section_plane_normal(plane, settings.flipped)
+        return replace(
+            settings,
+            plane=plane,
+            offset=_dot(_sub(origin, center), principal),
+            yaw=0.0,
+            pitch=0.0,
+            roll=0.0,
+        )
+    return replace(settings, offset=_dot(_sub(origin, center), normal))
+
+
+def apply_dragger_rotation(
+    settings: SectionViewSettings,
+    origin: tuple[float, float, float],
+    center: tuple[float, float, float],
+    rotation_counts: tuple[int, int, int],
+    degrees_per_count: float = 1.0,
+) -> SectionViewSettings:
+    """Map datum rotation-ring steps onto section tilt."""
+
+    pitch = wrap_degrees(
+        settings.pitch + int(rotation_counts[0]) * float(degrees_per_count)
+    )
+    yaw = wrap_degrees(settings.yaw + int(rotation_counts[1]) * float(degrees_per_count))
+    roll = wrap_degrees(
+        settings.roll + int(rotation_counts[2]) * float(degrees_per_count)
+    )
+    normal = section_plane_normal(
+        settings.plane, settings.flipped, yaw, pitch, roll
+    )
+    return replace(
+        settings,
+        yaw=yaw,
+        pitch=pitch,
+        roll=roll,
+        offset=_dot(_sub(origin, center), normal),
+    )
 
 
 def clip_plane_from_settings(
@@ -175,7 +675,9 @@ def clip_plane_from_settings(
 ) -> tuple[tuple[float, float, float], tuple[float, float, float]]:
     """Return (origin, clip-normal) for the SolidWorks/Fusion section plane."""
 
-    normal = section_plane_normal(settings.plane, settings.flipped)
+    normal = section_plane_normal(
+        settings.plane, settings.flipped, settings.yaw, settings.pitch, settings.roll
+    )
     origin = (
         center[0] + normal[0] * settings.offset,
         center[1] + normal[1] * settings.offset,
@@ -234,6 +736,607 @@ def section_plane_corners(
             )
         )
     return (corners[0], corners[1], corners[2], corners[3])
+
+
+def section_plane_distance(
+    origin: tuple[float, float, float],
+    normal: tuple[float, float, float],
+) -> float:
+    """Return ``n · origin`` for a unit or non-unit section-plane normal."""
+
+    return (
+        float(origin[0]) * float(normal[0])
+        + float(origin[1]) * float(normal[1])
+        + float(origin[2]) * float(normal[2])
+    )
+
+
+def hatch_spacing_for_bounds(bounds: ModelBounds | None) -> float:
+    """Pick an ANSI-style hatch pitch from the model size, like other CAD apps."""
+
+    if bounds is None:
+        return _DEFAULT_HATCH_SPACING
+    diagonal = (
+        (bounds.xmax - bounds.xmin) ** 2
+        + (bounds.ymax - bounds.ymin) ** 2
+        + (bounds.zmax - bounds.zmin) ** 2
+    ) ** 0.5
+    return max(diagonal / 18.0, 0.5)
+
+
+def _closed_ring(
+    loop: Sequence[tuple[float, float]],
+) -> tuple[tuple[float, float], ...]:
+    points = [(float(point[0]), float(point[1])) for point in loop]
+    if len(points) < 3:
+        return ()
+    if points[0] != points[-1]:
+        points.append(points[0])
+    return tuple(points)
+
+
+def _point_on_segment(
+    point: tuple[float, float],
+    start: tuple[float, float],
+    end: tuple[float, float],
+    eps: float = 1e-9,
+) -> bool:
+    dx = end[0] - start[0]
+    dy = end[1] - start[1]
+    length = (dx * dx + dy * dy) ** 0.5
+    if length <= eps:
+        return abs(point[0] - start[0]) <= eps and abs(point[1] - start[1]) <= eps
+    cross = (point[0] - start[0]) * dy - (point[1] - start[1]) * dx
+    if abs(cross) > eps * length:
+        return False
+    along = (point[0] - start[0]) * dx + (point[1] - start[1]) * dy
+    return -eps * length <= along <= length * length + eps * length
+
+
+def _point_in_ring(point: tuple[float, float], ring: Sequence[tuple[float, float]]) -> bool:
+    x, y = point
+    inside = False
+    for index in range(len(ring) - 1):
+        start = ring[index]
+        end = ring[index + 1]
+        if _point_on_segment(point, start, end):
+            return True
+        x1, y1 = start
+        x2, y2 = end
+        if (y1 > y) is (y2 > y):
+            continue
+        span = y2 - y1
+        if span == 0.0:
+            continue
+        x_at_y = (x2 - x1) * (y - y1) / span + x1
+        if x < x_at_y:
+            inside = not inside
+    return inside
+
+
+def _point_in_loops(
+    point: tuple[float, float],
+    loops: Sequence[Sequence[tuple[float, float]]],
+) -> bool:
+    inside = False
+    for loop in loops:
+        ring = _closed_ring(loop)
+        if len(ring) < 4:
+            continue
+        if _point_in_ring(point, ring):
+            inside = not inside
+    return inside
+
+
+def _segment_intersection_t(
+    start: tuple[float, float],
+    end: tuple[float, float],
+    other_start: tuple[float, float],
+    other_end: tuple[float, float],
+) -> float | None:
+    dx1 = end[0] - start[0]
+    dy1 = end[1] - start[1]
+    dx2 = other_end[0] - other_start[0]
+    dy2 = other_end[1] - other_start[1]
+    denom = dx1 * dy2 - dy1 * dx2
+    if abs(denom) < 1e-14:
+        return None
+    sx = other_start[0] - start[0]
+    sy = other_start[1] - start[1]
+    t = (sx * dy2 - sy * dx2) / denom
+    u = (sx * dy1 - sy * dx1) / denom
+    if -1e-10 <= t <= 1.0 + 1e-10 and -1e-10 <= u <= 1.0 + 1e-10:
+        return max(0.0, min(1.0, t))
+    return None
+
+
+def hatch_segments_for_loops(
+    loops: Sequence[Sequence[tuple[float, float]]],
+    spacing: float,
+    angle_deg: float = _HATCH_ANGLE_DEG,
+) -> tuple[tuple[tuple[float, float], tuple[float, float]], ...]:
+    """Clip 45-degree hatch strokes to planar section loops, including holes."""
+
+    pitch = float(spacing)
+    if pitch <= 0.0:
+        raise ValueError("Hatch spacing must be positive.")
+    rings = tuple(ring for ring in (_closed_ring(loop) for loop in loops) if len(ring) >= 4)
+    if not rings:
+        return ()
+    points = [point for ring in rings for point in ring]
+    xs = [point[0] for point in points]
+    ys = [point[1] for point in points]
+    angle = radians(float(angle_deg))
+    dx, dy = cos(angle), sin(angle)
+    px, py = -dy, dx
+    projections = [point[0] * px + point[1] * py for point in points]
+    along = [point[0] * dx + point[1] * dy for point in points]
+    t_min = min(projections)
+    t_max = max(projections)
+    a_min = min(along) - pitch
+    a_max = max(along) + pitch
+    xmin, xmax = min(xs), max(xs)
+    ymin, ymax = min(ys), max(ys)
+    if xmax <= xmin and ymax <= ymin:
+        return ()
+
+    segments: list[tuple[tuple[float, float], tuple[float, float]]] = []
+    t = floor(t_min / pitch) * pitch
+    while t <= t_max + 1e-9:
+        origin = (t * px, t * py)
+        line_start = (origin[0] + a_min * dx, origin[1] + a_min * dy)
+        line_end = (origin[0] + a_max * dx, origin[1] + a_max * dy)
+        hits: list[float] = []
+        for ring in rings:
+            for index in range(len(ring) - 1):
+                hit = _segment_intersection_t(
+                    line_start, line_end, ring[index], ring[index + 1]
+                )
+                if hit is not None:
+                    hits.append(hit)
+        unique: list[float] = []
+        for hit in sorted(hits):
+            if not unique or hit - unique[-1] > 1e-9:
+                unique.append(hit)
+        for left, right in zip(unique, unique[1:]):
+            if right - left <= 1e-8:
+                continue
+            mid_t = (left + right) / 2.0
+            midpoint = (
+                line_start[0] + (line_end[0] - line_start[0]) * mid_t,
+                line_start[1] + (line_end[1] - line_start[1]) * mid_t,
+            )
+            if not _point_in_loops(midpoint, rings):
+                continue
+            start = (
+                line_start[0] + (line_end[0] - line_start[0]) * left,
+                line_start[1] + (line_end[1] - line_start[1]) * left,
+            )
+            end = (
+                line_start[0] + (line_end[0] - line_start[0]) * right,
+                line_start[1] + (line_end[1] - line_start[1]) * right,
+            )
+            segments.append((start, end))
+        t += pitch
+    return tuple(segments)
+
+
+def project_point_to_uv(
+    point: tuple[float, float, float],
+    origin: tuple[float, float, float],
+    u_axis: tuple[float, float, float],
+    v_axis: tuple[float, float, float],
+) -> tuple[float, float]:
+    relative = (
+        point[0] - origin[0],
+        point[1] - origin[1],
+        point[2] - origin[2],
+    )
+    return (
+        relative[0] * u_axis[0] + relative[1] * u_axis[1] + relative[2] * u_axis[2],
+        relative[0] * v_axis[0] + relative[1] * v_axis[1] + relative[2] * v_axis[2],
+    )
+
+
+def unproject_uv(
+    u_value: float,
+    v_value: float,
+    origin: tuple[float, float, float],
+    u_axis: tuple[float, float, float],
+    v_axis: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    return (
+        origin[0] + u_axis[0] * u_value + v_axis[0] * v_value,
+        origin[1] + u_axis[1] * u_value + v_axis[1] * v_value,
+        origin[2] + u_axis[2] * u_value + v_axis[2] * v_value,
+    )
+
+
+def _offset_point(
+    point: tuple[float, float, float],
+    delta: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    return (point[0] + delta[0], point[1] + delta[1], point[2] + delta[2])
+
+
+def _closed_loop_3d(
+    loop: Sequence[tuple[float, float, float]],
+) -> tuple[tuple[float, float, float], ...]:
+    points = [
+        (float(point[0]), float(point[1]), float(point[2])) for point in loop
+    ]
+    if len(points) < 3:
+        return ()
+    if points[0] != points[-1]:
+        points.append(points[0])
+    return tuple(points)
+
+
+def fan_triangulate_loop(
+    loop: Sequence[tuple[float, float, float]],
+) -> tuple[
+    tuple[
+        tuple[float, float, float],
+        tuple[float, float, float],
+        tuple[float, float, float],
+    ],
+    ...,
+]:
+    points = [
+        (float(point[0]), float(point[1]), float(point[2])) for point in loop
+    ]
+    if len(points) >= 2 and points[0] == points[-1]:
+        points = points[:-1]
+    if len(points) < 3:
+        return ()
+    triangles = []
+    origin = points[0]
+    for index in range(1, len(points) - 1):
+        triangles.append((origin, points[index], points[index + 1]))
+    return tuple(triangles)
+
+
+def build_section_cap_geometry(
+    loops_3d: Sequence[Sequence[tuple[float, float, float]]],
+    origin: tuple[float, float, float],
+    normal: tuple[float, float, float],
+    spacing: float,
+    *,
+    triangles: Sequence[
+        tuple[
+            tuple[float, float, float],
+            tuple[float, float, float],
+            tuple[float, float, float],
+        ]
+    ]
+    | None = None,
+    offset_magnitude: float | None = None,
+) -> SectionCapGeometry:
+    """Build filled, hatched cut-face geometry from planar section loops."""
+
+    direction = _unit(normal)
+    u_axis, v_axis = section_plane_axes(direction)
+    magnitude = SECTION_CAP_OFFSET if offset_magnitude is None else float(offset_magnitude)
+    offset = (
+        -direction[0] * magnitude,
+        -direction[1] * magnitude,
+        -direction[2] * magnitude,
+    )
+    loops_uv = []
+    outlines: list[tuple[tuple[float, float, float], tuple[float, float, float]]] = []
+    for loop in loops_3d:
+        closed = _closed_loop_3d(loop)
+        if len(closed) < 4:
+            continue
+        loops_uv.append(
+            tuple(project_point_to_uv(point, origin, u_axis, v_axis) for point in closed[:-1])
+        )
+        shifted = [_offset_point(point, offset) for point in closed]
+        for start, end in zip(shifted, shifted[1:]):
+            outlines.append((start, end))
+    hatch_uv = hatch_segments_for_loops(loops_uv, spacing)
+    hatch = tuple(
+        (
+            _offset_point(unproject_uv(start[0], start[1], origin, u_axis, v_axis), offset),
+            _offset_point(unproject_uv(end[0], end[1], origin, u_axis, v_axis), offset),
+        )
+        for start, end in hatch_uv
+    )
+    if triangles is None:
+        filled = fan_triangulate_loop(loops_3d[0]) if len(loops_3d) == 1 else ()
+    else:
+        filled = tuple(triangles)
+    shifted_triangles = tuple(
+        tuple(_offset_point(point, offset) for point in triangle)  # type: ignore[misc]
+        for triangle in filled
+    )
+    return SectionCapGeometry(shifted_triangles, hatch, tuple(outlines))
+
+
+def _is_visible_object(obj: Any) -> bool:
+    try:
+        if getattr(obj, "Visibility", True) is False:
+            return False
+    except Exception:
+        return False
+    view = getattr(obj, "ViewObject", None)
+    if view is None:
+        return True
+    try:
+        return getattr(view, "Visibility", True) is not False
+    except Exception:
+        return True
+
+
+def _shape_has_solids(shape: Any) -> bool:
+    if shape is None:
+        return False
+    is_null = getattr(shape, "isNull", None)
+    if callable(is_null):
+        try:
+            if bool(is_null()):
+                return False
+        except Exception:
+            return False
+    solids = getattr(shape, "Solids", None)
+    try:
+        if solids:
+            return True
+    except Exception:
+        pass
+    shape_type = str(getattr(shape, "ShapeType", "") or "")
+    return shape_type in {"Solid", "CompSolid"}
+
+
+def _parent_already_has_solid(obj: Any) -> bool:
+    getter = getattr(obj, "getParentGeoFeatureGroup", None)
+    if not callable(getter):
+        return False
+    try:
+        parent = getter()
+    except Exception:
+        return False
+    if parent is None or not _is_visible_object(parent):
+        return False
+    return _shape_has_solids(getattr(parent, "Shape", None))
+
+
+def iter_sectionable_shapes(objects: Any) -> tuple[Any, ...]:
+    """Return visible solid shapes that can produce a hatched section cap."""
+
+    shapes: list[Any] = []
+    for obj in tuple(objects or ()):
+        if not _is_visible_object(obj):
+            continue
+        if _parent_already_has_solid(obj):
+            continue
+        shape = getattr(obj, "Shape", None)
+        if not _shape_has_solids(shape):
+            continue
+        shapes.append(shape)
+    return tuple(shapes)
+
+
+def _vec3(value: Any) -> tuple[float, float, float]:
+    nested = getattr(value, "getValue", None)
+    if callable(nested):
+        try:
+            unpacked = nested()
+            if unpacked is not None:
+                value = unpacked
+        except Exception:
+            pass
+    if isinstance(value, (tuple, list)) and len(value) >= 3:
+        return (float(value[0]), float(value[1]), float(value[2]))
+    try:
+        return (float(value[0]), float(value[1]), float(value[2]))
+    except Exception:
+        pass
+
+    def _component(*names: str) -> float | None:
+        for name in names:
+            attr = getattr(value, name, None)
+            if attr is None:
+                continue
+            if callable(attr):
+                try:
+                    attr = attr()
+                except Exception:
+                    continue
+            try:
+                return float(attr)
+            except Exception:
+                continue
+        return None
+
+    x_val = _component("x", "X")
+    y_val = _component("y", "Y")
+    z_val = _component("z", "Z")
+    if None not in (x_val, y_val, z_val):
+        return (x_val, y_val, z_val)
+    raise ValueError("Cannot read an XYZ vector.")
+
+
+def _discretize_wire(wire: Any, deflection: float = 0.25) -> tuple[tuple[float, float, float], ...]:
+    points: list[tuple[float, float, float]] = []
+    discretize = getattr(wire, "discretize", None)
+    if callable(discretize):
+        try:
+            raw = discretize(Deflection=deflection)
+        except TypeError:
+            try:
+                raw = discretize(deflection)
+            except Exception:
+                raw = ()
+        except Exception:
+            raw = ()
+        for item in tuple(raw or ()):
+            points.append(_vec3(item))
+    if len(points) < 3:
+        vertexes = getattr(wire, "OrderedVertexes", None) or getattr(wire, "Vertexes", ())
+        points = []
+        for vertex in tuple(vertexes or ()):
+            point = getattr(vertex, "Point", vertex)
+            points.append(_vec3(point))
+    return _closed_loop_3d(points)[:-1] if len(points) >= 3 else ()
+
+
+def _wire_key(wire: Any) -> object:
+    hasher = getattr(wire, "hashCode", None)
+    if callable(hasher):
+        try:
+            return hasher()
+        except Exception:
+            return id(wire)
+    return id(wire)
+
+
+def _faces_from_section_wires(wires: Sequence[Any]) -> tuple[Any, ...]:
+    try:
+        import Part
+    except ImportError:
+        return ()
+    closed = []
+    for wire in tuple(wires or ()):
+        is_closed = getattr(wire, "isClosed", None)
+        try:
+            if callable(is_closed) and not bool(is_closed()):
+                continue
+        except Exception:
+            continue
+        closed.append(wire)
+    if not closed:
+        return ()
+    try:
+        made = Part.makeFace(closed, "Part::FaceMakerBullseye")
+    except Exception:
+        made = None
+    faces: list[Any] = []
+    if made is not None:
+        found = getattr(made, "Faces", None)
+        faces = list(found) if found else [made]
+    if faces:
+        return tuple(faces)
+    for wire in closed:
+        try:
+            faces.append(Part.Face(wire))
+        except Exception:
+            continue
+    return tuple(faces)
+
+
+def _cap_geometry_from_shape(
+    shape: Any,
+    origin: tuple[float, float, float],
+    normal: tuple[float, float, float],
+    spacing: float,
+) -> SectionCapGeometry | None:
+    if App is None:
+        return None
+    try:
+        import Part  # noqa: F401
+    except ImportError:
+        return None
+    direction = _unit(normal)
+    distance = section_plane_distance(origin, direction)
+    slicer = getattr(shape, "slice", None)
+    if not callable(slicer):
+        return None
+    direction_vec = App.Vector(direction[0], direction[1], direction[2])
+    wires = ()
+    for candidate in (distance, distance + 1.0e-4, distance - 1.0e-4):
+        try:
+            found = slicer(direction_vec, candidate)
+        except Exception:
+            found = ()
+        if found:
+            wires = found
+            break
+    faces = _faces_from_section_wires(tuple(wires or ()))
+    if not faces:
+        return None
+    triangles: list[
+        tuple[
+            tuple[float, float, float],
+            tuple[float, float, float],
+            tuple[float, float, float],
+        ]
+    ] = []
+    loops: list[tuple[tuple[float, float, float], ...]] = []
+    for face in faces:
+        try:
+            outer = _discretize_wire(face.OuterWire)
+        except Exception:
+            continue
+        if len(outer) < 3:
+            continue
+        face_loops = [outer]
+        try:
+            outer_key = _wire_key(face.OuterWire)
+            for wire in tuple(getattr(face, "Wires", ()) or ()):
+                if _wire_key(wire) == outer_key:
+                    continue
+                inner = _discretize_wire(wire)
+                if len(inner) >= 3:
+                    face_loops.append(inner)
+        except Exception:
+            pass
+        loops.extend(face_loops)
+        tessellate = getattr(face, "tessellate", None)
+        if callable(tessellate):
+            try:
+                verts, tris = tessellate(0.25)
+                for tri in tris:
+                    triangles.append(
+                        (
+                            _vec3(verts[tri[0]]),
+                            _vec3(verts[tri[1]]),
+                            _vec3(verts[tri[2]]),
+                        )
+                    )
+                continue
+            except Exception:
+                pass
+        triangles.extend(fan_triangulate_loop(outer))
+    if not loops:
+        return None
+    return build_section_cap_geometry(
+        loops,
+        origin,
+        direction,
+        spacing,
+        triangles=triangles or None,
+    )
+
+
+def section_cap_geometry_from_objects(
+    objects: Any,
+    origin: tuple[float, float, float],
+    normal: tuple[float, float, float],
+    spacing: float,
+) -> SectionCapGeometry:
+    """Slice visible solids on the section plane and hatch the resulting faces."""
+
+    triangles: list[
+        tuple[
+            tuple[float, float, float],
+            tuple[float, float, float],
+            tuple[float, float, float],
+        ]
+    ] = []
+    hatch: list[tuple[tuple[float, float, float], tuple[float, float, float]]] = []
+    outlines: list[tuple[tuple[float, float, float], tuple[float, float, float]]] = []
+    for shape in iter_sectionable_shapes(objects):
+        try:
+            geometry = _cap_geometry_from_shape(shape, origin, normal, spacing)
+        except Exception:
+            continue
+        if geometry is None:
+            continue
+        triangles.extend(geometry.triangles)
+        hatch.extend(geometry.hatch)
+        outlines.extend(geometry.outlines)
+    return SectionCapGeometry(tuple(triangles), tuple(hatch), tuple(outlines))
 
 
 def _active_document() -> Any | None:
@@ -387,55 +1490,111 @@ def _overlay_size(
     return (max(half_width, 1.0) * pad, max(half_height, 1.0) * pad)
 
 
-def _remove_overlay(view: Any) -> None:
-    global _overlay_node
-    if _overlay_node is None:
+def _detach_scene_node(scene: Any, node: Any) -> None:
+    if scene is None or node is None:
         return
-    get_scene = getattr(view, "getSceneGraph", None)
-    if callable(get_scene):
+    try:
+        index = scene.findChild(node)
+    except Exception:
+        index = -1
+    if index >= 0:
         try:
-            scene = get_scene()
+            scene.removeChild(node)
         except Exception:
-            scene = None
-        if scene is not None:
-            try:
-                index = scene.findChild(_overlay_node)
-            except Exception:
-                index = -1
-            if index >= 0:
-                scene.removeChild(_overlay_node)
+            return
+
+
+def _scene_from_view(view: Any) -> Any | None:
+    get_scene = getattr(view, "getSceneGraph", None)
+    if not callable(get_scene):
+        return None
+    try:
+        return get_scene()
+    except Exception:
+        return None
+
+
+def _remove_overlay(view: Any) -> None:
+    global _overlay_node, _cap_node
+    scene = _scene_from_view(view)
+    _detach_scene_node(scene, _overlay_node)
+    _detach_scene_node(scene, _cap_node)
     _overlay_node = None
+    _cap_node = None
+
+
+def _remove_dragger(view: Any) -> None:
+    global _dragger_node, _dragger_busy, _drag_start_settings
+    global _drag_start_origin, _drag_start_axes, _drag_start_rot_counts, _triad_parts
+    scene = _scene_from_view(view)
+    _stop_dragger_poll()
+    _detach_scene_node(scene, _dragger_node)
+    _dragger_node = None
+    _dragger_busy = False
+    _drag_start_settings = None
+    _drag_start_origin = None
+    _drag_start_axes = None
+    _drag_start_rot_counts = None
+    _triad_parts = None
+
+
+def _overlay_insert_index(scene: Any, after_plane: bool = False) -> int:
+    index = 0
+    if _dragger_node is not None and scene is not None:
+        try:
+            found = scene.findChild(_dragger_node)
+        except Exception:
+            found = -1
+        if found >= 0:
+            index = found + 1
+    if after_plane and _overlay_node is not None and scene is not None:
+        try:
+            found = scene.findChild(_overlay_node)
+        except Exception:
+            found = -1
+        if found >= 0:
+            index = found + 1
+    return index
 
 
 def _sync_overlay(
     view: Any,
     document: Any | None,
     settings: SectionViewSettings,
+    *,
+    rebuild_caps: bool = True,
 ) -> None:
-    global _overlay_node
     _remove_overlay(view)
-    if not settings.show_plane:
-        return
-    get_scene = getattr(view, "getSceneGraph", None)
-    if not callable(get_scene):
-        return
     try:
         from pivy import coin
     except ImportError:
         return
-    try:
-        scene = get_scene()
-    except Exception:
-        return
+    scene = _scene_from_view(view)
     if scene is None:
         return
-    bounds = model_bounds(_document_objects(document))
+    objects = _document_objects(document)
+    bounds = model_bounds(objects)
     center = bounds.center if bounds is not None else (0.0, 0.0, 0.0)
     origin, normal = clip_plane_from_settings(settings, center)
-    half_width, half_height = _overlay_size(bounds, normal)
-    corners = section_plane_corners(origin, normal, half_width, half_height)
+    if settings.show_plane:
+        half_width, half_height = _overlay_size(bounds, normal)
+        corners = section_plane_corners(origin, normal, half_width, half_height)
+        try:
+            _install_overlay_node(coin, scene, corners)
+        except Exception:
+            pass
+    if not rebuild_caps:
+        return
+    caps = section_cap_geometry_from_objects(
+        objects,
+        origin,
+        normal,
+        hatch_spacing_for_bounds(bounds),
+    )
+    if not caps:
+        return
     try:
-        _install_overlay_node(coin, scene, corners)
+        _install_cap_node(coin, scene, caps)
     except Exception:
         return
 
@@ -474,16 +1633,971 @@ def _install_overlay_node(coin: Any, scene: Any, corners: Any) -> None:
     separator.addChild(line_material)
     separator.addChild(lines)
     try:
-        scene.insertChild(separator, 0)
+        scene.insertChild(separator, _overlay_insert_index(scene))
     except Exception:
         return
     _overlay_node = separator
+
+
+def _write_points(coords: Any, points: Sequence[tuple[float, float, float]]) -> None:
+    for index, point in enumerate(points):
+        coords.point.set1Value(index, float(point[0]), float(point[1]), float(point[2]))
+
+
+def _write_indexes(target: Any, values: Sequence[int]) -> None:
+    for index, value in enumerate(values):
+        target.coordIndex.set1Value(index, int(value))
+
+
+def _install_cap_node(coin: Any, scene: Any, caps: SectionCapGeometry) -> None:
+    global _cap_node
+    separator = coin.SoSeparator()
+    separator.setName(_CAP_OVERLAY_NAME)
+    light = coin.SoLightModel()
+    light.model = coin.SoLightModel.BASE_COLOR
+    separator.addChild(light)
+    hints = getattr(coin, "SoShapeHints", None)
+    if callable(hints):
+        shape_hints = hints()
+        unknown_order = getattr(coin.SoShapeHints, "UNKNOWN_ORDERING", None)
+        if unknown_order is not None:
+            shape_hints.vertexOrdering = unknown_order
+        unknown_shape = getattr(coin.SoShapeHints, "UNKNOWN_SHAPE_TYPE", None)
+        if unknown_shape is not None:
+            shape_hints.shapeType = unknown_shape
+        unknown_face = getattr(coin.SoShapeHints, "UNKNOWN_FACE_TYPE", None)
+        if unknown_face is not None:
+            shape_hints.faceType = unknown_face
+        separator.addChild(shape_hints)
+
+    if caps.triangles:
+        fill = coin.SoMaterial()
+        fill.diffuseColor.setValue(0.90, 0.78, 0.45)
+        fill.emissiveColor.setValue(0.35, 0.24, 0.08)
+        fill.transparency.setValue(0.0)
+        points: list[tuple[float, float, float]] = []
+        indexes: list[int] = []
+        for triangle in caps.triangles:
+            start = len(points)
+            points.extend(triangle)
+            indexes.extend((start, start + 1, start + 2, -1))
+            start = len(points)
+            points.extend((triangle[0], triangle[2], triangle[1]))
+            indexes.extend((start, start + 1, start + 2, -1))
+        coords = coin.SoCoordinate3()
+        _write_points(coords, points)
+        faces = coin.SoIndexedFaceSet()
+        _write_indexes(faces, indexes)
+        separator.addChild(fill)
+        separator.addChild(coords)
+        separator.addChild(faces)
+
+    if caps.hatch:
+        hatch_material = coin.SoMaterial()
+        hatch_material.diffuseColor.setValue(0.42, 0.26, 0.08)
+        hatch_material.emissiveColor.setValue(0.18, 0.10, 0.02)
+        style = coin.SoDrawStyle()
+        style.style = coin.SoDrawStyle.LINES
+        style.lineWidth = 1
+        points = []
+        indexes = []
+        for start_point, end_point in caps.hatch:
+            start = len(points)
+            points.extend((start_point, end_point))
+            indexes.extend((start, start + 1, -1))
+        coords = coin.SoCoordinate3()
+        _write_points(coords, points)
+        lines = coin.SoIndexedLineSet()
+        _write_indexes(lines, indexes)
+        separator.addChild(hatch_material)
+        separator.addChild(style)
+        separator.addChild(coords)
+        separator.addChild(lines)
+
+    if caps.outlines:
+        outline_material = coin.SoMaterial()
+        outline_material.diffuseColor.setValue(0.18, 0.10, 0.04)
+        outline_material.emissiveColor.setValue(0.08, 0.04, 0.01)
+        style = coin.SoDrawStyle()
+        style.style = coin.SoDrawStyle.LINES
+        style.lineWidth = 2
+        points = []
+        indexes = []
+        for start_point, end_point in caps.outlines:
+            start = len(points)
+            points.extend((start_point, end_point))
+            indexes.extend((start, start + 1, -1))
+        coords = coin.SoCoordinate3()
+        _write_points(coords, points)
+        lines = coin.SoIndexedLineSet()
+        _write_indexes(lines, indexes)
+        separator.addChild(outline_material)
+        separator.addChild(style)
+        separator.addChild(coords)
+        separator.addChild(lines)
+
+    insert_index = _overlay_insert_index(scene, after_plane=True)
+    try:
+        scene.insertChild(separator, insert_index)
+        touch = getattr(scene, "touch", None)
+        if callable(touch):
+            touch()
+    except Exception:
+        return
+    _cap_node = separator
+
+
+def _coin_type_instance(coin: Any, *names: str) -> Any | None:
+    type_getter = getattr(coin, "SoType", None)
+    from_name = getattr(type_getter, "fromName", None) if type_getter is not None else None
+    if not callable(from_name):
+        return None
+    for name in names:
+        try:
+            node_type = from_name(name)
+        except Exception:
+            continue
+        is_bad = getattr(node_type, "isBad", None)
+        try:
+            if callable(is_bad) and bool(is_bad()):
+                continue
+        except Exception:
+            continue
+        create = getattr(node_type, "createInstance", None)
+        if not callable(create):
+            continue
+        try:
+            instance = create()
+        except Exception:
+            continue
+        if instance is not None:
+            return instance
+    return None
+
+
+def _create_transform_dragger(coin: Any) -> Any | None:
+    try:
+        import FreeCADGui  # noqa: F401
+    except ImportError:
+        pass
+    return _coin_type_instance(
+        coin,
+        "SoTransformDragger",
+        "TransformDragger",
+    )
+
+
+def _field_int(node: Any, name: str) -> int:
+    field = getattr(node, name, None)
+    getter = getattr(field, "getValue", None)
+    if not callable(getter):
+        return 0
+    try:
+        return int(getter())
+    except Exception:
+        return 0
+
+
+def _field_vec3(node: Any, name: str) -> tuple[float, float, float] | None:
+    field = getattr(node, name, None)
+    getter = getattr(field, "getValue", None)
+    if not callable(getter):
+        return None
+    try:
+        value = getter()
+    except Exception:
+        return None
+    nested = getattr(value, "getValue", None)
+    if callable(nested):
+        try:
+            value = nested()
+        except Exception:
+            pass
+    try:
+        return (float(value[0]), float(value[1]), float(value[2]))
+    except Exception:
+        return None
+
+
+def _hide_dragger_clutter(dragger: Any) -> None:
+    for method_name in (
+        "hidePlanarTranslationXY",
+        "hidePlanarTranslationYZ",
+        "hidePlanarTranslationZX",
+        "showRotationX",
+        "showRotationY",
+        "showRotationZ",
+    ):
+        method = getattr(dragger, method_name, None)
+        if callable(method):
+            try:
+                method()
+            except Exception:
+                pass
+    getter = getattr(dragger, "getPart", None)
+    if not callable(getter):
+        return
+    for part_name in (
+        "xyPlanarTranslatorSwitch",
+        "yzPlanarTranslatorSwitch",
+        "zxPlanarTranslatorSwitch",
+    ):
+        try:
+            part = getter(part_name, 0)
+        except Exception:
+            continue
+        if part is None:
+            continue
+        try:
+            part.whichChild = -1
+        except Exception:
+            continue
+
+
+def _zero_transform_field(node: Any, name: str, identity_rotation: bool = False) -> None:
+    field = getattr(node, name, None)
+    setter = getattr(field, "setValue", None)
+    if not callable(setter):
+        return
+    try:
+        if identity_rotation:
+            setter(0.0, 0.0, 0.0, 1.0)
+        else:
+            setter(0.0, 0.0, 0.0)
+    except Exception:
+        try:
+            setter(0.0)
+        except Exception:
+            return
+
+
+def _apply_pose_fields(
+    coin: Any,
+    node: Any,
+    origin: tuple[float, float, float],
+    axes: tuple[
+        tuple[float, float, float],
+        tuple[float, float, float],
+        tuple[float, float, float],
+    ],
+) -> None:
+    u_axis, v_axis, normal = axes
+    translation = getattr(node, "translation", None)
+    setter = getattr(translation, "setValue", None)
+    if callable(setter):
+        try:
+            setter(float(origin[0]), float(origin[1]), float(origin[2]))
+        except Exception:
+            try:
+                setter(_coin_vec3(coin, origin))
+            except Exception:
+                pass
+    rotation = getattr(node, "rotation", None)
+    rot_set = getattr(rotation, "setValue", None)
+    if not callable(rot_set):
+        return
+    matrix_type = getattr(coin, "SbMatrix", None)
+    rotation_type = getattr(coin, "SbRotation", None)
+    if callable(matrix_type) and callable(rotation_type):
+        try:
+            matrix = matrix_type(
+                float(u_axis[0]),
+                float(v_axis[0]),
+                float(normal[0]),
+                0.0,
+                float(u_axis[1]),
+                float(v_axis[1]),
+                float(normal[1]),
+                0.0,
+                float(u_axis[2]),
+                float(v_axis[2]),
+                float(normal[2]),
+                0.0,
+                0.0,
+                0.0,
+                0.0,
+                1.0,
+            )
+            rot_set(rotation_type(matrix))
+            return
+        except Exception:
+            pass
+    if callable(rotation_type):
+        try:
+            rot_set(
+                rotation_type(
+                    _coin_vec3(coin, (0.0, 0.0, 1.0)),
+                    _coin_vec3(coin, normal),
+                )
+            )
+        except Exception:
+            return
+
+
+def _set_dragger_pose(
+    coin: Any,
+    dragger: Any,
+    origin: tuple[float, float, float],
+    axes: tuple[
+        tuple[float, float, float],
+        tuple[float, float, float],
+        tuple[float, float, float],
+    ],
+) -> None:
+    if _triad_parts is not None:
+        pose = _triad_parts.get("pose")
+        if pose is not None:
+            _apply_pose_fields(coin, pose, origin, axes)
+        if not _dragger_busy:
+            for key, is_rotation in (
+                ("x", False),
+                ("y", False),
+                ("z", False),
+                ("pitch", True),
+                ("yaw", True),
+            ):
+                child = _triad_parts.get(key)
+                if child is None:
+                    continue
+                _zero_transform_field(
+                    child,
+                    "rotation" if is_rotation else "translation",
+                    identity_rotation=is_rotation,
+                )
+        return
+    _apply_pose_fields(coin, dragger, origin, axes)
+
+
+def _dragger_center(document: Any | None) -> tuple[float, float, float]:
+    bounds = model_bounds(_document_objects(document))
+    if bounds is None:
+        return (0.0, 0.0, 0.0)
+    return bounds.center
+
+
+def _axis_drag_distance(dragger: Any) -> float:
+    if dragger is None:
+        return 0.0
+    value = _field_vec3(dragger, "translation")
+    if value is None:
+        return 0.0
+    return float(value[0])
+
+
+def _rotation_angle_degrees(dragger: Any) -> float:
+    if dragger is None:
+        return 0.0
+    field = getattr(dragger, "rotation", None)
+    getter = getattr(field, "getValue", None)
+    if not callable(getter):
+        return 0.0
+    try:
+        rotation = getter()
+    except Exception:
+        return 0.0
+    quat = rotation
+    nested = getattr(rotation, "getValue", None)
+    if callable(nested):
+        try:
+            quat = nested()
+        except Exception:
+            quat = rotation
+    try:
+        x, y, z, w = (float(quat[0]), float(quat[1]), float(quat[2]), float(quat[3]))
+    except Exception:
+        return 0.0
+    sine = (x * x + y * y + z * z) ** 0.5
+    angle = 2.0 * atan2(sine, w)
+    return angle * 180.0 / 3.141592653589793
+
+
+def _triad_origin() -> tuple[float, float, float] | None:
+    if _triad_parts is None or _drag_start_origin is None or _drag_start_axes is None:
+        return None
+    local = (
+        _axis_drag_distance(_triad_parts["x"]),
+        _axis_drag_distance(_triad_parts["y"]),
+        _axis_drag_distance(_triad_parts["z"]),
+    )
+    u_axis, v_axis, normal = _drag_start_axes
+    return (
+        _drag_start_origin[0]
+        + u_axis[0] * local[0]
+        + v_axis[0] * local[1]
+        + normal[0] * local[2],
+        _drag_start_origin[1]
+        + u_axis[1] * local[0]
+        + v_axis[1] * local[1]
+        + normal[1] * local[2],
+        _drag_start_origin[2]
+        + u_axis[2] * local[0]
+        + v_axis[2] * local[1]
+        + normal[2] * local[2],
+    )
+
+
+def _axis_aligned_rotation(coin: Any, axis: str) -> Any:
+    rotation = coin.SoRotation()
+    if axis == "y":
+        rotation.rotation.setValue(_coin_vec3(coin, (0.0, 0.0, 1.0)), radians(90.0))
+    elif axis == "z":
+        rotation.rotation.setValue(_coin_vec3(coin, (0.0, 1.0, 0.0)), radians(-90.0))
+    else:
+        rotation.rotation.setValue(_coin_vec3(coin, (1.0, 0.0, 0.0)), 0.0)
+    return rotation
+
+
+def _build_section_triad(coin: Any, scale: float) -> tuple[Any, dict[str, Any]] | None:
+    translate_type = _coin_type_instance(coin, "SoTranslate1Dragger", "Translate1Dragger")
+    rotate_type = _coin_type_instance(
+        coin, "SoRotateCylindricalDragger", "RotateCylindricalDragger"
+    )
+    if translate_type is None:
+        return None
+    root = _coin_type_instance(coin, "So3DAnnotation", "SoAnnotation")
+    if root is None:
+        root = coin.SoSeparator()
+    set_name = getattr(root, "setName", None)
+    if callable(set_name):
+        try:
+            set_name(_DRAGGER_NAME)
+        except Exception:
+            pass
+    pose = coin.SoTransform()
+    scaled = coin.SoScale()
+    try:
+        scaled.scaleFactor.setValue(float(scale), float(scale), float(scale))
+    except Exception:
+        pass
+    parts: dict[str, Any] = {"pose": pose, "scale": scaled}
+    colors = {
+        "x": (0.86, 0.18, 0.18),
+        "y": (0.18, 0.72, 0.22),
+        "z": (0.18, 0.42, 0.92),
+    }
+    root.addChild(pose)
+    root.addChild(scaled)
+    for axis in ("x", "y", "z"):
+        group = coin.SoSeparator()
+        group.addChild(_axis_aligned_rotation(coin, axis))
+        material = coin.SoMaterial()
+        material.diffuseColor.setValue(*colors[axis])
+        material.emissiveColor.setValue(*tuple(component * 0.35 for component in colors[axis]))
+        group.addChild(material)
+        arrow = _coin_type_instance(coin, "SoTranslate1Dragger", "Translate1Dragger")
+        if arrow is None:
+            continue
+        group.addChild(arrow)
+        root.addChild(group)
+        parts[axis] = arrow
+    if rotate_type is not None:
+        pitch_group = coin.SoSeparator()
+        pitch_rot = coin.SoRotation()
+        pitch_rot.rotation.setValue(_coin_vec3(coin, (0.0, 0.0, 1.0)), radians(90.0))
+        pitch_group.addChild(pitch_rot)
+        pitch = _coin_type_instance(coin, "SoRotateCylindricalDragger", "RotateCylindricalDragger")
+        if pitch is not None:
+            pitch_group.addChild(pitch)
+            root.addChild(pitch_group)
+            parts["pitch"] = pitch
+        yaw = _coin_type_instance(coin, "SoRotateCylindricalDragger", "RotateCylindricalDragger")
+        if yaw is not None:
+            root.addChild(yaw)
+            parts["yaw"] = yaw
+    if "x" not in parts or "y" not in parts or "z" not in parts:
+        return None
+    if "pitch" not in parts:
+        parts["pitch"] = None
+    if "yaw" not in parts:
+        parts["yaw"] = None
+    return root, parts
+
+
+def _view_look_direction(view: Any) -> tuple[float, float, float] | None:
+    if view is None:
+        try:
+            import FreeCADGui as Gui
+
+            view = getattr(getattr(Gui, "ActiveDocument", None), "ActiveView", None)
+        except Exception:
+            view = None
+    if view is None:
+        return None
+    getter = getattr(view, "getViewDirection", None)
+    if callable(getter):
+        try:
+            return _unit(_vec3(getter()))
+        except Exception:
+            pass
+    camera = _view_camera(view)
+    if camera is not None:
+        volume_getter = getattr(camera, "getViewVolume", None)
+        if callable(volume_getter):
+            try:
+                volume = volume_getter()
+                projection = getattr(volume, "getProjectionDirection", None)
+                if callable(projection):
+                    return _unit(_vec3(projection()))
+            except Exception:
+                pass
+    getter = getattr(view, "getCameraOrientation", None)
+    if callable(getter):
+        try:
+            rotation = getter()
+            quat = getattr(rotation, "Q", None)
+            if quat is not None and len(tuple(quat)) >= 4:
+                values = tuple(float(part) for part in quat)
+                return _unit(_quat_rotate(values, (0.0, 0.0, -1.0)))
+            multiply = getattr(rotation, "multVec", None)
+            if callable(multiply) and App is not None:
+                return _unit(_vec3(multiply(App.Vector(0.0, 0.0, -1.0))))
+        except Exception:
+            pass
+    camera = _view_camera(view)
+    if camera is None:
+        return None
+    orientation = getattr(camera, "orientation", None)
+    getter = getattr(orientation, "getValue", None)
+    if not callable(getter):
+        return None
+    try:
+        quat = getter()
+        nested = getattr(quat, "getValue", None)
+        if callable(nested):
+            quat = nested()
+        return _unit(
+            _quat_rotate(
+                (float(quat[0]), float(quat[1]), float(quat[2]), float(quat[3])),
+                (0.0, 0.0, -1.0),
+            )
+        )
+    except Exception:
+        return None
+
+
+def _view_camera(view: Any) -> Any | None:
+    for name in ("getCameraNode", "getCamera"):
+        getter = getattr(view, name, None)
+        if not callable(getter):
+            continue
+        try:
+            camera = getter()
+        except Exception:
+            camera = None
+        if camera is not None:
+            return camera
+    get_viewer = getattr(view, "getViewer", None)
+    if callable(get_viewer):
+        try:
+            viewer = get_viewer()
+        except Exception:
+            viewer = None
+        if viewer is not None:
+            manager = getattr(viewer, "getSoRenderManager", None)
+            if callable(manager):
+                try:
+                    render = manager()
+                    camera = render.getCamera() if render is not None else None
+                except Exception:
+                    camera = None
+                if camera is not None:
+                    return camera
+    return None
+
+
+def world_scale_for_ndc(
+    view: Any,
+    origin: tuple[float, float, float],
+    ndc_size: float = _DRAGGER_NDC_SIZE,
+) -> float | None:
+    """World size that matches Body Transform's screen-relative dragger."""
+
+    camera = _view_camera(view)
+    if camera is None:
+        return None
+    volume_getter = getattr(camera, "getViewVolume", None)
+    if not callable(volume_getter):
+        return None
+    try:
+        from pivy import coin
+    except ImportError:
+        return None
+    try:
+        volume = volume_getter()
+        scale_getter = getattr(volume, "getWorldToScreenScale", None)
+        if not callable(scale_getter):
+            return None
+        return float(scale_getter(_coin_vec3(coin, origin), float(ndc_size) / 2.0))
+    except Exception:
+        return None
+
+
+def _set_scale_factor(node: Any, scale: float) -> bool:
+    field = getattr(node, "scaleFactor", None)
+    if field is None:
+        field = getattr(node, "draggerSize", None)
+    setter = getattr(field, "setValue", None)
+    if not callable(setter):
+        return False
+    disconnect = getattr(field, "disconnect", None)
+    if callable(disconnect):
+        try:
+            disconnect()
+        except Exception:
+            pass
+    try:
+        setter(float(scale), float(scale), float(scale))
+        return True
+    except TypeError:
+        try:
+            setter(float(scale))
+            return True
+        except Exception:
+            return False
+    except Exception:
+        return False
+
+
+def _autoscale_dragger(view: Any, origin: tuple[float, float, float]) -> None:
+    if _dragger_node is None:
+        return
+    scale = world_scale_for_ndc(view, origin, _DRAGGER_NDC_SIZE)
+    if scale is None or scale <= 0.0:
+        bounds = model_bounds(_document_objects(None))
+        if bounds is None:
+            scale = 20.0
+        else:
+            diagonal = (
+                (bounds.xmax - bounds.xmin) ** 2
+                + (bounds.ymax - bounds.ymin) ** 2
+                + (bounds.zmax - bounds.zmin) ** 2
+            ) ** 0.5
+            scale = max(diagonal * 0.12, 15.0)
+    target = None
+    if _triad_parts is not None:
+        target = _triad_parts.get("scale")
+    if target is None:
+        getter = getattr(_dragger_node, "getPart", None)
+        if callable(getter):
+            try:
+                target = getter("scaleNode", 0)
+            except Exception:
+                target = None
+    if target is None:
+        target = _dragger_node
+    _set_scale_factor(target, scale)
+
+
+def _field_quat(node: Any) -> tuple[float, float, float, float] | None:
+    field = getattr(node, "rotation", None)
+    getter = getattr(field, "getValue", None)
+    if not callable(getter):
+        return None
+    try:
+        value = getter()
+    except Exception:
+        return None
+    nested = getattr(value, "getValue", None)
+    if callable(nested):
+        try:
+            value = nested()
+        except Exception:
+            pass
+    try:
+        return (float(value[0]), float(value[1]), float(value[2]), float(value[3]))
+    except Exception:
+        return None
+
+
+def _quat_rotate(
+    quat: tuple[float, float, float, float],
+    vector: tuple[float, float, float],
+) -> tuple[float, float, float]:
+    x, y, z, w = quat
+    vx, vy, vz = vector
+    tx = 2.0 * (y * vz - z * vy)
+    ty = 2.0 * (z * vx - x * vz)
+    tz = 2.0 * (x * vy - y * vx)
+    return (
+        vx + w * tx + (y * tz - z * ty),
+        vy + w * ty + (z * tx - x * tz),
+        vz + w * tz + (x * ty - y * tx),
+    )
+
+
+def _current_dragger_origin() -> tuple[float, float, float] | None:
+    if _triad_parts is not None:
+        dragged = _triad_origin()
+        if dragged is not None:
+            return dragged
+        pose = _triad_parts.get("pose")
+        if pose is not None:
+            return _field_vec3(pose, "translation")
+        return None
+    if _dragger_node is None:
+        return None
+    return _field_vec3(_dragger_node, "translation")
+
+
+def _snapshot_polled_pose() -> None:
+    global _last_polled_origin, _last_polled_quat, _stable_ticks
+    _last_polled_origin = _current_dragger_origin()
+    if _triad_parts is None and _dragger_node is not None:
+        _last_polled_quat = _field_quat(_dragger_node)
+    else:
+        _last_polled_quat = None
+    _stable_ticks = 0
+
+
+def _start_dragger_poll() -> None:
+    global _poll_timer
+    if _poll_timer is not None:
+        return
+    try:
+        from PySide import QtCore
+    except ImportError:
+        try:
+            from PySide6 import QtCore
+        except ImportError:
+            return
+    timer = QtCore.QTimer()
+    timer.setInterval(_POLL_MS)
+    timer.timeout.connect(_poll_dragger)
+    timer.start()
+    _poll_timer = timer
+
+
+def _stop_dragger_poll() -> None:
+    global _poll_timer, _last_polled_origin, _last_polled_quat, _stable_ticks
+    timer = _poll_timer
+    _poll_timer = None
+    _last_polled_origin = None
+    _last_polled_quat = None
+    _stable_ticks = 0
+    if timer is None:
+        return
+    try:
+        timer.stop()
+        timer.deleteLater()
+    except Exception:
+        return
+
+
+def _end_polled_drag() -> None:
+    global _dragger_busy, _drag_start_settings, _drag_start_origin, _drag_start_axes
+    global _drag_start_rot_counts, _stable_ticks
+    if not _dragger_busy:
+        return
+    _dragger_busy = False
+    _drag_start_settings = None
+    _drag_start_origin = None
+    _drag_start_axes = None
+    _drag_start_rot_counts = None
+    _stable_ticks = 0
+    clearer = getattr(_dragger_node, "clearIncrementCounts", None)
+    if callable(clearer):
+        try:
+            clearer()
+        except Exception:
+            pass
+    configure_section_view(preview=False, sync_dragger=True)
+    _refresh_dialog()
+
+
+def _poll_dragger() -> None:
+    global _dragger_busy, _drag_start_settings, _drag_start_origin, _drag_start_axes
+    global _drag_start_rot_counts, _last_polled_origin, _last_polled_quat, _stable_ticks
+    if _dragger_node is None:
+        return
+    view = _active_3d_view()
+    origin = _current_dragger_origin()
+    if origin is not None and view is not None:
+        _autoscale_dragger(view, origin)
+    if origin is None:
+        return
+    quat = None
+    if _triad_parts is None:
+        quat = _field_quat(_dragger_node)
+    previous_quat = _last_polled_quat
+    moved = False
+    quat_changed = False
+    if _last_polled_origin is not None:
+        delta = _sub(origin, _last_polled_origin)
+        if _dot(delta, delta) > 1.0e-6:
+            moved = True
+    if quat is not None and previous_quat is not None:
+        quat_changed = any(
+            abs(left - right) > 1.0e-4 for left, right in zip(quat, previous_quat)
+        )
+        if quat_changed:
+            moved = True
+    _last_polled_origin = origin
+    if quat is not None:
+        _last_polled_quat = quat
+    if not moved:
+        if _dragger_busy:
+            _stable_ticks += 1
+            if _stable_ticks >= _STABLE_TICKS:
+                _end_polled_drag()
+        return
+    _stable_ticks = 0
+    center = _dragger_center(None)
+    if not _dragger_busy:
+        _dragger_busy = True
+        _drag_start_settings = _settings
+        _drag_start_origin, _unused = clip_plane_from_settings(_settings, center)
+        _drag_start_axes = section_cs_axes(
+            _settings.plane,
+            _settings.flipped,
+            _settings.yaw,
+            _settings.pitch,
+            _settings.roll,
+        )
+        if _dragger_node is not None and _triad_parts is None:
+            _drag_start_rot_counts = (
+                _field_int(_dragger_node, "rotationIncrementCountX"),
+                _field_int(_dragger_node, "rotationIncrementCountY"),
+                _field_int(_dragger_node, "rotationIncrementCountZ"),
+            )
+        else:
+            _drag_start_rot_counts = (0, 0, 0)
+    start = _drag_start_settings if _drag_start_settings is not None else _settings
+    start_origin = _drag_start_origin if _drag_start_origin is not None else origin
+    start_axes = _drag_start_axes or section_cs_axes(
+        start.plane, start.flipped, start.yaw, start.pitch, start.roll
+    )
+    motion = _sub(origin, start_origin)
+    translation_counts = (
+        int(round(_dot(motion, start_axes[0]) * 10.0)),
+        int(round(_dot(motion, start_axes[1]) * 10.0)),
+        int(round(_dot(motion, start_axes[2]) * 10.0)),
+    )
+    rotation_counts = (0, 0, 0)
+    if _triad_parts is not None:
+        rotation_counts = (
+            int(round(_rotation_angle_degrees(_triad_parts.get("pitch")))),
+            int(round(_rotation_angle_degrees(_triad_parts.get("yaw")))),
+            0,
+        )
+    elif _dragger_node is not None:
+        start_counts = _drag_start_rot_counts or (0, 0, 0)
+        rotation_counts = (
+            _field_int(_dragger_node, "rotationIncrementCountX") - start_counts[0],
+            _field_int(_dragger_node, "rotationIncrementCountY") - start_counts[1],
+            _field_int(_dragger_node, "rotationIncrementCountZ") - start_counts[2],
+        )
+    origin_moved = _dot(motion, motion) > 1.0
+    if any(rotation_counts) and not origin_moved:
+        updated = apply_dragger_rotation(start, origin, center, rotation_counts)
+    elif quat is not None and quat_changed and not origin_moved:
+        updated = apply_world_rotation(start, origin, center, quat)
+    else:
+        updated = apply_dragger_translation(start, origin, center, translation_counts)
+    configure_section_view(
+        plane=updated.plane,
+        offset=updated.offset,
+        flipped=updated.flipped,
+        yaw=updated.yaw,
+        pitch=updated.pitch,
+        roll=updated.roll,
+        preview=True,
+        sync_dragger=False,
+    )
+    _refresh_dialog()
+
+
+def _sync_dragger(
+    view: Any,
+    document: Any | None,
+    settings: SectionViewSettings,
+) -> None:
+    global _dragger_node, _triad_parts
+    if _dragger_busy and _dragger_node is not None:
+        return
+    try:
+        from pivy import coin
+    except ImportError:
+        return
+    scene = _scene_from_view(view)
+    if scene is None:
+        return
+    bounds = model_bounds(_document_objects(document))
+    center = bounds.center if bounds is not None else (0.0, 0.0, 0.0)
+    origin, _normal = clip_plane_from_settings(settings, center)
+    axes = section_cs_axes(
+        settings.plane, settings.flipped, settings.yaw, settings.pitch, settings.roll
+    )
+    if _dragger_node is None:
+        dragger = _create_transform_dragger(coin)
+        if dragger is not None:
+            set_name = getattr(dragger, "setName", None)
+            if callable(set_name):
+                try:
+                    set_name(_DRAGGER_NAME)
+                except Exception:
+                    pass
+            increment = getattr(dragger, "translationIncrement", None)
+            inc_set = getattr(increment, "setValue", None)
+            if callable(inc_set):
+                try:
+                    inc_set(0.1)
+                except Exception:
+                    pass
+            rot_inc = getattr(dragger, "rotationIncrement", None)
+            rot_set = getattr(rot_inc, "setValue", None)
+            if callable(rot_set):
+                try:
+                    rot_set(radians(1.0))
+                except Exception:
+                    pass
+            _hide_dragger_clutter(dragger)
+        else:
+            diagonal = 50.0
+            if bounds is not None:
+                diagonal = (
+                    (bounds.xmax - bounds.xmin) ** 2
+                    + (bounds.ymax - bounds.ymin) ** 2
+                    + (bounds.zmax - bounds.zmin) ** 2
+                ) ** 0.5
+            built = _build_section_triad(coin, max(diagonal / 40.0, 0.8))
+            if built is None:
+                return
+            dragger, _triad_parts = built
+        try:
+            scene.insertChild(dragger, 0)
+        except Exception:
+            _triad_parts = None
+            return
+        _dragger_node = dragger
+        _start_dragger_poll()
+    _set_dragger_pose(coin, _dragger_node, origin, axes)
+    _autoscale_dragger(view, origin)
+    _snapshot_polled_pose()
+    touch = getattr(scene, "touch", None)
+    if callable(touch):
+        try:
+            touch()
+        except Exception:
+            pass
+
+
+def _refresh_dialog() -> None:
+    try:
+        import VibeCADSectionViewGui as gui
+    except Exception:
+        return
+    refresh = getattr(gui, "refresh_section_view_dialog", None)
+    if callable(refresh):
+        refresh()
 
 
 def _apply_clip(
     view: Any,
     document: Any | None,
     settings: SectionViewSettings,
+    *,
+    preview: bool = False,
+    sync_dragger: bool = True,
 ) -> None:
     placement = section_view_placement(document, settings)
     if is_section_view_active(view):
@@ -492,7 +2606,11 @@ def _apply_clip(
             view.toggleClippingPlane(toggle=1, noManip=True, pla=placement)
     else:
         view.toggleClippingPlane(toggle=1, noManip=True, pla=placement)
-    _sync_overlay(view, document, settings)
+    if preview:
+        return
+    _sync_overlay(view, document, settings, rebuild_caps=True)
+    if sync_dragger:
+        _sync_dragger(view, document, settings)
 
 
 def _close_ui() -> None:
@@ -515,6 +2633,143 @@ def _show_ui() -> None:
         shower()
 
 
+def snap_section_to_point(
+    point: tuple[float, float, float],
+    *,
+    axis: tuple[float, float, float] | None = None,
+    view: Any | None = None,
+    document: Any | None = None,
+) -> dict[str, object]:
+    """Move the section through ``point``. Holes are sliced along their depth."""
+
+    center = bounds_center(_document_objects(document)) or (0.0, 0.0, 0.0)
+    look = _view_look_direction(view if view is not None else _active_3d_view())
+    updated = apply_feature_snap(
+        current_section_view_settings(),
+        center,
+        point,
+        axis,
+        look,
+    )
+    return configure_section_view(
+        plane=updated.plane,
+        offset=updated.offset,
+        flipped=updated.flipped,
+        yaw=updated.yaw,
+        pitch=updated.pitch,
+        roll=updated.roll,
+        view=view,
+        document=document,
+    )
+
+
+def _shape_from_selection(document_name: Any, object_name: Any, sub_name: Any) -> Any | None:
+    if App is None:
+        return None
+    try:
+        document = App.getDocument(str(document_name)) if document_name else App.ActiveDocument
+        obj = document.getObject(str(object_name)) if document is not None else None
+    except Exception:
+        return None
+    if obj is None:
+        return None
+    shape = getattr(obj, "Shape", None)
+    sub = str(sub_name or "")
+    if sub and shape is not None:
+        getter = getattr(shape, "getElement", None)
+        if callable(getter):
+            try:
+                return getter(sub)
+            except Exception:
+                return shape
+    return shape
+
+
+def _current_selection_snap_geometry() -> tuple[
+    tuple[float, float, float] | None,
+    tuple[float, float, float] | None,
+]:
+    try:
+        import FreeCADGui as Gui
+    except ImportError:
+        return None, None
+    selection = getattr(Gui, "Selection", None)
+    get_ex = getattr(selection, "getSelectionEx", None)
+    if not callable(get_ex):
+        return None, None
+    try:
+        selected = tuple(get_ex() or ())
+    except Exception:
+        return None, None
+    for sel in selected:
+        for subshape in tuple(getattr(sel, "SubObjects", ()) or ()):
+            point, axis = snap_geometry_from_shape(subshape)
+            if point is not None:
+                return point, axis
+        point, axis = snap_geometry_from_shape(
+            getattr(getattr(sel, "Object", None), "Shape", None)
+        )
+        if point is not None:
+            return point, axis
+    return None, None
+
+
+class _SectionSnapObserver:
+    def addSelection(self, document: Any, object_name: Any, sub_name: Any, *_args: Any) -> None:
+        if not is_section_view_active():
+            return
+        shape = _shape_from_selection(document, object_name, sub_name)
+        point, axis = snap_geometry_from_shape(shape)
+        if point is None:
+            return
+        snap_section_to_point(point, axis=axis)
+        _refresh_dialog()
+
+    def setPreselection(self, *_args: Any) -> None:
+        return
+
+    def removeSelection(self, *_args: Any) -> None:
+        return
+
+    def clearSelection(self, *_args: Any) -> None:
+        return
+
+
+def _start_selection_snap() -> None:
+    global _selection_observer
+    if _selection_observer is not None:
+        return
+    try:
+        import FreeCADGui as Gui
+    except ImportError:
+        return
+    adder = getattr(getattr(Gui, "Selection", None), "addObserver", None)
+    if not callable(adder):
+        return
+    observer = _SectionSnapObserver()
+    try:
+        adder(observer)
+    except Exception:
+        return
+    _selection_observer = observer
+
+
+def _stop_selection_snap() -> None:
+    global _selection_observer
+    observer = _selection_observer
+    _selection_observer = None
+    if observer is None:
+        return
+    try:
+        import FreeCADGui as Gui
+
+        remover = getattr(getattr(Gui, "Selection", None), "removeObserver", None)
+        if callable(remover):
+            remover(observer)
+    except Exception:
+        return
+
+
 def set_section_view(
     visible: bool,
     *,
@@ -535,7 +2790,9 @@ def set_section_view(
         if visible and show_ui:
             _show_ui()
         if not visible:
+            _stop_selection_snap()
             _remove_overlay(active)
+            _remove_dragger(active)
             _close_ui()
         return {"section_view": current}
     toggle = getattr(active, "toggleClippingPlane", None)
@@ -543,10 +2800,13 @@ def set_section_view(
         raise RuntimeError("The active 3D view cannot toggle a section plane.")
     if visible:
         _apply_clip(active, document, _settings)
+        _start_selection_snap()
         if show_ui:
             _show_ui()
     else:
+        _stop_selection_snap()
         _remove_overlay(active)
+        _remove_dragger(active)
         toggle(toggle=0)
         _close_ui()
     observed = is_section_view_active(active)
@@ -561,8 +2821,13 @@ def configure_section_view(
     offset: float | None = None,
     flipped: bool | None = None,
     show_plane: bool | None = None,
+    yaw: float | None = None,
+    pitch: float | None = None,
+    roll: float | None = None,
     view: Any | None = None,
     document: Any | None = None,
+    preview: bool = False,
+    sync_dragger: bool = True,
 ) -> dict[str, object]:
     """Update the live Front/Top/Right section without changing geometry."""
 
@@ -576,15 +2841,30 @@ def configure_section_view(
         updates["flipped"] = flipped
     if show_plane is not None:
         updates["show_plane"] = show_plane
+    if yaw is not None:
+        updates["yaw"] = yaw
+    if pitch is not None:
+        updates["pitch"] = pitch
+    if roll is not None:
+        updates["roll"] = roll
     _settings = replace(_settings, **updates) if updates else _settings
     active = view if view is not None else _active_3d_view()
     if active is not None and is_section_view_active(active):
-        _apply_clip(active, document, _settings)
+        _apply_clip(
+            active,
+            document,
+            _settings,
+            preview=preview,
+            sync_dragger=sync_dragger,
+        )
     return {
         "plane": _settings.plane,
         "offset": _settings.offset,
         "flipped": _settings.flipped,
         "show_plane": _settings.show_plane,
+        "yaw": _settings.yaw,
+        "pitch": _settings.pitch,
+        "roll": _settings.roll,
         "section_view": is_section_view_active(active) if active is not None else False,
     }
 
@@ -602,7 +2882,8 @@ def toggle_section_view(
         raise RuntimeError("Section view requires an active 3D view.")
     if is_section_view_active(active):
         return set_section_view(False, view=active, document=document)
-    reset_section_view_settings()
+    global _settings
+    _settings = initial_section_settings(_view_look_direction(active))
     return set_section_view(
         True,
         view=active,

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -2957,7 +2957,11 @@ def _start_plane_drag(view):
                 # vertical dragging then uses the view's world-units-per-pixel.
                 a = view.getPoint(pixel_x, pixel_y)
                 b = view.getPoint(pixel_x, pixel_y + 1)
-                self.pixel_scale = (b - a).Length
+                # A face-on pull has no projected normal. Keep its world
+                # direction tied to the camera when Flip reverses the normal.
+                look = _view_look_direction(view)
+                toward_camera = tuple(-value for value in look)
+                self.pixel_scale = (b - a).Length * (1 if _dot(normal, toward_camera) >= 0 else -1)
                 self.dragging = True
                 return True
             if not self.dragging:

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -1443,10 +1443,10 @@ def is_section_view_active(view: Any | None = None) -> bool:
     active = view if view is not None else _active_3d_view()
     if active is None:
         return False
-    has_clip = getattr(active, "hasClippingPlane", None)
-    if not callable(has_clip):
-        return False
     try:
+        has_clip = getattr(active, "hasClippingPlane", None)
+        if not callable(has_clip):
+            return False
         return bool(has_clip())
     except Exception:
         return False
@@ -2730,6 +2730,10 @@ def _poll_dragger() -> None:
     if _dragger_node is None:
         return
     view = _active_3d_view()
+    # A queued timeout can arrive after deactivation. Do not read the old
+    # scene's Pivy nodes when another view (or no view) is active.
+    if view is None or view != _dragger_view:
+        return
     if (_cap_dirty and not _dragger_busy and view is not None
             and _dragger_document is not None and _dragger_document.isClosable()):
         _sync_overlay(view, _dragger_document, _settings)

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -135,6 +135,10 @@ _dragger_document: Any | None = None
 _section_document_observer: Any | None = None
 _bounds_view: Any | None = None
 _section_bounds: ModelBounds | None = None
+_cap_worker: Any | None = None
+_cap_dirty = False
+_last_dragger_scale: float | None = None
+_cap_document_observer: Any | None = None
 _dragger_busy = False
 _drag_start_settings: SectionViewSettings | None = None
 _drag_start_origin: tuple[float, float, float] | None = None
@@ -1083,6 +1087,12 @@ def _shape_has_solids(shape: Any) -> bool:
                 return False
         except Exception:
             return False
+    count = getattr(shape, "countElement", None)
+    if callable(count):
+        try:
+            return count("Solid") > 0
+        except Exception:
+            pass
     solids = getattr(shape, "Solids", None)
     try:
         if solids:
@@ -1404,6 +1414,25 @@ def _placement_from_bounds(settings: SectionViewSettings, bounds: ModelBounds | 
     return App.Placement(App.Vector(*origin), rotation)
 
 
+def _render_bounds(view: Any) -> ModelBounds | None:
+    """Use the displayed scene, without materializing document compound shapes."""
+    scene = _scene_from_view(view)
+    if scene is None:
+        return None
+    try:
+        from pivy import coin
+
+        action = coin.SoGetBoundingBoxAction(coin.SbViewportRegion(1, 1))
+        action.apply(scene)
+        box = action.getBoundingBox()
+        if box.isEmpty():
+            return None
+        low, high = _vec3(box.getMin()), _vec3(box.getMax())
+        return ModelBounds(low[0], high[0], low[1], high[1], low[2], high[2])
+    except (ImportError, AttributeError, TypeError):
+        return None
+
+
 def _bounds_for_view(view: Any, document: Any | None) -> ModelBounds | None:
     if view is not None and view == _bounds_view:
         return _section_bounds
@@ -1531,11 +1560,139 @@ def _scene_from_view(view: Any) -> Any | None:
 
 def _remove_overlay(view: Any) -> None:
     global _overlay_node, _cap_node
+    if _cap_worker is not None:
+        _cap_worker.cancel()
     scene = _scene_from_view(view)
     _detach_scene_node(scene, _overlay_node)
     _detach_scene_node(scene, _cap_node)
     _overlay_node = None
     _cap_node = None
+
+
+class _SectionDisplaySequence:
+    """Read immutable worker geometry in bounded batches during GUI adoption."""
+
+    def __init__(self, handle, kind, size, read):
+        self._handle = handle
+        self._kind = kind
+        self._size = size
+        self._read = read
+
+    def __len__(self):
+        return self._size
+
+    def __iter__(self):
+        for first in range(0, self._size, 256):
+            yield from self._read(
+                self._handle, self._kind, first, min(256, self._size - first)
+            )
+
+
+class _NativeSectionCapWorker:
+    """Capture and adopt on the owner; compute geometry on native workers."""
+
+    def __init__(self, backend):
+        self._backend = backend
+        self._handle = backend.createSectionFaceController()
+        self._generation = 0
+        self._steps = None
+        self._running = False
+
+    def cancel(self):
+        self._generation += 1
+        self._running = False
+        steps, self._steps = self._steps, None
+        self._backend.cancelSectionFaces(self._handle)
+        if steps is not None:
+            close = getattr(steps, "close", None)
+            if close is not None:
+                close()
+
+    def _queue(self, generation, callback):
+        def run():
+            if generation != self._generation:
+                return
+            try:
+                callback()
+            except Exception:
+                self.cancel()
+                raise
+
+        if not self._backend._deferSectionDisplay(run):
+            self.cancel()
+
+    def request(self, snapshots, origin, normal, spacing, publish):
+        from time import perf_counter
+
+        self.cancel()
+        generation = self._generation
+        self._steps = iter(snapshots)
+        self._running = True
+        instances = []
+
+        def adopt():
+            try:
+                next(self._steps)
+            except StopIteration:
+                self._steps = None
+                self._running = False
+                return
+            self._queue(generation, adopt)
+
+        def completed(handle, error):
+            if generation != self._generation:
+                return
+            self._running = False
+            if error:
+                raise RuntimeError(error)
+            steps = publish(handle)
+            if steps is not None:
+                self._steps = iter(steps)
+                self._running = True
+                self._queue(generation, adopt)
+
+        def capture():
+            started = perf_counter()
+            for _ in range(128):
+                try:
+                    instance = next(self._steps)
+                except StopIteration:
+                    self._steps = None
+                    self._backend.requestSectionDisplay(
+                        self._handle, instances, origin, normal, spacing, completed
+                    )
+                    return
+                if instance is not None:
+                    instances.append(instance)
+                if perf_counter() - started >= 0.008:
+                    break
+            self._queue(generation, capture)
+
+        self._queue(generation, capture)
+
+
+def _invalidate_caps():
+    global _cap_dirty
+    _cap_dirty = True
+    if _cap_worker is not None:
+        _cap_worker.cancel()
+
+
+class _SectionCapDocumentObserver:
+    def slotChangedObject(self, obj, property_name):
+        if property_name in {"Shape", "Placement", "Visibility", "Group", "LinkedObject"}:
+            self._changed(obj)
+
+    def slotCreatedObject(self, obj):
+        self._changed(obj)
+
+    def slotDeletedObject(self, obj):
+        self._changed(obj)
+
+    @staticmethod
+    def _changed(obj):
+        if _dragger_document is not None and getattr(obj, "Document", None) is _dragger_document:
+            _invalidate_caps()
 
 
 class _SectionViewDocumentObserver:
@@ -1563,20 +1720,25 @@ class _SectionViewDocumentObserver:
 
 
 def _observe_section_document(view: Any, document: Any | None) -> None:
-    global _dragger_view, _dragger_document, _section_document_observer
+    global _dragger_view, _dragger_document, _section_document_observer, _cap_document_observer
     import FreeCADGui as Gui
 
     if _section_document_observer is None:
         observer = _SectionViewDocumentObserver()
         Gui.addDocumentObserver(observer)
         _section_document_observer = observer
+    if _cap_document_observer is None:
+        observer = _SectionCapDocumentObserver()
+        App.addDocumentObserver(observer)
+        _cap_document_observer = observer
     _dragger_view = view
     _dragger_document = document if document is not None else _active_document()
 
 
 def _remove_dragger(view: Any) -> None:
     global _dragger_node, _dragger_busy, _drag_start_settings
-    global _dragger_view, _dragger_document, _bounds_view, _section_bounds
+    global _dragger_view, _dragger_document, _bounds_view, _section_bounds, _cap_dirty
+    global _last_dragger_scale
     global _drag_start_origin, _drag_start_axes, _drag_start_rot_counts, _triad_parts
     scene = _scene_from_view(view)
     _stop_dragger_poll()
@@ -1586,6 +1748,8 @@ def _remove_dragger(view: Any) -> None:
     _dragger_document = None
     _bounds_view = None
     _section_bounds = None
+    _cap_dirty = False
+    _last_dragger_scale = None
     _dragger_busy = False
     _drag_start_settings = None
     _drag_start_origin = None
@@ -1641,18 +1805,80 @@ def _sync_overlay(
             pass
     if not rebuild_caps:
         return
-    caps = section_cap_geometry_from_objects(
-        objects,
-        origin,
-        normal,
-        hatch_spacing_for_bounds(bounds),
+    _schedule_cap_build(coin, view, document, origin, normal, hatch_spacing_for_bounds(bounds))
+
+
+def _rendered_section_snapshot_steps(view):
+    """Capture displayed instances on the owner, yielding between providers.
+
+    Only detached native shape references and matrices leave this generator.
+    Coin traversal uses the visible scene, including Link snapshots and their
+    current display transforms, rather than document Placement properties.
+    """
+    from pivy import coin
+
+    face_type = coin.SoType.fromName("SoBrepFaceSet")
+    sources = {}
+    for document in App.listDocuments().values():
+        for obj in document.Objects:
+            provider = obj.ViewObject
+            snapshot = getattr(provider, "getRenderedShapeSnapshot", None)
+            if callable(snapshot):
+                shape = snapshot()
+                if not shape.isNull():
+                    search = coin.SoSearchAction()
+                    search.setType(face_type)
+                    search.setInterest(coin.SoSearchAction.FIRST)
+                    search.setSearchingAll(True)
+                    search.apply(provider.RootNode)
+                    path = search.getPath()
+                    if path is not None:
+                        sources[path.getTail().getNodeId()] = shape
+            yield None
+
+    search = coin.SoSearchAction()
+    search.setType(face_type)
+    search.setInterest(coin.SoSearchAction.ALL)
+    search.setSearchingAll(False)
+    search.apply(view.getSceneGraph())
+    for path in search.getPaths():
+        shape = sources.get(path.getTail().getNodeId())
+        if shape is None:
+            yield None
+            continue
+        action = coin.SoGetMatrixAction(coin.SbViewportRegion(1, 1))
+        action.apply(path)
+        matrix = action.getMatrix().getValue()
+        # Coin uses row vectors; FreeCAD's matrix convention is transposed.
+        transform = App.Matrix(*(matrix[column][row] for row in range(4) for column in range(4)))
+        yield shape, transform
+
+
+def _schedule_cap_build(coin, view, document, origin, normal, spacing):
+    global _cap_worker, _cap_dirty
+    import PartGui
+
+    _cap_dirty = False
+    owner = document if document is not None else _active_document()
+    if owner is None:
+        return
+    if _cap_worker is None:
+        _cap_worker = _NativeSectionCapWorker(PartGui)
+
+    def publish(handle):
+        sizes = PartGui.sectionDisplaySizes(handle)
+        caps = SectionCapGeometry(*(
+            _SectionDisplaySequence(handle, kind, size, PartGui.readSectionDisplay)
+            for kind, size in zip(("triangles", "hatch", "outlines"), sizes)
+        ))
+        scene = _scene_from_view(view)
+        if scene is not None:
+            return _install_cap_node_steps(coin, scene, caps)
+
+    _cap_worker.request(
+        _rendered_section_snapshot_steps(view),
+        App.Vector(*origin), App.Vector(*normal), spacing, publish,
     )
-    if not caps:
-        return
-    try:
-        _install_cap_node(coin, scene, caps)
-    except Exception:
-        return
 
 
 def _install_overlay_node(coin: Any, scene: Any, corners: Any) -> None:
@@ -1705,7 +1931,26 @@ def _write_indexes(target: Any, values: Sequence[int]) -> None:
         target.coordIndex.set1Value(index, int(value))
 
 
+def _write_points_steps(coords, points):
+    for index, point in enumerate(points):
+        coords.point.set1Value(index, float(point[0]), float(point[1]), float(point[2]))
+        if (index + 1) % 256 == 0:
+            yield
+
+
+def _write_indexes_steps(target, values):
+    for index, value in enumerate(values):
+        target.coordIndex.set1Value(index, int(value))
+        if (index + 1) % 256 == 0:
+            yield
+
+
 def _install_cap_node(coin: Any, scene: Any, caps: SectionCapGeometry) -> None:
+    for _ in _install_cap_node_steps(coin, scene, caps):
+        pass
+
+
+def _install_cap_node_steps(coin: Any, scene: Any, caps: SectionCapGeometry) -> None:
     global _cap_node
     separator = coin.SoSeparator()
     separator.setName(_CAP_OVERLAY_NAME)
@@ -1733,7 +1978,9 @@ def _install_cap_node(coin: Any, scene: Any, caps: SectionCapGeometry) -> None:
         fill.transparency.setValue(0.0)
         points: list[tuple[float, float, float]] = []
         indexes: list[int] = []
-        for triangle in caps.triangles:
+        for index, triangle in enumerate(caps.triangles):
+            if index and index % 256 == 0:
+                yield
             start = len(points)
             points.extend(triangle)
             indexes.extend((start, start + 1, start + 2, -1))
@@ -1741,9 +1988,9 @@ def _install_cap_node(coin: Any, scene: Any, caps: SectionCapGeometry) -> None:
             points.extend((triangle[0], triangle[2], triangle[1]))
             indexes.extend((start, start + 1, start + 2, -1))
         coords = coin.SoCoordinate3()
-        _write_points(coords, points)
+        yield from _write_points_steps(coords, points)
         faces = coin.SoIndexedFaceSet()
-        _write_indexes(faces, indexes)
+        yield from _write_indexes_steps(faces, indexes)
         separator.addChild(fill)
         separator.addChild(coords)
         separator.addChild(faces)
@@ -1757,14 +2004,16 @@ def _install_cap_node(coin: Any, scene: Any, caps: SectionCapGeometry) -> None:
         style.lineWidth = 1
         points = []
         indexes = []
-        for start_point, end_point in caps.hatch:
+        for index, (start_point, end_point) in enumerate(caps.hatch):
+            if index and index % 256 == 0:
+                yield
             start = len(points)
             points.extend((start_point, end_point))
             indexes.extend((start, start + 1, -1))
         coords = coin.SoCoordinate3()
-        _write_points(coords, points)
+        yield from _write_points_steps(coords, points)
         lines = coin.SoIndexedLineSet()
-        _write_indexes(lines, indexes)
+        yield from _write_indexes_steps(lines, indexes)
         separator.addChild(hatch_material)
         separator.addChild(style)
         separator.addChild(coords)
@@ -1779,14 +2028,16 @@ def _install_cap_node(coin: Any, scene: Any, caps: SectionCapGeometry) -> None:
         style.lineWidth = 2
         points = []
         indexes = []
-        for start_point, end_point in caps.outlines:
+        for index, (start_point, end_point) in enumerate(caps.outlines):
+            if index and index % 256 == 0:
+                yield
             start = len(points)
             points.extend((start_point, end_point))
             indexes.extend((start, start + 1, -1))
         coords = coin.SoCoordinate3()
-        _write_points(coords, points)
+        yield from _write_points_steps(coords, points)
         lines = coin.SoIndexedLineSet()
-        _write_indexes(lines, indexes)
+        yield from _write_indexes_steps(lines, indexes)
         separator.addChild(outline_material)
         separator.addChild(style)
         separator.addChild(coords)
@@ -2319,6 +2570,7 @@ def _set_scale_factor(node: Any, scale: float) -> bool:
 
 
 def _autoscale_dragger(view: Any, origin: tuple[float, float, float]) -> None:
+    global _last_dragger_scale
     if _dragger_node is None:
         return
     scale = world_scale_for_ndc(view, origin, _DRAGGER_NDC_SIZE)
@@ -2333,6 +2585,9 @@ def _autoscale_dragger(view: Any, origin: tuple[float, float, float]) -> None:
                 + (bounds.zmax - bounds.zmin) ** 2
             ) ** 0.5
             scale = max(diagonal * 0.12, 15.0)
+    if (_last_dragger_scale is not None
+            and abs(scale - _last_dragger_scale) <= 1e-6 * max(abs(scale), 1.0)):
+        return
     target = None
     if _triad_parts is not None:
         target = _triad_parts.get("scale")
@@ -2345,7 +2600,8 @@ def _autoscale_dragger(view: Any, origin: tuple[float, float, float]) -> None:
                 target = None
     if target is None:
         target = _dragger_node
-    _set_scale_factor(target, scale)
+    if _set_scale_factor(target, scale):
+        _last_dragger_scale = scale
 
 
 def _field_quat(node: Any) -> tuple[float, float, float, float] | None:
@@ -2470,6 +2726,9 @@ def _poll_dragger() -> None:
     if _dragger_node is None:
         return
     view = _active_3d_view()
+    if (_cap_dirty and not _dragger_busy and view is not None
+            and _dragger_document is not None and _dragger_document.isClosable()):
+        _sync_overlay(view, _dragger_document, _settings)
     origin = _current_dragger_origin()
     if origin is not None and view is not None:
         _autoscale_dragger(view, origin)
@@ -2665,8 +2924,12 @@ def _apply_clip(
         # The section editor owns one scene. Transfer it before attaching new
         # nodes, rather than leaving the previous view with dangling wrappers.
         set_section_view(False, view=_dragger_view, document=_dragger_document)
-    if not preview or view != _bounds_view:
-        _section_bounds = model_bounds(_document_objects(document))
+    if view != _bounds_view:
+        _section_bounds = _render_bounds(view)
+        if _section_bounds is None:
+            _section_bounds = model_bounds(_document_objects(document))
+        # Keep the section's world-space reference stable throughout a drag;
+        # subsequently added cap/plane/gizmo nodes must not affect its bounds.
         _bounds_view = view
     placement = _placement_from_bounds(settings, _section_bounds)
     if is_section_view_active(view):
@@ -2676,6 +2939,8 @@ def _apply_clip(
     else:
         view.toggleClippingPlane(toggle=1, noManip=True, pla=placement)
     if preview:
+        if _cap_worker is not None:
+            _cap_worker.cancel()
         return
     _sync_overlay(view, document, settings, rebuild_caps=True)
     if sync_dragger:

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -1644,7 +1644,9 @@ class _NativeSectionCapWorker:
                 return
             self._running = False
             if error:
-                raise RuntimeError(error)
+                # The native worker preserves successful instances when an
+                # individual solid cannot be cut, as the geometry API does.
+                App.Console.PrintWarning("Section View: " + error + "\n")
             steps = publish(handle)
             if steps is not None:
                 self._steps = iter(steps)

--- a/src/Mod/VibeCAD/VibeCADSectionViewGui.py
+++ b/src/Mod/VibeCAD/VibeCADSectionViewGui.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-"""SolidWorks/Fusion-style Section View dialog for the 3D viewport."""
+"""Section View offset panel, docked with Tasks and VibeCAD Assistant."""
 
 from __future__ import annotations
 
@@ -18,91 +18,65 @@ import VibeCADSectionView as section
 
 
 _dialog: "SectionViewDialog | None" = None
-_PLANE_LABELS = (
-    ("front", "Front (XY)"),
-    ("top", "Top (XZ)"),
-    ("right", "Right (YZ)"),
-)
+_dock: Any | None = None
 
 
-class SectionViewDialog(QtWidgets.QDialog):
-    """Non-modal Front/Top/Right section controls, live-previewed in the 3D view."""
+class SectionViewDialog(QtWidgets.QWidget):
+    """Offset control for the plane currently being sectioned."""
 
     def __init__(self, parent: Any | None = None) -> None:
         super().__init__(parent)
         self.setObjectName("VibeCADSectionViewDialog")
-        self.setWindowTitle("Section View")
-        self.setModal(False)
-        self.setAttribute(QtCore.Qt.WA_DeleteOnClose, True)
         self._updating = False
 
         layout = QtWidgets.QVBoxLayout(self)
-        plane_group = QtWidgets.QGroupBox("Section plane", self)
-        plane_layout = QtWidgets.QVBoxLayout(plane_group)
-        self._plane_buttons: dict[str, QtWidgets.QRadioButton] = {}
-        for name, label in _PLANE_LABELS:
-            button = QtWidgets.QRadioButton(label, plane_group)
-            object_name = {
-                "front": "planeFront",
-                "top": "planeTop",
-                "right": "planeRight",
-            }[name]
-            button.setObjectName(object_name)
-            button.toggled.connect(self._plane_changed)
-            plane_layout.addWidget(button)
-            self._plane_buttons[name] = button
-        layout.addWidget(plane_group)
+        layout.setContentsMargins(10, 8, 10, 8)
+        layout.setSpacing(6)
+
+        self.plane_label = QtWidgets.QLabel(self)
+        self.plane_label.setObjectName("sectionPlaneLabel")
+        layout.addWidget(self.plane_label)
 
         offset_row = QtWidgets.QHBoxLayout()
-        offset_label = QtWidgets.QLabel("Offset", self)
         self.offset_spin = QtWidgets.QDoubleSpinBox(self)
         self.offset_spin.setObjectName("sectionOffset")
         self.offset_spin.setDecimals(3)
         self.offset_spin.setSingleStep(1.0)
         self.offset_spin.setRange(-1_000_000.0, 1_000_000.0)
         self.offset_spin.setSuffix(" mm")
-        self.offset_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal, self)
-        self.offset_slider.setObjectName("sectionOffsetSlider")
-        self.offset_slider.setRange(-1000, 1000)
-        offset_row.addWidget(offset_label)
         offset_row.addWidget(self.offset_spin)
-        layout.addLayout(offset_row)
-        layout.addWidget(self.offset_slider)
-
         self.flip_button = QtWidgets.QPushButton("Flip", self)
         self.flip_button.setObjectName("sectionFlip")
         self.flip_button.setCheckable(True)
-        layout.addWidget(self.flip_button)
+        offset_row.addWidget(self.flip_button)
+        layout.addLayout(offset_row)
 
-        self.show_plane = QtWidgets.QCheckBox("Show section plane", self)
-        self.show_plane.setObjectName("sectionShowPlane")
-        self.show_plane.setChecked(True)
-        layout.addWidget(self.show_plane)
-
-        buttons = QtWidgets.QDialogButtonBox(
-            QtWidgets.QDialogButtonBox.Ok | QtWidgets.QDialogButtonBox.Cancel,
-            self,
-        )
-        buttons.accepted.connect(self.accept)
-        buttons.rejected.connect(self.reject)
-        layout.addWidget(buttons)
+        self.offset_slider = QtWidgets.QSlider(QtCore.Qt.Horizontal, self)
+        self.offset_slider.setObjectName("sectionOffsetSlider")
+        self.offset_slider.setRange(-1000, 1000)
+        layout.addWidget(self.offset_slider)
+        layout.addStretch(1)
 
         self.offset_spin.valueChanged.connect(self._offset_spin_changed)
         self.offset_slider.valueChanged.connect(self._offset_slider_changed)
         self.flip_button.toggled.connect(self._flip_changed)
-        self.show_plane.toggled.connect(self._show_plane_changed)
         self.destroyed.connect(_clear_dialog)
         self._load_from_settings()
 
     def _load_from_settings(self) -> None:
         settings = section.current_section_view_settings()
         self._updating = True
-        self._plane_buttons[settings.plane].setChecked(True)
+        self.plane_label.setText(section.section_offset_label(settings))
+        if _dock is not None:
+            try:
+                _dock.setWindowTitle(f"Section · {settings.plane.capitalize()}")
+            except RuntimeError:
+                pass
         self._sync_offset_limits()
         self.offset_spin.setValue(settings.offset)
         self._set_slider_from_offset(settings.offset)
-        self.flip_button.setChecked(settings.flipped)
-        self.show_plane.setChecked(settings.show_plane)
+        if self.flip_button.isChecked() != bool(settings.flipped):
+            self.flip_button.setChecked(settings.flipped)
         self._updating = False
 
     def _sync_offset_limits(self) -> None:
@@ -115,8 +89,13 @@ class SectionViewDialog(QtWidgets.QDialog):
         bounds = section.model_bounds(objects)
         if bounds is None:
             return
+        settings = section.current_section_view_settings()
         low, high = section.section_offset_range(
-            bounds, section.current_section_view_settings().plane
+            bounds,
+            settings.plane,
+            yaw=settings.yaw,
+            pitch=settings.pitch,
+            flipped=settings.flipped,
         )
         if high <= low:
             high = low + 1.0
@@ -159,19 +138,6 @@ class SectionViewDialog(QtWidgets.QDialog):
         ratio = (float(offset) - low) / span
         self.offset_slider.setValue(int(round(ratio * 2000.0 - 1000.0)))
 
-    def _plane_changed(self, checked: bool) -> None:
-        if self._updating or not checked:
-            return
-        plane = next(
-            name for name, button in self._plane_buttons.items() if button.isChecked()
-        )
-        self._updating = True
-        section.configure_section_view(plane=plane, offset=0.0)
-        self._sync_offset_limits()
-        self.offset_spin.setValue(0.0)
-        self._set_slider_from_offset(0.0)
-        self._updating = False
-
     def _offset_spin_changed(self, value: float) -> None:
         if self._updating:
             return
@@ -194,30 +160,13 @@ class SectionViewDialog(QtWidgets.QDialog):
             return
         section.configure_section_view(flipped=bool(checked))
 
-    def _show_plane_changed(self, checked: bool) -> None:
-        if self._updating:
-            return
-        section.configure_section_view(show_plane=bool(checked))
-
-    def accept(self) -> None:
-        """Keep the section cut and close the editor, like SolidWorks OK."""
-
-        super().accept()
-
-    def reject(self) -> None:
-        """Cancel the section cut, like SolidWorks/Fusion dismissing without keeping it."""
-
-        global _dialog
-        _dialog = None
-        view = None
-        try:
-            if Gui is not None and Gui.ActiveDocument is not None:
-                view = Gui.ActiveDocument.ActiveView
-        except Exception:
-            view = None
-        if view is not None and section.is_section_view_active(view):
-            section.set_section_view(False, view=view, show_ui=False)
-        super().reject()
+    def isVisible(self) -> bool:  # noqa: N802
+        if _dock is not None:
+            try:
+                return bool(_dock.isVisible())
+            except RuntimeError:
+                pass
+        return super().isVisible()
 
 
 def _clear_dialog(*_args: Any) -> None:
@@ -237,31 +186,75 @@ def _main_window() -> Any | None:
         return None
 
 
-def show_section_view_dialog() -> SectionViewDialog | None:
-    """Show the Front/Top/Right section editor without stealing a modeling task."""
+def _install_section_dock(widget: SectionViewDialog) -> Any | None:
+    main = _main_window()
+    if main is None or QtWidgets is None or QtCore is None:
+        widget.show()
+        return None
+    dock = QtWidgets.QDockWidget("Section View", main)
+    dock.setObjectName("VibeCADSectionViewDock")
+    dock.setWidget(widget)
+    left = getattr(QtCore.Qt, "LeftDockWidgetArea", None)
+    right = getattr(QtCore.Qt, "RightDockWidgetArea", None)
+    if left is not None and right is not None:
+        dock.setAllowedAreas(left | right)
+    dock.setMinimumWidth(260)
+    if right is not None:
+        main.addDockWidget(right, dock)
+    else:
+        main.addDockWidget(dock)
+    tabify = getattr(main, "tabifyDockWidget", None)
+    if callable(tabify):
+        for name in ("Std_TaskView", "VibeCADAssistantPanel"):
+            sibling = main.findChild(QtWidgets.QDockWidget, name)
+            if sibling is None:
+                continue
+            try:
+                tabify(sibling, dock)
+            except Exception:
+                continue
+    dock.show()
+    dock.raise_()
+    return dock
 
-    global _dialog
+
+def show_section_view_dialog() -> SectionViewDialog | None:
+    """Show the offset panel in the right sidebar with Tasks and Assistant."""
+
+    global _dialog, _dock
     if QtWidgets is None:
         return None
     if _dialog is not None:
         try:
             _dialog._load_from_settings()
-            _dialog.show()
-            _dialog.raise_()
-            _dialog.activateWindow()
+            if _dock is not None:
+                _dock.show()
+                _dock.raise_()
+            else:
+                _dialog.show()
             return _dialog
         except RuntimeError:
             _dialog = None
+            _dock = None
     dialog = SectionViewDialog(_main_window())
     _dialog = dialog
-    dialog.show()
+    _dock = _install_section_dock(dialog)
     return dialog
 
 
 def close_section_view_dialog() -> None:
-    global _dialog
+    global _dialog, _dock
+    dock = _dock
     dialog = _dialog
+    _dock = None
     _dialog = None
+    if dock is not None:
+        try:
+            dock.hide()
+            dock.deleteLater()
+            return
+        except RuntimeError:
+            pass
     if dialog is None:
         return
     try:
@@ -276,3 +269,12 @@ def sync_section_view_dialog(visible: bool) -> None:
         show_section_view_dialog()
         return
     close_section_view_dialog()
+
+
+def refresh_section_view_dialog() -> None:
+    if _dialog is None:
+        return
+    try:
+        _dialog._load_from_settings()
+    except RuntimeError:
+        return

--- a/src/Mod/VibeCAD/VibeCADSectionViewGui.py
+++ b/src/Mod/VibeCAD/VibeCADSectionViewGui.py
@@ -85,8 +85,9 @@ class SectionViewDialog(QtWidgets.QWidget):
         except ImportError:
             return
         document = getattr(App, "ActiveDocument", None)
-        objects = getattr(document, "Objects", ()) if document is not None else ()
-        bounds = section.model_bounds(objects)
+        # Use the same displayed bounds as the clipping plane. Reading model
+        # bounds here can materialize compounds and disagree with the view.
+        bounds = section._bounds_for_view(section._active_3d_view(), document)
         if bounds is None:
             return
         settings = section.current_section_view_settings()
@@ -142,18 +143,22 @@ class SectionViewDialog(QtWidgets.QWidget):
         if self._updating:
             return
         self._updating = True
-        self._set_slider_from_offset(value)
-        section.configure_section_view(offset=float(value))
-        self._updating = False
+        try:
+            self._set_slider_from_offset(value)
+            section.configure_section_view(offset=float(value))
+        finally:
+            self._updating = False
 
     def _offset_slider_changed(self, value: int) -> None:
         if self._updating:
             return
         offset = self._slider_to_offset(value)
         self._updating = True
-        self.offset_spin.setValue(offset)
-        section.configure_section_view(offset=float(offset))
-        self._updating = False
+        try:
+            self.offset_spin.setValue(offset)
+            section.configure_section_view(offset=float(offset))
+        finally:
+            self._updating = False
 
     def _flip_changed(self, checked: bool) -> None:
         if self._updating:

--- a/src/Mod/VibeCAD/VibeCADSectionViewGui.py
+++ b/src/Mod/VibeCAD/VibeCADSectionViewGui.py
@@ -55,11 +55,21 @@ class SectionViewDialog(QtWidgets.QWidget):
         self.offset_slider.setObjectName("sectionOffsetSlider")
         self.offset_slider.setRange(-1000, 1000)
         layout.addWidget(self.offset_slider)
+        self.show_plane_checkbox = QtWidgets.QCheckBox("Show plane", self)
+        self.show_plane_checkbox.setObjectName("sectionShowPlane")
+        self.show_plane_checkbox.setToolTip("Show the plane guide while keeping the section cut active")
+        layout.addWidget(self.show_plane_checkbox)
+        self.show_handles_checkbox = QtWidgets.QCheckBox("Show handles", self)
+        self.show_handles_checkbox.setObjectName("sectionShowHandles")
+        self.show_handles_checkbox.setToolTip("Show the on-canvas translation and rotation handles")
+        layout.addWidget(self.show_handles_checkbox)
         layout.addStretch(1)
 
         self.offset_spin.valueChanged.connect(self._offset_spin_changed)
         self.offset_slider.valueChanged.connect(self._offset_slider_changed)
         self.flip_button.toggled.connect(self._flip_changed)
+        self.show_plane_checkbox.toggled.connect(self._show_plane_changed)
+        self.show_handles_checkbox.toggled.connect(self._show_handles_changed)
         self.destroyed.connect(_clear_dialog)
         self._load_from_settings()
 
@@ -77,6 +87,8 @@ class SectionViewDialog(QtWidgets.QWidget):
         self._set_slider_from_offset(settings.offset)
         if self.flip_button.isChecked() != bool(settings.flipped):
             self.flip_button.setChecked(settings.flipped)
+        self.show_plane_checkbox.setChecked(settings.show_plane)
+        self.show_handles_checkbox.setChecked(settings.show_handles)
         self._updating = False
 
     def _sync_offset_limits(self) -> None:
@@ -164,6 +176,16 @@ class SectionViewDialog(QtWidgets.QWidget):
         if self._updating:
             return
         section.configure_section_view(flipped=bool(checked))
+
+    def _show_plane_changed(self, checked: bool) -> None:
+        if self._updating:
+            return
+        section.configure_section_view(show_plane=bool(checked))
+
+    def _show_handles_changed(self, checked: bool) -> None:
+        if self._updating:
+            return
+        section.configure_section_view(show_handles=bool(checked))
 
     def isVisible(self) -> bool:  # noqa: N802
         if _dock is not None:

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -498,6 +498,36 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         self.assertEqual(box.Placement, placement)
         self.assertEqual(self.document.UndoCount, undo)
 
+    def test_face_on_plane_pull_keeps_world_direction_when_flipped(self):
+        view = Gui.ActiveDocument.ActiveView
+        view.viewTop()
+        view.fitAll()
+        widget = view.graphicsView().viewport()
+        for flipped in (False, True):
+            VibeCADSectionView.reset_section_view_settings()
+            VibeCADSectionView.configure_section_view(plane="top", flipped=flipped)
+            VibeCADSectionView.set_section_view(True, view=view, document=self.document)
+            self._process_events()
+            bounds = VibeCADSectionView._bounds_for_view(view, self.document)
+            before, _ = VibeCADSectionView.clip_plane_from_settings(
+                VibeCADSectionView.current_section_view_settings(), bounds.center)
+            point = view.getPointOnScreen(App.Vector(-0.8, -0.4, 5))
+            start = QtCore.QPoint(int(point[0]), widget.height() - 1 - int(point[1]))
+            finish = start + QtCore.QPoint(0, -10)
+            for kind, position, button, buttons in (
+                (QtCore.QEvent.MouseButtonPress, start, QtCore.Qt.LeftButton, QtCore.Qt.LeftButton),
+                (QtCore.QEvent.MouseMove, finish, QtCore.Qt.NoButton, QtCore.Qt.LeftButton),
+                (QtCore.QEvent.MouseButtonRelease, finish, QtCore.Qt.LeftButton, QtCore.Qt.NoButton),
+            ):
+                event = QtGui.QMouseEvent(kind, QtCore.QPointF(position),
+                                         QtCore.QPointF(widget.mapToGlobal(position)),
+                                         button, buttons, QtCore.Qt.NoModifier)
+                QtCore.QCoreApplication.sendEvent(widget, event)
+            after, _ = VibeCADSectionView.clip_plane_from_settings(
+                VibeCADSectionView.current_section_view_settings(), bounds.center)
+            self.assertGreater(after[2], before[2], f"Pull reversed with flipped={flipped}")
+            VibeCADSectionView.set_section_view(False, view=view, document=self.document)
+
     def test_scene_helpers_do_not_expand_section_bounds(self):
         from pivy import coin
 

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -120,6 +120,34 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
                 return widget
         return None
 
+    def test_display_bounds_include_visible_meshes_but_exclude_grid(self):
+        import Mesh
+        import MeshGui
+        from pivy import coin
+
+        mesh = self.document.addObject("Mesh::Feature", "SectionMesh")
+        mesh.Mesh = Mesh.createBox(20, 20, 20)
+        mesh.Placement.Base = App.Vector(100, 0, 0)
+        self.document.recompute()
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        view = Gui.ActiveDocument.ActiveView
+        scene = view.getSceneGraph()
+        helper = coin.SoCube()
+        helper.width = helper.height = helper.depth = 45000
+        scene.addChild(helper)
+        try:
+            self._process_events()
+            bounds = VibeCADSectionView._render_bounds(view)
+            self.assertIsNotNone(bounds)
+            self.assertAlmostEqual(bounds.xmin, 0, places=4)
+            self.assertAlmostEqual(bounds.xmax, 110, places=4)
+            mesh.ViewObject.Visibility = False
+            self._process_events()
+            hidden = VibeCADSectionView._render_bounds(view)
+            self.assertAlmostEqual(hidden.xmax, 40, places=4)
+        finally:
+            scene.removeChild(helper)
+
     def test_native_command_toggles_clip_plane_action_and_scene(self):
         command_name = "VibeCAD_SectionView"
         self.assertTrue(Gui.isCommandActive(command_name))

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -214,3 +214,142 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         self.assertIsNone(VibeCADSectionView._cap_node)
         self.assertIsNone(VibeCADSectionView._dragger_document)
         VibeCADSectionView._poll_dragger()
+
+    def test_section_updates_preserve_document_geometry_and_undo_history(self):
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        box = self.document.getObject("SectionBox")
+        before = (box.Placement.toMatrix().A, box.Shape.Volume, self.document.UndoCount)
+        view = Gui.ActiveDocument.ActiveView
+        VibeCADSectionView.set_section_view(True, view=view, document=self.document)
+        for offset in range(6):
+            VibeCADSectionView.configure_section_view(
+                offset=float(offset), view=view, document=self.document,
+                preview=True, sync_dragger=False,
+            )
+        VibeCADSectionView.configure_section_view(view=view, document=self.document)
+        self.assertTrue(self._wait_until(
+            lambda: VibeCADSectionView._cap_worker is not None
+            and not VibeCADSectionView._cap_worker._running
+        ))
+        after = (box.Placement.toMatrix().A, box.Shape.Volume, self.document.UndoCount)
+        self.assertEqual(after, before)
+
+    def test_native_rendered_snapshot_survives_document_close(self):
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        box = self.document.getObject("SectionBox")
+        snapshot = box.ViewObject.getRenderedShapeSnapshot()
+        self.assertFalse(snapshot.isNull())
+        self.assertAlmostEqual(snapshot.Volume, 8000.0)
+        App.closeDocument(self.document.Name)
+        self._process_events()
+        self.assertAlmostEqual(snapshot.Volume, 8000.0)
+
+    def test_rendered_instances_follow_link_display_transform(self):
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        box = self.document.getObject("SectionBox")
+        link = self.document.addObject("App::Link", "SectionInstance")
+        link.setLink(box)
+        link.Placement = App.Placement(App.Vector(100, 20, 30), App.Rotation())
+        box.Visibility = False
+        self.document.recompute()
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        displayed = App.Placement(App.Vector(200, 40, 60), App.Rotation())
+        link.ViewObject.setTransformation(displayed)
+        view = Gui.ActiveDocument.ActiveView
+        instances = [item for item in VibeCADSectionView._rendered_section_snapshot_steps(view)
+                     if item is not None]
+        self.assertEqual(len(instances), 1)
+        shape, transform = instances[0]
+        self.assertAlmostEqual(shape.Volume, 8000.0)
+        self.assertEqual(transform.multVec(App.Vector()), displayed.Base)
+        self.assertEqual(link.Placement.Base, App.Vector(100, 20, 30))
+
+    def test_native_section_controller_delivers_faces_on_gui(self):
+        import PartGui
+
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        snapshot = self.document.getObject("SectionBox").ViewObject.getRenderedShapeSnapshot()
+        controller = PartGui.createSectionFaceController()
+        received = []
+
+        def completed(faces, error):
+            self.assertEqual(QtCore.QThread.currentThread(), Gui.getMainWindow().thread())
+            received.append((faces, error))
+
+        PartGui.requestSectionFaces(controller, [(snapshot, App.Matrix())],
+                                    App.Vector(0, 0, 5), App.Vector(0, 0, 1), completed)
+        self.assertTrue(self._wait_until(lambda: bool(received)))
+        faces, error = received[0]
+        self.assertEqual(error, "")
+        self.assertEqual(len(faces), 1)
+        self.assertAlmostEqual(faces[0].Area, 800.0)
+        PartGui.cancelSectionFaces(controller)
+        from threading import Thread
+
+        errors = []
+
+        def cancel_off_owner():
+            try:
+                PartGui.cancelSectionFaces(controller)
+            except RuntimeError as error:
+                errors.append(str(error))
+
+        thread = Thread(target=cancel_off_owner)
+        thread.start()
+        thread.join()
+        self.assertEqual(len(errors), 1)
+        self.assertIn("GUI owner", errors[0])
+
+    def test_native_section_display_is_read_in_bounded_chunks(self):
+        import PartGui
+
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        snapshot = self.document.getObject("SectionBox").ViewObject.getRenderedShapeSnapshot()
+        controller = PartGui.createSectionFaceController()
+        received = []
+        PartGui.requestSectionDisplay(controller, [(snapshot, App.Matrix())],
+                                      App.Vector(0, 0, 5), App.Vector(0, 0, 1), 0.01,
+                                      lambda geometry, error: received.append((geometry, error)))
+        self.assertTrue(self._wait_until(lambda: bool(received)))
+        geometry, error = received[0]
+        self.assertEqual(error, "")
+        triangles, hatch, outlines = PartGui.sectionDisplaySizes(geometry)
+        self.assertGreater(triangles, 0)
+        self.assertGreater(hatch, 256)
+        self.assertGreater(outlines, 0)
+        chunk = PartGui.readSectionDisplay(geometry, "hatch", 0, 10000)
+        self.assertEqual(len(chunk), 256)
+        following = PartGui.readSectionDisplay(geometry, "hatch", 256, 256)
+        self.assertTrue(following)
+        self.assertNotEqual(chunk, following)
+        self.assertAlmostEqual(chunk[0][0][2], 4.95)
+        deferred = []
+        self.assertTrue(PartGui._deferSectionDisplay(lambda: deferred.append(True)))
+        self.assertFalse(deferred)
+        self.assertTrue(self._wait_until(lambda: bool(deferred)))
+
+    def test_close_during_cap_computation_discards_worker_result(self):
+        import PartGui
+        from unittest.mock import patch
+
+        submitted = []
+        original = PartGui.requestSectionDisplay
+
+        def close_after_submit(*args):
+            original(*args)
+            submitted.append(True)
+            # The native completion is queued to the owner, so close before
+            # its delivery without blocking the GUI or any worker.
+            App.closeDocument(self.document.Name)
+
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        with patch.object(PartGui, "requestSectionDisplay", close_after_submit):
+            view = Gui.ActiveDocument.ActiveView
+            VibeCADSectionView.set_section_view(True, view=view, document=self.document)
+            self.assertTrue(self._wait_until(lambda: bool(submitted)))
+            self.assertTrue(self._wait_until(
+                lambda: not VibeCADSectionView._cap_worker._running
+            ))
+        self.assertIsNone(VibeCADSectionView._cap_node)
+        self.assertIsNone(VibeCADSectionView._dragger_node)
+        self.assertIsNone(VibeCADSectionView._poll_timer)

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -353,3 +353,31 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         self.assertIsNone(VibeCADSectionView._cap_node)
         self.assertIsNone(VibeCADSectionView._dragger_node)
         self.assertIsNone(VibeCADSectionView._poll_timer)
+
+    def test_hidden_infinite_datum_does_not_expand_offset_slider(self):
+        import VibeCADSectionViewGui as panel
+        plane = self.document.addObject("App::Plane", "InfiniteDatum")
+        plane.Placement = App.Placement(App.Vector(), App.Rotation(App.Vector(1, 0, 0), 90))
+        plane.Visibility = False
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        self.document.recompute()
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        self.assertGreater(abs(plane.Shape.BoundBox.ZMax), 1e90)
+        view = Gui.ActiveDocument.ActiveView
+        VibeCADSectionView.reset_section_view_settings()
+        VibeCADSectionView.set_section_view(True, view=view, document=self.document)
+        dialog = panel.show_section_view_dialog()
+        self.assertIsNotNone(dialog)
+        self.assertAlmostEqual(dialog.offset_spin.minimum(), -5., places=3)
+        self.assertAlmostEqual(dialog.offset_spin.maximum(), 5., places=3)
+        dialog.offset_slider.setValue(500)
+        self.assertFalse(dialog._updating)
+        self.assertAlmostEqual(VibeCADSectionView.current_section_view_settings().offset, 2.5, places=3)
+
+    def test_section_queries_are_safe_after_native_view_deletion(self):
+        view = Gui.ActiveDocument.ActiveView
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        App.closeDocument(self.document.Name)
+        self._process_events()
+        self.assertIsNone(VibeCADSectionView._scene_from_view(view))
+        self.assertFalse(VibeCADSectionView.is_section_view_active(view))

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -24,6 +24,7 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         box.Length = 40.0
         box.Width = 20.0
         box.Height = 10.0
+        self.assertTrue(self._wait_until(self.document.isClosable))
         self.document.recompute()
         view = Gui.ActiveDocument.ActiveView
         if VibeCADSectionView.is_section_view_active(view):
@@ -46,6 +47,7 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
             VibeCADSectionView.set_section_view(False, view=view, document=self.document)
         self._process_events()
         if "VibeCADSectionViewCommand" in App.listDocuments():
+            self.assertTrue(self._wait_until(self.document.isClosable))
             App.closeDocument("VibeCADSectionViewCommand")
         self._process_events()
 
@@ -58,6 +60,7 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         loop = QtCore.QEventLoop()
         QtCore.QTimer.singleShot(wait_ms, loop.quit)
         loop.exec()
+        QtCore.QCoreApplication.sendPostedEvents(None, QtCore.QEvent.DeferredDelete)
 
     def _wait_until(self, predicate, timeout_ms=5000):
         timer = QtCore.QElapsedTimer()
@@ -164,7 +167,9 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         )
         self.assertIsNotNone(dock)
         self.assertTrue(dock.isVisible())
-        self.assertEqual(int(Gui.getMainWindow().dockWidgetArea(dock)), int(QtCore.Qt.RightDockWidgetArea))
+        self.assertEqual(
+            Gui.getMainWindow().dockWidgetArea(dock), QtCore.Qt.RightDockWidgetArea
+        )
         self.assertIsNotNone(dialog.findChild(QtWidgets.QLabel, "sectionPlaneLabel"))
         self.assertIsNotNone(dialog.findChild(QtWidgets.QDoubleSpinBox, "sectionOffset"))
         self.assertIsNotNone(dialog.findChild(QtWidgets.QPushButton, "sectionFlip"))
@@ -194,3 +199,18 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
             self._wait_until(lambda: self._section_dialog() is None),
             "Section View did not close its editor dialog.",
         )
+
+    def test_close_with_section_enabled_releases_poll_and_scene(self):
+        view = Gui.ActiveDocument.ActiveView
+        VibeCADSectionView.set_section_view(True, view=view, document=self.document)
+        self.assertIsNotNone(VibeCADSectionView._poll_timer)
+        self.assertIsNotNone(VibeCADSectionView._dragger_node)
+        self.assertTrue(self._wait_until(self.document.isClosable))
+        App.closeDocument(self.document.Name)
+        self._process_events()
+        self.assertIsNone(VibeCADSectionView._poll_timer)
+        self.assertIsNone(VibeCADSectionView._dragger_node)
+        self.assertIsNone(VibeCADSectionView._overlay_node)
+        self.assertIsNone(VibeCADSectionView._cap_node)
+        self.assertIsNone(VibeCADSectionView._dragger_document)
+        VibeCADSectionView._poll_dragger()

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -76,6 +76,23 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         return actions[0]
 
     @staticmethod
+    def _named_scene_nodes(view, name):
+        scene = view.getSceneGraph()
+        children = tuple(scene.getChildren()) if scene is not None else ()
+        found = []
+        for node in children:
+            getter = getattr(node, "getName", None)
+            if not callable(getter):
+                continue
+            try:
+                node_name = str(getter())
+            except Exception:
+                continue
+            if node_name == name:
+                found.append(node)
+        return tuple(found)
+
+    @staticmethod
     def _scene_clip_nodes(view):
         scene = view.getSceneGraph()
         children = tuple(scene.getChildren()) if scene is not None else ()
@@ -87,10 +104,15 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
 
     @staticmethod
     def _section_dialog():
+        main = Gui.getMainWindow()
+        if main is not None:
+            found = main.findChild(QtWidgets.QWidget, "VibeCADSectionViewDialog")
+            if found is not None:
+                return found
         application = QtGui.QApplication.instance()
         if application is None:
             return None
-        for widget in application.topLevelWidgets():
+        for widget in application.allWidgets():
             if widget.objectName() == "VibeCADSectionViewDialog":
                 return widget
         return None
@@ -118,19 +140,45 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
             any(type(node).__name__ == "SoClipPlaneManip" for node in clip_nodes),
             "Section View must not use the Coin clip manipulator.",
         )
+        self.assertTrue(
+            self._wait_until(lambda: self._named_scene_nodes(view, "VibeCADSectionCapOverlay")),
+            "Section View did not add hatched solid cap faces.",
+        )
+        cap_nodes = self._named_scene_nodes(view, "VibeCADSectionCapOverlay")
+        self.assertTrue(cap_nodes)
+        cap_children = tuple(cap_nodes[0].getChildren()) if hasattr(cap_nodes[0], "getChildren") else ()
+        child_types = {type(child).__name__ for child in cap_children}
+        self.assertIn("SoIndexedFaceSet", child_types)
+        self.assertIn("SoIndexedLineSet", child_types)
+        self.assertTrue(
+            self._wait_until(
+                lambda: self._named_scene_nodes(view, "VibeCADSectionDragger")
+            ),
+            "Section View did not add a datum-origin drag gizmo.",
+        )
         dialog = self._section_dialog()
         self.assertIsNotNone(dialog)
         self.assertTrue(dialog.isVisible())
-        self.assertIsNotNone(dialog.findChild(QtWidgets.QRadioButton, "planeFront"))
-        self.assertIsNotNone(dialog.findChild(QtWidgets.QRadioButton, "planeTop"))
-        self.assertIsNotNone(dialog.findChild(QtWidgets.QRadioButton, "planeRight"))
+        dock = Gui.getMainWindow().findChild(
+            QtWidgets.QDockWidget, "VibeCADSectionViewDock"
+        )
+        self.assertIsNotNone(dock)
+        self.assertTrue(dock.isVisible())
+        self.assertEqual(int(Gui.getMainWindow().dockWidgetArea(dock)), int(QtCore.Qt.RightDockWidgetArea))
+        self.assertIsNotNone(dialog.findChild(QtWidgets.QLabel, "sectionPlaneLabel"))
         self.assertIsNotNone(dialog.findChild(QtWidgets.QDoubleSpinBox, "sectionOffset"))
         self.assertIsNotNone(dialog.findChild(QtWidgets.QPushButton, "sectionFlip"))
+        self.assertIsNone(dialog.findChild(QtWidgets.QRadioButton, "planeFront"))
+        self.assertIsNone(dialog.findChild(QtWidgets.QDoubleSpinBox, "sectionPitch"))
 
-        top = dialog.findChild(QtWidgets.QRadioButton, "planeTop")
-        top.setChecked(True)
+        VibeCADSectionView.configure_section_view(plane="top")
+        import VibeCADSectionViewGui
+
+        VibeCADSectionViewGui.refresh_section_view_dialog()
         self._process_events()
         self.assertEqual(VibeCADSectionView.current_section_view_settings().plane, "top")
+        label = dialog.findChild(QtWidgets.QLabel, "sectionPlaneLabel")
+        self.assertIn("Top", label.text())
         self.assertTrue(view.hasClippingPlane())
 
         Gui.runCommand(command_name, 0)

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -263,6 +263,11 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         self.assertAlmostEqual(shape.Volume, 8000.0)
         self.assertEqual(transform.multVec(App.Vector()), displayed.Base)
         self.assertEqual(link.Placement.Base, App.Vector(100, 20, 30))
+        bounds = VibeCADSectionView._render_bounds(view)
+        self.assertAlmostEqual(bounds.xmin, 200, places=3)
+        self.assertAlmostEqual(bounds.xmax, 240, places=3)
+        self.assertAlmostEqual(bounds.ymin, 40, places=3)
+        self.assertAlmostEqual(bounds.zmin, 60, places=3)
 
     def test_native_section_controller_delivers_faces_on_gui(self):
         import PartGui
@@ -333,7 +338,7 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         from unittest.mock import patch
 
         submitted = []
-        original = PartGui.requestSectionDisplay
+        original = PartGui.requestSectionMeshDisplay
 
         def close_after_submit(*args):
             original(*args)
@@ -343,7 +348,7 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
             App.closeDocument(self.document.Name)
 
         self.assertTrue(self._wait_until(self.document.isClosable))
-        with patch.object(PartGui, "requestSectionDisplay", close_after_submit):
+        with patch.object(PartGui, "requestSectionMeshDisplay", close_after_submit):
             view = Gui.ActiveDocument.ActiveView
             VibeCADSectionView.set_section_view(True, view=view, document=self.document)
             self.assertTrue(self._wait_until(lambda: bool(submitted)))
@@ -373,6 +378,127 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         dialog.offset_slider.setValue(500)
         self.assertFalse(dialog._updating)
         self.assertAlmostEqual(VibeCADSectionView.current_section_view_settings().offset, 2.5, places=3)
+
+    def test_mesh_snapshot_keeps_caps_available_after_document_close(self):
+        import PartGui
+
+        snapshot = self.document.getObject("SectionBox").ViewObject.getRenderedMeshSnapshot()
+        self.assertIsNotNone(snapshot)
+        controller = PartGui.createSectionFaceController()
+        received = []
+        App.closeDocument(self.document.Name)
+        PartGui.requestSectionMeshDisplay(controller, [(snapshot, App.Matrix())],
+                                          App.Vector(0, 0, 5), App.Vector(0, 0, 1), 1.0,
+                                          lambda geometry, error: received.append((geometry, error)))
+        self.assertTrue(self._wait_until(lambda: bool(received)))
+        geometry, error = received[0]
+        self.assertEqual(error, "")
+        triangles, hatch, outlines = PartGui.sectionDisplaySizes(geometry)
+        self.assertGreater(triangles, 0)
+        self.assertGreater(hatch, 0)
+        self.assertGreater(outlines, 0)
+
+    def test_panel_can_hide_plane_without_rebuilding_cut(self):
+        import VibeCADSectionViewGui as panel
+        from unittest.mock import patch
+
+        view = Gui.ActiveDocument.ActiveView
+        VibeCADSectionView.reset_section_view_settings()
+        VibeCADSectionView.set_section_view(True, view=view, document=self.document)
+        self.assertTrue(self._wait_until(lambda: not VibeCADSectionView._cap_worker._running))
+        cap = VibeCADSectionView._cap_node
+        dialog = panel.show_section_view_dialog()
+        checkbox = dialog.findChild(QtWidgets.QCheckBox, "sectionShowPlane")
+        self.assertIsNotNone(checkbox)
+        with patch.object(VibeCADSectionView, "_schedule_cap_build", side_effect=AssertionError("Rebuilt cut")):
+            checkbox.setChecked(False)
+            self.assertIsNone(VibeCADSectionView._overlay_node)
+            self.assertIs(VibeCADSectionView._cap_node, cap)
+            self.assertTrue(view.hasClippingPlane())
+            checkbox.setChecked(True)
+            self.assertIsNotNone(VibeCADSectionView._overlay_node)
+            self.assertIs(VibeCADSectionView._cap_node, cap)
+
+    def test_panel_can_hide_handles_without_rebuilding_cut(self):
+        import VibeCADSectionViewGui as panel
+        from unittest.mock import patch
+
+        view = Gui.ActiveDocument.ActiveView
+        VibeCADSectionView.reset_section_view_settings()
+        VibeCADSectionView.set_section_view(True, view=view, document=self.document)
+        self.assertTrue(self._wait_until(lambda: not VibeCADSectionView._cap_worker._running))
+        cap, guide = VibeCADSectionView._cap_node, VibeCADSectionView._overlay_node
+        dragger = VibeCADSectionView._dragger_node
+        checkbox = panel.show_section_view_dialog().findChild(QtWidgets.QCheckBox, "sectionShowHandles")
+        self.assertIsNotNone(checkbox)
+        with patch.object(VibeCADSectionView, "_schedule_cap_build", side_effect=AssertionError("Rebuilt cut")):
+            checkbox.setChecked(False)
+            self.assertEqual(view.getSceneGraph().findChild(dragger), -1)
+            self.assertIs(VibeCADSectionView._cap_node, cap)
+            self.assertIs(VibeCADSectionView._overlay_node, guide)
+            self.assertTrue(view.hasClippingPlane())
+            checkbox.setChecked(True)
+            self.assertGreaterEqual(view.getSceneGraph().findChild(dragger), 0)
+            self.assertIs(VibeCADSectionView._cap_node, cap)
+
+    def test_drag_plane_in_canvas_preserves_document(self):
+        view = Gui.ActiveDocument.ActiveView
+        view.viewAxonometric()
+        view.fitAll()
+        VibeCADSectionView.reset_section_view_settings()
+        VibeCADSectionView.set_section_view(True, view=view, document=self.document)
+        self._process_events()
+        widget = view.graphicsView().viewport()
+        # Just inside the guide's padded corner, outside the model and gizmo.
+        point = view.getPointOnScreen(App.Vector(-0.8, -0.4, 5))
+        start = QtCore.QPoint(int(point[0]), widget.height() - 1 - int(point[1]))
+        finish = start + QtCore.QPoint(0, -40)
+        box = self.document.getObject("SectionBox")
+        placement = box.Placement
+        undo = self.document.UndoCount
+        for kind, position, button, buttons in (
+            (QtCore.QEvent.MouseButtonPress, start, QtCore.Qt.LeftButton, QtCore.Qt.LeftButton),
+            (QtCore.QEvent.MouseMove, finish, QtCore.Qt.NoButton, QtCore.Qt.LeftButton),
+            (QtCore.QEvent.MouseButtonRelease, finish, QtCore.Qt.LeftButton, QtCore.Qt.NoButton),
+        ):
+            event = QtGui.QMouseEvent(kind, QtCore.QPointF(position),
+                                     QtCore.QPointF(widget.mapToGlobal(position)),
+                                     button, buttons, QtCore.Qt.NoModifier)
+            QtCore.QCoreApplication.sendEvent(widget, event)
+        self._process_events()
+        self.assertNotAlmostEqual(VibeCADSectionView.current_section_view_settings().offset, 0)
+        self.assertEqual(box.Placement, placement)
+        self.assertEqual(self.document.UndoCount, undo)
+
+    def test_scene_helpers_do_not_expand_section_bounds(self):
+        from pivy import coin
+
+        view = Gui.ActiveDocument.ActiveView
+        scene = view.getSceneGraph()
+        helper = coin.SoSeparator()
+        # A visible grid/datum is scene geometry, but is not model geometry.
+        cube = coin.SoCube()
+        cube.width = 45000
+        cube.height = 45000
+        cube.depth = 1
+        helper.addChild(cube)
+        scene.addChild(helper)
+        try:
+            bounds = VibeCADSectionView._render_bounds(view)
+            self.assertIsNotNone(bounds)
+            self.assertAlmostEqual(bounds.xmin, 0, places=3)
+            self.assertAlmostEqual(bounds.xmax, 40, places=3)
+            self.assertAlmostEqual(bounds.ymax, 20, places=3)
+            self.assertAlmostEqual(bounds.zmax, 10, places=3)
+            import VibeCADSectionViewGui as panel
+            VibeCADSectionView.reset_section_view_settings()
+            VibeCADSectionView.configure_section_view(plane="right")
+            VibeCADSectionView.set_section_view(True, view=view, document=self.document)
+            dialog = panel.show_section_view_dialog()
+            self.assertAlmostEqual(dialog.offset_spin.minimum(), -20, places=3)
+            self.assertAlmostEqual(dialog.offset_spin.maximum(), 20, places=3)
+        finally:
+            scene.removeChild(helper)
 
     def test_section_queries_are_safe_after_native_view_deletion(self):
         view = Gui.ActiveDocument.ActiveView

--- a/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
@@ -944,3 +944,49 @@ def test_look_direction_reads_indexable_vectors() -> None:
     assert section.initial_section_settings(
         section._view_look_direction(view)
     ).plane == "right"
+
+
+def test_closing_section_document_releases_scene_before_view_destruction(monkeypatch):
+    owner = object()
+    other = object()
+    view = _View(clipped=True)
+    calls = []
+    monkeypatch.setattr(section, "_dragger_view", view, raising=False)
+    monkeypatch.setattr(section, "_dragger_document", owner, raising=False)
+    monkeypatch.setattr(section, "_stop_selection_snap", lambda: calls.append("selection"))
+    monkeypatch.setattr(section, "_close_ui", lambda: calls.append("dialog"))
+    monkeypatch.setattr(section, "_remove_overlay", lambda v: calls.append(("overlay", v)))
+    monkeypatch.setattr(section, "_remove_dragger", lambda v: calls.append(("dragger", v)))
+    observer = section._SectionViewDocumentObserver()
+    observer.slotDeletedDocument(SimpleNamespace(Document=other))
+    assert calls == []
+    observer.slotDeletedDocument(SimpleNamespace(Document=owner))
+    assert calls == ["selection", ("dragger", view), ("overlay", view), "dialog"]
+    assert section._dragger_view is None
+    assert section._dragger_document is None
+
+
+def test_section_poll_pauses_when_another_document_is_active(monkeypatch):
+    owner = object()
+    calls = []
+    monkeypatch.setattr(section, "_dragger_document", owner)
+    monkeypatch.setattr(section, "_dragger_node", object())
+    monkeypatch.setattr(section, "_stop_dragger_poll", lambda: calls.append("stop"))
+    monkeypatch.setattr(section, "_start_dragger_poll", lambda: calls.append("start"))
+    observer = section._SectionViewDocumentObserver()
+    observer.slotActivateDocument(SimpleNamespace(Document=object()))
+    observer.slotActivateDocument(SimpleNamespace(Document=owner))
+    assert calls == ["stop", "start"]
+
+
+def test_new_section_view_releases_previous_scene_first(monkeypatch):
+    previous = _View(clipped=True)
+    current = _View()
+    calls = []
+    monkeypatch.setattr(section, "_dragger_view", previous)
+    monkeypatch.setattr(section, "set_section_view", lambda value, **kw: calls.append((value, kw["view"])))
+    monkeypatch.setattr(section, "section_view_placement", lambda *_: object())
+    monkeypatch.setattr(section, "_sync_overlay", lambda *_a, **_kw: calls.append("overlay"))
+    monkeypatch.setattr(section, "_sync_dragger", lambda *_a, **_kw: calls.append("dragger"))
+    section._apply_clip(current, None, section.SectionViewSettings())
+    assert calls == [(False, previous), "overlay", "dragger"]

--- a/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
@@ -69,6 +69,8 @@ def _reset_section_settings() -> None:
     section._dragger_node = None
     section._dragger_busy = False
     section._triad_parts = None
+    section._bounds_view = None
+    section._section_bounds = None
     yield
     section.reset_section_view_settings()
     section._overlay_node = None
@@ -76,6 +78,8 @@ def _reset_section_settings() -> None:
     section._dragger_node = None
     section._dragger_busy = False
     section._triad_parts = None
+    section._bounds_view = None
+    section._section_bounds = None
 
 
 def test_bounds_center_combines_valid_shape_boxes() -> None:
@@ -160,8 +164,8 @@ def test_set_section_view_uses_a_clean_clip_without_a_coin_manipulator(
     placement = object()
     monkeypatch.setattr(
         section,
-        "section_view_placement",
-        lambda document=None, settings=None: placement,
+        "_placement_from_bounds",
+        lambda settings, bounds: placement,
     )
 
     assert section.set_section_view(True, view=view) == {"section_view": True}
@@ -182,11 +186,11 @@ def test_configure_section_view_reapplies_a_live_cut(monkeypatch) -> None:
     view = _View(clipped=False)
     seen: list[object] = []
 
-    def fake_placement(document=None, settings=None):
+    def fake_placement(settings, bounds):
         seen.append(settings)
         return object()
 
-    monkeypatch.setattr(section, "section_view_placement", fake_placement)
+    monkeypatch.setattr(section, "_placement_from_bounds", fake_placement)
     section.set_section_view(True, view=view)
     section.configure_section_view(plane="top", offset=8.0, flipped=True, view=view)
 
@@ -683,7 +687,7 @@ def test_preview_clip_does_not_rebuild_scene_overlay(monkeypatch) -> None:
     calls: list[str] = []
     monkeypatch.setattr(section, "_update_clip_plane", lambda *_a, **_k: True)
     monkeypatch.setattr(section, "is_section_view_active", lambda view=None: True)
-    monkeypatch.setattr(section, "section_view_placement", lambda *_a, **_k: object())
+    monkeypatch.setattr(section, "_placement_from_bounds", lambda *_a, **_k: object())
     monkeypatch.setattr(
         section, "_sync_overlay", lambda *_a, **_k: calls.append("overlay")
     )
@@ -914,7 +918,7 @@ def test_look_direction_is_read_from_getViewDirection() -> None:
 def test_toggle_starts_on_the_active_view_plane(monkeypatch) -> None:
     front_view = _View(look=(0.0, -1.0, 0.0))
     monkeypatch.setattr(
-        section, "section_view_placement", lambda document=None, settings=None: object()
+        section, "_placement_from_bounds", lambda settings, bounds: object()
     )
     section.toggle_section_view(view=front_view, show_ui=False)
     assert section.current_section_view_settings().plane == "front"
@@ -985,8 +989,32 @@ def test_new_section_view_releases_previous_scene_first(monkeypatch):
     calls = []
     monkeypatch.setattr(section, "_dragger_view", previous)
     monkeypatch.setattr(section, "set_section_view", lambda value, **kw: calls.append((value, kw["view"])))
-    monkeypatch.setattr(section, "section_view_placement", lambda *_: object())
+    monkeypatch.setattr(section, "_placement_from_bounds", lambda *_: object())
     monkeypatch.setattr(section, "_sync_overlay", lambda *_a, **_kw: calls.append("overlay"))
     monkeypatch.setattr(section, "_sync_dragger", lambda *_a, **_kw: calls.append("dragger"))
     section._apply_clip(current, None, section.SectionViewSettings())
     assert calls == [(False, previous), "overlay", "dragger"]
+
+
+def test_drag_preview_reuses_bounds_instead_of_rescanning_document(monkeypatch):
+    view = _View(clipped=True)
+    bounds = section.ModelBounds(0, 10, 0, 20, 0, 30)
+    monkeypatch.setattr(section, "_bounds_view", view, raising=False)
+    monkeypatch.setattr(section, "_section_bounds", bounds, raising=False)
+    monkeypatch.setattr(section, "_placement_from_bounds", lambda settings, cached: cached, raising=False)
+    monkeypatch.setattr(section, "model_bounds", lambda *_: pytest.fail("Preview rescanned document shapes"))
+    monkeypatch.setattr(section, "_update_clip_plane", lambda v, placement: placement is bounds)
+    section._apply_clip(view, None, section.SectionViewSettings(), preview=True)
+
+
+def test_full_section_update_refreshes_cached_bounds_once(monkeypatch):
+    view = _View(clipped=True)
+    bounds = section.ModelBounds(0, 10, 0, 20, 0, 30)
+    calls = []
+    monkeypatch.setattr(section, "model_bounds", lambda *_: calls.append("bounds") or bounds)
+    monkeypatch.setattr(section, "_placement_from_bounds", lambda *_: object(), raising=False)
+    monkeypatch.setattr(section, "_update_clip_plane", lambda *_: True)
+    monkeypatch.setattr(section, "_sync_overlay", lambda *_a, **_k: calls.append(section._bounds_for_view(view, None)))
+    monkeypatch.setattr(section, "_sync_dragger", lambda *_a, **_k: calls.append(section._bounds_for_view(view, None)))
+    section._apply_clip(view, None, section.SectionViewSettings())
+    assert calls == ["bounds", bounds, bounds]

--- a/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
@@ -530,7 +530,10 @@ def test_sync_overlay_installs_hatched_caps_not_just_the_section_plane(monkeypat
         spacing=5.0,
     )
     monkeypatch.setattr(section, "model_bounds", lambda _objects: section.ModelBounds(0, 40, 0, 20, 0, 10))
-    monkeypatch.setattr(section, "section_cap_geometry_from_objects", lambda *_a, **_k: caps)
+    monkeypatch.setattr(
+        section, "_schedule_cap_build",
+        lambda coin, view, *_args: section._install_cap_node(coin, view.getSceneGraph(), caps),
+    )
     monkeypatch.setattr(
         section,
         "_document_objects",
@@ -1018,3 +1021,204 @@ def test_full_section_update_refreshes_cached_bounds_once(monkeypatch):
     monkeypatch.setattr(section, "_sync_dragger", lambda *_a, **_k: calls.append(section._bounds_for_view(view, None)))
     section._apply_clip(view, None, section.SectionViewSettings())
     assert calls == ["bounds", bounds, bounds]
+
+
+def test_cap_schedule_uses_native_display_without_document_shape_copy(monkeypatch):
+    import sys
+    backend = _NativeSectionBackend()
+    backend.sectionDisplaySizes = lambda handle: (0, 0, 0)
+    backend.readSectionDisplay = lambda *args: ()
+    monkeypatch.setitem(sys.modules, "PartGui", backend)
+    monkeypatch.setattr(section, "App", SimpleNamespace(Vector=lambda *xyz: xyz))
+    monkeypatch.setattr(section, "_cap_worker", None)
+    snapshots, published = [], []
+
+    def capture(view):
+        snapshots.append(view)
+        yield ("cached-shape", "display-matrix")
+
+    monkeypatch.setattr(section, "_rendered_section_snapshot_steps", capture)
+    monkeypatch.setattr(section, "iter_sectionable_shapes", lambda *args: pytest.fail("live shape access"))
+    monkeypatch.setattr(section, "_scene_from_view", lambda view: "scene")
+    monkeypatch.setattr(section, "_install_cap_node_steps", lambda *args: published.append(args[-1]))
+    view = object()
+    section._schedule_cap_build(None, view, object(), (0, 0, 0), (0, 0, 1), 1.0)
+    assert not snapshots
+    assert not backend.requests
+    backend.queued.pop(0)()
+    assert snapshots == [view]
+    assert backend.requests[-1][1] == [("cached-shape", "display-matrix")]
+    backend.requests[-1][-1](object(), "")
+    assert len(published) == 1
+    assert not published[0].triangles
+
+
+def test_removing_overlay_cancels_pending_caps(monkeypatch):
+    cancelled = []
+    monkeypatch.setattr(section, "_cap_worker", SimpleNamespace(cancel=lambda: cancelled.append(True)), raising=False)
+    section._remove_overlay(_View())
+    assert cancelled == [True]
+
+
+@pytest.mark.parametrize("kind", ["points", "indexes"])
+def test_cap_scene_writes_yield_before_large_buffers_finish(kind):
+    writes = []
+    field = SimpleNamespace(set1Value=lambda *args: writes.append(args))
+    if kind == "points":
+        steps = section._write_points_steps(SimpleNamespace(point=field), [(1, 2, 3)] * 700)
+    else:
+        steps = section._write_indexes_steps(SimpleNamespace(coordIndex=field), list(range(700)))
+    next(steps)
+    assert 0 < len(writes) <= 256
+    list(steps)
+    assert len(writes) == 700
+
+
+def test_model_change_invalidates_inflight_cap_snapshot(monkeypatch):
+    owner = object()
+    cancelled = []
+    monkeypatch.setattr(section, "_dragger_document", owner)
+    monkeypatch.setattr(section, "_cap_dirty", False, raising=False)
+    monkeypatch.setattr(section, "_cap_worker", SimpleNamespace(cancel=lambda: cancelled.append(True)))
+    observer = section._SectionCapDocumentObserver()
+    observer.slotChangedObject(SimpleNamespace(Document=object()), "Shape")
+    observer.slotChangedObject(SimpleNamespace(Document=owner), "Label")
+    assert cancelled == []
+    observer.slotChangedObject(SimpleNamespace(Document=owner), "Shape")
+    assert cancelled == [True]
+    assert section._cap_dirty
+
+
+def test_section_enable_uses_render_bounds_without_shape_scan(monkeypatch):
+    view = _View(clipped=True)
+    bounds = section.ModelBounds(0, 10, 0, 20, 0, 30)
+    monkeypatch.setattr(section, "_render_bounds", lambda v: bounds, raising=False)
+    monkeypatch.setattr(section, "model_bounds", lambda *_: pytest.fail("Render section traversed document shapes"))
+    monkeypatch.setattr(section, "_placement_from_bounds", lambda settings, cached: cached)
+    monkeypatch.setattr(section, "_update_clip_plane", lambda v, placement: placement is bounds)
+    monkeypatch.setattr(section, "_sync_overlay", lambda *_a, **_kw: None)
+    monkeypatch.setattr(section, "_sync_dragger", lambda *_a, **_kw: None)
+    section._apply_clip(view, None, section.SectionViewSettings())
+    assert section._section_bounds == bounds
+
+
+def test_idle_dragger_does_not_request_repeated_scene_redraws(monkeypatch):
+    writes = []
+    sizes = iter((3.0, 3.0, 3.00000001, 4.0))
+    monkeypatch.setattr(section, "_dragger_node", object())
+    monkeypatch.setattr(section, "_last_dragger_scale", None, raising=False)
+    monkeypatch.setattr(section, "world_scale_for_ndc", lambda *_: next(sizes))
+    monkeypatch.setattr(section, "_set_scale_factor", lambda node, scale: writes.append(scale) or True)
+    for _ in range(4):
+        section._autoscale_dragger(object(), (0, 0, 0))
+    assert writes == [3.0, 4.0]
+
+
+def test_solid_check_does_not_materialize_every_solid_wrapper():
+    class Shape:
+        def isNull(self):
+            return False
+
+        def countElement(self, kind):
+            assert kind == "Solid"
+            return 4000
+
+        @property
+        def Solids(self):
+            pytest.fail("A visibility check materialized thousands of solids")
+
+    assert section._shape_has_solids(Shape())
+
+
+def test_native_display_sequences_fetch_bounded_chunks_lazily():
+    handle = object()
+    calls = []
+    values = tuple(((float(i), 0., 0.), (float(i), 1., 0.)) for i in range(600))
+
+    def read(actual_handle, kind, first, count):
+        assert actual_handle is handle
+        assert kind == "hatch"
+        assert count <= 256
+        calls.append((first, count))
+        return values[first:first + count]
+
+    primitives = section._SectionDisplaySequence(handle, "hatch", 600, read)
+    assert len(primitives) == 600
+    assert bool(primitives)
+    assert calls == []
+    iterator = iter(primitives)
+    assert next(iterator) == values[0]
+    assert calls == [(0, 256)]
+    assert tuple(iterator) == values[1:]
+    assert calls == [(0, 256), (256, 256), (512, 88)]
+    assert tuple(primitives) == values
+
+
+def test_empty_native_display_sequence_does_not_read():
+    def read(*args):
+        pytest.fail("empty geometry must not fetch a chunk")
+
+    primitives = section._SectionDisplaySequence(object(), "triangles", 0, read)
+    assert not primitives
+    assert tuple(primitives) == ()
+
+
+class _NativeSectionBackend:
+    def __init__(self):
+        self.queued = []
+        self.requests = []
+        self.cancelled = 0
+
+    def createSectionFaceController(self):
+        return object()
+
+    def cancelSectionFaces(self, handle):
+        self.cancelled += 1
+
+    def _deferSectionDisplay(self, callback):
+        self.queued.append(callback)
+        return True
+
+    def requestSectionDisplay(self, *args):
+        self.requests.append(args)
+
+
+def test_native_cap_worker_cancels_capture_and_rejects_stale_delivery():
+    backend = _NativeSectionBackend()
+    worker = section._NativeSectionCapWorker(backend)
+    published = []
+    worker.request(iter([("old", "matrix")]), (0, 0, 0), (0, 0, 1), 1, published.append)
+    assert not backend.requests
+    worker.cancel()
+    backend.queued.pop(0)()
+    assert not backend.requests
+    worker.request(iter([("new", "matrix")]), (0, 0, 0), (0, 0, 1), 1, published.append)
+    backend.queued.pop(0)()
+    assert backend.requests[-1][1] == [("new", "matrix")]
+    callback = backend.requests[-1][-1]
+    worker.cancel()
+    callback(object(), "")
+    assert published == []
+    assert not worker._running
+
+
+def test_native_cap_worker_adoption_yields_and_cancels():
+    backend = _NativeSectionBackend()
+    worker = section._NativeSectionCapWorker(backend)
+    adopted = []
+
+    def publish(handle):
+        adopted.append("started")
+        yield
+        adopted.append("finished")
+
+    worker.request(iter([]), (0, 0, 0), (0, 0, 1), 1, publish)
+    backend.queued.pop(0)()
+    backend.requests[-1][-1](object(), "")
+    assert adopted == []
+    backend.queued.pop(0)()
+    assert adopted == ["started"]
+    worker.cancel()
+    backend.queued.pop(0)()
+    assert adopted == ["started"]
+    assert not worker._running

--- a/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
@@ -1222,3 +1222,20 @@ def test_native_cap_worker_adoption_yields_and_cancels():
     backend.queued.pop(0)()
     assert adopted == ["started"]
     assert not worker._running
+
+
+def test_native_cap_worker_keeps_valid_caps_when_another_solid_fails(monkeypatch):
+    backend = _NativeSectionBackend()
+    worker = section._NativeSectionCapWorker(backend)
+    warnings, published = [], []
+    monkeypatch.setattr(section, "App", SimpleNamespace(
+        Console=SimpleNamespace(PrintWarning=warnings.append),
+    ))
+    worker.request(iter([]), (0, 0, 0), (0, 0, 1), 1, published.append)
+    backend.queued.pop(0)()
+    geometry = object()
+    backend.requests[-1][-1](geometry, "invalid solid")
+    assert published == [geometry]
+    assert len(warnings) == 1
+    assert "invalid solid" in warnings[0]
+    assert not worker._running

--- a/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from math import cos, radians, sin
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -35,9 +36,13 @@ class _Object:
 
 
 class _View:
-    def __init__(self, clipped=False):
+    def __init__(self, clipped=False, look=(0.0, 0.0, -1.0)):
         self.clipped = clipped
         self.calls: list[dict] = []
+        self._look = look
+
+    def getViewDirection(self):
+        return self._look
 
     def hasClippingPlane(self) -> bool:
         return self.clipped
@@ -59,8 +64,18 @@ class _View:
 @pytest.fixture(autouse=True)
 def _reset_section_settings() -> None:
     section.reset_section_view_settings()
+    section._overlay_node = None
+    section._cap_node = None
+    section._dragger_node = None
+    section._dragger_busy = False
+    section._triad_parts = None
     yield
     section.reset_section_view_settings()
+    section._overlay_node = None
+    section._cap_node = None
+    section._dragger_node = None
+    section._dragger_busy = False
+    section._triad_parts = None
 
 
 def test_bounds_center_combines_valid_shape_boxes() -> None:
@@ -91,12 +106,12 @@ def test_toggle_requires_an_active_3d_view() -> None:
         section.toggle_section_view(view=None)
 
 
-def test_principal_planes_match_solidworks_and_fusion() -> None:
-    assert section.section_plane_normal("front") == (0.0, 0.0, 1.0)
-    assert section.section_plane_normal("top") == (0.0, 1.0, 0.0)
+def test_principal_planes_match_vibecad_top_front_right_views() -> None:
+    assert section.section_plane_normal("front") == (0.0, 1.0, 0.0)
+    assert section.section_plane_normal("top") == (0.0, 0.0, 1.0)
     assert section.section_plane_normal("right") == (1.0, 0.0, 0.0)
-    assert section.section_plane_normal("front", flipped=True) == (0.0, 0.0, -1.0)
-    assert section.section_plane_normal("top", flipped=True) == (0.0, -1.0, 0.0)
+    assert section.section_plane_normal("front", flipped=True) == (0.0, -1.0, 0.0)
+    assert section.section_plane_normal("top", flipped=True) == (0.0, 0.0, -1.0)
     assert section.section_plane_normal("right", flipped=True) == (-1.0, 0.0, 0.0)
     with pytest.raises(ValueError, match="front, top, or right"):
         section.section_plane_normal("camera")
@@ -104,7 +119,7 @@ def test_principal_planes_match_solidworks_and_fusion() -> None:
 
 def test_clip_plane_origin_offsets_along_the_section_normal() -> None:
     center = (10.0, 4.0, 2.0)
-    settings = section.SectionViewSettings(plane="front", offset=5.0)
+    settings = section.SectionViewSettings(plane="top", offset=5.0)
     origin, normal = section.clip_plane_from_settings(settings, center)
     assert normal == (0.0, 0.0, 1.0)
     assert origin == (10.0, 4.0, 7.0)
@@ -120,8 +135,8 @@ def test_offset_range_follows_the_selected_axis_extent() -> None:
         (_Object(_Box(0.0, 20.0, -4.0, 4.0, -10.0, 10.0)),)
     )
     assert bounds is not None
-    assert section.section_offset_range(bounds, "front") == (-10.0, 10.0)
-    assert section.section_offset_range(bounds, "top") == (-4.0, 4.0)
+    assert section.section_offset_range(bounds, "front") == (-4.0, 4.0)
+    assert section.section_offset_range(bounds, "top") == (-10.0, 10.0)
     assert section.section_offset_range(bounds, "right") == (-10.0, 10.0)
 
 
@@ -219,15 +234,24 @@ def test_section_view_dialog_matches_solidworks_and_fusion_controls() -> None:
     ).read_text(encoding="utf-8")
     assert "class SectionViewDialog" in gui
     assert 'setObjectName("VibeCADSectionViewDialog")' in gui
-    assert "Front (XY)" in gui
-    assert "Top (XZ)" in gui
-    assert "Right (YZ)" in gui
+    assert 'setObjectName("sectionPlaneLabel")' in gui
+    assert "sectionOffset" in gui
     assert "Flip" in gui
-    assert "Offset" in gui
+    assert "planeFront" not in gui
+    assert "sectionPitch" not in gui
+    assert "Tilt X" not in gui
+    assert "VibeCADSectionDragger" in helper
+    assert "SoTransformDragger" in helper
+    assert "apply_world_rotation" in helper
     assert "noManip=True" in helper or "noManip=True" in gui
     assert "SoClipPlaneManip" not in helper
     assert "show_section_view_dialog" in gui
     assert "close_section_view_dialog" in gui
+    assert "RightDockWidgetArea" in gui
+    assert "tabifyDockWidget" in gui
+    assert "Std_TaskView" in gui
+    assert "VibeCADAssistantPanel" in gui
+    assert 'setObjectName("VibeCADSectionViewDock")' in gui
 
 
 class _RejectingSbVec3f:
@@ -305,3 +329,618 @@ def test_install_overlay_writes_corners_as_three_floats() -> None:
     section._install_overlay_node(coin, _Scene(), corners)
     assert [item[0] for item in recorded[:4]] == [0, 1, 2, 3]
     assert all(len(item[1]) == 3 for item in recorded[:4])
+
+
+def test_section_plane_distance_is_the_plane_equation() -> None:
+    assert section.section_plane_distance((10.0, 4.0, 7.0), (0.0, 0.0, 1.0)) == 7.0
+    assert section.section_plane_distance((8.0, 4.0, 2.0), (1.0, 0.0, 0.0)) == 8.0
+    assert section.section_plane_distance((1.0, 2.0, 3.0), (0.0, -1.0, 0.0)) == -2.0
+
+
+def test_hatch_spacing_scales_with_model_size() -> None:
+    small = section.ModelBounds(0.0, 10.0, 0.0, 4.0, 0.0, 2.0)
+    large = section.ModelBounds(0.0, 180.0, 0.0, 90.0, 0.0, 40.0)
+    assert section.hatch_spacing_for_bounds(None) == pytest.approx(2.5)
+    assert section.hatch_spacing_for_bounds(small) >= 0.5
+    assert section.hatch_spacing_for_bounds(large) > section.hatch_spacing_for_bounds(small)
+
+
+def _point_in_rectangle(point, xmin, xmax, ymin, ymax, eps=1e-8) -> bool:
+    return xmin - eps <= point[0] <= xmax + eps and ymin - eps <= point[1] <= ymax + eps
+
+
+def test_hatch_segments_fill_a_rectangle_at_forty_five_degrees() -> None:
+    loop = ((0.0, 0.0), (40.0, 0.0), (40.0, 20.0), (0.0, 20.0))
+    segments = section.hatch_segments_for_loops((loop,), spacing=5.0, angle_deg=45.0)
+    assert len(segments) >= 6
+    for start, end in segments:
+        assert _point_in_rectangle(start, 0.0, 40.0, 0.0, 20.0)
+        assert _point_in_rectangle(end, 0.0, 40.0, 0.0, 20.0)
+        dx = end[0] - start[0]
+        dy = end[1] - start[1]
+        length = (dx * dx + dy * dy) ** 0.5
+        assert length > 0.5
+        assert abs(dx / length - dy / length) < 1e-6
+
+
+def test_hatch_segments_do_not_enter_a_hole() -> None:
+    outer = ((0.0, 0.0), (20.0, 0.0), (20.0, 20.0), (0.0, 20.0))
+    hole = ((7.0, 7.0), (13.0, 7.0), (13.0, 13.0), (7.0, 13.0))
+    segments = section.hatch_segments_for_loops((outer, hole), spacing=2.0, angle_deg=45.0)
+    assert segments
+    for start, end in segments:
+        mid = ((start[0] + end[0]) / 2.0, (start[1] + end[1]) / 2.0)
+        assert not _point_in_rectangle(mid, 7.05, 12.95, 7.05, 12.95)
+
+
+def test_section_caps_are_filled_faces_with_hatch_on_the_cut_plane() -> None:
+    origin = (20.0, 10.0, 5.0)
+    normal = (0.0, 0.0, 1.0)
+    loop = (
+        (0.0, 0.0, 5.0),
+        (40.0, 0.0, 5.0),
+        (40.0, 20.0, 5.0),
+        (0.0, 20.0, 5.0),
+    )
+    caps = section.build_section_cap_geometry((loop,), origin, normal, spacing=5.0)
+    assert len(caps.triangles) >= 2
+    assert caps.hatch
+    assert len(caps.outlines) == 4
+    for triangle in caps.triangles:
+        assert len(triangle) == 3
+        for point in triangle:
+            assert point[2] == pytest.approx(5.0 - section.SECTION_CAP_OFFSET)
+    for start, end in caps.hatch:
+        assert start[2] == pytest.approx(5.0 - section.SECTION_CAP_OFFSET)
+        assert end[2] == pytest.approx(5.0 - section.SECTION_CAP_OFFSET)
+
+
+def test_sectionable_shapes_skip_hidden_and_non_solid_objects() -> None:
+    solid = SimpleNamespace(
+        Visibility=True,
+        ViewObject=SimpleNamespace(Visibility=True),
+        Shape=SimpleNamespace(isNull=lambda: False, Solids=(object(),)),
+    )
+    hidden = SimpleNamespace(
+        Visibility=False,
+        ViewObject=SimpleNamespace(Visibility=True),
+        Shape=SimpleNamespace(isNull=lambda: False, Solids=(object(),)),
+    )
+    shell = SimpleNamespace(
+        Visibility=True,
+        ViewObject=SimpleNamespace(Visibility=True),
+        Shape=SimpleNamespace(isNull=lambda: False, Solids=()),
+    )
+    parent = SimpleNamespace(
+        Visibility=True,
+        ViewObject=SimpleNamespace(Visibility=True),
+        Shape=SimpleNamespace(isNull=lambda: False, Solids=(object(),)),
+    )
+    child = SimpleNamespace(
+        Visibility=True,
+        ViewObject=SimpleNamespace(Visibility=True),
+        Shape=SimpleNamespace(isNull=lambda: False, Solids=(object(),)),
+        getParentGeoFeatureGroup=lambda: parent,
+    )
+    hidden_parent = SimpleNamespace(
+        Visibility=False,
+        ViewObject=SimpleNamespace(Visibility=False),
+        Shape=SimpleNamespace(isNull=lambda: False, Solids=(object(),)),
+    )
+    visible_child = SimpleNamespace(
+        Visibility=True,
+        ViewObject=SimpleNamespace(Visibility=True),
+        Shape=SimpleNamespace(isNull=lambda: False, Solids=(object(),)),
+        getParentGeoFeatureGroup=lambda: hidden_parent,
+    )
+    assert section.iter_sectionable_shapes((solid, hidden, shell, child, visible_child)) == (
+        solid.Shape,
+        visible_child.Shape,
+    )
+
+
+def test_sync_overlay_installs_hatched_caps_not_just_the_section_plane(monkeypatch) -> None:
+    recorded_names: list[str] = []
+    inserted: list[object] = []
+    recorded: list[tuple[int, tuple[float, ...]]] = []
+
+    class _Points:
+        def set1Value(self, index, *xyz) -> None:
+            recorded.append((int(index), tuple(float(v) for v in xyz)))
+
+    class _Node:
+        BASE_COLOR = "base"
+        LINES = "lines"
+        COUNTERCLOCKWISE = "ccw"
+        UNKNOWN_ORDERING = "unknown_order"
+        UNKNOWN_SHAPE_TYPE = "unknown"
+        UNKNOWN_FACE_TYPE = "unknown_face"
+
+        def __init__(self) -> None:
+            self.point = _Points()
+            self.coordIndex = _Points()
+            self.model = None
+            self.diffuseColor = SimpleNamespace(setValue=lambda *_a: None)
+            self.transparency = SimpleNamespace(setValue=lambda *_a: None)
+            self.emissiveColor = SimpleNamespace(setValue=lambda *_a: None)
+            self.style = None
+            self.lineWidth = None
+            self.vertexOrdering = None
+            self.shapeType = None
+            self.faceType = None
+            self._name = ""
+            self.children: list[object] = []
+
+        def setName(self, name) -> None:
+            self._name = str(name)
+            recorded_names.append(self._name)
+
+        def addChild(self, child) -> None:
+            self.children.append(child)
+
+    class _Scene:
+        def __init__(self) -> None:
+            self.children: list[object] = []
+
+        def insertChild(self, node, index) -> None:
+            inserted.append(node)
+            self.children.insert(int(index), node)
+
+        def findChild(self, node) -> int:
+            try:
+                return self.children.index(node)
+            except ValueError:
+                return -1
+
+        def removeChild(self, node) -> None:
+            if node in self.children:
+                self.children.remove(node)
+
+        def getChildren(self):
+            return tuple(self.children)
+
+    coin = SimpleNamespace(
+        SoSeparator=_Node,
+        SoLightModel=_Node,
+        SoMaterial=_Node,
+        SoCoordinate3=_Node,
+        SoIndexedFaceSet=_Node,
+        SoIndexedLineSet=_Node,
+        SoDrawStyle=_Node,
+        SoShapeHints=_Node,
+        SbVec3f=_RejectingSbVec3f,
+    )
+    scene = _Scene()
+    view = SimpleNamespace(getSceneGraph=lambda: scene)
+    caps = section.build_section_cap_geometry(
+        (
+            (
+                (0.0, 0.0, 5.0),
+                (40.0, 0.0, 5.0),
+                (40.0, 20.0, 5.0),
+                (0.0, 20.0, 5.0),
+            ),
+        ),
+        (20.0, 10.0, 5.0),
+        (0.0, 0.0, 1.0),
+        spacing=5.0,
+    )
+    monkeypatch.setattr(section, "model_bounds", lambda _objects: section.ModelBounds(0, 40, 0, 20, 0, 10))
+    monkeypatch.setattr(section, "section_cap_geometry_from_objects", lambda *_a, **_k: caps)
+    monkeypatch.setattr(
+        section,
+        "_document_objects",
+        lambda _document: (_Object(_Box(0, 40, 0, 20, 0, 10)),),
+    )
+
+    import sys
+    import types
+
+    pivy = types.ModuleType("pivy")
+    pivy.coin = coin
+    monkeypatch.setitem(sys.modules, "pivy", pivy)
+    monkeypatch.setitem(sys.modules, "pivy.coin", coin)
+
+    section._overlay_node = None
+    section._cap_node = None
+    section._sync_overlay(view, None, section.SectionViewSettings(show_plane=True))
+
+    assert "VibeCADSectionPlaneOverlay" in recorded_names
+    assert "VibeCADSectionCapOverlay" in recorded_names
+    assert any(len(item[1]) == 3 for item in recorded[4:])
+    assert len(inserted) == 2
+
+    recorded_names.clear()
+    inserted.clear()
+    section._sync_overlay(view, None, section.SectionViewSettings(show_plane=False))
+    assert "VibeCADSectionPlaneOverlay" not in recorded_names
+    assert "VibeCADSectionCapOverlay" in recorded_names
+
+
+def test_clip_plane_alone_cannot_represent_a_solid_cut() -> None:
+    helper = (REPO / "src/Mod/VibeCAD/VibeCADSectionView.py").read_text(
+        encoding="utf-8"
+    )
+    assert "section_cap_geometry_from_objects" in helper
+    assert "hatch_segments_for_loops" in helper
+    assert "VibeCADSectionCapOverlay" in helper
+
+
+def test_principal_plane_for_axis_picks_the_dominant_world_axis() -> None:
+    assert section.principal_plane_for_axis((1.0, 0.0, 0.0)) == "right"
+    assert section.principal_plane_for_axis((0.0, 1.0, 0.0)) == "front"
+    assert section.principal_plane_for_axis((0.0, 0.0, 1.0)) == "top"
+    assert section.principal_plane_for_axis((-0.2, 0.1, 0.97)) == "top"
+
+
+def test_untilted_top_cs_matches_world_xyz() -> None:
+    u_axis, v_axis, normal = section.section_cs_axes("top")
+    assert u_axis == pytest.approx((1.0, 0.0, 0.0))
+    assert v_axis == pytest.approx((0.0, 1.0, 0.0))
+    assert normal == pytest.approx((0.0, 0.0, 1.0))
+
+
+def test_top_pitch_tilts_the_section_normal() -> None:
+    normal = section.section_plane_normal("top", pitch=30.0)
+    assert normal[0] == pytest.approx(0.0, abs=1e-9)
+    assert normal[2] == pytest.approx(cos(radians(30.0)))
+    assert abs(normal[1]) == pytest.approx(sin(radians(30.0)))
+    assert normal != (0.0, 0.0, 1.0)
+
+
+def test_dragger_z_arrow_slides_offset_on_the_current_plane() -> None:
+    settings = section.SectionViewSettings(plane="top", offset=0.0)
+    updated = section.apply_dragger_translation(
+        settings,
+        origin=(10.0, 4.0, 7.0),
+        center=(10.0, 4.0, 2.0),
+        translation_counts=(0, 0, 4),
+    )
+    assert updated.plane == "top"
+    assert updated.offset == pytest.approx(5.0)
+    assert updated.yaw == 0.0
+    assert updated.pitch == 0.0
+
+
+def test_dragger_x_arrow_switches_to_the_right_plane() -> None:
+    settings = section.SectionViewSettings(plane="top", offset=8.0, yaw=12.0, pitch=-5.0)
+    updated = section.apply_dragger_translation(
+        settings,
+        origin=(13.0, 4.0, 2.0),
+        center=(10.0, 4.0, 2.0),
+        translation_counts=(30, 0, 0),
+    )
+    assert updated.plane == "right"
+    assert updated.offset == pytest.approx(3.0)
+    assert updated.yaw == 0.0
+    assert updated.pitch == 0.0
+
+
+def test_dragger_y_arrow_switches_to_the_front_plane() -> None:
+    settings = section.SectionViewSettings(plane="top")
+    updated = section.apply_dragger_translation(
+        settings,
+        origin=(10.0, 9.0, 2.0),
+        center=(10.0, 4.0, 2.0),
+        translation_counts=(0, 30, 0),
+    )
+    assert updated.plane == "front"
+    assert updated.offset == pytest.approx(5.0)
+
+
+def test_dragger_rotation_rings_change_plane_angle() -> None:
+    settings = section.SectionViewSettings(plane="top", offset=0.0)
+    updated = section.apply_dragger_rotation(
+        settings,
+        origin=(10.0, 4.0, 2.0),
+        center=(10.0, 4.0, 2.0),
+        rotation_counts=(15, -10, 0),
+    )
+    assert updated.pitch == pytest.approx(15.0)
+    assert updated.yaw == pytest.approx(-10.0)
+    assert updated.plane == "top"
+    assert section.section_plane_normal(
+        updated.plane, yaw=updated.yaw, pitch=updated.pitch
+    ) != (0.0, 0.0, 1.0)
+
+
+def test_remove_overlay_keeps_the_datum_dragger() -> None:
+    class _Scene:
+        def __init__(self) -> None:
+            self.children = ["overlay", "dragger"]
+
+        def findChild(self, node) -> int:
+            try:
+                return self.children.index(node)
+            except ValueError:
+                return -1
+
+        def removeChild(self, node) -> None:
+            self.children.remove(node)
+
+    scene = _Scene()
+    view = SimpleNamespace(getSceneGraph=lambda: scene)
+    section._overlay_node = "overlay"
+    section._cap_node = None
+    section._dragger_node = "dragger"
+    section._remove_overlay(view)
+    assert scene.children == ["dragger"]
+    assert section._dragger_node == "dragger"
+
+
+def test_section_gizmo_does_not_register_pivy_dragger_callbacks() -> None:
+    helper = (
+        REPO / "src/Mod/VibeCAD/VibeCADSectionView.py"
+    ).read_text(encoding="utf-8")
+    assert "addStartCallback" not in helper
+    assert "addValueChangedCallback" not in helper
+    assert "addFinishCallback" not in helper
+    assert "_start_dragger_poll" in helper
+    assert "_DRAGGER_NDC_SIZE = 0.03" in helper
+
+
+def test_preview_clip_does_not_rebuild_scene_overlay(monkeypatch) -> None:
+    calls: list[str] = []
+    monkeypatch.setattr(section, "_update_clip_plane", lambda *_a, **_k: True)
+    monkeypatch.setattr(section, "is_section_view_active", lambda view=None: True)
+    monkeypatch.setattr(section, "section_view_placement", lambda *_a, **_k: object())
+    monkeypatch.setattr(
+        section, "_sync_overlay", lambda *_a, **_k: calls.append("overlay")
+    )
+    monkeypatch.setattr(
+        section, "_sync_dragger", lambda *_a, **_k: calls.append("dragger")
+    )
+    view = SimpleNamespace()
+    section._apply_clip(view, None, section.SectionViewSettings(), preview=True)
+    assert calls == []
+    section._apply_clip(view, None, section.SectionViewSettings(), preview=False)
+    assert calls == ["overlay", "dragger"]
+
+
+def test_identity_quaternion_keeps_the_section_normal() -> None:
+    assert section._quat_rotate((0.0, 0.0, 0.0, 1.0), (0.0, 0.0, 1.0)) == pytest.approx(
+        (0.0, 0.0, 1.0)
+    )
+
+
+def test_section_offset_label_names_the_active_axis() -> None:
+    assert "Y" in section.section_offset_label(section.SectionViewSettings(plane="front"))
+    assert "Z" in section.section_offset_label(section.SectionViewSettings(plane="top"))
+    assert "X" in section.section_offset_label(section.SectionViewSettings(plane="right"))
+    tilted = section.SectionViewSettings(plane="top", pitch=25.0)
+    assert "cut" in section.section_offset_label(tilted)
+
+
+def test_orientation_roundtrip_preserves_the_cut_normal() -> None:
+    for plane in ("front", "top", "right"):
+        for yaw, pitch, roll in (
+            (0.0, 0.0, 0.0),
+            (20.0, 0.0, 0.0),
+            (0.0, -35.0, 0.0),
+            (0.0, 0.0, 40.0),
+            (15.0, -20.0, 30.0),
+        ):
+            u_axis, _v_axis, normal = section.section_cs_axes(
+                plane, False, yaw, pitch, roll
+            )
+            yaw2, pitch2, roll2 = section.orientation_from_axes(
+                plane, False, u_axis, normal
+            )
+            _u2, _v2, normal2 = section.section_cs_axes(
+                plane, False, yaw2, pitch2, roll2
+            )
+            assert normal2 == pytest.approx(normal, abs=1.0e-6)
+            u2, _v2, _n2 = section.section_cs_axes(plane, False, yaw2, pitch2, roll2)
+            assert u2 == pytest.approx(u_axis, abs=1.0e-5)
+
+
+def test_world_rotation_tilts_instead_of_snapping_to_a_principal_plane() -> None:
+    settings = section.SectionViewSettings(plane="top", offset=0.0)
+    u_axis, _v_axis, normal = section.section_cs_axes("top", False, 0.0, 25.0, 0.0)
+    # Quaternion mapping +Z to the tilted normal and +X to u.
+    quat = _axes_to_quat(u_axis, _cross(normal, u_axis), normal)
+    updated = section.apply_world_rotation(
+        settings,
+        origin=(10.0, 4.0, 2.0),
+        center=(10.0, 4.0, 2.0),
+        quat=quat,
+    )
+    assert updated.plane == "top"
+    assert abs(updated.pitch) > 10.0
+    tilted = section.section_plane_normal(
+        updated.plane, yaw=updated.yaw, pitch=updated.pitch, roll=updated.roll
+    )
+    assert tilted == pytest.approx(normal, abs=1.0e-5)
+
+
+def _cross(left, right):
+    return (
+        left[1] * right[2] - left[2] * right[1],
+        left[2] * right[0] - left[0] * right[2],
+        left[0] * right[1] - left[1] * right[0],
+    )
+
+
+def _axes_to_quat(u_axis, v_axis, normal):
+    m00, m01, m02 = u_axis[0], v_axis[0], normal[0]
+    m10, m11, m12 = u_axis[1], v_axis[1], normal[1]
+    m20, m21, m22 = u_axis[2], v_axis[2], normal[2]
+    trace = m00 + m11 + m22
+    if trace > 0.0:
+        scale = (trace + 1.0) ** 0.5 * 2.0
+        w = 0.25 * scale
+        x = (m21 - m12) / scale
+        y = (m02 - m20) / scale
+        z = (m10 - m01) / scale
+    elif m00 > m11 and m00 > m22:
+        scale = (1.0 + m00 - m11 - m22) ** 0.5 * 2.0
+        w = (m21 - m12) / scale
+        x = 0.25 * scale
+        y = (m01 + m10) / scale
+        z = (m02 + m20) / scale
+    elif m11 > m22:
+        scale = (1.0 + m11 - m00 - m22) ** 0.5 * 2.0
+        w = (m02 - m20) / scale
+        x = (m01 + m10) / scale
+        y = 0.25 * scale
+        z = (m12 + m21) / scale
+    else:
+        scale = (1.0 + m22 - m00 - m11) ** 0.5 * 2.0
+        w = (m10 - m01) / scale
+        x = (m02 + m20) / scale
+        y = (m12 + m21) / scale
+        z = 0.25 * scale
+    return (x, y, z, w)
+
+
+def test_tiny_axis_jitter_does_not_switch_planes() -> None:
+    settings = section.SectionViewSettings(plane="top", offset=5.0)
+    updated = section.apply_dragger_translation(
+        settings,
+        origin=(10.1, 4.0, 7.0),
+        center=(10.0, 4.0, 2.0),
+        translation_counts=(1, 0, 0),
+    )
+    assert updated.plane == "top"
+
+
+def test_section_plane_from_view_picks_nearest_parallel_and_keeps_the_far_half() -> None:
+    plane, flipped = section.section_plane_from_view_direction((0.0, 0.0, -1.0))
+    assert plane == "top"
+    assert flipped is False
+    plane, flipped = section.section_plane_from_view_direction((0.0, 0.0, 1.0))
+    assert plane == "top"
+    assert flipped is True
+    plane, flipped = section.section_plane_from_view_direction((0.0, -1.0, 0.0))
+    assert plane == "front"
+    assert flipped is False
+    plane, flipped = section.section_plane_from_view_direction((1.0, 0.0, 0.0))
+    assert plane == "right"
+    assert flipped is True
+
+
+def test_initial_settings_follow_the_camera_look_direction() -> None:
+    settings = section.initial_section_settings((0.2, 0.9, 0.1))
+    assert settings.plane == "front"
+    assert settings.offset == 0.0
+
+
+def test_world_rotation_does_not_reverse_the_kept_half() -> None:
+    settings = section.SectionViewSettings(plane="top", flipped=False)
+    opposite = section._quat_rotate((1.0, 0.0, 0.0, 0.0), (0.0, 0.0, 1.0))
+    assert opposite[2] == pytest.approx(-1.0)
+    updated = section.apply_world_rotation(
+        settings,
+        origin=(10.0, 4.0, 2.0),
+        center=(10.0, 4.0, 2.0),
+        quat=(1.0, 0.0, 0.0, 0.0),
+    )
+    normal = section.section_plane_normal(
+        updated.plane,
+        updated.flipped,
+        updated.yaw,
+        updated.pitch,
+        updated.roll,
+    )
+    assert normal[2] == pytest.approx(1.0, abs=1.0e-5)
+    assert updated.flipped is False
+
+
+def test_offset_through_point_keeps_the_current_plane() -> None:
+    settings = section.SectionViewSettings(plane="top", offset=0.0)
+    offset = section.offset_through_point(settings, (10.0, 4.0, 2.0), (12.0, 8.0, 9.0))
+    assert offset == pytest.approx(7.0)
+    front = section.SectionViewSettings(plane="front")
+    assert section.offset_through_point(front, (10.0, 4.0, 2.0), (12.0, 8.0, 9.0)) == pytest.approx(4.0)
+
+
+def test_snap_point_from_a_hole_uses_the_circle_or_cylinder_center() -> None:
+    edge = SimpleNamespace(
+        ShapeType="Edge",
+        Curve=SimpleNamespace(Center=SimpleNamespace(x=5.0, y=6.0, z=7.0)),
+        CenterOfMass=SimpleNamespace(x=0.0, y=0.0, z=0.0),
+    )
+    face = SimpleNamespace(
+        ShapeType="Face",
+        Surface=SimpleNamespace(
+            Center=SimpleNamespace(x=1.0, y=2.0, z=3.0),
+            Axis=SimpleNamespace(x=0.0, y=0.0, z=1.0),
+        ),
+        CenterOfMass=SimpleNamespace(x=9.0, y=9.0, z=4.0),
+    )
+    vertex = SimpleNamespace(
+        ShapeType="Vertex",
+        Point=SimpleNamespace(x=4.0, y=5.0, z=6.0),
+    )
+    assert section.snap_point_from_shape(edge) == (5.0, 6.0, 7.0)
+    assert section.snap_point_from_shape(face) == (9.0, 9.0, 4.0)
+    assert section.snap_point_from_shape(vertex) == (4.0, 5.0, 6.0)
+
+
+def test_hole_snap_cuts_along_the_hole_depth() -> None:
+    settings = section.SectionViewSettings(plane="top", offset=0.0)
+    # Vertical hole: Top plane would cut a circle; switch to a plane that
+    # contains the hole axis so the cut follows the hole depth.
+    updated = section.apply_feature_snap(
+        settings,
+        model_center=(10.0, 10.0, 5.0),
+        point=(10.0, 10.0, 5.0),
+        axis=(0.0, 0.0, 1.0),
+        view_direction=(0.0, 0.0, -1.0),
+    )
+    assert updated.plane in {"front", "right"}
+    assert updated.plane != "top"
+    assert updated.offset == pytest.approx(0.0)
+    # Already on a plane that contains the axis: keep it and only move offset.
+    along = section.SectionViewSettings(plane="front", offset=0.0)
+    moved = section.apply_feature_snap(
+        along,
+        model_center=(0.0, 0.0, 0.0),
+        point=(4.0, 8.0, 2.0),
+        axis=(0.0, 0.0, 1.0),
+        view_direction=(0.0, -1.0, 0.0),
+    )
+    assert moved.plane == "front"
+    assert moved.offset == pytest.approx(8.0)
+
+
+def test_look_direction_is_read_from_getViewDirection() -> None:
+    view = SimpleNamespace(getViewDirection=lambda: SimpleNamespace(x=0.0, y=-1.0, z=0.0))
+    assert section._view_look_direction(view) == pytest.approx((0.0, -1.0, 0.0))
+    settings = section.initial_section_settings(section._view_look_direction(view))
+    assert settings.plane == "front"
+
+
+def test_toggle_starts_on_the_active_view_plane(monkeypatch) -> None:
+    front_view = _View(look=(0.0, -1.0, 0.0))
+    monkeypatch.setattr(
+        section, "section_view_placement", lambda document=None, settings=None: object()
+    )
+    section.toggle_section_view(view=front_view, show_ui=False)
+    assert section.current_section_view_settings().plane == "front"
+    section.set_section_view(False, view=front_view)
+
+    top_view = _View(look=(0.0, 0.0, -1.0))
+    section.toggle_section_view(view=top_view, show_ui=False)
+    assert section.current_section_view_settings().plane == "top"
+
+
+def test_look_direction_reads_coin_vectors_with_getvalue() -> None:
+    class _CoinVec:
+        def getValue(self):
+            return (0.0, -1.0, 0.0)
+
+    view = SimpleNamespace(getViewDirection=lambda: _CoinVec())
+    assert section._view_look_direction(view) == pytest.approx((0.0, -1.0, 0.0))
+
+
+def test_look_direction_reads_indexable_vectors() -> None:
+    class _IndexVec:
+        def __getitem__(self, index):
+            return (1.0, 0.0, 0.0)[index]
+
+    view = SimpleNamespace(getViewDirection=lambda: _IndexVec())
+    assert section._view_look_direction(view) == pytest.approx((1.0, 0.0, 0.0))
+    assert section.initial_section_settings(
+        section._view_look_direction(view)
+    ).plane == "right"

--- a/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
@@ -1317,3 +1317,16 @@ def test_section_dialog_slider_failure_does_not_disable_further_input(monkeypatc
     with pytest.raises(RuntimeError, match="plane update failed"):
         dialog._offset_slider_changed(10)
     assert not dialog._updating
+
+
+def test_section_state_query_handles_a_deleted_view_wrapper():
+    assert not section.is_section_view_active(_DeletedSectionView())
+
+
+@pytest.mark.parametrize("active", [None, object()])
+def test_dragger_poll_does_not_touch_nodes_without_its_own_active_view(monkeypatch, active):
+    monkeypatch.setattr(section, "_dragger_node", object())
+    monkeypatch.setattr(section, "_dragger_view", object())
+    monkeypatch.setattr(section, "_active_3d_view", lambda: active)
+    monkeypatch.setattr(section, "_current_dragger_origin", lambda: pytest.fail("stale scene access"))
+    section._poll_dragger()

--- a/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
@@ -1239,3 +1239,81 @@ def test_native_cap_worker_keeps_valid_caps_when_another_solid_fails(monkeypatch
     assert len(warnings) == 1
     assert "invalid solid" in warnings[0]
     assert not worker._running
+
+
+class _DeletedSectionView:
+    def __getattribute__(self, name):
+        raise RuntimeError(f"Cannot access attribute '{name}' of deleted object")
+
+
+def test_scene_lookup_handles_a_deleted_view_wrapper():
+    assert section._scene_from_view(_DeletedSectionView()) is None
+
+
+def test_document_close_cleans_section_state_after_view_was_deleted(monkeypatch):
+    document = object()
+    events = []
+    monkeypatch.setattr(section, "_dragger_document", document)
+    monkeypatch.setattr(section, "_dragger_view", _DeletedSectionView())
+    for name in ("_dragger_node", "_overlay_node", "_cap_node"):
+        monkeypatch.setattr(section, name, object())
+    monkeypatch.setattr(section, "_cap_worker", SimpleNamespace(cancel=lambda: events.append("cancel")))
+    monkeypatch.setattr(section, "_stop_dragger_poll", lambda: events.append("stop"))
+    monkeypatch.setattr(section, "_stop_selection_snap", lambda: None)
+    monkeypatch.setattr(section, "_close_ui", lambda: events.append("close"))
+    section._SectionViewDocumentObserver().slotDeletedDocument(SimpleNamespace(Document=document))
+    assert events == ["stop", "cancel", "close"]
+    assert section._dragger_view is None
+    assert section._dragger_document is None
+    assert section._dragger_node is None
+    assert section._overlay_node is None
+    assert section._cap_node is None
+
+
+def _section_dialog_without_gui(monkeypatch):
+    import importlib.util
+    import sys
+    monkeypatch.setitem(sys.modules, "FreeCADGui", SimpleNamespace())
+    monkeypatch.setitem(sys.modules, "PySide", SimpleNamespace(
+        QtCore=SimpleNamespace(), QtWidgets=SimpleNamespace(QWidget=object),
+    ))
+    path = REPO / "src/Mod/VibeCAD/VibeCADSectionViewGui.py"
+    spec = importlib.util.spec_from_file_location("section_dialog_unit_test", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return object.__new__(module.SectionViewDialog)
+
+
+def test_section_dialog_range_uses_the_displayed_section_bounds(monkeypatch):
+    import sys
+    dialog = _section_dialog_without_gui(monkeypatch)
+    class Document:
+        @property
+        def Objects(self):
+            pytest.fail("Slider refresh must not read document shapes")
+    monkeypatch.setitem(sys.modules, "FreeCAD", SimpleNamespace(ActiveDocument=Document()))
+    view = object()
+    monkeypatch.setattr(section, "_active_3d_view", lambda: view)
+    monkeypatch.setattr(section, "_bounds_view", view)
+    monkeypatch.setattr(section, "_section_bounds", section.ModelBounds(0, 40, 0, 20, 0, 10))
+    limits = []
+    dialog.offset_spin = SimpleNamespace(
+        setRange=lambda low, high: limits.append((low, high)),
+        setMinimum=lambda value: None, setMaximum=lambda value: None,
+    )
+    dialog.offset_slider = SimpleNamespace(setRange=lambda *args: None)
+    dialog._sync_offset_limits()
+    assert limits == [(-5., 5.)]
+
+
+def test_section_dialog_slider_failure_does_not_disable_further_input(monkeypatch):
+    dialog = _section_dialog_without_gui(monkeypatch)
+    dialog._updating = False
+    dialog._slider_to_offset = lambda value: 2.
+    dialog.offset_spin = SimpleNamespace(setValue=lambda value: None)
+    def fail(**kwargs):
+        raise RuntimeError("plane update failed")
+    monkeypatch.setattr(section, "configure_section_view", fail)
+    with pytest.raises(RuntimeError, match="plane update failed"):
+        dialog._offset_slider_changed(10)
+    assert not dialog._updating

--- a/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_section_view.py
@@ -811,19 +811,13 @@ def test_tiny_axis_jitter_does_not_switch_planes() -> None:
     assert updated.plane == "top"
 
 
-def test_section_plane_from_view_picks_nearest_parallel_and_keeps_the_far_half() -> None:
-    plane, flipped = section.section_plane_from_view_direction((0.0, 0.0, -1.0))
-    assert plane == "top"
-    assert flipped is False
-    plane, flipped = section.section_plane_from_view_direction((0.0, 0.0, 1.0))
-    assert plane == "top"
-    assert flipped is True
-    plane, flipped = section.section_plane_from_view_direction((0.0, -1.0, 0.0))
-    assert plane == "front"
-    assert flipped is False
-    plane, flipped = section.section_plane_from_view_direction((1.0, 0.0, 0.0))
-    assert plane == "right"
-    assert flipped is True
+@pytest.mark.parametrize("look", [(0, 0, -1), (0, 0, 1), (0, -1, 0), (1, 0, 0), (0.2, 0.9, 0.1)])
+def test_section_plane_from_view_keeps_half_away_from_camera(look) -> None:
+    settings = section.initial_section_settings(look)
+    origin, normal = section.clip_plane_from_settings(settings, (0, 0, 0))
+    # SoClipPlane keeps its positive half-space. The camera must be in
+    # the removed half, so the cut face opens toward the viewer.
+    assert section._dot(normal, look) > 0
 
 
 def test_initial_settings_follow_the_camera_look_direction() -> None:
@@ -1033,7 +1027,8 @@ def test_cap_schedule_uses_native_display_without_document_shape_copy(monkeypatc
     monkeypatch.setattr(section, "_cap_worker", None)
     snapshots, published = [], []
 
-    def capture(view):
+    def capture(view, *, mesh=False):
+        assert mesh
         snapshots.append(view)
         yield ("cached-shape", "display-matrix")
 
@@ -1181,6 +1176,21 @@ class _NativeSectionBackend:
 
     def requestSectionDisplay(self, *args):
         self.requests.append(args)
+
+    def requestSectionMeshDisplay(self, *args):
+        self.requests.append(args)
+
+
+def test_mesh_cap_worker_uses_mesh_request_without_exact_geometry():
+    backend = _NativeSectionBackend()
+    received = []
+    backend.requestSectionMeshDisplay = lambda *args: received.append(args)
+    worker = section._NativeSectionCapWorker(backend)
+    worker.request(iter([("mesh", "matrix")]), (0, 0, 0), (0, 0, 1), 1,
+                   lambda *_: None, mesh=True)
+    backend.queued.pop(0)()
+    assert received[0][1] == [("mesh", "matrix")]
+    assert not backend.requests
 
 
 def test_native_cap_worker_cancels_capture_and_rejects_stale_delivery():

--- a/tests/src/Gui/RenderMeshController.cpp
+++ b/tests/src/Gui/RenderMeshController.cpp
@@ -10,6 +10,8 @@
 #include <BRepPrimAPI_MakeCylinder.hxx>
 #include <BRepAlgoAPI_Cut.hxx>
 #include <BRepAlgoAPI_Fuse.hxx>
+#include <BRep_Builder.hxx>
+#include <TopoDS_Compound.hxx>
 #include <BRepGProp.hxx>
 #include <GProp_GProps.hxx>
 #include <Inventor/nodes/SoMaterial.h>
@@ -369,6 +371,27 @@ private Q_SLOTS:
             GProp_GProps area;
             BRepGProp::SurfaceProperties(faces, area);
             QVERIFY(std::abs(area.Mass() - (sign > 0 ? 2.0 : 4.0)) < 1e-6);
+        }
+    }
+
+    void meshSectionKeepsCompoundSolidsSeparate()
+    {
+        for (const auto& position : {gp_Pnt(2, 2, 0), gp_Pnt(2, 0, 0), gp_Pnt(1, 1, 0)}) {
+            BRep_Builder builder;
+            TopoDS_Compound compound;
+            builder.MakeCompound(compound);
+            builder.Add(compound, BRepPrimAPI_MakeBox(2.0, 2.0, 2.0).Shape());
+            builder.Add(compound, BRepPrimAPI_MakeBox(position, 2.0, 2.0, 2.0).Shape());
+            const auto mesh = Part::prepareRenderMesh(compound, 0.1, 5.0);
+            for (double sign : {1.0, -1.0}) {
+                const auto faces = Part::prepareSectionMeshFaces(
+                    mesh, {}, Base::Vector3d(0, 0, 1), Base::Vector3d(0, 0, sign));
+                QVERIFY(!faces.IsNull());
+                GProp_GProps area;
+                BRepGProp::SurfaceProperties(faces, area);
+                // A compound retains its independent solids, including overlaps.
+                QVERIFY(std::abs(area.Mass() - 8.0) < 1e-6);
+            }
         }
     }
 

--- a/tests/src/Gui/RenderMeshController.cpp
+++ b/tests/src/Gui/RenderMeshController.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <cmath>
+#include <tuple>
 #include <QThread>
 #include <QTest>
 #include <QElapsedTimer>
@@ -8,6 +9,7 @@
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
 #include <BRepAlgoAPI_Cut.hxx>
+#include <BRepAlgoAPI_Fuse.hxx>
 #include <BRepGProp.hxx>
 #include <GProp_GProps.hxx>
 #include <Inventor/nodes/SoMaterial.h>
@@ -314,6 +316,69 @@ private Q_SLOTS:
         const auto [offOwner, faces] = read.get();
         QVERIFY(offOwner);
         QCOMPARE(faces, 6UL);
+    }
+
+    void meshSectionPreservesHolesAndDisplayedPlacement()
+    {
+        const auto tube = BRepAlgoAPI_Cut(
+            BRepPrimAPI_MakeCylinder(5.0, 6.0).Shape(),
+            BRepPrimAPI_MakeCylinder(2.0, 6.0).Shape()).Shape();
+        auto mesh = Part::prepareRenderMesh(tube, 0.05, 5.0);
+        const auto originalVertices = mesh.vertices;
+        Base::Matrix4D displayed;
+        displayed.move(Base::Vector3d(200.0, 40.0, 60.0));
+        const auto result = Part::prepareSectionMeshFaces(
+            mesh, displayed, Base::Vector3d(200.0, 40.0, 63.0), Base::Vector3d(0.0, 0.0, 1.0));
+        QVERIFY(!result.IsNull());
+        GProp_GProps area;
+        BRepGProp::SurfaceProperties(result, area);
+        QVERIFY(std::abs(area.Mass() - 21.0 * std::acos(-1.0)) < 0.2);
+        QVERIFY(std::abs(area.CentreOfMass().Z() - 63.0) < 1e-7);
+        QVERIFY(mesh.vertices == originalVertices);
+        QVERIFY(Part::prepareSectionMeshFaces(mesh, displayed, Base::Vector3d(0, 0, 100), Base::Vector3d(0, 0, 1)).IsNull());
+        std::stop_source cancelled;
+        cancelled.request_stop();
+        QVERIFY_EXCEPTION_THROWN(Part::prepareSectionMeshFaces(
+            mesh, displayed, Base::Vector3d(0, 0, 63), Base::Vector3d(0, 0, 1), cancelled.get_token()), std::runtime_error);
+    }
+
+    void meshSectionHandlesVerticesAndCoplanarBoundary()
+    {
+        const auto mesh = Part::prepareRenderMesh(BRepPrimAPI_MakeBox(2.0, 2.0, 2.0).Shape(), 0.5, 10.0);
+        for (const auto& [origin, normal, expected] : {
+                 std::tuple {Base::Vector3d(1, 1, 0), Base::Vector3d(1, 1, 0), 4 * std::sqrt(2.0)},
+                 std::tuple {Base::Vector3d(), Base::Vector3d(1, 0, 0), 4.0}}) {
+            const auto faces = Part::prepareSectionMeshFaces(mesh, {}, origin, normal);
+            QVERIFY(!faces.IsNull());
+            GProp_GProps area;
+            BRepGProp::SurfaceProperties(faces, area);
+            QVERIFY(std::abs(area.Mass() - expected) < 1e-6);
+        }
+    }
+
+    void meshSectionAtStepUsesTheKeptSideContour()
+    {
+        const auto step = BRepAlgoAPI_Fuse(
+            BRepPrimAPI_MakeBox(2.0, 2.0, 1.0).Shape(),
+            BRepPrimAPI_MakeBox(gp_Pnt(0, 0, 1), 1.0, 2.0, 1.0).Shape()).Shape();
+        const auto mesh = Part::prepareRenderMesh(step, 0.1, 5.0);
+        for (double sign : {1.0, -1.0}) {
+            const auto faces = Part::prepareSectionMeshFaces(
+                mesh, {}, Base::Vector3d(0, 0, 1), Base::Vector3d(0, 0, sign));
+            QVERIFY(!faces.IsNull());
+            GProp_GProps area;
+            BRepGProp::SurfaceProperties(faces, area);
+            QVERIFY(std::abs(area.Mass() - (sign > 0 ? 2.0 : 4.0)) < 1e-6);
+        }
+    }
+
+    void meshSectionRejectsOpenContours()
+    {
+        Part::RenderMesh mesh;
+        mesh.vertices = {0, 0, -1, 1, 0, 1, 0, 1, 1};
+        mesh.triangleIndices = {0, 1, 2, -1};
+        QVERIFY_EXCEPTION_THROWN(Part::prepareSectionMeshFaces(
+            mesh, {}, Base::Vector3d(), Base::Vector3d(0, 0, 1)), std::runtime_error);
     }
 
     void sectionFacesUseDisplayedPlacementAndPreserveHoles()

--- a/tests/src/Gui/RenderMeshController.cpp
+++ b/tests/src/Gui/RenderMeshController.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <cmath>
 #include <QThread>
 #include <QTest>
 #include <QElapsedTimer>
@@ -27,6 +28,7 @@
 #include <Mod/Part/App/PropertyTopoShape.h>
 #include <Mod/Part/App/SectionGeometry.h>
 #include <Mod/Part/Gui/RenderMeshController.h>
+#include <Mod/Part/Gui/SectionFaceController.h>
 #include <Mod/Part/Gui/SoBrepEdgeSet.h>
 #include <Mod/Part/Gui/SoBrepFaceSet.h>
 #include <Mod/Part/Gui/SoBrepPointSet.h>
@@ -366,6 +368,66 @@ private Q_SLOTS:
                                                  Base::Vector3d(0.0, 0.0, 1.0), token);
             });
         QVERIFY_EXCEPTION_THROWN(cancellation.get(), std::runtime_error);
+    }
+
+    void sectionControllerDeliversOnlyLatestOnOwner()
+    {
+        PartGui::SectionFaceController controller;
+        const auto source = BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape();
+        int deliveries = 0;
+        for (int index = 0; index < 3; ++index) {
+            controller.request({{source, {}}}, Base::Vector3d(0.0, 0.0, 1.0 + index),
+                               Base::Vector3d(0.0, 0.0, 1.0),
+                [&, index](PartGui::SectionFaceResult result) {
+                    QCOMPARE(QThread::currentThread(), qApp->thread());
+                    QCOMPARE(index, 2);
+                    QVERIFY2(result.error.empty(), result.error.c_str());
+                    QCOMPARE(result.faces.size(), std::size_t(1));
+                    ++deliveries;
+                });
+        }
+        QTRY_COMPARE(deliveries, 1);
+    }
+
+    void sectionCancellationReleasesCapturesOnOwner()
+    {
+        PartGui::SectionFaceController controller;
+        bool released = false;
+        auto capture = std::make_shared<ReleaseCallback>();
+        capture->callback = [&] {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            released = true;
+        };
+        controller.request({{BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape(), {}}},
+                           Base::Vector3d(0.0, 0.0, 1.0), Base::Vector3d(0.0, 0.0, 1.0),
+                           [capture](PartGui::SectionFaceResult) { QFAIL("Cancelled result delivered"); });
+        capture.reset();
+        QVERIFY(!released);
+        controller.cancel();
+        QVERIFY(released);
+    }
+
+    void sectionCaptureReleaseCanSubmitANewerRequest()
+    {
+        PartGui::SectionFaceController controller;
+        const auto shape = BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape();
+        const Base::Vector3d origin(0.0, 0.0, 1.0), normal(0.0, 0.0, 1.0);
+        int delivered = 0;
+        auto capture = std::make_shared<ReleaseCallback>();
+        capture->callback = [&] {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            controller.request({{shape, {}}}, origin, normal, [&](PartGui::SectionFaceResult result) {
+                QVERIFY(result.error.empty());
+                QCOMPARE(result.faces.size(), std::size_t(1));
+                ++delivered;
+            });
+        };
+        controller.request({{shape, {}}}, origin, normal,
+                           [capture](PartGui::SectionFaceResult) { QFAIL("Obsolete first result"); });
+        capture.reset();
+        controller.request({{shape, {}}}, origin, normal,
+                           [](PartGui::SectionFaceResult) { QFAIL("Obsolete pending result"); });
+        QTRY_COMPARE(delivered, 1);
     }
 
     void cancelledCompletionCannotAdoptIntoReusedTarget()

--- a/tests/src/Gui/RenderMeshController.cpp
+++ b/tests/src/Gui/RenderMeshController.cpp
@@ -389,6 +389,59 @@ private Q_SLOTS:
         QTRY_COMPARE(deliveries, 1);
     }
 
+    void sectionDisplayKeepsTrianglesAndHatchOutOfHoles()
+    {
+        const auto tube = BRepAlgoAPI_Cut(
+            BRepPrimAPI_MakeCylinder(5.0, 6.0).Shape(),
+            BRepPrimAPI_MakeCylinder(2.0, 6.0).Shape()).Shape();
+        auto geometry = App::GetApplication().hostRuntime().submit([tube](std::stop_token stop) {
+            const Base::Vector3d origin(0.0, 0.0, 3.0), normal(0.0, 0.0, 1.0);
+            const auto faces = Part::prepareSectionFaces(tube, {}, origin, normal, stop);
+            return Part::prepareSectionDisplay(faces, origin, normal, 0.5, stop);
+        }).get();
+        QVERIFY(!geometry.triangles.empty());
+        QVERIFY(!geometry.hatch.empty());
+        QVERIFY(!geometry.outlines.empty());
+        double area = 0.0;
+        for (const auto& triangle : geometry.triangles) {
+            area += (triangle[1] - triangle[0]).Cross(triangle[2] - triangle[0]).Length() * 0.5;
+            const auto center = (triangle[0] + triangle[1] + triangle[2]) / 3.0;
+            QVERIFY(std::hypot(center.x, center.y) >= 1.75);
+            for (const auto& point : triangle) {
+                QVERIFY(std::abs(point.z - 2.95) < 1e-7);
+            }
+        }
+        QVERIFY(std::abs(area - 21.0 * std::acos(-1.0)) < 1.0);
+        for (const auto& line : geometry.hatch) {
+            const auto delta = line[1] - line[0];
+            const double lengthSquared = delta.Dot(delta);
+            QVERIFY(lengthSquared > 0);
+            const double t = std::clamp(-line[0].Dot(delta) / lengthSquared, 0.0, 1.0);
+            const auto nearest = line[0] + delta * t;
+            QVERIFY(std::hypot(nearest.x, nearest.y) >= 1.75);
+            QVERIFY(std::abs(line[0].z - 2.95) < 1e-7);
+            QVERIFY(std::abs(line[1].z - 2.95) < 1e-7);
+        }
+    }
+
+    void sectionControllerDeliversPreparedDisplay()
+    {
+        PartGui::SectionFaceController controller;
+        bool completed = false;
+        controller.requestDisplay({{BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape(), {}}},
+                                  Base::Vector3d(0.0, 0.0, 1.0), Base::Vector3d(0.0, 0.0, 1.0), 0.5,
+            [&](PartGui::SectionFaceResult result) {
+                QCOMPARE(QThread::currentThread(), qApp->thread());
+                QVERIFY(result.error.empty());
+                QVERIFY(result.geometry);
+                QVERIFY(!result.geometry->triangles.empty());
+                QVERIFY(!result.geometry->hatch.empty());
+                QVERIFY(!result.geometry->outlines.empty());
+                completed = true;
+            });
+        QTRY_VERIFY(completed);
+    }
+
     void sectionCancellationReleasesCapturesOnOwner()
     {
         PartGui::SectionFaceController controller;

--- a/tests/src/Gui/RenderMeshController.cpp
+++ b/tests/src/Gui/RenderMeshController.cpp
@@ -45,7 +45,8 @@ public:
     void setFaceCount(int count) { faceset->partIndex.setNum(count); }
     void clearLineGeometry() { lineset->coordIndex.setNum(0); }
     mutable unsigned shapeReads {0};
-    Part::TopoShape getRenderedShape() const override { ++shapeReads; return {}; }
+    Part::TopoShape renderedShape;
+    Part::TopoShape getRenderedShape() const override { ++shapeReads; return renderedShape; }
     void refreshUnchangedGeometry() { VisualTouched = false; updateVisual(); }
 };
 
@@ -237,6 +238,7 @@ private Q_SLOTS:
             auto* view = new InspectablePartView;
             view->attach(object);
             guiApplication.getDocument(document)->addViewProvider(view);
+            guiApplication.getDocument(document)->signalNewObject(*view);
             view->Visibility.setValue(true);
             return view;
         };
@@ -258,6 +260,54 @@ private Q_SLOTS:
         // because its name and its first object's name/ID were reused.
         QCOMPARE(replacementView->shapeReads, 0U);
         QVERIFY(app.closeDocument("DeferredRestoreIdentity"));
+    }
+
+    void renderedSnapshotDoesNotReadDocumentAndSurvivesViewRemoval()
+    {
+        if (PartGui::SoBrepFaceSet::getClassTypeId().isBad()) {
+            PartGui::SoBrepFaceSet::initClass();
+            PartGui::SoBrepEdgeSet::initClass();
+            PartGui::SoBrepPointSet::initClass();
+        }
+        if (PartGui::ViewProviderPartExt::getClassTypeId().isBad()) {
+            PartGui::ViewProviderPartExt::init();
+        }
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("RenderedSectionSnapshot");
+        auto* object = document->addObject("App::DocumentObject", "Shape");
+        auto* view = new InspectablePartView;
+        view->attach(object);
+        application->getDocument(document)->addViewProvider(view);
+        application->getDocument(document)->signalNewObject(*view);
+        QVERIFY(view->getRenderedShapeSnapshot().IsNull());
+        view->renderedShape = Part::TopoShape(BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape());
+        QVERIFY(!view->renderedShape.isNull());
+        QCOMPARE(application->getViewProvider<PartGui::ViewProviderPartExt>(object), view);
+        view->refreshUnchangedGeometry();
+        QVERIFY(document->isPresentationUpdateActive());
+        QTRY_VERIFY(document->isClosable());
+        view->shapeReads = 0;
+        const auto snapshot = view->getRenderedShapeSnapshot();
+        QVERIFY(!snapshot.IsNull());
+        QVERIFY(snapshot.IsPartner(view->renderedShape.getShape()));
+        QCOMPARE(view->shapeReads, 0U);
+        // Capturing the displayed generation must not inspect a newer model
+        // shape which has not yet been installed by the presentation worker.
+        view->renderedShape = Part::TopoShape(BRepPrimAPI_MakeCylinder(5.0, 6.0).Shape());
+        QVERIFY(view->getRenderedShapeSnapshot().IsPartner(snapshot));
+        document->removeObject("Shape");
+        QVERIFY(app.closeDocument("RenderedSectionSnapshot"));
+        // The snapshot owns native geometry, not a view/document wrapper.
+        const auto owner = std::this_thread::get_id();
+        auto read = app.hostRuntime().submit([snapshot, owner](std::stop_token) {
+            return std::pair {
+                std::this_thread::get_id() != owner,
+                Part::TopoShape(snapshot).countSubElements("Face")
+            };
+        });
+        const auto [offOwner, faces] = read.get();
+        QVERIFY(offOwner);
+        QCOMPARE(faces, 6UL);
     }
 
     void cancelledCompletionCannotAdoptIntoReusedTarget()

--- a/tests/src/Gui/RenderMeshController.cpp
+++ b/tests/src/Gui/RenderMeshController.cpp
@@ -6,6 +6,9 @@
 
 #include <BRepPrimAPI_MakeBox.hxx>
 #include <BRepPrimAPI_MakeCylinder.hxx>
+#include <BRepAlgoAPI_Cut.hxx>
+#include <BRepGProp.hxx>
+#include <GProp_GProps.hxx>
 #include <Inventor/nodes/SoMaterial.h>
 #include <Inventor/nodes/SoSeparator.h>
 
@@ -22,6 +25,7 @@
 #include <Gui/Inventor/SoFCBoundingBox.h>
 #include <Gui/ViewProviderGeometryObject.h>
 #include <Mod/Part/App/PropertyTopoShape.h>
+#include <Mod/Part/App/SectionGeometry.h>
 #include <Mod/Part/Gui/RenderMeshController.h>
 #include <Mod/Part/Gui/SoBrepEdgeSet.h>
 #include <Mod/Part/Gui/SoBrepFaceSet.h>
@@ -308,6 +312,60 @@ private Q_SLOTS:
         const auto [offOwner, faces] = read.get();
         QVERIFY(offOwner);
         QCOMPARE(faces, 6UL);
+    }
+
+    void sectionFacesUseDisplayedPlacementAndPreserveHoles()
+    {
+        auto source = BRepPrimAPI_MakeBox(2.0, 3.0, 4.0).Shape();
+        gp_Trsf oldPlacement;
+        oldPlacement.SetTranslation(gp_Vec(700.0, 800.0, 900.0));
+        source.Location(TopLoc_Location(oldPlacement));
+        Base::Matrix4D displayed;
+        displayed.move(Base::Vector3d(200.0, 40.0, 60.0));
+        auto result = App::GetApplication().hostRuntime().submit(
+            [source, displayed](std::stop_token stop) {
+                return Part::prepareSectionFaces(
+                    source, displayed, Base::Vector3d(201.0, 40.0, 60.0),
+                    Base::Vector3d(1.0, 0.0, 0.0), stop);
+            }).get();
+        QVERIFY(!result.IsNull());
+        GProp_GProps area;
+        BRepGProp::SurfaceProperties(result, area);
+        QVERIFY(std::abs(area.Mass() - 12.0) < 1e-7);
+        QCOMPARE(source.Location().Transformation().TranslationPart().X(), 700.0);
+
+        const auto tube = BRepAlgoAPI_Cut(
+            BRepPrimAPI_MakeCylinder(5.0, 6.0).Shape(),
+            BRepPrimAPI_MakeCylinder(2.0, 6.0).Shape()).Shape();
+        result = App::GetApplication().hostRuntime().submit([tube](std::stop_token stop) {
+            return Part::prepareSectionFaces(tube, {}, Base::Vector3d(0.0, 0.0, 3.0),
+                                             Base::Vector3d(0.0, 0.0, 1.0), stop);
+        }).get();
+        QVERIFY(!result.IsNull());
+        GProp_GProps tubeArea;
+        BRepGProp::SurfaceProperties(result, tubeArea);
+        QVERIFY2(std::abs(tubeArea.Mass() - 21.0 * std::acos(-1.0)) < 1e-7,
+                 qPrintable(QString::number(tubeArea.Mass(), 'g', 17)));
+
+        Base::Matrix4D scaled;
+        scaled.scale(-2.0, 3.0, 0.5);
+        result = App::GetApplication().hostRuntime().submit([source, scaled](std::stop_token stop) {
+            return Part::prepareSectionFaces(source, scaled, Base::Vector3d(0.0, 0.0, 1.0),
+                                             Base::Vector3d(0.0, 0.0, 1.0), stop);
+        }).get();
+        QVERIFY(!result.IsNull());
+        GProp_GProps scaledArea;
+        BRepGProp::SurfaceProperties(result, scaledArea);
+        QVERIFY(std::abs(scaledArea.Mass() - 36.0) < 1e-7);
+
+        std::stop_source cancelled;
+        cancelled.request_stop();
+        auto cancellation = App::GetApplication().hostRuntime().submit(
+            [source, token = cancelled.get_token()](std::stop_token) {
+                return Part::prepareSectionFaces(source, {}, Base::Vector3d(),
+                                                 Base::Vector3d(0.0, 0.0, 1.0), token);
+            });
+        QVERIFY_EXCEPTION_THROWN(cancellation.get(), std::runtime_error);
     }
 
     void cancelledCompletionCannotAdoptIntoReusedTarget()


### PR DESCRIPTION
Section View shows hatched cuts while keeping plane movement responsive. The cut uses the displayed model and leaves document geometry, undo history, simulation, and deferred presentation intact.

The plane starts with its open side facing the camera. Drag the plane directly or use its translation/rotation handles; separate **Show plane** and **Show handles** controls hide these decorations without rebuilding the cut. Model bounds include visible CAD solids and imported meshes, exclude grids and datum decorations, fixing oversized planes and unusable offset ranges.

## Implementation

- Capture immutable cached render meshes and actual displayed instance transforms, including Links, on the GUI owner. Generate caps, hole boundaries, hatch lines, and outlines on native HostRuntime workers. Existing exact-shape section APIs remain available.
- Keep one active calculation and one replaceable pending request; cancel obsolete results and adopt display geometry in bounded batches through the existing frame dispatcher.
- At a step exactly on the cutting plane, use the contour of the retained half. Preserve per-solid face membership in the cached render mesh so touching or overlapping solids do not get welded into branching contours. Vertex buffers are shared and transformed once, with no GUI-thread geometry work.
- Keep face-on mouse pulls tied to the camera direction when Flip reverses the clipping normal.
- Keep native ownership of detached handles, stop polling on document closure, and reject stale callbacks and deleted view wrappers.

## Verification

- [x] Tests failed before implementation and pass afterward.
- [x] Exact build/test commands and results are listed below.

The complete Linux Release build passed with sanitizers disabled, including a final build and test run after integrating the merged #199 runtime fixes from main. The owner tested the feature and requested the final 5-axis contour and drag-direction corrections before merging. Those regressions now pass. Final incremental build command: `cmake --build build/release --parallel 12` (exit 0).

Completed-build validation:

- `PYTHONPATH=src/Mod/VibeCAD /tmp/vibecad-pr-review-env/bin/python -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_section_view.py` — **80 passed**.
- `python /tmp/vibecad-section-test/run-final-section-native.py` — **21 native Qt checks passed**, exit 0.
- `python /tmp/vibecad-section-test/run-final-section-gui.py` — **17 GUI tests passed**, exit 0. Includes actual mouse dragging, independent decoration toggles without cap regeneration, Link transforms, snapshot lifetime after document closure, cancellation, and unchanged document geometry/undo.
- `python /tmp/vibecad-section-test/run-contour-survey.py` — **252 component cuts** on a private roller-model copy, covering three principal planes, three offsets, and both Flip directions; **zero contour errors**, exit 0. The centered top cut previously failed on its nut and shaft.
- `python /tmp/vibecad-section-test/run-mixed-mesh-bounds.py` — focused GUI regression passed for visible/hidden meshes beside CAD solids, with a large grid decoration excluded. This caught the previously omitted mesh extent.
- `python /tmp/vibecad-section-test/run-final-runtime-tests.py` — **16 App tests, six production document GUI tests, and the GUI shutdown regression passed** against the combined build (Qt reports 8 and 3 including fixture entries), exit 0.
- `python /tmp/vibecad-section-test/launch-integrated-user-release.py --check` — passed: full build completion, disabled sanitizers, and copied Python source hashes verified.
- `python /tmp/vibecad-section-test/run-five-axis-survey.py` — **324 component cuts on the 5-axis CNC model, zero contour errors**, exit 0. The identical baseline sweep reported 66 errors.
- `python /tmp/vibecad-section-test/run-five-axis-performance.py` — opened the private model copy, completed both cap builds and 60 preview updates, and closed successfully; no section warnings.
- `git diff --check` — passed.

Red/green cases include missing snapshot APIs, stale result cancellation, infinite datum bounds, direct plane dragging, missing visibility controls, detached-handle lifetime, reversed camera-side selection, and a stepped-solid cut that previously threw the reported branching-contour exception. The stepped-solid test checks the correct cap area in both directions; genuinely open contours still retain their error test. A compound-solid regression checks point contact, shared edges, and overlap in both directions; it failed with the reported contour exception before the fix. Actual Qt mouse events reproduced reversed world movement with Flip enabled and now verify the same pull direction with either setting.

Local harnesses use private profiles, temporary socket directories, separate displays, and process/library assertions. They never operate on an existing user instance. The `/tmp` scripts are diagnostic harnesses, not repository build requirements.

## Performance and limits

On the roller model, the mesh-cap approach reduced cap completion from 58.7 seconds for full solid cuts to 4.17 seconds in the earlier implementation benchmark. The final 5-axis CNC validation opened in **5.67 seconds**, enabled section view in **21 ms**, completed initial/updated caps in **4.98/3.49 seconds**, and processed 60 preview updates in **82 ms total**. The longest measured owner-side adoption callback was 24 ms. Preview timing and background cap completion are separate measurements, not a guaranteed frame rate; further cap optimization remains useful on large models.

Hatching follows display tessellation and preserves independent compound solids; it does not replace exact document geometry. The owner confirmed plane sizing, the camera-facing cut, and smooth movement before reporting the final two corrected cases. These changes do not establish a fix for the separate malloc corruption investigation. Native macOS/Windows execution was not tested locally.

The final GitHub contract and Windows updater checks passed. The Windows job first hit a temporary-directory cleanup race (`helper.log` still open after the helper wrote its success marker); the unchanged job passed on retry. No updater or CI-gate changes are included in this PR.

## Compatibility

- [x] Existing public functions/APIs remain present; mesh snapshot/display entry points are additive.
- [x] No preference keys, tool names, or schemas renamed or removed.
- [x] Decorations remain visible by default; initial camera-side correction was requested by the owner.
- [x] No deprecations or public API removals.
- [x] Simulation and deferred presentation performance enhancements remain intact.

Related: #79, #87, #103.
