### PR TITLE
Improve core performance, document responsiveness and assembly simulation

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,0 +1,225 @@
+# VibeCAD performance work
+
+Status: active
+Last updated: 2026-09-09
+
+## What this work delivers
+
+This work makes VibeCAD stay responsive while it opens, updates, publishes,
+renders, and simulates large models. The main change is a shared execution
+model: expensive work runs against detached data on application-owned workers,
+while the GUI thread performs only the document mutations and presentation that
+must happen there.
+
+People using VibeCAD should see practical improvements:
+
+- Large documents open and become usable sooner instead of monopolizing the
+  interface until every follow-up task finishes.
+- Independent geometry and publication work can use available CPU cores while
+  respecting a shared CPU and memory budget.
+- Tree and History updates reuse prepared projections and avoid repeated
+  whole-document scans when the underlying structure has not changed.
+- Saved assembly simulations reopen from authenticated native results instead
+  of solving the same unchanged mechanism again.
+- Simulation playback moves existing scene objects directly. It no longer
+  rewrites hundreds of document placements and refreshes the Tree every frame.
+- Cancellation, close, rollback, and stale-result rejection follow the same
+  operation state instead of leaving detached work to race a changed document.
+- Linux AppImages use the host's matching DRM stack, avoiding startup failures
+  caused by an older bundled `libdrm` shadowing the libraries used by host Mesa.
+- Large valid requests are governed by real resource admission and explicit
+  caller limits instead of arbitrary model, output, source-event, or JSON-size
+  ceilings.
+
+This is shared infrastructure rather than a collection of workbench-specific
+fast paths. Assembly, VibeScript, Tree, History, rendering, document lifecycle,
+and import/export code use the same runtime and ownership rules.
+
+## What changed
+
+### Shared runtime and resource admission
+
+VibeCAD now has an application-owned runtime for CPU work, I/O work, isolated
+processes, and GUI adoption. Nested work shares one CPU budget, so parallel
+algorithms cannot silently create competing pools and oversubscribe the host.
+Cancellation and shutdown propagate through nested submissions.
+
+Numerical libraries are initialized with bounded thread teams and admitted
+according to available CPU and memory. This prevents large per-thread OpenBLAS
+scratch allocations from scaling with every logical processor before useful
+work begins. The native pool still retains roughly 75% of logical CPU capacity
+for independent CAD work.
+
+### Document lifecycle and interface responsiveness
+
+Open, restore, recompute, save, close, and presentation work now expose
+authoritative operation state and queue eligible follow-up work. Expensive
+preparation can run away from the GUI thread; live document adoption remains on
+the document owner. Results carry document and revision identity so obsolete
+work is rejected rather than applied to a replacement or edited document.
+
+Tree and History maintain reusable projections of document structure. Ordinary
+placement, visibility, and value changes can update presentation without
+rebuilding the hierarchy, while structural, schema, extension, and linked
+document changes still invalidate the projection.
+
+Rendering preparation can fan out detached mesh and buffer work. Final Coin and
+view-provider installation remains coordinated with the GUI, preserving
+selection, appearance, transformed normals, edge indices, and document
+ownership.
+
+### Publication
+
+VibeScript publication now uses indexed live-object membership, call-local
+History ownership, batched dependency rebasing, persistent isolated validation,
+and narrower observer work during adoption and rollback. Independent candidate
+preparation overlaps where dependencies permit. Final document changes remain
+serial and transactional so identities, links, revision checks, rollback, and
+cancellation keep their existing meaning.
+
+Automatic source-operation and definition-size ceilings were removed from the
+default path. Explicit caller-requested limits, cancellation, overflow checks,
+resource admission, candidate isolation, and geometry validation remain.
+
+### Assembly solving and simulation playback
+
+OndselSolver kinematic work now preserves the host executor and receives host
+cancellation checks. VibeCAD prepares and authenticates native playback tracks
+that can be reused after reopening an unchanged document. An edit that changes
+the simulation input invalidates the cached result and schedules a fresh solve.
+
+Interactive playback reads placements from those cached tracks and applies
+them directly to existing ViewProvider scene-graph transforms. The document is
+not changed for transient frames, so playback avoids recompute, property
+notifications, undo traffic, and Tree refreshes. Frames advance sequentially;
+a delayed render does not cause wall-clock catch-up jumps. Closing the player,
+changing workflows, or starting export restores the graphics from the current
+document placements. The existing document-backed presentation path remains
+available where durable state is required.
+
+This distinction is what makes smooth playback possible: the renderer moves
+already-created geometry, while the CAD document remains authoritative before
+and after the animation.
+
+### Linux AppImage graphics compatibility
+
+The AppImage build removes every `libdrm*.so*` file from its staged runtime.
+Mesa loads hardware drivers from the host, so their DRM dependencies must come
+from the same host graphics stack. A wildcard handles present and future ABI
+filenames for core DRM and vendor libraries. The existing AMD host-library
+launcher fallback remains compatible.
+
+This fixes the failure tracked in
+[issue #191](https://github.com/10-X-eng/vibecad/issues/191), where the AppImage
+could fail graphics initialization even though a local build launched correctly.
+Qt itself was not the incompatibility: the AppImage's older DRM library was
+being loaded alongside the host's newer Mesa driver.
+
+### Diagnostics and regression tooling
+
+Opt-in phase tracing records elapsed time, execution lane, operation, document,
+and presentation phases without synchronous file I/O on the GUI thread.
+Reusable probes cover publication, simulation, native input delivery, document
+lifecycle, memory, numerical-runtime behavior, rendering, and portable-package
+round trips. Detailed measurements and red/green history are retained in
+[the performance results ledger](src/Tools/performance/PUBLICATION_SIMULATION_RESULTS.md).
+
+## Measured results
+
+These are concrete checkpoints from the tested documents and machines, not
+universal performance guarantees:
+
+- A saved robot simulation prepared and displayed in 47.648 seconds from a
+  fresh solve and 0.571 seconds after reopen from matching authenticated native
+  results. All 337 component poses were checked at three frames, along with 672
+  joint-marker poses.
+- A packaged 60-frame jet-engine playback probe produced consecutive frames
+  with zero document-property changes, Tree updates continuously enabled, and
+  zero active Tree refresh timers. Owner testing found the resulting simulation
+  substantially smoother.
+- The real 1,159-item publication replay completed in 42.750 seconds. Cancelling
+  after 900 objects restored the exact 3,022-object inventory; retry completed
+  with 3,253 objects. Profiled cancellation callback time fell from 1.187 to
+  0.453 seconds.
+- A concurrent linked-source regression produced 12,663 wrong results in
+  60,000 lookups before the fix. The corrected path completed 1.5 million
+  concurrent lookups without an error.
+- Avoiding the blocking native camera animation reduced measured simulation
+  setup from 1,554 to 33 milliseconds. Retained Coin marker fields reduced the
+  measured display cost for 336 joints from 662 to 504 milliseconds.
+- The complete Linux AppImage built successfully, contained no bundled DRM
+  libraries, passed its packaged command-line and simulation probes, and
+  launched successfully on the owner's real display.
+
+## Verification
+
+The final Linux playback and AppImage changes were developed with focused
+red/green tests. Before implementation, the playback regression observed
+document-placement use, the Tree regression observed an active refresh timer,
+and the packaging regression had no wildcard DRM exclusion. After the fixes:
+
+```text
+cmake --build build/release --target Assembly_tests_run -j4
+cmake --build build/release --target FreeCADGui DocumentBulkMutation_Tests_run -j4
+  PASS: touched native targets rebuilt.
+
+ctest --test-dir build/release \
+  -R '^AssemblyObjectTest\.SimulationFramePlacementsSuppressTransientTouchState$' \
+  --output-on-failure
+  PASS: 1/1.
+
+xvfb-run -a build/release/tests/DocumentBulkMutation_Tests_run \
+  transientLinkPlacementsDoNotScheduleTreeRefresh
+  PASS: 3 passed, 0 failed with Qt 6.11.1.
+
+python3 -m pytest -q \
+  src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py
+  PASS: 54 passed.
+
+python3 -m unittest src.Tools.tests.test_linux_appimage_launcher
+  PASS: 3 passed.
+
+cd package/rattler-build/linux
+CREATE_BUNDLE_PHASE=appdir ./create_bundle.sh
+CREATE_BUNDLE_PHASE=appimage ./create_bundle.sh
+  PASS: VibeCAD-26.3.1-RC6-build1-Linux-x86_64.AppImage built; SHA-256 verified.
+
+APPIMAGE_EXTRACT_AND_RUN=1 \
+  ./VibeCAD-26.3.1-RC6-build1-Linux-x86_64.AppImage \
+  freecadcmd --safe-mode --version
+  PASS: VibeCAD 26.3.1-RC6 (Build 1).
+```
+
+The performance results ledger records the broader Windows native/Python test
+runs, real-GUI probes, failure history, and exact fixture measurements.
+
+## Compatibility and remaining work
+
+Existing public entry points, preference keys, schemas, and default workflows
+remain available. New simulation frame APIs are additive. Durable presentation
+and export behavior retain the document-backed path, while ordinary interactive
+playback uses transient graphics transforms. The OndselSolver dependency points
+to revision `f6498019`, merged into the `10-X-eng/OndselSolver` fork's `main`.
+
+The current Linux AppImage has direct build and owner acceptance evidence.
+Remaining work is focused on final acceptance rather than another architecture
+rewrite:
+
+- Build and exercise one final ABI-consistent Windows portable archive without
+  source overlays. Repeat publication cancel/rollback/retry, independent
+  multi-output create/patch/input edits, playback invalidation, export, and
+  document lifecycle checks.
+- Attribute and reduce the measured 1.219-second combined cleanup,
+  close, and reopen callback while preserving safe document shutdown.
+- Complete the application-wide acceptance inventory for Analyze, Drawing,
+  Manufacturing, Mesh, import/export, multi-document, memory-pressure, and
+  shutdown scenarios.
+- Run equivalent packaging and lifecycle acceptance on macOS.
+- Continue measuring direct GUI callbacks against the 8-millisecond p95 target
+  and investigate any repeatable heartbeat or native-input gap over 100
+  milliseconds.
+
+Future fixes should identify a measured failing path, add a focused regression
+first, use the shared runtime and ownership model, and preserve public behavior.
+Passing an isolated unit test is evidence for that path; final acceptance still
+requires the complete packaged application and real documents.

--- a/package/rattler-build/linux/create_bundle.sh
+++ b/package/rattler-build/linux/create_bundle.sh
@@ -77,6 +77,7 @@ EOF
     ../scripts/purge_vibecad_retired_authoring_artifacts.sh \
         "${conda_env}" \
         "${conda_env}/Mod/VibeCAD"
+    ../scripts/exclude_appimage_host_graphics_libraries.sh "${conda_env}"
 
     echo -e "\nDelete unnecessary stuff"
     rm -rf ${conda_env}/include

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 1
+  number: 2
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell
@@ -154,6 +154,13 @@ requirements:
 
   run:
     - blas * openblas*
+    - if: win
+      then:
+        # pthread builds honor OPENBLAS_NUM_THREADS independently of other
+        # OpenMP users. Paired with job-scoped CPU/RAM scratch admission.
+        - libopenblas ==0.3.30 pthreads_*
+        - psutil
+        - threadpoolctl >=3.6,<4
     - blinker
     - calculix
     - casadi ==3.7.2

--- a/package/rattler-build/scripts/exclude_appimage_host_graphics_libraries.sh
+++ b/package/rattler-build/scripts/exclude_appimage_host_graphics_libraries.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -euo pipefail
+
+prefix="${1:?Usage: $0 PREFIX}"
+library_dir="${prefix}/lib"
+
+[ -d "${library_dir}" ] || exit 0
+
+# Mesa loads the host's hardware driver at runtime. Bundled libdrm libraries can
+# be older than that driver and shadow the matching host copies, preventing GLX
+# and EGL initialization. Keep these hardware-facing libraries on the host.
+find "${library_dir}" -maxdepth 1 \
+    \( -type f -o -type l \) \
+    -name 'libdrm*.so*' \
+    -print \
+    -delete

--- a/package/rattler-build/scripts/install_vibecad_codex_runtime.sh
+++ b/package/rattler-build/scripts/install_vibecad_codex_runtime.sh
@@ -15,7 +15,7 @@ download_cache="${VIBECAD_DOWNLOAD_CACHE:-${repository_root}/package/rattler-bui
 runtime_root="${module_directory}/codex_runtime"
 stamp="${runtime_root}/runtime-spec.sha256"
 
-codex_version="0.144.5"
+codex_version="0.153.4"
 release_tag="rust-v${codex_version}"
 release_root="https://github.com/openai/codex/releases/download/${release_tag}"
 license_url="https://raw.githubusercontent.com/openai/codex/${release_tag}/LICENSE"
@@ -30,34 +30,34 @@ platform="$(${python_executable} -c 'import sys; print(sys.platform)')"
 machine="$(${python_executable} -c 'import platform; print(platform.machine().lower())')"
 case "${platform}:${machine}" in
     linux:x86_64|linux:amd64)
-        archive="codex-app-server-x86_64-unknown-linux-musl.tar.gz"
-        archive_sha256="834a0c85947cd1840141f347f4b7368e2e21bf9c1b85934bcc8c397ece93ee74"
-        executable="${runtime_root}/codex-app-server"
+        archive="codex-app-server-package-x86_64-unknown-linux-musl.tar.gz"
+        archive_sha256="a5d37ff1fa6953ee6d317b7e69bfafd39f5f53350b631d790fa7531159f22420"
+        executable="${runtime_root}/bin/codex-app-server"
         ;;
     linux:aarch64|linux:arm64)
-        archive="codex-app-server-aarch64-unknown-linux-musl.tar.gz"
-        archive_sha256="d2230513fcbe363e6230a4cb53917fafd68c2d2bad953035d99059eb18c07117"
-        executable="${runtime_root}/codex-app-server"
+        archive="codex-app-server-package-aarch64-unknown-linux-musl.tar.gz"
+        archive_sha256="5673c5a8935ff2f85ca67b489e560fdd5e08fb0f0e2f7426f048ec7449aa4fdc"
+        executable="${runtime_root}/bin/codex-app-server"
         ;;
     win32:amd64|win32:x86_64)
-        archive="codex-app-server-x86_64-pc-windows-msvc.exe.tar.gz"
-        archive_sha256="dd79c88858523619273faeb50d4d79923dca53095d88e2ad0b477d5222fcf19d"
-        executable="${runtime_root}/codex-app-server.exe"
+        archive="codex-app-server-package-x86_64-pc-windows-msvc.tar.gz"
+        archive_sha256="69441ca4c8f6197923dc1b70a8aa870ff912b5367347287d021eaca1f3add971"
+        executable="${runtime_root}/bin/codex-app-server.exe"
         ;;
     win32:arm64|win32:aarch64)
-        archive="codex-app-server-aarch64-pc-windows-msvc.exe.tar.gz"
-        archive_sha256="6dc2fa9de0b0f88d9578d66319b2fa9069bdc9f61c7ce1f0897fdea0e8861801"
-        executable="${runtime_root}/codex-app-server.exe"
+        archive="codex-app-server-package-aarch64-pc-windows-msvc.tar.gz"
+        archive_sha256="d5f0ef33223912a1559a7e97012afa18eef3369f1d07dde199edfada062503ee"
+        executable="${runtime_root}/bin/codex-app-server.exe"
         ;;
     darwin:arm64|darwin:aarch64)
-        archive="codex-app-server-aarch64-apple-darwin.tar.gz"
-        archive_sha256="ec98c5647ff482cde7fe7b4091950a23f19ffceb0b343612a1bab0de0857f5d1"
-        executable="${runtime_root}/codex-app-server"
+        archive="codex-app-server-package-aarch64-apple-darwin.tar.gz"
+        archive_sha256="90f0467fd03294896204e8856bf969a0691590e8bef78dc2563a264b186f3265"
+        executable="${runtime_root}/bin/codex-app-server"
         ;;
     darwin:x86_64|darwin:amd64)
-        archive="codex-app-server-x86_64-apple-darwin.tar.gz"
-        archive_sha256="6900e9f59347d9ea0909cffd56a8e6659dd89c793e33f70372ff5fb2c00081da"
-        executable="${runtime_root}/codex-app-server"
+        archive="codex-app-server-package-x86_64-apple-darwin.tar.gz"
+        archive_sha256="ee286ca326a0df4a2b81dddb213d61e610d7b9c4f3173cc16f6023683a94ca82"
+        executable="${runtime_root}/bin/codex-app-server"
         ;;
     *)
         echo "No pinned Codex app-server is available for ${platform}/${machine}." >&2
@@ -92,6 +92,27 @@ runtime_spec="$({
 
 smoke_runtime() {
     local output
+    "${python_executable}" - "${runtime_root}" "${codex_version}" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+manifest = json.loads((root / "codex-package.json").read_text())
+if manifest.get("layoutVersion") != 1 or manifest.get("version") != sys.argv[2]:
+    raise SystemExit("Unexpected Codex package layout or version")
+suffix = ".exe" if sys.platform == "win32" else ""
+required = ["bin/codex-app-server" + suffix, "bin/codex-code-mode-host" + suffix,
+            "codex-path/rg" + suffix]
+if suffix:
+    required += ["codex-resources/codex-command-runner.exe",
+                 "codex-resources/codex-windows-sandbox-setup.exe"]
+if manifest.get("entrypoint") != required[0]:
+    raise SystemExit("Unexpected Codex package entrypoint")
+for name in required:
+    if not (root / name).is_file():
+        raise SystemExit(f"Missing Codex package companion: {name}")
+PY
     output="$("${executable}" --version)"
     if [[ "${output}" != *"${codex_version}"* ]]; then
         echo "Unexpected Codex app-server version: ${output}" >&2
@@ -160,27 +181,10 @@ with tarfile.open(archive, "r:gz") as package:
     package.extractall(target)
 PY
 
-source_executable="$(${python_executable} - "${temporary_root}" <<'PY'
-import pathlib
-import sys
-
-root = pathlib.Path(sys.argv[1])
-candidates = [
-    path
-    for path in root.rglob("*")
-    if path.is_file() and path.name.startswith("codex-app-server-")
-]
-if len(candidates) != 1:
-    raise SystemExit(
-        f"Codex archive must contain exactly one app-server executable; found {candidates}"
-    )
-print(candidates[0])
-PY
-)"
-
 rm -rf "${runtime_root}"
 mkdir -p "${runtime_root}"
-cp "${source_executable}" "${executable}"
+# Preserve the official package layout: companion discovery is relative to bin.
+cp -R "${temporary_root}/." "${runtime_root}/"
 cp "${license_path}" "${runtime_root}/LICENSE"
 chmod +x "${executable}"
 

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -40,6 +40,7 @@
 # include <boost/date_time/posix_time/posix_time.hpp>
 # include <boost/scope_exit.hpp>
 # include <chrono>
+# include <atomic>
 # include <optional>
 # include <memory>
 # include <utility>
@@ -126,6 +127,8 @@
 #include "FeaturePython.h"
 #include "GeoFeature.h"
 #include "GeoFeatureGroupExtension.h"
+#include "HostRuntime.h"
+#include "HostWorkflow.h"
 #include "ImagePlane.h"
 #include "InventorObject.h"
 #include "Link.h"
@@ -210,11 +213,26 @@ namespace fs = std::filesystem;
 namespace
 {
 
-RecomputeRequest takeNextRecomputeRequest(std::deque<RecomputeRequest>& requests)
+std::atomic<App::MainThreadSignalConfig::IsMainThreadFn>& mainThreadCheckHook()
 {
-    RecomputeRequest request = std::move(requests.front());
-    requests.pop_front();
-    return request;
+    static std::atomic<App::MainThreadSignalConfig::IsMainThreadFn> hook {nullptr};
+    return hook;
+}
+
+std::atomic<App::MainThreadSignalConfig::InvokeFn>& mainThreadInvokeHook()
+{
+    static std::atomic<App::MainThreadSignalConfig::InvokeFn> hook {nullptr};
+    return hook;
+}
+
+auto findRecomputeRequest(
+    std::deque<RecomputeRequest>& requests,
+    const std::string& documentName
+)
+{
+    return std::ranges::find_if(requests, [&documentName](const RecomputeRequest& request) {
+        return request.documentName == documentName;
+    });
 }
 
 bool requestTargetsDocument(const RecomputeRequest& request, const std::string& documentName)
@@ -254,17 +272,52 @@ void reportRecomputeException(const Base::Exception& exception)
     exception.reportException();
 }
 
-RecomputeResult processRecomputeRequest(RecomputeRequest& request)
+RecomputeResult processRecomputeRequest(RecomputeRequest& request, std::stop_token stopToken)
 {
     RecomputeResult result;
 
     try {
-        if (Document* document = request.resolveDocument()) {
-            document->recompute({}, request.force, nullptr, request.options);
+        if (stopToken.stop_requested()) {
+            result.success = false;
+            result.failure = RecomputeFailure::Cancelled;
+            return result;
+        }
+        Document* document = request.resolveDocument();
+        if (!document) {
+            throw Base::RuntimeError("The queued recompute document is no longer available");
         }
 
-        if (DocumentObject* documentObject = request.resolveDocumentObject()) {
-            documentObject->recomputeFeature(request.recursive);
+        if (request.documentObjectName.empty()) {
+            document->recomputeCancellable(
+                {},
+                request.force,
+                nullptr,
+                request.options,
+                stopToken
+            );
+        }
+        else {
+            DocumentObject* documentObject = request.resolveDocumentObject();
+            if (!documentObject) {
+                throw Base::RuntimeError("The queued recompute object is no longer available");
+            }
+            if (request.recursive) {
+                document->recomputeCancellable(
+                    {documentObject},
+                    true,
+                    nullptr,
+                    request.options,
+                    stopToken
+                );
+            }
+            else if (!stopToken.stop_requested()) {
+                document->recomputeFeature(documentObject, false);
+            }
+        }
+
+        if (stopToken.stop_requested()) {
+            result.success = false;
+            result.failure = RecomputeFailure::Cancelled;
         }
     }
     catch (Base::BadGraphError& exception) {
@@ -278,11 +331,56 @@ RecomputeResult processRecomputeRequest(RecomputeRequest& request)
         result.failure = RecomputeFailure::Exception;
         result.success = false;
     }
+    catch (const std::exception& exception) {
+        Base::RuntimeError wrapped(exception.what());
+        reportRecomputeException(wrapped);
+        result.exception = std::make_unique<Base::RuntimeError>(exception.what());
+        result.failure = RecomputeFailure::Exception;
+        result.success = false;
+    }
+    catch (...) {
+        Base::RuntimeError wrapped("Unknown exception while recomputing document");
+        reportRecomputeException(wrapped);
+        result.exception = std::make_unique<Base::RuntimeError>(wrapped.what());
+        result.failure = RecomputeFailure::Exception;
+        result.success = false;
+    }
 
     return result;
 }
 
 }  // namespace
+
+void App::MainThreadSignalConfig::setHooks(IsMainThreadFn isMainThread, InvokeFn invoke)
+{
+    // The predicate is the publication flag: readers cannot observe it until
+    // the matching invoker has already been stored.
+    mainThreadInvokeHook().store(invoke, std::memory_order_release);
+    mainThreadCheckHook().store(isMainThread, std::memory_order_release);
+}
+
+bool App::MainThreadSignalConfig::isMainThread()
+{
+    const auto hook = mainThreadCheckHook().load(std::memory_order_acquire);
+    return hook ? hook() : true;
+}
+
+bool App::MainThreadSignalConfig::hasHooks()
+{
+    return mainThreadCheckHook().load(std::memory_order_acquire)
+        && mainThreadInvokeHook().load(std::memory_order_acquire);
+}
+
+void App::MainThreadSignalConfig::invoke(std::function<void()>&& fn, bool blocking)
+{
+    const auto hook = mainThreadInvokeHook().load(std::memory_order_acquire);
+    if (hook) {
+        hook(std::move(fn), blocking);
+    }
+    else {
+        fn();
+    }
+}
 
 //==========================================================================
 // Application
@@ -415,21 +513,42 @@ Application::Application(std::map<std::string,std::string> &mConfig)
     mpcPramManager["System parameter"] = _pcSysParamMngr;
     mpcPramManager["User parameter"] = _pcUserParamMngr;
 
-    _stopRecomputeThread = false;
-    _recomputeThread = std::thread(&Application::recomputeWorker, this);
+    const bool isolationChild = getenvUTF8("VIBECAD_ISOLATION_CHILD") == "1";
+    _hostRuntime = std::make_unique<HostRuntime>(0, isolationChild);
 
     setupPythonTypes();
+
+    // A synchronous caller may already be restoring when an asynchronous
+    // request arrives. Start the queued request at its terminal event, never
+    // from a timer or a nested event loop.
+    signalFinishOpenDocument.connect([this] {
+        if (!_documentOpens.empty() && !_documentOpenActive) {
+            MainThreadSignalConfig::invoke([this] { startNextDocumentOpen(); }, false);
+        }
+    });
 }
 
 Application::~Application()
 {
-    // Signal the recompute worker thread to stop and join it.
-    _stopRecomputeThread = true;
-    _recomputeRequestAvailable.notify_all();
-
-    if (_recomputeThread.joinable()) {
-        _recomputeThread.join();
+    {
+        std::lock_guard<std::mutex> lock(_recomputeMutex);
+        for (auto& [name, cancellation] : _recomputeCancellation) {
+            (void)name;
+            cancellation.request_stop();
+        }
+        _recomputeRequests.clear();
     }
+    _hostRuntime->shutdown();
+}
+
+HostRuntime& Application::hostRuntime()
+{
+    return *_hostRuntime;
+}
+
+const HostRuntime& Application::hostRuntime() const
+{
+    return *_hostRuntime;
 }
 
 void Application::setupPythonTypes()
@@ -654,6 +773,9 @@ Document* Application::newDocument(const char * proposedName, const char * propo
     doc->signalRecomputedObject.connect(std::bind(&Application::slotRecomputedObject, this, sp::_1));
     doc->signalRecomputed.connect(std::bind(&Application::slotRecomputed, this, sp::_1));
     doc->signalBeforeRecompute.connect(std::bind(&Application::slotBeforeRecompute, this, sp::_1));
+    doc->signalCooperativeMutationChanged.connect([this](const Document& document, bool active) {
+        signalCooperativeMutationChanged(document, active);
+    });
     doc->signalOpenTransaction.connect(std::bind(&Application::slotOpenTransaction, this, sp::_1, sp::_2));
     doc->signalCommitTransaction.connect(std::bind(&Application::slotCommitTransaction, this, sp::_1));
     doc->signalAbortTransaction.connect(std::bind(&Application::slotAbortTransaction, this, sp::_1));
@@ -691,20 +813,41 @@ bool Application::closeDocument(const char* name)
     if (pos == DocMap.end()) // no such document
         return false;
 
-    if (pos->second->isCooperativeMutationActive()) {
-        Base::Console().warning(
-            "Cannot close document '%s' while a cooperative mutation is active\n",
+    if (!_closingDocuments.insert(documentName).second) {
+        return false;
+    }
+    BOOST_SCOPE_EXIT_ALL(&) {
+        _closingDocuments.erase(documentName);
+    };
+
+    if (!cancelRecomputeRequestsForDocument(documentName)) {
+        Base::Console().message(
+            "Cancelling background work before closing document '%s'\n",
             name
         );
         return false;
     }
 
-    cancelRecomputeRequestsForDocument(documentName);
+    if (pos->second->isCooperativeMutationActive()
+        || pos->second->isPresentationUpdateActive()) {
+        Base::Console().warning(
+            "Cannot close document '%s' while a document update is active\n",
+            name
+        );
+        return false;
+    }
 
     // Give scoped transaction owners one synchronous boundary at which to
     // roll back and release their own critical lock. The document remains
     // registered and fully live while observers run.
     signalBeforeCloseDocument(*pos->second);
+
+    // Observers may start asynchronous cleanup. Do not invalidate that work
+    // merely because the document was idle before the notification.
+    if (pos->second->isCooperativeMutationActive()
+        || pos->second->isPresentationUpdateActive()) {
+        return false;
+    }
 
     // A transaction lock marks a synchronous critical section whose property
     // and view-provider callbacks still hold pointers into this document.
@@ -754,10 +897,25 @@ bool Application::closeDocument(const char* name)
 
 void Application::closeAllDocuments()
 {
+    if (_isClosingAll) {
+        return;
+    }
     Base::FlagToggler<bool> flag(_isClosingAll);
-    std::map<std::string,Document*>::iterator pos;
-    while((pos = DocMap.begin()) != DocMap.end())
-        closeDocument(pos->first.c_str());
+    std::vector<std::pair<std::string, std::string>> targets;
+    targets.reserve(DocMap.size());
+    for (const auto& [name, document] : DocMap) {
+        targets.emplace_back(name, document->Uid.getValueStr());
+    }
+    // Attempt each original document once. Retrying a refused close here
+    // prevents the owner event loop from adopting the worker's final result.
+    // Close observers may also delete/replace another target, so names alone
+    // cannot identify the documents this invocation was asked to close.
+    for (const auto& [name, uid] : targets) {
+        if (auto* document = getDocument(name.c_str());
+            document && document->Uid.getValueStr() == uid) {
+            closeDocument(name.c_str());
+        }
+    }
 }
 
 Document* Application::getDocument(const char *Name) const
@@ -829,6 +987,13 @@ std::string Application::getUniqueDocumentName(const char* Name, bool tempDoc) c
 
 int Application::addPendingDocument(const char *FileName, const char *objName, bool allowPartial)
 {
+    if (!MainThreadSignalConfig::isMainThread()) {
+        int result = 0;
+        MainThreadSignalConfig::invoke([&] {
+            result = addPendingDocument(FileName, objName, allowPartial);
+        }, true);
+        return result;
+    }
     if(!_isRestoring)
         return 0;
     if(allowPartial && _allowPartial)
@@ -921,18 +1086,54 @@ bool Application::tryQueueRecomputeRequest(RecomputeRequest req)
 
 bool Application::tryQueueRecomputeRequests(std::vector<RecomputeRequest> requests)
 {
-    const bool hasRequests = !requests.empty();
+    if (!std::ranges::all_of(requests, [this](const RecomputeRequest& request) {
+            return !request.documentName.empty() && request.resolveDocument()
+                && canRecomputeRequestOnWorker(request);
+        })) {
+        return false;
+    }
+
+    std::map<std::string, std::size_t> documentsToSchedule;
+    std::map<std::string, Document*> documentsToLease;
     {
         std::lock_guard<std::mutex> lock(_recomputeMutex);
         if (!std::ranges::all_of(requests, [this](const RecomputeRequest& request) {
-                return canRecomputeRequestOnWorker(request);
+                Document* document = request.resolveDocument();
+                return !request.documentName.empty() && document
+                    && (!(document->isCooperativeMutationActive()
+                          || document->isPresentationUpdateActive())
+                        || _recomputeDocumentsScheduled.contains(request.documentName));
             })) {
             return false;
         }
+        if (std::ranges::any_of(requests, [this](const RecomputeRequest& request) {
+                const auto cancellation = _recomputeCancellation.find(request.documentName);
+                return cancellation != _recomputeCancellation.end()
+                    && cancellation->second.stop_requested();
+            })) {
+            return false;
+        }
+        for (const auto& request : requests) {
+            if (_recomputeDocumentsScheduled.insert(request.documentName).second) {
+                _recomputeCancellation.insert_or_assign(request.documentName, std::stop_source {});
+                const auto generation = ++_nextRecomputeGeneration;
+                _recomputeGeneration.insert_or_assign(request.documentName, generation);
+                documentsToSchedule.emplace(request.documentName, generation);
+                documentsToLease.emplace(request.documentName, request.resolveDocument());
+            }
+        }
         std::ranges::move(requests, std::back_inserter(_recomputeRequests));
     }
-    if (hasRequests) {
-        notifyRecomputeWorker();
+
+    for (const auto& lease : documentsToLease) {
+        Document* document = lease.second;
+        if (!document) {
+            continue;
+        }
+        document->beginCooperativeMutation();
+    }
+    for (const auto& [documentName, generation] : documentsToSchedule) {
+        scheduleRecomputeDocument(documentName, generation);
     }
     return true;
 }
@@ -944,7 +1145,7 @@ bool Application::hasPendingRecomputeRequest(const std::string& documentName)
     }
 
     std::lock_guard<std::mutex> lock(_recomputeMutex);
-    if (_recomputeDocumentsInProgress.contains(documentName)) {
+    if (_recomputeDocumentsScheduled.contains(documentName)) {
         return true;
     }
     return std::ranges::any_of(_recomputeRequests, [&documentName](const RecomputeRequest& request) {
@@ -954,53 +1155,45 @@ bool Application::hasPendingRecomputeRequest(const std::string& documentName)
 
 void Application::queueRecomputeRequest(RecomputeRequest req)
 {
-    if (!canRecomputeRequestOnWorker(req)) {
-        RecomputeResult result;
-
-        // Requests that are not worker-safe stay on the caller thread unless a
-        // GUI main-thread hop is required. In App-only/headless mode there are
-        // no GUI hooks, so processing inline preserves the "stay off the
-        // worker" guarantee without inventing a synthetic main thread.
-        if (App::MainThreadSignalConfig::hasHooks()
-            && !App::MainThreadSignalConfig::isMainThread()) {
-            App::MainThreadSignalConfig::invoke(
-                [&req, &result]() { result = processRecomputeRequest(req); },
-                /*blocking=*/true
-            );
-        }
-        else {
-            result = processRecomputeRequest(req);
-        }
-
-        if (req.callback) {
-            req.callback(req, result);
-        }
-        return;
+    if (!tryQueueRecomputeRequest(std::move(req))) {
+        throw Base::RuntimeError(
+            "Cannot queue recompute: the target is unavailable, busy, or explicitly rejects "
+            "worker execution"
+        );
     }
-
-    {
-        std::lock_guard<std::mutex> lock(_recomputeMutex);
-        _recomputeRequests.push_back(std::move(req));
-    }
-    notifyRecomputeWorker();
 }
 
-void Application::cancelRecomputeRequestsForDocument(const std::string& documentName)
+bool Application::cancelRecomputeRequestsForDocument(const std::string& documentName)
 {
     if (documentName.empty()) {
-        return;
+        return true;
     }
 
-    std::unique_lock<std::mutex> lock(_recomputeMutex);
-    _recomputeStateChanged.wait(lock, [this, &documentName] {
-        return !_recomputeDocumentsInProgress.contains(documentName);
-    });
-
-    // Cancellation runs on document-close boundaries, so a linear scan keeps
-    // the queue simple without affecting the steady-state worker path.
-    std::erase_if(_recomputeRequests, [&documentName](const RecomputeRequest& request) {
-        return requestTargetsDocument(request, documentName);
-    });
+    bool mayClose = false;
+    bool releaseLease = false;
+    {
+        std::lock_guard<std::mutex> lock(_recomputeMutex);
+        std::erase_if(_recomputeRequests, [&documentName](const RecomputeRequest& request) {
+            return requestTargetsDocument(request, documentName);
+        });
+        if (auto cancellation = _recomputeCancellation.find(documentName);
+            cancellation != _recomputeCancellation.end()) {
+            cancellation->second.request_stop();
+        }
+        mayClose = !_recomputeDocumentsInProgress.contains(documentName);
+        if (mayClose) {
+            releaseLease = _recomputeDocumentsScheduled.erase(documentName) != 0;
+            _recomputeCancellation.erase(documentName);
+            _recomputeGeneration.erase(documentName);
+        }
+    }
+    if (releaseLease) {
+        if (Document* document = getDocument(documentName.c_str());
+            document && document->isCooperativeMutationActive()) {
+            document->endCooperativeMutation();
+        }
+    }
+    return mayClose;
 }
 
 struct DocTiming {
@@ -1014,9 +1207,9 @@ struct DocTiming {
 
 class DocOpenGuard {
 public:
-    bool &flag;
+    std::atomic<bool> &flag;
     fastsignals::signal<void ()> &signal;
-    DocOpenGuard(bool &f, fastsignals::signal<void ()> &s)
+    DocOpenGuard(std::atomic<bool> &f, fastsignals::signal<void ()> &s)
         :flag(f),signal(s)
     {
         flag = true;
@@ -1086,14 +1279,137 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
                                                   std::vector<std::string> *errs,
                                                   DocumentInitFlags initFlags)
 {
-    std::vector<Document*> res(filenames.size(), nullptr);
+    if (_documentOpenActive) {
+        throw Base::RuntimeError("A queued document restore is active; queue the next open request");
+    }
+    return openDocumentsWorkflow(filenames, paths, labels, errs, initFlags).runSynchronously();
+}
+
+struct Application::PendingDocumentOpen
+{
+    OpenDocumentsRequest request;
+    OpenDocumentsResult result;
+    std::future<std::vector<Document*>> work;
+};
+
+void Application::openDocumentsAsync(OpenDocumentsRequest request)
+{
+    if (!MainThreadSignalConfig::hasHooks() || !MainThreadSignalConfig::isMainThread()) {
+        throw Base::RuntimeError("Asynchronous document open requires the application owner dispatcher");
+    }
+    if (!request.callback) {
+        throw Base::RuntimeError("Asynchronous document open requires a completion callback");
+    }
+    auto task = std::make_shared<PendingDocumentOpen>();
+    task->request = std::move(request);
+    _documentOpens.push_back(std::move(task));
+    startNextDocumentOpen();
+}
+
+bool Application::hasPendingDocumentOpens() const
+{
+    // Used by the GUI shutdown gate, on the same owner as queue submission.
+    return _documentOpenActive || !_documentOpens.empty();
+}
+
+void Application::cancelPendingDocumentOpens()
+{
+    if (!MainThreadSignalConfig::isMainThread()) {
+        throw Base::RuntimeError("Document-open cancellation requires the application owner");
+    }
+    for (const auto& task : _documentOpens) {
+        task->request.cancellation.request_stop();
+    }
+}
+
+void Application::startNextDocumentOpen()
+{
+    if (_documentOpenActive || _isRestoring || _documentOpens.empty()) {
+        return;
+    }
+    const auto task = _documentOpens.front();
+    _documentOpenActive = true;
+    auto& request = task->request;
+    try {
+        if (request.prepare) {
+            request.prepare(request);
+        }
+        task->work = openDocumentsWorkflow(
+            request.filenames,
+            request.paths.empty() ? nullptr : &request.paths,
+            request.labels.empty() ? nullptr : &request.labels,
+            &task->result.errors, request.initFlags, &request.inputFlags
+        ).runAsync(hostRuntime(), [](std::function<void()> resume) {
+            MainThreadSignalConfig::invoke(std::move(resume), false);
+        }, [this, task] { finishDocumentOpen(task); }, request.cancellation.get_token());
+    }
+    catch (...) {
+        task->result.failure = std::current_exception();
+        finishDocumentOpen(task);
+    }
+}
+
+void Application::finishDocumentOpen(const std::shared_ptr<PendingDocumentOpen>& task)
+{
+    // HostWorkflow delivers this event only after making its future ready and
+    // destroying the coordinator frame on the owner. get() cannot wait here.
+    if (task->work.valid()) {
+        try {
+            task->result.documents = task->work.get();
+        }
+        catch (...) {
+            task->result.failure = std::current_exception();
+        }
+    }
+    _documentOpens.pop_front();
+    try {
+        task->request.callback(std::move(task->result));
+    }
+    catch (const std::exception& error) {
+        Base::Console().error("Document-open completion callback failed: %s\n", error.what());
+    }
+    catch (...) {
+        Base::Console().error("Document-open completion callback failed with an unknown exception\n");
+    }
+    _documentOpenActive = false;
+    startNextDocumentOpen();
+    if (!hasPendingDocumentOpens()) {
+        signalDocumentOpenQueueIdle();
+    }
+}
+
+HostWorkflow<std::vector<Document*>> Application::openDocumentsWorkflow(
+    const std::vector<std::string>& filenames,
+    const std::vector<std::string>* paths,
+    const std::vector<std::string>* labels,
+    std::vector<std::string>* errs,
+    DocumentInitFlags initFlags, const std::vector<DocumentInitFlags>* inputFlags)
+{
+    // An earlier input can become closable while a later input restores.
+    // Resolve names on the owner at completion instead of retaining pointers
+    // to documents across worker phases.
+    std::vector<std::pair<DocumentT, std::string>> res(filenames.size());
     if (filenames.empty())
-        return res;
+        co_return std::vector<Document*> {};
 
     if (errs)
         errs->resize(filenames.size());
 
     DocOpenGuard guard(_isRestoring, signalFinishOpenDocument);
+    std::vector<std::pair<DocumentT, std::string>> incompleteDocuments;
+    BOOST_SCOPE_EXIT_ALL(&) {
+        // Worker phases have unwound before this owner-side scope exits. Drop
+        // only incomplete restores owned by this request, never accepted files
+        // or a different document that subsequently reused an internal name.
+        for (const auto& reference : incompleteDocuments) {
+            auto* doc = reference.first.getDocument();
+            if (doc && doc->Uid.getValueStr() == reference.second
+                && doc->testStatus(Document::Restoring)) {
+                doc->abandonRestore();
+                closeDocument(doc->getName());
+            }
+        }
+    };
     _pendingDocs.clear();
     _pendingDocsReopen.clear();
     _pendingDocMap.clear();
@@ -1148,16 +1464,36 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
                         label = (*labels)[count].c_str();
                 }
 
-                auto doc = openDocumentPrivate(path, name.c_str(), label, isMainDoc, initFlags, std::move(objNames));
+                auto opening = openDocumentWorkflow(
+                    path, name.c_str(), label, isMainDoc,
+                    isMainDoc && inputFlags && count < inputFlags->size()
+                        ? (*inputFlags)[count] : initFlags,
+                    std::move(objNames)
+                );
+                while (opening.advance()) {
+                    try {
+                        co_yield opening.step();
+                    }
+                    catch (...) {
+                        opening.failStep(std::current_exception());
+                    }
+                }
+                auto doc = opening.takeResult();
                 timing.d1 += std::chrono::duration_cast<std::chrono::duration<double>>(std::chrono::high_resolution_clock::now() - startTime);
                 if (doc) {
                     timings[doc].d1 += timing.d1;
-                    newDocs.emplace(doc);
+                    if (doc->testStatus(Document::Restoring)) {
+                        newDocs.emplace(doc);
+                        incompleteDocuments.emplace_back(DocumentT(doc), doc->Uid.getValueStr());
+                    }
                 }
 
-                if (isMainDoc)
-                    res[count] = doc;
+                if (isMainDoc && doc)
+                    res[count] = {DocumentT(doc), doc->Uid.getValueStr()};
                 _objCount = -1;
+            }
+            catch (const Base::AbortException&) {
+                throw;
             }
             catch (const Base::Exception &e) {
                 e.reportException();
@@ -1196,8 +1532,10 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
                 _pendingDocsReopen.clear();
                 for(const auto &file : _pendingDocs) {
                     auto doc = getDocumentByPath(file.c_str());
-                    if(doc)
-                        closeDocument(doc->getName());
+                    if (doc && !closeDocument(doc->getName())) {
+                        throw Base::RuntimeError(
+                            "Cannot reload a dependency while its document update is active: " + file);
+                    }
                 }
             }
         }
@@ -1241,7 +1579,16 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
             std::chrono::high_resolution_clock::time_point startTime = std::chrono::high_resolution_clock::now();
 
             // Finalize document restoring with the correct order
-            if(doc->afterRestore(true)) {
+            bool restored = false;
+            doc->beginPresentationUpdate();
+            BOOST_SCOPE_EXIT_ALL(doc) {
+                doc->endPresentationUpdate();
+            };
+            co_yield HostWorkflow<std::vector<Document*>>::Step {
+                HostRuntime::Lane::Document,
+                [doc, &restored](std::stop_token) { restored = doc->afterRestore(true); }
+            };
+            if(restored) {
                 openedDocs.emplace_back(doc);
                 it = docs.erase(it);
             } else {
@@ -1260,14 +1607,24 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
             seq.next();
         }
         // Close the document for reloading
-        for(const auto doc : docs)
-            closeDocument(doc->getName());
+        for (const auto doc : docs) {
+            if (!closeDocument(doc->getName())) {
+                throw Base::RuntimeError(
+                    "Cannot reload a dependency while its document update is active: "
+                    + doc->FileName.getStrValue());
+            }
+        }
 
     }while(!_pendingDocs.empty());
 
     // Set the active document using the first successfully restored main
     // document (i.e. documents explicitly asked for by caller).
-    for (auto doc : res) {
+    const auto resolveResult = [](const auto& reference) {
+        auto* doc = reference.first.getDocument();
+        return doc && doc->Uid.getValueStr() == reference.second ? doc : nullptr;
+    };
+    for (const auto& reference : res) {
+        auto* doc = resolveResult(reference);
         if (doc) {
             setActiveDocument(doc);
             break;
@@ -1283,7 +1640,12 @@ std::vector<Document*> Application::openDocuments(const std::vector<std::string>
     _isRestoring = false;
 
     signalFinishOpenDocument();
-    return res;
+    std::vector<Document*> result;
+    result.reserve(res.size());
+    for (const auto& reference : res) {
+        result.push_back(resolveResult(reference));
+    }
+    co_return result;
 }
 
 Document* Application::openDocumentPrivate(const char * FileName,
@@ -1291,9 +1653,22 @@ Document* Application::openDocumentPrivate(const char * FileName,
         bool isMainDoc, DocumentInitFlags initFlags,
         std::vector<std::string> &&objNames)
 {
+    return openDocumentWorkflow(FileName, propFileName, label, isMainDoc, initFlags,
+                                std::move(objNames)).runSynchronously();
+}
+
+HostWorkflow<Document*> Application::openDocumentWorkflow(const char* FileName,
+        const char* propFileName, const char* label,
+        bool isMainDoc, DocumentInitFlags initFlags,
+        std::vector<std::string> objNames)
+{
     Base::FileInfo File(FileName);
 
-    if (!File.exists()) {
+    bool exists = false;
+    co_yield HostWorkflow<Document*>::Step {
+        HostRuntime::Lane::Io, [&File, &exists](std::stop_token) { exists = File.exists(); }
+    };
+    if (!exists) {
         std::stringstream str;
         str << "File '" << FileName << "' does not exist!";
         throw Base::FileSystemError(str.str());
@@ -1310,7 +1685,9 @@ Document* Application::openDocumentPrivate(const char * FileName,
 
             if(isMainDoc) {
                 // Main document must be open fully, so close and reopen
-                closeDocument(doc->getName());
+                if (!closeDocument(doc->getName())) {
+                    throw Base::RuntimeError("Cannot reload a partial document while its update is active");
+                }
                 doc = nullptr;
             } else if(_allowPartial) {
                 bool reopen = false;
@@ -1332,21 +1709,21 @@ Document* Application::openDocumentPrivate(const char * FileName,
                     }
                 }
                 if(!reopen)
-                    return nullptr;
+                    co_return nullptr;
             }
 
             if(doc) {
                 _pendingDocsReopen.emplace_back(FileName);
-                return nullptr;
+                co_return nullptr;
             }
         }
 
         if (!isMainDoc) {
-            return nullptr;
+            co_return nullptr;
         }
 
         if (doc) {
-            return doc;
+            co_return doc;
         }
     }
 
@@ -1365,17 +1742,36 @@ Document* Application::openDocumentPrivate(const char * FileName,
 
     initFlags.createView &= isMainDoc;
     Document* newDoc = newDocument(name.c_str(), label, initFlags);
-    newDoc->FileName.setValue(propFileName==FileName?File.filePath():propFileName);
 
     try {
+        // Protect the document before publishing its path or yielding to a
+        // queued worker. restore() acquires its own presentation scope and
+        // transfers that scope through afterRestore(); this outer scope only
+        // bridges the scheduling gap and unwinds before error cleanup closes it.
+        newDoc->beginPresentationUpdate();
+        BOOST_SCOPE_EXIT_ALL(newDoc) {
+            newDoc->endPresentationUpdate();
+        };
+        newDoc->FileName.setValue(propFileName==FileName?File.filePath():propFileName);
+
         // read the document
-        newDoc->restore(File.filePath().c_str(),true,objNames);
+        co_yield HostWorkflow<Document*>::Step {
+            HostRuntime::Lane::Document,
+            [newDoc, &File, &objNames](std::stop_token) {
+                newDoc->restore(File.filePath().c_str(), true, objNames);
+            }
+        };
         if(!DocFileMap.empty())
             DocFileMap[Base::FileInfo(newDoc->FileName.getValue()).filePath()] = newDoc;
-        return newDoc;
+        co_return newDoc;
     }
     // if the project file itself is corrupt then
     // close the document
+    catch (const Base::AbortException&) {
+        newDoc->abandonRestore();
+        closeDocument(newDoc->getName());
+        throw;
+    }
     catch (const Base::FileException&) {
         closeDocument(newDoc->getName());
         throw;
@@ -2234,6 +2630,15 @@ void initExceptions()
 
 void Application::init(int argc, char ** argv)
 {
+#ifdef FC_OS_WIN32
+    // The packaged pthread OpenBLAS backend must not allocate one 128 MiB
+    // scratch buffer per machine CPU before any numerical job exists. Native
+    // compute uses HostRuntime's outer pool; isolated jobs set their BLAS team
+    // from their exclusive CPU lease. Respect explicit administrator settings.
+    if (qEnvironmentVariableIsEmpty("OPENBLAS_NUM_THREADS")) {
+        qputenv("OPENBLAS_NUM_THREADS", "1");
+    }
+#endif
     try {
         Base::SystemHandler::installNewHandler();
         Base::SystemHandler::installSegfaultHandler();
@@ -3289,59 +3694,166 @@ void Application::runApplication()
     }
 }
 
-void Application::notifyRecomputeWorker()
+void Application::scheduleRecomputeDocument(
+    const std::string& documentName,
+    std::size_t generation
+)
 {
-    _recomputeRequestAvailable.notify_one();
+    try {
+        auto scheduled = _hostRuntime->submit(
+            HostRuntime::Lane::Document,
+            [this, documentName, generation](std::stop_token runtimeStop) {
+                drainRecomputeDocument(documentName, generation, runtimeStop);
+            }
+        );
+        (void)scheduled;
+    }
+    catch (...) {
+        bool releaseLease = false;
+        {
+            std::lock_guard<std::mutex> lock(_recomputeMutex);
+            if (const auto current = _recomputeGeneration.find(documentName);
+                current != _recomputeGeneration.end() && current->second == generation) {
+                _recomputeDocumentsScheduled.erase(documentName);
+                _recomputeCancellation.erase(documentName);
+                _recomputeGeneration.erase(current);
+                std::erase_if(_recomputeRequests, [&documentName](const RecomputeRequest& request) {
+                    return requestTargetsDocument(request, documentName);
+                });
+                releaseLease = true;
+            }
+        }
+        if (releaseLease) {
+            if (Document* document = getDocument(documentName.c_str());
+                document && document->isCooperativeMutationActive()) {
+                document->endCooperativeMutation();
+            }
+        }
+        throw;
+    }
 }
 
-void Application::recomputeWorker()
+void Application::drainRecomputeDocument(
+    const std::string& documentName,
+    std::size_t generation,
+    std::stop_token runtimeStop
+)
 {
-    while (!_stopRecomputeThread) {
-        std::unique_lock<std::mutex> lock(_recomputeMutex);
-        // Wait until either stop is signaled or there is at least one pending request.
-        _recomputeRequestAvailable.wait(lock, [this] {
-            return _stopRecomputeThread || !_recomputeRequests.empty();
-        });
-        if (_stopRecomputeThread) {
-            break;
-        }
-
-        // Process all pending recompute requests.
-        while (!_recomputeRequests.empty()) {
-            RecomputeRequest request = takeNextRecomputeRequest(_recomputeRequests);
-            if (!request.documentName.empty()) {
-                _recomputeDocumentsInProgress.insert(request.documentName);
+    bool ownsGeneration = true;
+    bool finalized = false;
+    try {
+        while (true) {
+            RecomputeRequest request;
+            std::stop_source documentCancellation;
+            {
+                std::lock_guard<std::mutex> lock(_recomputeMutex);
+                const auto current = _recomputeGeneration.find(documentName);
+                if (current == _recomputeGeneration.end() || current->second != generation) {
+                    ownsGeneration = false;
+                    break;
+                }
+                const auto next = findRecomputeRequest(_recomputeRequests, documentName);
+                if (runtimeStop.stop_requested() || next == _recomputeRequests.end()) {
+                    if (runtimeStop.stop_requested()) {
+                        std::erase_if(
+                            _recomputeRequests,
+                            [&documentName](const RecomputeRequest& queued) {
+                                return requestTargetsDocument(queued, documentName);
+                            }
+                        );
+                    }
+                    _recomputeDocumentsInProgress.erase(documentName);
+                    _recomputeDocumentsScheduled.erase(documentName);
+                    _recomputeCancellation.erase(documentName);
+                    _recomputeGeneration.erase(current);
+                    finalized = true;
+                    break;
+                }
+                request = std::move(*next);
+                _recomputeRequests.erase(next);
+                _recomputeDocumentsInProgress.insert(documentName);
+                documentCancellation = _recomputeCancellation.at(documentName);
             }
 
-            // Unlock while processing to allow other threads to add new requests.
-            lock.unlock();
-
-            RecomputeResult result = processRecomputeRequest(request);
-
+            const auto documentStop = documentCancellation.get_token();
+            std::stop_callback runtimeCancellation(runtimeStop, [documentCancellation]() mutable {
+                documentCancellation.request_stop();
+            });
+            RecomputeResult result = processRecomputeRequest(request, documentStop);
             if (request.callback) {
-                request.callback(request, result);
+                try {
+                    request.callback(request, result);
+                }
+                catch (const std::exception& exception) {
+                    Base::Console().error(
+                        "Async recompute callback failed for '%s': %s\n",
+                        documentName.c_str(),
+                        exception.what()
+                    );
+                }
+                catch (...) {
+                    Base::Console().error(
+                        "Async recompute callback failed for '%s' with an unknown exception\n",
+                        documentName.c_str()
+                    );
+                }
             }
 
-            lock.lock();
-            if (!request.documentName.empty()) {
-                _recomputeDocumentsInProgress.erase(request.documentName);
-                _recomputeStateChanged.notify_all();
-
-                const std::string completedDocumentName = request.documentName;
-                lock.unlock();
-                auto notifyFinished = [this, completedDocumentName]() {
-                    signalRecomputeRequestFinished(completedDocumentName);
-                };
-                if (App::MainThreadSignalConfig::hasHooks()
-                    && !App::MainThreadSignalConfig::isMainThread()) {
-                    App::MainThreadSignalConfig::invoke(std::move(notifyFinished), false);
-                }
-                else {
-                    notifyFinished();
-                }
-                lock.lock();
+            if (documentStop.stop_requested()) {
+                std::lock_guard<std::mutex> lock(_recomputeMutex);
+                std::erase_if(_recomputeRequests, [&documentName](const RecomputeRequest& queued) {
+                    return requestTargetsDocument(queued, documentName);
+                });
             }
         }
+    }
+    catch (const std::exception& exception) {
+        Base::Console().error(
+            "Async recompute drain failed for '%s': %s\n",
+            documentName.c_str(),
+            exception.what()
+        );
+    }
+    catch (...) {
+        Base::Console().error(
+            "Async recompute drain failed for '%s' with an unknown exception\n",
+            documentName.c_str()
+        );
+    }
+
+    if (!ownsGeneration) {
+        return;
+    }
+
+    if (!finalized) {
+        std::lock_guard<std::mutex> lock(_recomputeMutex);
+        const auto current = _recomputeGeneration.find(documentName);
+        if (current == _recomputeGeneration.end() || current->second != generation) {
+            return;
+        }
+        std::erase_if(_recomputeRequests, [&documentName](const RecomputeRequest& queued) {
+            return requestTargetsDocument(queued, documentName);
+        });
+        _recomputeDocumentsInProgress.erase(documentName);
+        _recomputeDocumentsScheduled.erase(documentName);
+        _recomputeCancellation.erase(documentName);
+        _recomputeGeneration.erase(current);
+    }
+
+    if (Document* document = getDocument(documentName.c_str());
+        document && document->isCooperativeMutationActive()) {
+        document->endCooperativeMutation();
+    }
+
+    auto notifyFinished = [this, documentName]() {
+        signalRecomputeRequestFinished(documentName);
+    };
+    if (App::MainThreadSignalConfig::hasHooks()
+        && !App::MainThreadSignalConfig::isMainThread()) {
+        App::MainThreadSignalConfig::invoke(std::move(notifyFinished), false);
+    }
+    else {
+        notifyFinished();
     }
 }
 

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -37,12 +37,12 @@
 #include <memory>
 #include <string>
 #include <optional>
+#include <atomic>
+#include <exception>
 
 #include <functional>
-#include <thread>
 #include <mutex>
-#include <condition_variable>
-#include <atomic>
+#include <stop_token>
 
 #include <Base/Exception.h>
 
@@ -70,6 +70,8 @@ class ApplicationObserver;
 class Property;
 class AutoTransaction;
 class ExtensionContainer;
+class HostRuntime;
+template<typename Result> class HostWorkflow;
 
 /// Options for acquiring links.
 enum GetLinkOption {
@@ -96,6 +98,30 @@ struct DocumentInitFlags {
     bool temporary {false}; ///< Whether the document should be a temporary one.
 };
 
+/// Delivered on the application owner after all requested restore phases finish.
+struct OpenDocumentsResult
+{
+    std::vector<Document*> documents;
+    std::vector<std::string> errors;
+    std::exception_ptr failure;
+};
+
+/// Owns input strings through queued archive reads and linked-document restore.
+struct OpenDocumentsRequest
+{
+    std::vector<std::string> filenames;
+    std::vector<std::string> paths;
+    std::vector<std::string> labels;
+    DocumentInitFlags initFlags;
+    // Optional per-input overrides; linked documents still do not create views.
+    std::vector<DocumentInitFlags> inputFlags;
+    // Owner-side preparation runs when this request reaches the queue head,
+    // so selections and partial-document dependencies cannot go stale in queue.
+    std::function<void(OpenDocumentsRequest&)> prepare;
+    std::stop_source cancellation;
+    std::function<void(OpenDocumentsResult)> callback;
+};
+
 /**
  * @brief Failure category for async recompute processing.
  */
@@ -103,6 +129,7 @@ enum class RecomputeFailure
 {
     None,
     DependencyCycle,
+    Cancelled,
     Exception
 };
 
@@ -245,6 +272,14 @@ public:
                                          std::vector<std::string>* errs = nullptr,
                                          DocumentInitFlags initFlags = DocumentInitFlags {});
 
+    /// Queue native restore without waiting on the caller. Requires the GUI
+    /// owner dispatcher; callback is delivered there, including on failure.
+    /// Requests are ordered because linked-file discovery shares application
+    /// state. Existing synchronous APIs retain their explicit synchronous contract.
+    void openDocumentsAsync(OpenDocumentsRequest request);
+    bool hasPendingDocumentOpens() const;
+    void cancelPendingDocumentOpens();
+
     /// Get the active document.
     App::Document* getActiveDocument() const;
 
@@ -308,7 +343,8 @@ public:
     /// Set the active document.
     void setActiveDocument(const char* Name);
 
-    /// Close all documents (without saving)
+    /// Attempt to close each current document once (without saving or waiting).
+    /// Documents with active work remain open; callbacks may create new ones.
     void closeAllDocuments();
 
     /**
@@ -396,9 +432,8 @@ public:
     bool isFineGrainedRecomputeEnabled();
     bool canRecomputeRequestOnWorker(const RecomputeRequest& req) const;
 
-    // Queue a recompute only when it can execute on the worker. Unlike
-    // queueRecomputeRequest(), this never falls back to the caller or GUI
-    // thread. This is the safe entry point for asynchronous integrations.
+    // Queue recompute work on the authoritative runtime. The call is atomic
+    // for a batch and never executes work on the caller or GUI thread.
     bool tryQueueRecomputeRequest(RecomputeRequest req);
     bool tryQueueRecomputeRequests(std::vector<RecomputeRequest> requests);
 
@@ -407,6 +442,10 @@ public:
 
     // Adds a recompute request to the processing queue.
     void queueRecomputeRequest(RecomputeRequest req);
+
+    /// The process-lifetime worker pool created eagerly during application startup.
+    HostRuntime& hostRuntime();
+    const HostRuntime& hostRuntime() const;
 
     // NOLINTBEGIN
     // clang-format off
@@ -434,6 +473,9 @@ public:
     fastsignals::signal<void (const Document&)> signalStartRestoreDocument;
     /// Signal after the document has restored.
     fastsignals::signal<void (const Document&)> signalFinishRestoreDocument;
+    /// Owner-dispatched wake-up after the last active restore scope exits.
+    /// Consumers recheck their document and enclosing open/mutation state.
+    fastsignals::signal<void ()> signalRestoreActivityIdle;
     /**
      * Signal after one complete object-import batch has restored all links.
      *
@@ -502,6 +544,8 @@ public:
     fastsignals::signal<void ()> signalStartOpenDocument;
     /// Signal after opening document(s) has finished.
     fastsignals::signal<void ()> signalFinishOpenDocument;
+    /// All queued native opens have delivered their terminal owner callbacks.
+    fastsignals::signal<void ()> signalDocumentOpenQueueIdle;
     /// @}
 
 
@@ -540,6 +584,8 @@ public:
     fastsignals::signal<void (const App::DocumentObject&)> signalObjectRecomputed;
     /// Signal after an asynchronous recompute request has completely left the worker queue.
     fastsignals::signal<void(const std::string&)> signalRecomputeRequestFinished;
+    /// Outermost native mutation boundary, forwarded on the document notification owner.
+    fastsignals::signal<void(const App::Document&, bool)> signalCooperativeMutationChanged;
     /// Signal on an opened transaction.
     fastsignals::signal<void (const App::Document&, std::string)> signalOpenTransaction;
     /// Signal on a committed transaction.
@@ -1044,6 +1090,20 @@ private:
     App::Document* openDocumentPrivate(const char * FileName, const char *propFileName,
             const char *label, bool isMainDoc, DocumentInitFlags initFlags, std::vector<std::string> &&objNames);
 
+    HostWorkflow<Document*> openDocumentWorkflow(const char* filename, const char* propertyFilename,
+            const char* label, bool mainDocument, DocumentInitFlags flags,
+            std::vector<std::string> objectNames);
+    HostWorkflow<std::vector<Document*>> openDocumentsWorkflow(
+            const std::vector<std::string>& filenames, const std::vector<std::string>* paths,
+            const std::vector<std::string>* labels, std::vector<std::string>* errors,
+            DocumentInitFlags flags, const std::vector<DocumentInitFlags>* inputFlags = nullptr);
+
+    struct PendingDocumentOpen;
+    std::deque<std::shared_ptr<PendingDocumentOpen>> _documentOpens;
+    std::atomic<bool> _documentOpenActive {false};
+    void startNextDocumentOpen();
+    void finishDocumentOpen(const std::shared_ptr<PendingDocumentOpen>& task);
+
     void setActiveDocumentNoSignal(App::Document* pDoc);
 
     static Base::Reference<ParameterManager> _pcSysParamMngr;
@@ -1109,29 +1169,35 @@ private:
     // missing object
     std::map<std::string,std::set<std::string> > _docReloadAttempts;
 
-    // Worker thread for processing pending recompute requests
-    std::thread _recomputeThread;
-    // Protects the queued/in-progress recompute state below
+    // The process-lifetime worker pool, created eagerly during startup.
+    std::unique_ptr<HostRuntime> _hostRuntime;
+
+    // Protects the queued/in-progress recompute state below. Recompute drains
+    // run on HostRuntime's persistent document-orchestration lane; there is no
+    // private recompute thread.
     std::mutex _recomputeMutex;
     std::deque<RecomputeRequest> _recomputeRequests;
+    std::set<std::string> _recomputeDocumentsScheduled;
     std::set<std::string> _recomputeDocumentsInProgress;
-    std::condition_variable _recomputeRequestAvailable;
-    std::condition_variable _recomputeStateChanged;
-    // Separate from the mutex-protected queue state so shutdown can request a
-    // worker stop and wake waiters without first taking _recomputeMutex.
-    std::atomic<bool> _stopRecomputeThread{false};
+    std::map<std::string, std::stop_source> _recomputeCancellation;
+    std::map<std::string, std::size_t> _recomputeGeneration;
+    std::size_t _nextRecomputeGeneration {0};
 
-    // Worker thread function that processes _recomputeRequests
-    void recomputeWorker();
-    // Helper to notify the worker thread when new requests are available
-    void notifyRecomputeWorker();
-    // Drop queued requests for a document and wait for any active recompute of
-    // that document to finish before closing it
-    void cancelRecomputeRequestsForDocument(const std::string& documentName);
+    void scheduleRecomputeDocument(const std::string& documentName, std::size_t generation);
+    void drainRecomputeDocument(
+        const std::string& documentName,
+        std::size_t generation,
+        std::stop_token runtimeStop
+    );
+    // Drop queued requests and request cancellation without blocking the caller.
+    // Returns true when the document has no executing recompute and may be closed.
+    bool cancelRecomputeRequestsForDocument(const std::string& documentName);
 
-    bool _isRestoring{false};
+    std::atomic<bool> _isRestoring{false};
     bool _allowPartial{false};
     bool _isClosingAll{false};
+    // Owner-thread close callbacks may re-enter document closure.
+    std::set<std::string> _closingDocuments;
 
     // for estimate max link depth
     int _objCount{-1};

--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -26,6 +26,7 @@
 #include <FCConfig.h>
 
 #include <array>
+#include <chrono>
 
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -41,6 +42,7 @@
 #include "DocumentObserverPython.h"
 #include "DocumentObjectPy.h"
 #include "DocumentTimeline.h"
+#include "HostRuntime.h"
 #include "RecoverySnapshot.h"
 
 
@@ -287,6 +289,22 @@ PyMethodDef ApplicationPy::Methods[] = {
      "There is an active sequencer during document restore and recomputation. User may\n"
      "abort the operation by pressing the ESC key. Once detected, this function will\n"
      "trigger a Base.FreeCADAbort exception."},
+    {"configureHostIsolationRuntime",
+     (PyCFunction)ApplicationPy::sConfigureHostIsolationRuntime,
+     METH_VARARGS,
+     "configureHostIsolationRuntime(executable, module_root, workers=0) -> dict\n\n"
+     "Start the application-owned persistent isolation worker processes."},
+    {"executeHostIsolationRequest",
+     (PyCFunction)ApplicationPy::sExecuteHostIsolationRequest,
+     METH_VARARGS,
+     "executeHostIsolationRequest(request, cancellation_check=None, "
+     "memory_limit_bytes=0, cpu_slots=1) -> dict\n\n"
+     "Execute one protocol-safe request on the persistent isolation pool."},
+    {"hostRuntimeStatus",
+     (PyCFunction)ApplicationPy::sHostRuntimeStatus,
+     METH_VARARGS,
+     "hostRuntimeStatus() -> dict\n\n"
+     "Return authoritative worker counts for the application runtime."},
     {nullptr, nullptr, 0, nullptr} /* Sentinel */
 };
 // NOLINTEND
@@ -1367,5 +1385,186 @@ PyObject* ApplicationPy::sCheckAbort(PyObject* /*self*/, PyObject* args)
         Py_Return;
     }
     PY_CATCH
+}
+
+PyObject* ApplicationPy::sConfigureHostIsolationRuntime(
+    PyObject* /*self*/,
+    PyObject* args
+)
+{
+    const char* executable = nullptr;
+    const char* moduleRoot = nullptr;
+    unsigned long long requestedWorkers = 0;
+    if (!PyArg_ParseTuple(
+            args,
+            "ss|K",
+            &executable,
+            &moduleRoot,
+            &requestedWorkers
+        )) {
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        HostRuntime::IsolationConfiguration configuration;
+        configuration.executable = executable;
+        configuration.arguments = {
+            "--safe-mode",
+            "-c",
+            "import os,sys;"
+            "sys.path.insert(0,os.environ['VIBECAD_ISOLATION_MODULE_ROOT']);"
+            "import VibeCADIsolationWorker as _worker;"
+            "raise SystemExit(_worker.main())",
+        };
+        configuration.workingDirectory = moduleRoot;
+        configuration.environment = {
+            {"VIBECAD_ISOLATION_CHILD", "1"},
+            {"VIBECAD_ISOLATION_MODULE_ROOT", moduleRoot},
+            {"PYTHONHASHSEED", "0"},
+            {"PYTHONNOUSERSITE", "1"},
+            {"PYTHONUNBUFFERED", "1"},
+        };
+        configuration.workerCount = static_cast<std::size_t>(requestedWorkers);
+        auto& runtime = GetApplication().hostRuntime();
+        runtime.startIsolationWorkers(std::move(configuration));
+
+        Py::Dict status;
+        status.setItem("workers", Py::Long(runtime.isolationWorkerCount()));
+        status.setItem("ready", Py::Long(runtime.readyIsolationWorkerCount()));
+        return Py::new_reference_to(status);
+    }
+    PY_CATCH;
+}
+
+PyObject* ApplicationPy::sExecuteHostIsolationRequest(
+    PyObject* /*self*/,
+    PyObject* args
+)
+{
+    const char* request = nullptr;
+    PyObject* cancellationCheck = Py_None;
+    unsigned long long memoryLimitBytes = 0;
+    unsigned long long cpuSlots = 1;
+    if (!PyArg_ParseTuple(
+            args,
+            "s|OKK",
+            &request,
+            &cancellationCheck,
+            &memoryLimitBytes,
+            &cpuSlots
+        )) {
+        return nullptr;
+    }
+    if (cancellationCheck != Py_None && !PyCallable_Check(cancellationCheck)) {
+        PyErr_SetString(
+            PyExc_TypeError,
+            "cancellation_check must be callable or None"
+        );
+        return nullptr;
+    }
+
+    PY_TRY
+    {
+        using namespace std::chrono_literals;
+        auto& runtime = GetApplication().hostRuntime();
+        auto submission = runtime.submitIsolation(
+            request,
+            static_cast<std::size_t>(memoryLimitBytes),
+            static_cast<std::size_t>(cpuSlots)
+        );
+        bool cancellationSent = false;
+
+        if (cancellationCheck == Py_None) {
+            Base::PyGILStateRelease release;
+            submission.completion.wait();
+        }
+        else {
+            while (submission.completion.wait_for(0ms) != std::future_status::ready) {
+                std::future_status state;
+                {
+                    Base::PyGILStateRelease release;
+                    state = submission.completion.wait_for(50ms);
+                }
+                if (state == std::future_status::ready || cancellationSent) {
+                    continue;
+                }
+                PyObject* requested = PyObject_CallNoArgs(cancellationCheck);
+                if (!requested) {
+                    (void)runtime.cancelIsolation(submission.id);
+                    Base::PyGILStateRelease release;
+                    submission.completion.wait();
+                    return nullptr;
+                }
+                const int shouldCancel = PyObject_IsTrue(requested);
+                Py_DECREF(requested);
+                if (shouldCancel < 0) {
+                    (void)runtime.cancelIsolation(submission.id);
+                    Base::PyGILStateRelease release;
+                    submission.completion.wait();
+                    return nullptr;
+                }
+                if (shouldCancel != 0) {
+                    cancellationSent = runtime.cancelIsolation(submission.id);
+                }
+            }
+        }
+
+        const auto result = submission.completion.get();
+        const char* status = result.status == HostRuntime::IsolationStatus::Completed
+            ? "completed"
+            : result.status == HostRuntime::IsolationStatus::Cancelled ? "cancelled"
+                                                                       : "failed";
+        Py::Dict response;
+        response.setItem("job_id", Py::Long(submission.id));
+        response.setItem("status", Py::String(status));
+        response.setItem("response", Py::String(result.response));
+        response.setItem("diagnostic", Py::String(result.diagnostic));
+        response.setItem("output_tail", Py::String(result.outputTail));
+        response.setItem("memory_exceeded", Py::Boolean(result.memoryExceeded));
+        response.setItem(
+            "observed_memory_bytes",
+            Py::Long(result.observedMemoryBytes)
+        );
+        return Py::new_reference_to(response);
+    }
+    PY_CATCH;
+}
+
+PyObject* ApplicationPy::sHostRuntimeStatus(PyObject* /*self*/, PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    PY_TRY
+    {
+        auto& runtime = GetApplication().hostRuntime();
+        Py::Dict status;
+        status.setItem("logical_processors", Py::Long(runtime.logicalProcessorCount()));
+        status.setItem("compute_workers", Py::Long(runtime.workerCount()));
+        status.setItem(
+            "io_workers",
+            Py::Long(runtime.workerCount(HostRuntime::Lane::Io))
+        );
+        status.setItem(
+            "document_workers",
+            Py::Long(runtime.workerCount(HostRuntime::Lane::Document))
+        );
+        status.setItem("isolation_workers", Py::Long(runtime.isolationWorkerCount()));
+        status.setItem(
+            "isolation_ready",
+            Py::Long(runtime.readyIsolationWorkerCount())
+        );
+        status.setItem(
+            "isolation_queued",
+            Py::Long(runtime.queuedIsolationTaskCount())
+        );
+        status.setItem(
+            "isolation_active",
+            Py::Long(runtime.activeIsolationTaskCount())
+        );
+        return Py::new_reference_to(status);
+    }
+    PY_CATCH;
 }
 // NOLINTEND(cppcoreguidelines-pro-type-*)

--- a/src/App/ApplicationPy.h
+++ b/src/App/ApplicationPy.h
@@ -88,6 +88,9 @@ public:
     static PyObject *sGetActiveTransaction   (PyObject *self,PyObject *args);
     static PyObject *sCloseActiveTransaction (PyObject *self,PyObject *args);
     static PyObject *sCheckAbort             (PyObject *self,PyObject *args);
+    static PyObject *sConfigureHostIsolationRuntime(PyObject *self, PyObject *args);
+    static PyObject *sExecuteHostIsolationRequest(PyObject *self, PyObject *args);
+    static PyObject *sHostRuntimeStatus      (PyObject *self, PyObject *args);
     static PyMethodDef    Methods[];
     // clang-format on
 };

--- a/src/App/CMakeLists.txt
+++ b/src/App/CMakeLists.txt
@@ -83,6 +83,12 @@ set(FreeCADApp_LIBS
     fmt::fmt
 )
 
+if(WIN32)
+    list(APPEND FreeCADApp_LIBS psapi)
+elseif(APPLE)
+    list(APPEND FreeCADApp_LIBS proc)
+endif()
+
 if(BUILD_TRACY_FRAME_PROFILER)
     list(APPEND FreeCADApp_LIBS TracyClient)
 endif()
@@ -209,6 +215,7 @@ SET(Document_HPP_SRCS
     BackupPolicy.h
     Document.h
     DocumentTimeline.h
+    SemanticDependencyOrder.h
     RecoverySnapshot.h
     DepEdge.h
     DocumentObject.h
@@ -310,6 +317,7 @@ SET(FreeCADApp_CPP_SRCS
     TranslationQtBridge.cpp
     ElementMap.cpp
     Enumeration.cpp
+    HostRuntime.cpp
     IndexedName.cpp
     MappedElement.cpp
     MappedName.cpp
@@ -341,6 +349,9 @@ SET(FreeCADApp_HPP_SRCS
     ComplexGeoData.h
     ElementMap.h
     Enumeration.h
+    HostRuntime.h
+    private/CpuBudget.h
+    HostWorkflow.h
     IndexedName.h
     MappedName.h
     MappedElement.h

--- a/src/App/ConsoleQtBridge.cpp
+++ b/src/App/ConsoleQtBridge.cpp
@@ -2,6 +2,7 @@
 
 #include "ConsoleQtBridge.h"
 
+#include <QAbstractEventDispatcher>
 #include <QCoreApplication>
 #include <QEventLoop>
 #include <QMetaObject>
@@ -91,12 +92,13 @@ public:
             return;
         }
 
-        // Best-effort: avoid blocking from background threads (can deadlock during shutdown).
-        QMetaObject::invokeMethod(
-            app,
-            []() { QCoreApplication::processEvents(QEventLoop::ExcludeUserInputEvents); },
-            Qt::QueuedConnection
-        );
+        // Queued console delivery already wakes Qt. Explicitly wake the owner
+        // dispatcher as well, but never enter a nested GUI event loop from a
+        // worker-requested refresh: doing so can drain an unbounded amount of
+        // unrelated projection and paint work inside one MetaCall.
+        if (auto* dispatcher = QAbstractEventDispatcher::instance(app->thread())) {
+            dispatcher->wakeUp();
+        }
     }
 };
 

--- a/src/App/Datums.cpp
+++ b/src/App/Datums.cpp
@@ -412,6 +412,5 @@ bool LocalCoordinateSystem::extensionGetSubObject(DocumentObject*& ret,
 
 bool LocalCoordinateSystem::hasObject(const DocumentObject* obj, [[maybe_unused]] bool recursive) const
 {
-    const auto& features = OriginFeatures.getValues();
-    return std::ranges::find(features, obj) != features.end();
+    return OriginFeatures.findObject(obj) >= 0;
 }

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include <bitset>
+#include <atomic>
 #include <stack>
 #include <deque>
 #include <exception>
@@ -37,8 +38,11 @@
 #include <vector>
 #include <list>
 #include <algorithm>
+#include <chrono>
+#include <cstdlib>
 #include <filesystem>
 #include <format>
+#include <future>
 #include <optional>
 
 #include <boost/algorithm/string.hpp>
@@ -53,10 +57,12 @@
 
 #include <QCryptographicHash>
 #include <QCoreApplication>
+#include <QEventLoop>
 
 #include <FCConfig.h>
 
 #include <App/DocumentPy.h>
+#include <Base/CancellationScope.h>
 #include <Base/Interpreter.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
@@ -80,6 +86,8 @@
 #include "BackupPolicy.h"
 #include "ExpressionParser.h"
 #include "GeoFeature.h"
+#include "PropertyGeo.h"
+#include "HostRuntime.h"
 #include "License.h"
 #include "Link.h"
 #include "MergeDocuments.h"
@@ -122,13 +130,232 @@ bool transactionStateBlocksRecoveryWrite(const DocumentP& documentPrivate)
         || documentPrivate.activeUndoTransaction != nullptr || documentPrivate.committing;
 }
 
+class RestorePresentationStartGuard final
+{
+public:
+    RestorePresentationStartGuard(Document& document, unsigned int& persistentDepth)
+        : document(document)
+        , persistentDepth(persistentDepth)
+    {
+        document.beginPresentationUpdate();
+        ++persistentDepth;
+    }
+
+    ~RestorePresentationStartGuard()
+    {
+        if (!transferred) {
+            --persistentDepth;
+            document.endPresentationUpdate();
+        }
+    }
+
+    void transfer() noexcept
+    {
+        transferred = true;
+    }
+
+    RestorePresentationStartGuard(const RestorePresentationStartGuard&) = delete;
+    RestorePresentationStartGuard& operator=(const RestorePresentationStartGuard&) = delete;
+
+private:
+    Document& document;
+    unsigned int& persistentDepth;
+    bool transferred {false};
+};
+
+class RestorePresentationFinishGuard final
+{
+public:
+    RestorePresentationFinishGuard(Document& document, unsigned int& persistentDepth)
+        : document(document)
+        , persistentDepth(persistentDepth)
+    {}
+
+    ~RestorePresentationFinishGuard()
+    {
+        if (persistentDepth > 0) {
+            --persistentDepth;
+            document.endPresentationUpdate();
+        }
+    }
+
+    RestorePresentationFinishGuard(const RestorePresentationFinishGuard&) = delete;
+    RestorePresentationFinishGuard& operator=(const RestorePresentationFinishGuard&) = delete;
+
+private:
+    Document& document;
+    unsigned int& persistentDepth;
+};
+
+std::vector<DocumentObject*> recomputeDependencies(
+    DocumentObject* object,
+    bool fineGrained,
+    int options
+)
+{
+    const int outListOptions = ((options & Document::DepNoXLinked) != 0)
+        ? DocumentObject::OutListNoXLinked
+        : 0;
+    if (!fineGrained) {
+        return object->getOutList(outListOptions);
+    }
+
+    std::vector<DocumentObject*> dependencies;
+    std::unordered_set<DocumentObject*> uniqueDependencies;
+    for (const auto& [objFrom, propFrom, objTo, propNameTo] :
+         object->getOutListProp(outListOptions)) {
+        (void)objFrom;
+        (void)propFrom;
+        if (!objTo) {
+            continue;
+        }
+        if (propNameTo.empty() || !objTo->isInputProperty(propNameTo)) {
+            if (uniqueDependencies.insert(objTo).second) {
+                dependencies.push_back(objTo);
+            }
+        }
+    }
+    return dependencies;
+}
+
+std::vector<std::vector<DocumentObject*>> makeRecomputeWaves(
+    const std::vector<DocumentObject*>& objects,
+    bool fineGrained,
+    int options
+)
+{
+    std::unordered_map<DocumentObject*, std::size_t> positions;
+    positions.reserve(objects.size());
+    for (std::size_t index = 0; index < objects.size(); ++index) {
+        positions.emplace(objects[index], index);
+    }
+
+    std::vector<std::size_t> remainingDependencies(objects.size(), 0);
+    std::vector<std::vector<std::size_t>> dependents(objects.size());
+    for (std::size_t index = 0; index < objects.size(); ++index) {
+        std::unordered_set<std::size_t> uniqueDependencies;
+        for (auto* dependency : recomputeDependencies(objects[index], fineGrained, options)) {
+            const auto dependencyPosition = positions.find(dependency);
+            if (dependencyPosition == positions.end()
+                || !uniqueDependencies.insert(dependencyPosition->second).second) {
+                continue;
+            }
+            ++remainingDependencies[index];
+            dependents[dependencyPosition->second].push_back(index);
+        }
+    }
+
+    std::vector<std::size_t> ready;
+    ready.reserve(objects.size());
+    for (std::size_t index = 0; index < objects.size(); ++index) {
+        if (remainingDependencies[index] == 0) {
+            ready.push_back(index);
+        }
+    }
+
+    std::vector<std::vector<DocumentObject*>> waves;
+    std::size_t scheduledCount = 0;
+    while (!ready.empty()) {
+        std::vector<DocumentObject*> wave;
+        wave.reserve(ready.size());
+        std::vector<std::size_t> next;
+        for (const auto index : ready) {
+            wave.push_back(objects[index]);
+            ++scheduledCount;
+            for (const auto dependent : dependents[index]) {
+                if (--remainingDependencies[dependent] == 0) {
+                    next.push_back(dependent);
+                }
+            }
+        }
+        std::ranges::sort(next);
+        waves.push_back(std::move(wave));
+        ready = std::move(next);
+    }
+
+    if (scheduledCount != objects.size()) {
+        FC_THROWM(Base::BadGraphError, "Dependency cycle detected while scheduling recompute");
+    }
+    return waves;
+}
+
 }  // namespace
 
 namespace App
 {
 
-static bool globalIsRestoring;
-static bool globalIsRelabeling;
+namespace
+{
+// A thread-local identity avoids a mutex (and therefore an owner-thread wait)
+// when a direct property or object edit races with worker archive serialization.
+thread_local const char archiveThreadIdentity = 0;
+
+void checkArchiveMutation(const DocumentP& state)
+{
+    const auto writer = state.archiveWriter.load(std::memory_order_acquire);
+    if (writer && writer != &archiveThreadIdentity) {
+        throw Base::RuntimeError("Cannot modify document while its archive is being saved");
+    }
+}
+
+class ArchiveReadScope
+{
+public:
+    ArchiveReadScope(DocumentP& state, const void* writer) : state(&state)
+    {
+        const void* expected = nullptr;
+        if (!state.archiveWriter.compare_exchange_strong(
+                expected, writer, std::memory_order_acq_rel)) {
+            throw Base::RuntimeError("A document archive save is already active");
+        }
+    }
+    ~ArchiveReadScope() { release(); }
+    void release()
+    {
+        if (state) {
+            state->archiveWriter.store(nullptr, std::memory_order_release);
+            state = nullptr;
+        }
+    }
+    ArchiveReadScope(const ArchiveReadScope&) = delete;
+    ArchiveReadScope& operator=(const ArchiveReadScope&) = delete;
+
+private:
+    DocumentP* state;
+};
+
+std::atomic<unsigned int> activeRestoreScopes {0};
+
+class RestoreActivityScope final
+{
+public:
+    RestoreActivityScope() { activeRestoreScopes.fetch_add(1, std::memory_order_acq_rel); }
+    ~RestoreActivityScope()
+    {
+        if (activeRestoreScopes.fetch_sub(1, std::memory_order_acq_rel) != 1) { return; }
+        // FinishRestoreDocument is emitted inside this scope. A GUI consumer
+        // can observe that signal while the worker still reports restoring;
+        // wake it again at the real idle transition, including exception exits.
+        try {
+            MainThreadSignalConfig::invoke([] {
+                GetApplication().signalRestoreActivityIdle();
+            }, false);
+        }
+        catch (const std::exception& error) {
+            Base::Console().error("Cannot dispatch restore-idle notification: %s\n", error.what());
+        }
+        catch (...) {
+            Base::Console().error("Cannot dispatch restore-idle notification\n");
+        }
+    }
+    RestoreActivityScope(const RestoreActivityScope&) = delete;
+    RestoreActivityScope& operator=(const RestoreActivityScope&) = delete;
+};
+}
+
+// Relabel observers suppress only changes made in that notification stack,
+// never unrelated transactions executing on another document worker.
+static thread_local bool globalIsRelabeling;
 
 DocumentP::DocumentP()
 {
@@ -179,8 +406,8 @@ bool Document::checkOnCycle()
 
 bool Document::undo(const int id)
 {
-    if (isCooperativeMutationActive()) {
-        FC_WARN("Cannot undo while a cooperative document mutation is active");
+    if (isCooperativeMutationActive() || isPresentationUpdateActive()) {
+        FC_WARN("Cannot undo while a document update is active");
         return false;
     }
     if (d->iUndoMode != 0) {
@@ -230,7 +457,7 @@ bool Document::undo(const int id)
         }
 
         signalUndo(*this);  // now signal the undo
-        signalBecameStable(*this);
+        notifyBecameStable();
 
         return true;
     }
@@ -240,8 +467,8 @@ bool Document::undo(const int id)
 
 bool Document::redo(const int id)
 {
-    if (isCooperativeMutationActive()) {
-        FC_WARN("Cannot redo while a cooperative document mutation is active");
+    if (isCooperativeMutationActive() || isPresentationUpdateActive()) {
+        FC_WARN("Cannot redo while a document update is active");
         return false;
     }
     if (d->iUndoMode != 0) {
@@ -288,7 +515,7 @@ bool Document::redo(const int id)
         }
 
         signalRedo(*this);
-        signalBecameStable(*this);
+        notifyBecameStable();
         return true;
     }
 
@@ -324,13 +551,29 @@ void Document::changePropertyOfObject(
 
 void Document::renamePropertyOfObject(TransactionalObject* obj, const Property* prop, const char* oldName)
 {
+    advanceObjectChangeGeneration();
+    invalidateTimelineVisibilityResources(oldName);
+    invalidateTimelineVisibilityResources(prop ? prop->getName() : nullptr);
     changePropertyOfObject(obj, prop, [this, obj, prop, oldName]() {
         d->activeUndoTransaction->renameProperty(obj, prop, oldName);
     });
 }
 
+void Document::invalidateTimelineVisibilityResources(const char* name)
+{
+    if (name && (strcmp(name, DocumentTimeline::OwnerPropertyName) == 0
+                 || strcmp(name, DocumentTimeline::RolePropertyName) == 0)) {
+        std::lock_guard lock(d->propertyChangeMutex);
+        if (auto* timeline = DocumentTimeline::get(this)) {
+            timeline->invalidateVisibilityResources();
+        }
+    }
+}
+
 void Document::addOrRemovePropertyOfObject(TransactionalObject* obj, const Property* prop, const bool add)
 {
+    advanceObjectChangeGeneration();
+    invalidateTimelineVisibilityResources(prop ? prop->getName() : nullptr);
     changePropertyOfObject(obj, prop, [this, obj, prop, add]() {
         d->activeUndoTransaction->addOrRemoveProperty(obj, prop, add);
     });
@@ -530,29 +773,160 @@ bool Document::isTransactionLocked() const
 
 void Document::beginCooperativeMutation()
 {
-    if (++d->cooperativeMutationDepth == 1) {
+    unsigned int previous;
+    {
+        std::lock_guard lock(d->presentationUpdateMutex);
+        previous = d->cooperativeMutationDepth.fetch_add(1, std::memory_order_acq_rel);
+    }
+    if (previous == 0) {
         signalCooperativeMutationChanged(*this, true);
     }
 }
 
 void Document::endCooperativeMutation()
 {
-    if (d->cooperativeMutationDepth == 0) {
+    unsigned int depth;
+    bool presentationBecameActive = false;
+    {
+        std::lock_guard lock(d->presentationUpdateMutex);
+        depth = d->cooperativeMutationDepth.load(std::memory_order_acquire);
+        if (depth == 1) {
+            // Keep completion false while stable observers synchronously
+            // acquire their asynchronous presentation work.
+            const auto presentationDepth =
+                d->presentationUpdateDepth.fetch_add(1, std::memory_order_acq_rel);
+            presentationBecameActive = presentationDepth == 0;
+        }
+        if (depth != 0) {
+            d->cooperativeMutationDepth.fetch_sub(1, std::memory_order_acq_rel);
+        }
+    }
+    if (depth == 0) {
         FC_WARN("Ignoring unmatched cooperative document mutation end");
         return;
     }
-    if (--d->cooperativeMutationDepth == 0) {
-        signalCooperativeMutationChanged(*this, false);
-        // Projection observers may have ignored the transaction's earlier
-        // stable signal while this explicit bulk mutation was still active.
-        signalBecameStable(*this);
+    if (depth == 1) {
+        try {
+            if (presentationBecameActive) {
+                signalPresentationUpdateChanged(*this, true);
+            }
+            signalCooperativeMutationChanged(*this, false);
+            // Projection observers may have ignored the transaction's earlier
+            // stable signal while this explicit bulk mutation was still active.
+            signalBecameStable(*this);
+        }
+        catch (...) {
+            endPresentationUpdate();
+            throw;
+        }
+        endPresentationUpdate();
     }
 }
 
 bool Document::isCooperativeMutationActive() const
 {
-    return d->cooperativeMutationDepth > 0;
+    return d->cooperativeMutationDepth.load(std::memory_order_acquire) > 0;
 }
+
+void Document::beginPresentationUpdate() const
+{
+    bool becameActive = false;
+    {
+        std::lock_guard lock(d->presentationUpdateMutex);
+        const auto depth =
+            d->presentationUpdateDepth.fetch_add(1, std::memory_order_acq_rel);
+        becameActive = depth == 0;
+    }
+    if (becameActive) {
+        signalPresentationUpdateChanged(*this, true);
+    }
+}
+
+void Document::endPresentationUpdate() const
+{
+    const bool tracePresentation = std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
+    const auto presentationStarted = std::chrono::steady_clock::now();
+    bool ready = false;
+    {
+        std::lock_guard lock(d->presentationUpdateMutex);
+        const auto depth = d->presentationUpdateDepth.load(std::memory_order_acquire);
+        if (depth == 0) {
+            FC_WARN("Ignoring unmatched document presentation update end");
+            return;
+        }
+        d->presentationUpdateDepth.fetch_sub(1, std::memory_order_acq_rel);
+        ready = depth == 1
+            && d->cooperativeMutationDepth.load(std::memory_order_acquire) == 0;
+    }
+    if (ready) {
+        const auto notification = d->presentationUpdateChanged;
+        try {
+            signalPresentationUpdateChanged(*this, false);
+        }
+        catch (...) {
+            notification->notify_all();
+            throw;
+        }
+        notification->notify_all();
+    }
+    if (tracePresentation && ready) {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - presentationStarted
+        ).count();
+        Base::Console().message(
+            "VIBECAD_RESTORE_DETAIL presentation_release signal_ms=%lld\n",
+            static_cast<long long>(elapsed)
+        );
+    }
+}
+
+bool Document::isPresentationUpdateActive() const
+{
+    std::lock_guard lock(d->presentationUpdateMutex);
+    return d->presentationUpdateDepth.load(std::memory_order_acquire) > 0
+        || d->presentationWaiterCount > 0;
+}
+
+void Document::waitForPresentationReady() const
+{
+    std::unique_lock lock(d->presentationUpdateMutex);
+    ++d->presentationWaiterCount;
+    d->presentationUpdateChanged->wait(lock, [this] {
+        return d->cooperativeMutationDepth.load(std::memory_order_acquire) == 0
+            && d->presentationUpdateDepth.load(std::memory_order_acquire) == 0;
+    });
+    --d->presentationWaiterCount;
+    if (d->presentationWaiterCount == 0) {
+        // Waiters are part of isPresentationUpdateActive()/isClosable(). The
+        // earlier mesh/projection completion signal still saw these waiters;
+        // publish their final release as well, without retaining a raw document
+        // pointer after its lifetime protection is released.
+        auto finished = [name = std::string(getName()), uid = Uid.getValueStr()] {
+            auto* document = GetApplication().getDocument(name.c_str());
+            if (document && document->Uid.getValueStr() == uid
+                && !document->isCooperativeMutationActive()
+                && !document->isPresentationUpdateActive()) {
+                document->signalPresentationUpdateChanged(*document, false);
+            }
+        };
+        lock.unlock();
+        MainThreadSignalConfig::invoke(std::move(finished), false);
+    }
+}
+
+void Document::notifyBecameStable() const
+{
+    beginPresentationUpdate();
+    try {
+        signalBecameStable(*this);
+    }
+    catch (...) {
+        endPresentationUpdate();
+        throw;
+    }
+    endPresentationUpdate();
+}
+
 bool Document::transacting() const
 {
     return isPerformingTransaction() || d->committing;
@@ -652,7 +1026,7 @@ void Document::commitTransaction()  // NOLINT
         const bool wasRecoveryWriteBlocked = transactionStateBlocksRecoveryWrite(*d);
         setBookedTransaction(NullTransaction);
         if (wasRecoveryWriteBlocked) {
-            signalBecameStable(*this);
+            notifyBecameStable();
         }
     }
 }
@@ -697,7 +1071,7 @@ bool Document::_commitTransaction(const bool notify)
         committed = true;
     }
     if (committed) {
-        signalBecameStable(*this);
+        notifyBecameStable();
     }
     return true;
 }
@@ -723,7 +1097,7 @@ void Document::abortTransaction() const
         const bool wasRecoveryWriteBlocked = transactionStateBlocksRecoveryWrite(*d);
         setBookedTransaction(NullTransaction);
         if (wasRecoveryWriteBlocked) {
-            signalBecameStable(*this);
+            notifyBecameStable();
         }
     }
 }
@@ -755,7 +1129,7 @@ void Document::_abortTransaction()
         aborted = true;
     }
     if (aborted) {
-        signalBecameStable(*this);
+        notifyBecameStable();
     }
 }
 
@@ -825,18 +1199,19 @@ void Document::clearDocument()  // NOLINT
     d->activeObject = nullptr;
 
     if (!d->objectArray.empty()) {
-        GetApplication().signalDeleteDocument(*this);
+        MainThreadSignalConfig::invoke([this] { GetApplication().signalDeleteDocument(*this); }, true);
         d->clearDocument();
-        GetApplication().signalNewDocument(*this, false);
+        MainThreadSignalConfig::invoke([this] { GetApplication().signalNewDocument(*this, false); }, true);
     }
 
-    Base::FlagToggler<> flag(globalIsRestoring, false);
+    RestoreActivityScope restoreActivity;
 
     setStatus(Document::PartialDoc, false);
 
     d->clearRecomputeLog();
     d->objectLabelManager.clear();
     d->objectArray.clear();
+    d->objectAddresses.clear();
     d->objectMap.clear();
     d->objectNameManager.clear();
     d->objectIdMap.clear();
@@ -955,6 +1330,7 @@ unsigned int Document::getMaxUndoStackSize() const
 
 void Document::onBeforeChange(const Property* prop)
 {
+    checkArchiveMutation(*d);
     if (prop == &Label) {
         oldLabel = Label.getValue();
     }
@@ -967,11 +1343,13 @@ void Document::onChanged(const Property* prop)
 
     // the Name property is a label for display purposes
     if (prop == &Label) {
-        Base::FlagToggler<> flag(globalIsRelabeling);
-        GetApplication().signalRelabelDocument(*this);
+        MainThreadSignalConfig::invoke([this] {
+            Base::FlagToggler<> flag(globalIsRelabeling, false);
+            GetApplication().signalRelabelDocument(*this);
+        }, true);
     }
     else if (prop == &ShowHidden) {
-        GetApplication().signalShowHidden(*this);
+        MainThreadSignalConfig::invoke([this] { GetApplication().signalShowHidden(*this); }, true);
     }
     else if (prop == &Uid) {
         std::string new_dir
@@ -1029,9 +1407,11 @@ void Document::onChanged(const Property* prop)
 
 void Document::onBeforeChangeProperty(const TransactionalObject* Who, const Property* What)
 {
+    checkArchiveMutation(*d);
     if (Who->isDerivedFrom<DocumentObject>()) {
         signalBeforeChangeObject(*static_cast<const DocumentObject*>(Who), *What);
     }
+    std::lock_guard lock(d->propertyChangeMutex);
     if (!d->rollback && !globalIsRelabeling) {
         _checkTransaction(nullptr, What, __LINE__);
         if (d->activeUndoTransaction) {
@@ -1043,21 +1423,30 @@ void Document::onBeforeChangeProperty(const TransactionalObject* Who, const Prop
 void Document::onChangedProperty(const DocumentObject* Who, const Property* What)
 {
     const auto* suppressible = Who ? Who->getExtensionByType<SuppressibleExtension>(true) : nullptr;
-    const bool timelineOwnershipChanged = Who && What
-        && (What == Who->PropertyContainer::getDynamicPropertyByName(DocumentTimeline::RolePropertyName)
-            || What
-                == Who->PropertyContainer::getDynamicPropertyByName(
-                    DocumentTimeline::OwnerPropertyName
-                ));
+    const char* propertyName = What ? What->getName() : nullptr;
+    const bool timelineOwnershipChanged = Who && propertyName
+        && (strcmp(propertyName, DocumentTimeline::RolePropertyName) == 0
+            || strcmp(propertyName, DocumentTimeline::OwnerPropertyName) == 0);
     const bool timelineStateChanged = Who && What
         && (What == &Who->Visibility || (suppressible && What == &suppressible->Suppressed)
             || timelineOwnershipChanged);
-    if (timelineStateChanged && !testStatus(Document::Restoring) && !isPerformingTransaction()) {
-        if (auto* timeline = DocumentTimeline::get(this); timeline && !timeline->isApplying()) {
-            if (timelineOwnershipChanged) {
-                timeline->recordOperation(const_cast<DocumentObject*>(Who));
+    {
+        std::lock_guard lock(d->propertyChangeMutex);
+        if (timelineOwnershipChanged) {
+            if (auto* timeline = DocumentTimeline::get(this)) {
+                timeline->invalidateVisibilityResources();
             }
-            timeline->captureVisibility();
+        }
+        if (timelineStateChanged && !testStatus(Document::Restoring) && !isPerformingTransaction()) {
+            if (auto* timeline = DocumentTimeline::get(this); timeline && !timeline->isApplying()) {
+                if (timelineOwnershipChanged) {
+                    timeline->recordOperation(const_cast<DocumentObject*>(Who));
+                    timeline->captureVisibility();
+                }
+                else {
+                    timeline->captureVisibility(const_cast<DocumentObject*>(Who));
+                }
+            }
         }
     }
     signalChangedObject(*Who, *What);
@@ -1685,6 +2074,8 @@ static void loadDeps(
 
 std::vector<DocumentObject*> Document::readObjects(Base::XMLReader& reader)
 {
+    const bool traceRestore = std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
+    const auto objectsStarted = std::chrono::steady_clock::now();
     d->touchedObjs.clear();
     bool keepDigits = testStatus(Document::KeepTrailingDigits);
     setStatus(Document::KeepTrailingDigits, !reader.doNameMapping());
@@ -1749,6 +2140,7 @@ std::vector<DocumentObject*> Document::readObjects(Base::XMLReader& reader)
     bool warnedRemovedArchitecture = false;
     Base::SequencerLauncher restoreObjects("Creating document objects...", 2 * Cnt);
     for (int i = 0; i < Cnt; i++) {
+        const auto objectStarted = std::chrono::steady_clock::now();
         restoreObjects.next();
         reader.readElement("Object");
         std::string type = reader.getAttribute<const char*>("type");
@@ -1836,7 +2228,24 @@ std::vector<DocumentObject*> Document::readObjects(Base::XMLReader& reader)
                 );
             }
         }
+        if (traceRestore) {
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - objectStarted
+            ).count();
+            if (elapsed >= 20) {
+                Base::Console().message(
+                    "VIBECAD_RESTORE_DETAIL create_object index=%d count=%d type=%s name=%s "
+                    "elapsed_ms=%lld\n",
+                    i + 1,
+                    Cnt,
+                    type.c_str(),
+                    name.c_str(),
+                    static_cast<long long>(elapsed)
+                );
+            }
+        }
     }
+    const auto objectsCreated = std::chrono::steady_clock::now();
     if (!testStatus(Status::Importing)) {
         d->lastObjectId = lastId;
     }
@@ -1850,6 +2259,7 @@ std::vector<DocumentObject*> Document::readObjects(Base::XMLReader& reader)
     Cnt = static_cast<int>(reader.getAttribute<long>("Count"));
     restoreObjects.setText("Restoring document properties...");
     for (int i = 0; i < Cnt; i++) {
+        const auto objectStarted = std::chrono::steady_clock::now();
         restoreObjects.next();
         reader.readElement("Object");
         std::string name = reader.getName(reader.getAttribute<const char*>("name"));
@@ -1880,6 +2290,23 @@ std::vector<DocumentObject*> Document::readObjects(Base::XMLReader& reader)
 
             pObj->setStatus(ObjectStatus::Restore, false);
 
+            if (traceRestore) {
+                const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - objectStarted
+                ).count();
+                if (elapsed >= 20) {
+                    Base::Console().message(
+                        "VIBECAD_RESTORE_DETAIL restore_object index=%d count=%d type=%s name=%s "
+                        "elapsed_ms=%lld\n",
+                        i + 1,
+                        Cnt,
+                        pObj->getTypeId().getName(),
+                        name.c_str(),
+                        static_cast<long long>(elapsed)
+                    );
+                }
+            }
+
             if (reader.testStatus(Base::XMLReader::ReaderStatus::PartialRestoreInDocumentObject)) {
                 Base::Console().error(
                     "Object \"%s\" was subject to a partial restore. As a result "
@@ -1892,6 +2319,21 @@ std::vector<DocumentObject*> Document::readObjects(Base::XMLReader& reader)
         reader.readEndElement("Object");
     }
     reader.readEndElement("ObjectData");
+
+    if (traceRestore) {
+        const auto objectsRestored = std::chrono::steady_clock::now();
+        const auto elapsed = [](auto begin, auto end) {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count();
+        };
+        Base::Console().message(
+            "VIBECAD_RESTORE_DETAIL object_phases count=%d create_ms=%lld restore_ms=%lld "
+            "total_ms=%lld\n",
+            Cnt,
+            static_cast<long long>(elapsed(objectsStarted, objectsCreated)),
+            static_cast<long long>(elapsed(objectsCreated, objectsRestored)),
+            static_cast<long long>(elapsed(objectsStarted, objectsRestored))
+        );
+    }
 
     return objs;
 }
@@ -1908,7 +2350,7 @@ void Document::addRecomputeObject(DocumentObject* obj)  // NOLINT
 std::vector<DocumentObject*> Document::importObjects(Base::XMLReader& reader)
 {
     d->hashers.clear();
-    Base::FlagToggler<> flag(globalIsRestoring, false);
+    RestoreActivityScope restoreActivity;
     Base::ObjectStatusLocker<Status, Document> restoreBit(Status::Restoring, this);
     Base::ObjectStatusLocker<Status, Document> restoreBit2(Status::Importing, this);
     ExpressionParser::ExpressionImporter expImporter(reader);
@@ -1957,7 +2399,9 @@ std::vector<DocumentObject*> Document::importObjects(Base::XMLReader& reader)
     signalImportObjects(objs, reader);
     afterRestore(objs, true);
 
-    GetApplication().signalFinishImportObjects(*this, objs);
+    MainThreadSignalConfig::invoke([this, &objs] {
+        GetApplication().signalFinishImportObjects(*this, objs);
+    }, true);
     signalFinishImportObjects(objs);
 
     for (const auto o : objs) {
@@ -2230,9 +2674,31 @@ bool Document::save()
     return false;
 }
 
-bool Document::saveToFile(const char* filename) const
+bool Document::saveToFile(const char* inputFilename) const
 {
-    signalStartSave(*this, filename);
+    // Start-save observers may change FileName. Keep the requested target alive.
+    const std::string requestedFilename(inputFilename);
+    const char* filename = requestedFilename.c_str();
+    const bool traceSave = std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
+    auto phaseStarted = std::chrono::steady_clock::now();
+    const auto tracePhase = [&](const char* phase) {
+        if (!traceSave) { return; }
+        const auto now = std::chrono::steady_clock::now();
+        const auto elapsed = std::chrono::duration<double, std::milli>(now - phaseStarted).count();
+        Base::Console().message(
+            "VIBECAD_SAVE_DETAIL phase=%s document=%s thread=%s elapsed_ms=%.3f\n",
+            phase, getName(), MainThreadSignalConfig::isMainThread() ? "gui" : "worker", elapsed);
+        phaseStarted = now;
+    };
+    std::optional<ArchiveReadScope> archiveRead;
+    const auto* writerThread = &archiveThreadIdentity;
+    MainThreadSignalConfig::invoke([&] {
+        signalStartSave(*this, filename);
+        // Admit the reader on the GUI owner, after its current edit/callback
+        // finishes and before another user event can start a property write.
+        archiveRead.emplace(*d, writerThread);
+    }, true);
+    tracePhase("start_observers");
 
     auto hGrp = GetApplication().GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document");
     int compression = static_cast<int>(hGrp->GetInt("CompressionLevel", 7));
@@ -2318,13 +2784,17 @@ bool Document::saveToFile(const char* filename) const
                         << " FreeCAD Document, see https://www.freecad.org for more information..."
                         << '\n'
                         << "-->" << '\n';
+        tracePhase("open_archive");
         Document::Save(writer);
+        tracePhase("document_xml");
 
         // Special handling for Gui document.
         signalSaveDocument(writer);
+        tracePhase("register_gui_files");
 
         // write additional files
         writer.writeFiles();
+        tracePhase("embedded_files");
         if (writer.hasErrors()) {
             // retrieve Writer error strings
             std::stringstream message;
@@ -2333,8 +2803,13 @@ bool Document::saveToFile(const char* filename) const
             throw Base::FileException(message.str().c_str(), tmp);
         }
 
-        GetApplication().signalSaveDocument(*this);
+        // All document-owned data is now captured. Compression finalization and
+        // file publication below no longer read it; save observers may edit again.
+        archiveRead->release();
+        MainThreadSignalConfig::invoke([this] { GetApplication().signalSaveDocument(*this); }, true);
+        tracePhase("archive_observers");
     }
+    tracePhase("close_archive");
 
     if (policy) {
         // if saving the project data succeeded rename to the actual file name
@@ -2373,7 +2848,9 @@ bool Document::saveToFile(const char* filename) const
         backupPolicy.apply(fn, nativePath);
     }
 
+    tracePhase("publish_file");
     signalFinishSave(*this, filename);
+    tracePhase("finish_observers");
 
     return true;
 }
@@ -2408,12 +2885,17 @@ std::string Document::makeUniqueLabel(std::string_view modelLabel)
 
 bool Document::isAnyRestoring()
 {
-    return globalIsRestoring;
+    return activeRestoreScopes.load(std::memory_order_acquire) != 0;
 }
 
 // Open the document
 void Document::restore(const char* filename, bool delaySignal, const std::vector<std::string>& objNames)
 {
+    Base::CancellationScope::check();
+    const bool traceRestore = std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
+    const auto restoreStarted = std::chrono::steady_clock::now();
+    RestorePresentationStartGuard restorePresentation(*this, d->restorePresentationDepth);
+
     clearUndos();
     d->activeObject = nullptr;
 
@@ -2421,27 +2903,30 @@ void Document::restore(const char* filename, bool delaySignal, const std::vector
     Document* activeDoc = GetApplication().getActiveDocument();
     if (!d->objectArray.empty()) {
         signal = true;
-        GetApplication().signalDeleteDocument(*this);
+        MainThreadSignalConfig::invoke([this] { GetApplication().signalDeleteDocument(*this); }, true);
         d->clearDocument();
     }
 
-    Base::FlagToggler<> flag(globalIsRestoring, false);
+    RestoreActivityScope restoreActivity;
 
     setStatus(Document::PartialDoc, false);
 
     d->clearRecomputeLog();
     d->objectLabelManager.clear();
     d->objectArray.clear();
+    d->objectAddresses.clear();
     d->objectNameManager.clear();
     d->objectMap.clear();
     d->objectIdMap.clear();
     d->lastObjectId = 0;
 
     if (signal) {
-        GetApplication().signalNewDocument(*this, true);
-        if (activeDoc == this) {
-            GetApplication().setActiveDocument(this);
-        }
+        MainThreadSignalConfig::invoke([this, activeDoc] {
+            GetApplication().signalNewDocument(*this, true);
+            if (activeDoc == this) {
+                GetApplication().setActiveDocument(this);
+            }
+        }, true);
     }
 
     if (!filename) {
@@ -2463,7 +2948,7 @@ void Document::restore(const char* filename, bool delaySignal, const std::vector
         throw Base::FileException("Error reading compression file", filename);
     }
 
-    GetApplication().signalStartRestoreDocument(*this);
+    MainThreadSignalConfig::invoke([this] { GetApplication().signalStartRestoreDocument(*this); }, true);
     setStatus(Document::Restoring, true);
 
     d->partialLoadObjects.clear();
@@ -2473,10 +2958,14 @@ void Document::restore(const char* filename, bool delaySignal, const std::vector
     try {
         Document::Restore(reader);
     }
+    catch (const Base::AbortException&) {
+        throw;
+    }
     catch (const Base::Exception& e) {
         Base::Console().error("Invalid Document.xml: %s\n", e.what());
         setStatus(Document::RestoreError, true);
     }
+    const auto documentXmlRestored = std::chrono::steady_clock::now();
 
     d->partialLoadObjects.clear();
     d->programVersion = reader.ProgramVersion;
@@ -2487,6 +2976,7 @@ void Document::restore(const char* filename, bool delaySignal, const std::vector
     // without GUI. But if available then follow after all data files of the App document.
     signalRestoreDocument(reader);
     reader.readFiles(zipstream);
+    const auto embeddedFilesRestored = std::chrono::steady_clock::now();
 
     DocumentP::checkStringHasher(reader);
 
@@ -2499,29 +2989,75 @@ void Document::restore(const char* filename, bool delaySignal, const std::vector
         );
     }
 
+    restorePresentation.transfer();
     if (!delaySignal) {
         afterRestore(true);
+    }
+    if (traceRestore) {
+        const auto restoreFinished = std::chrono::steady_clock::now();
+        const auto elapsed = [](auto begin, auto end) {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count();
+        };
+        Base::Console().message(
+            "VIBECAD_RESTORE_DETAIL document_restore document_xml_ms=%lld embedded_files_ms=%lld "
+            "after_restore_ms=%lld total_ms=%lld\n",
+            static_cast<long long>(elapsed(restoreStarted, documentXmlRestored)),
+            static_cast<long long>(elapsed(documentXmlRestored, embeddedFilesRestored)),
+            static_cast<long long>(elapsed(embeddedFilesRestored, restoreFinished)),
+            static_cast<long long>(elapsed(restoreStarted, restoreFinished))
+        );
+    }
+}
+
+void Document::abandonRestore()
+{
+    // Leave Restoring set until close: releasing the presentation scopes must
+    // not attach/render a document whose archive was cancelled halfway through.
+    while (d->restorePresentationDepth > 0) {
+        --d->restorePresentationDepth;
+        endPresentationUpdate();
     }
 }
 
 bool Document::afterRestore(const bool checkPartial)
 {
-    Base::FlagToggler<> flag(globalIsRestoring, false);
+    const bool traceRestore = std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
+    const auto restoreStarted = std::chrono::steady_clock::now();
+    RestorePresentationFinishGuard restorePresentation(*this, d->restorePresentationDepth);
+
+    Base::CancellationScope::check();
+    RestoreActivityScope restoreActivity;
     if (!afterRestore(d->objectArray, checkPartial)) {
         FC_WARN("Reload partial document " << getName());
-        GetApplication().signalPendingReloadDocument(*this);
+        MainThreadSignalConfig::invoke([this] { GetApplication().signalPendingReloadDocument(*this); }, true);
         return false;
     }
     if (!testStatus(Document::TempDoc)) {
         DocumentTimeline::ensure(this)->normalizeAfterRestore();
     }
-    GetApplication().signalFinishRestoreDocument(*this);
+    MainThreadSignalConfig::invoke([this] { GetApplication().signalFinishRestoreDocument(*this); }, true);
+    const auto finishSignalComplete = std::chrono::steady_clock::now();
     setStatus(Document::Restoring, false);
+    if (traceRestore) {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            finishSignalComplete - restoreStarted
+        ).count();
+        Base::Console().message(
+            "VIBECAD_RESTORE_DETAIL after_restore finish_signal_ms=%lld\n",
+            static_cast<long long>(elapsed)
+        );
+    }
     return true;
 }
 
 bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool checkPartial)
 {
+    const bool traceRestore = std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
+    const auto restoreStarted = std::chrono::steady_clock::now();
+    Base::SequencerLauncher finalizeRestore(
+        "Finalizing restored document...",
+        objArray.size() * 2
+    );
     checkPartial = checkPartial && testStatus(Document::PartialDoc);
     if (checkPartial && !d->touchedObjs.empty()) {
         return false;
@@ -2535,11 +3071,18 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
     // information is not ready yet.
     std::map<DocumentObject*, std::vector<Property*>> propMap;
     for (auto obj : objArray) {
+        Base::CancellationScope::check();
+        finalizeRestore.next(false);
+        const auto objectStarted = std::chrono::steady_clock::now();
         auto& props = propMap[obj];
         obj->getPropertyList(props);
         for (auto prop : props) {
+            Base::CancellationScope::check();
             try {
                 prop->afterRestore();
+            }
+            catch (const Base::AbortException&) {
+                throw;
             }
             catch (const Base::Exception& e) {
                 FC_ERR(
@@ -2548,7 +3091,21 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
                 );
             }
         }
+        if (traceRestore) {
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - objectStarted
+            ).count();
+            if (elapsed >= 20) {
+                Base::Console().message(
+                    "VIBECAD_RESTORE_DETAIL property_after_restore type=%s name=%s elapsed_ms=%lld\n",
+                    obj->getTypeId().getName(),
+                    obj->getNameInDocument(),
+                    static_cast<long long>(elapsed)
+                );
+            }
+        }
     }
+    const auto propertiesRestored = std::chrono::steady_clock::now();
 
     if (checkPartial && !d->touchedObjs.empty()) {
         // partial document touched, signal full reload
@@ -2557,12 +3114,17 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
 
     std::set<DocumentObject*> objSet(objArray.begin(), objArray.end());
     auto objs = getDependencyList(objArray.empty() ? d->objectArray : objArray, DepSort);
+    const auto dependenciesSorted = std::chrono::steady_clock::now();
     for (auto obj : objs) {
+        Base::CancellationScope::check();
         if (objSet.find(obj) == objSet.end()) {
             continue;
         }
+        finalizeRestore.next(false);
+        const auto objectStarted = std::chrono::steady_clock::now();
         try {
             for (auto prop : propMap[obj]) {
+                Base::CancellationScope::check();
                 prop->onContainerRestored();
             }
             bool touched = false;
@@ -2580,6 +3142,9 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
                 d->touchedObjs.insert(obj);
             }
         }
+        catch (const Base::AbortException&) {
+            throw;
+        }
         catch (const Base::Exception& e) {
             d->addRecomputeLog(e.what(), obj);
             FC_ERR("Failed to restore " << obj->getFullName() << ": " << e.what());
@@ -2593,10 +3158,15 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
             // If a Python exception occurred, it must be cleared immediately.
             // Otherwise, the interpreter remains in a dirty state, causing
             // Segfaults later when FreeCAD interacts with Python.
-            if (PyErr_Occurred()) {
-                Base::Console().error("Python error during object restore:\n");
-                PyErr_Print();  // Print the traceback to stderr/Console
-                PyErr_Clear();  // Reset the interpreter state
+            {
+                // Native restore phases do not hold the GIL. Even querying
+                // Python's error indicator requires an attached thread state.
+                Base::PyGILStateLocker python;
+                if (PyErr_Occurred()) {
+                    Base::Console().error("Python error during object restore:\n");
+                    PyErr_Print();  // Print the traceback to stderr/Console
+                    PyErr_Clear();  // Reset the interpreter state
+                }
             }
 
             d->addRecomputeLog("Unknown exception on restore", obj);
@@ -2638,9 +3208,37 @@ bool Document::afterRestore(const std::vector<DocumentObject*>& objArray, bool c
         }
 
         signalFinishRestoreObject(*obj);
+        if (traceRestore) {
+            const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - objectStarted
+            ).count();
+            if (elapsed >= 20) {
+                Base::Console().message(
+                    "VIBECAD_RESTORE_DETAIL finalize_object type=%s name=%s elapsed_ms=%lld\n",
+                    obj->getTypeId().getName(),
+                    obj->getNameInDocument(),
+                    static_cast<long long>(elapsed)
+                );
+            }
+        }
     }
 
     d->touchedObjs.clear();
+    if (traceRestore) {
+        const auto restoreFinished = std::chrono::steady_clock::now();
+        const auto elapsed = [](auto begin, auto end) {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count();
+        };
+        Base::Console().message(
+            "VIBECAD_RESTORE_DETAIL after_restore_phases count=%llu property_ms=%lld "
+            "dependency_ms=%lld finalize_ms=%lld total_ms=%lld\n",
+            static_cast<unsigned long long>(objArray.size()),
+            static_cast<long long>(elapsed(restoreStarted, propertiesRestored)),
+            static_cast<long long>(elapsed(propertiesRestored, dependenciesSorted)),
+            static_cast<long long>(elapsed(dependenciesSorted, restoreFinished)),
+            static_cast<long long>(elapsed(restoreStarted, restoreFinished))
+        );
+    }
     return true;
 }
 
@@ -2739,7 +3337,8 @@ void Document::setClosable(bool c)  // NOLINT
 
 bool Document::isClosable() const
 {
-    return testStatus(Document::Closable) && !isCooperativeMutationActive();
+    return testStatus(Document::Closable) && !isCooperativeMutationActive()
+        && !isPresentationUpdateActive();
 }
 
 int Document::countObjects() const
@@ -3145,20 +3744,74 @@ void Document::renameObjectIdentifiers(
 
 int Document::recompute(const std::vector<DocumentObject*>& objs, bool force, bool* hasError, int options)
 {
-    ZoneScoped;
-
-    if (isCooperativeMutationActive()) {
-        FC_WARN("Cannot recompute while a cooperative document mutation is active");
+    if (isCooperativeMutationActive() || isPresentationUpdateActive()) {
+        FC_WARN("Cannot recompute while a document update is active");
         return 0;
     }
+    if (MainThreadSignalConfig::hasHooks() && MainThreadSignalConfig::isMainThread()) {
+        // Preserve the synchronous public API, but not a synchronous GUI wait:
+        // feature workers emit owner-thread notifications before they finish.
+        // The coordinator must therefore run off-owner while Qt keeps serving
+        // those notifications, input and paint. The existing document lease
+        // prevents an intervening edit/undo/close from invalidating its targets.
+        beginCooperativeMutation();
+        int count = 0;
+        std::exception_ptr failure;
+        try {
+            QEventLoop events;
+            bool complete = false;
+            std::unique_ptr<Base::PyGILStateRelease> release;
+            if (Py_IsInitialized() && PyGILState_Check()) {
+                release = std::make_unique<Base::PyGILStateRelease>();
+            }
+            GetApplication().hostRuntime().submitWithCompletion(
+                HostRuntime::Lane::Document,
+                [this, &objs, force, hasError, options](std::stop_token stop) {
+                    return recomputeCancellable(objs, force, hasError, options, stop);
+                },
+                [&](std::future<int> result) {
+                    QMetaObject::invokeMethod(
+                        &events,
+                        [&, result = result.share()] {
+                            try { count = result.get(); }
+                            catch (...) { failure = std::current_exception(); }
+                            complete = true;
+                            // Stop WaitForMoreEvents in this dispatch, rather
+                            // than waiting for unrelated input after completion.
+                            events.quit();
+                        },
+                        Qt::QueuedConnection
+                    );
+                }
+            );
+            // Event-driven, not a polling timer or a deadline. Keep the frame
+            // dispatcher alive even if an outer event loop is asked to quit;
+            // stack-owned targets stay alive until the worker acknowledges.
+            while (!complete) {
+                events.processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents);
+            }
+        }
+        catch (...) {
+            failure = std::current_exception();
+        }
+        endCooperativeMutation();
+        if (failure) {
+            std::rethrow_exception(failure);
+        }
+        return count;
+    }
+    return recomputeCancellable(objs, force, hasError, options, {});
+}
 
-    // Recompute can execute Python-backed features. Keep the GIL for the full
-    // recompute so async recompute still serializes Python execution the same
-    // way the main-thread path does, preserving compatibility with existing
-    // Python-backed objects and addons. Main-thread signal hops such as
-    // signalBeforeRecompute() temporarily release it when they need to run
-    // Python on the GUI thread to avoid deadlocks.
-    Base::PyGILStateLocker locker;
+int Document::recomputeCancellable(
+    const std::vector<DocumentObject*>& objs,
+    bool force,
+    bool* hasError,
+    int options,
+    std::stop_token stopToken
+)
+{
+    ZoneScoped;
 
     if (d->undoing || d->rollback) {
         if (FC_LOG_INSTANCE.isEnabled(FC_LOGLEVEL_LOG)) {
@@ -3232,96 +3885,149 @@ int Document::recompute(const std::vector<DocumentObject*>& objs, bool force, bo
     tracker.checkpoint("pre-recompute & topo sort");
 
     try {
+        const auto recomputeWaves = makeRecomputeWaves(
+            topoSortedObjects,
+            fineGrained,
+            options
+        );
+        auto& runtime = GetApplication().hostRuntime();
         std::set<DocumentObject*> filter;
-        size_t idx = 0;
-        // maximum two passes to allow some form of dependency inversion
-        for (int passes = 0; passes < 2 && idx < topoSortedObjects.size(); ++passes) {
+        bool terminatePasses = false;
+
+        // A second pass preserves the established dependency-inversion repair
+        // behavior. Within each pass, only dependency-independent objects are
+        // evaluated together; touched propagation remains deterministic.
+        for (int pass = 0; pass < 2 && !terminatePasses; ++pass) {
             std::unique_ptr<Base::SequencerLauncher> seq;
             if (canAbort) {
                 seq = std::make_unique<Base::SequencerLauncher>(
-                    "Recompute...",
+                    (std::string("Recomputing updated geometry: ") + Label.getValue()).c_str(),
                     topoSortedObjects.size()
                 );
             }
-            FC_LOG("Recompute pass " << passes);
-            for (; idx < topoSortedObjects.size(); ++idx) {
-                auto obj = topoSortedObjects[idx];
-                if (!obj->isAttachedToDocument() || filter.find(obj) != filter.end()) {
-                    continue;
+            FC_LOG("Recompute pass " << pass);
+
+            for (const auto& wave : recomputeWaves) {
+                if (stopToken.stop_requested()) {
+                    terminatePasses = true;
+                    break;
                 }
-                // A rolled-back document state must be computational, not
-                // merely visual. Native suppressible features still execute
-                // their explicit bypass branch. Other future operations keep
-                // their touched state so edits and upstream changes are
-                // recomputed exactly once when the marker advances again.
-                if (const auto* timeline = DocumentTimeline::get(obj->getDocument()); timeline
-                    && !timeline->isOperationActive(obj)
-                    && !obj->getExtensionByType<SuppressibleExtension>(true)) {
-                    filter.insert(obj);
-                    continue;
-                }
-                // ask the object if it should be recomputed
-                bool doRecompute = false;
-                if (obj->mustRecompute()) {
-                    doRecompute = true;
+
+                struct PendingFeature
+                {
+                    DocumentObject* object;
+                    std::future<int> result;
+                };
+                std::vector<PendingFeature> pending;
+                pending.reserve(wave.size());
+                std::unordered_set<DocumentObject*> eligible;
+                eligible.reserve(wave.size());
+
+                for (auto* object : wave) {
+                    if (!object->isAttachedToDocument() || filter.contains(object)) {
+                        continue;
+                    }
+                    if (const auto* timeline = DocumentTimeline::get(object->getDocument());
+                        timeline && !timeline->isOperationActive(object)
+                        && !object->getExtensionByType<SuppressibleExtension>(true)) {
+                        filter.insert(object);
+                        continue;
+                    }
+                    eligible.insert(object);
+                    if (!object->mustRecompute()) {
+                        continue;
+                    }
+                    if (!object->canRecomputeOnWorker()) {
+                        FC_THROWM(
+                            Base::RuntimeError,
+                            "Object '" << object->getFullName()
+                                       << "' rejects worker-thread recompute"
+                        );
+                    }
                     ++objectCount;
-                    int res = _recomputeFeature(obj);
-                    if (res != 0) {
+                    pending.push_back(PendingFeature {
+                        object,
+                        runtime.submit([this, object, stopToken](std::stop_token runtimeStop) {
+                            if (stopToken.stop_requested() || runtimeStop.stop_requested()) {
+                                return -1;
+                            }
+                            return _recomputeFeature(object);
+                        })
+                    });
+                }
+
+                std::unordered_map<DocumentObject*, int> results;
+                results.reserve(pending.size());
+                for (auto& feature : pending) {
+                    results.emplace(feature.object, runtime.wait(feature.result));
+                }
+
+                bool abortAfterWave = false;
+                for (auto* object : wave) {
+                    if (seq) {
+                        seq->next(true);
+                    }
+                    if (!eligible.contains(object)) {
+                        continue;
+                    }
+
+                    const auto result = results.find(object);
+                    const bool didRecompute = result != results.end();
+                    if (didRecompute && result->second != 0) {
                         if (hasError) {
                             *hasError = true;
                         }
-                        if (res < 0) {
-                            passes = 2;
-                            break;
+                        if (result->second < 0) {
+                            abortAfterWave = true;
+                            continue;
                         }
-                        // if something happened filter all object in its
-                        // inListRecursive from the queue then proceed
-                        obj->getInListEx(filter, true);
-                        filter.insert(obj);
+                        object->getInListEx(filter, true);
+                        filter.insert(object);
                         continue;
                     }
-                }
-                if (obj->isTouched() || doRecompute) {
-                    signalRecomputedObject(*obj);
-                    if (fineGrained) {
-                        // set all dependent objects touched based on properties
-                        std::vector<DepEdge> inList = obj->getInListProp();
-                        for (auto& [objFrom, propFrom, objTo, propTo] : inList) {
-                            if (obj->touchedProps.contains(propTo) || propTo.empty()) {
-                                objFrom->enforceRecompute(propFrom);
+
+                    if (object->isTouched() || didRecompute) {
+                        signalRecomputedObject(*object);
+                        if (fineGrained) {
+                            const std::vector<DepEdge> inList = object->getInListProp();
+                            for (const auto& [objFrom, propFrom, objTo, propTo] : inList) {
+                                (void)objTo;
+                                if (object->touchedProps.contains(propTo) || propTo.empty()) {
+                                    objFrom->enforceRecompute(propFrom);
+                                }
+                            }
+                            object->purgeTouched();
+                        }
+                        else {
+                            object->purgeTouched();
+                            for (auto* dependent : object->getInList()) {
+                                dependent->enforceRecompute();
                             }
                         }
-                        obj->purgeTouched();
-                    }
-                    else {
-                        obj->purgeTouched();
-                        // set all dependent objects touched to force recompute
-                        for (auto inObjIt : obj->getInList()) {
-                            inObjIt->enforceRecompute();
-                        }
                     }
                 }
-                if (seq) {
-                    seq->next(true);
+                if (abortAfterWave) {
+                    terminatePasses = true;
+                    break;
                 }
             }
-            // check if all objects are recomputed but still thouched
-            for (size_t i = 0; i < topoSortedObjects.size(); ++i) {
-                auto obj = topoSortedObjects[i];
-                obj->setStatus(ObjectStatus::Recompute2, false);
-                if (!filter.contains(obj) && obj->isTouched()) {
-                    if (passes > 0) {
-                        FC_ERR(obj->getFullName() << " still touched after recompute");
+
+            bool needsAnotherPass = false;
+            for (auto* object : topoSortedObjects) {
+                object->setStatus(ObjectStatus::Recompute2, false);
+                if (!filter.contains(object) && object->isTouched()) {
+                    if (pass > 0) {
+                        FC_ERR(object->getFullName() << " still touched after recompute");
                     }
                     else {
-                        FC_LOG(obj->getFullName() << " still touched after recompute");
-                        if (idx >= topoSortedObjects.size()) {
-                            // let's start the next pass on the first touched object
-                            idx = i;
-                        }
-                        obj->setStatus(ObjectStatus::Recompute2, true);
+                        FC_LOG(object->getFullName() << " still touched after recompute");
+                        object->setStatus(ObjectStatus::Recompute2, true);
+                        needsAnotherPass = true;
                     }
                 }
+            }
+            if (!needsAnotherPass) {
+                break;
             }
         }
     }
@@ -3347,11 +4053,11 @@ int Document::recompute(const std::vector<DocumentObject*>& objs, bool force, bo
 
     signalRecomputed(*this, topoSortedObjects);
     recomputingStatus.reset();
-    signalBecameStable(*this);
+    notifyBecameStable();
 
     tracker.checkpoint("Recompute total");
 
-    if (!d->_RecomputeLog.empty()) {
+    if (d->hasRecomputeLog()) {
         if (!testStatus(Status::IgnoreErrorOnRecompute)) {
             for (auto it : topoSortedObjects) {
                 if (it->isError()) {
@@ -3573,7 +4279,7 @@ const char* Document::getErrorDescription(const DocumentObject* Obj) const
 
 std::uint64_t Document::getRecomputeDiagnosticGeneration() const
 {
-    return d->recomputeDiagnosticGeneration;
+    return d->getRecomputeDiagnosticGeneration();
 }
 
 const std::vector<RecomputeDiagnostic>& Document::getRecomputeDiagnostics() const
@@ -3787,8 +4493,13 @@ DocumentObject* Document::addObject(
     const bool isPartial
 )
 {
+    checkArchiveMutation(*d);
+    const bool traceRestore = testStatus(Status::Restoring)
+        && std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
+    const auto traceStart = std::chrono::steady_clock::now();
     const Base::Type type
         = Base::Type::getTypeIfDerivedFrom(sType, DocumentObject::getClassTypeId(), true);
+    const auto typeReady = std::chrono::steady_clock::now();
     if (type.isBad()) {
         std::stringstream str;
         str << "Document::addObject: '" << sType << "' is not a document object type";
@@ -3796,6 +4507,7 @@ DocumentObject* Document::addObject(
     }
 
     void* typeInstance = type.createInstance();
+    const auto instanceReady = std::chrono::steady_clock::now();
     if (!typeInstance) {
         return nullptr;
     }
@@ -3812,6 +4524,27 @@ DocumentObject* Document::addObject(
             | AddObjectOption::ActivateObject,
         viewType
     );
+    const auto objectAdded = std::chrono::steady_clock::now();
+
+    if (traceRestore) {
+        const auto elapsed = [](auto begin, auto end) {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count();
+        };
+        const auto total = elapsed(traceStart, objectAdded);
+        if (total >= 20) {
+            Base::Console().message(
+                "VIBECAD_RESTORE_DETAIL add_object type=%.*s name=%s type_lookup_ms=%lld "
+                "create_instance_ms=%lld register_and_signal_ms=%lld total_ms=%lld\n",
+                static_cast<int>(sType.size()),
+                sType.data(),
+                pObjectName ? pObjectName : "",
+                static_cast<long long>(elapsed(traceStart, typeReady)),
+                static_cast<long long>(elapsed(typeReady, instanceReady)),
+                static_cast<long long>(elapsed(instanceReady, objectAdded)),
+                static_cast<long long>(total)
+            );
+        }
+    }
 
     // return the Object
     return pcObject;
@@ -3823,6 +4556,7 @@ std::vector<DocumentObject*> Document::addObjects(
     bool isNew
 )
 {
+    checkArchiveMutation(*d);
     Base::Type type = Base::Type::getTypeIfDerivedFrom(sType, DocumentObject::getClassTypeId(), true);
     if (type.isBad()) {
         std::stringstream str;
@@ -3861,6 +4595,7 @@ std::vector<DocumentObject*> Document::addObjects(
 
 void Document::addObject(DocumentObject* obj, const char* name)
 {
+    checkArchiveMutation(*d);
     if (obj->getDocument()) {
         throw Base::RuntimeError("Document object is already added to a document");
     }
@@ -3893,6 +4628,8 @@ void Document::_addObject(
         DocumentP& state;
     } addObjectCriticalScope(*d);
 
+    advanceObjectChangeGeneration();
+
     // get unique name
     string ObjectName;
     if (!Base::Tools::isNullOrEmpty(pObjectName)) {
@@ -3917,6 +4654,7 @@ void Document::_addObject(
     }
     d->objectIdMap[pcObject->_Id] = pcObject;
     d->objectArray.push_back(pcObject);
+    d->objectAddresses.insert(pcObject);
 
     // do no transactions if we do a rollback!
     if (!d->rollback) {
@@ -4039,6 +4777,7 @@ void Document::_addObject(
         }
     }
 
+    advanceObjectChangeGeneration();
     if (setupException) {
         std::rethrow_exception(setupException);
     }
@@ -4049,7 +4788,7 @@ bool Document::containsObject(const DocumentObject* pcObject) const
     // Compare stored addresses without dereferencing the candidate. Callers
     // use this during link cleanup, where a property may briefly retain the
     // address of an object which has already left the document.
-    return pcObject && std::ranges::find(d->objectArray, pcObject) != d->objectArray.end();
+    return pcObject && d->objectAddresses.contains(pcObject);
 }
 
 /// Remove an object out of the document
@@ -4063,6 +4802,7 @@ void Document::removeObject(const DocumentObject* object)
 /// Remove an object out of the document
 void Document::removeObject(const char* sName)
 {
+    checkArchiveMutation(*d);
     auto pos = d->objectMap.find(sName);
     if (pos == d->objectMap.end()) {
         FC_MSG("Object " << sName << " already deleted in document " << getName());
@@ -4102,6 +4842,7 @@ void Document::removeObject(const char* sName)
 }
 void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions options)
 {
+    advanceObjectChangeGeneration();
     if (!options.testFlag(RemoveObjectOption::MayRemoveWhileRecomputing)
         && testStatus(Document::Recomputing)) {
         FC_ERR("Cannot delete " << pcObject->getFullName() << " while recomputing");
@@ -4156,6 +4897,7 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
     }
 
     // Mark the object as about to be removed
+    d->objectRemovalGeneration.fetch_add(1, std::memory_order_release);
     pcObject->setStatus(ObjectStatus::Remove, true);
     if (!d->undoing && !d->rollback) {
         pcObject->unsetupObject();
@@ -4198,6 +4940,7 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
             break;
         }
     }
+    d->objectAddresses.erase(pcObject);
 
     // In case the object gets deleted the pointer must be nullified
     if (tobedestroyed) {
@@ -4207,6 +4950,8 @@ void Document::_removeObject(DocumentObject* pcObject, RemoveObjectOptions optio
     // Erase last to avoid invalidating pcObject->pcNameInDocument
     // when it is still needed in Transaction::addObjectNew
     d->objectMap.erase(pos);
+    d->objectRemovalGeneration.fetch_add(1, std::memory_order_release);
+    advanceObjectChangeGeneration();
 }
 
 void Document::breakDependency(DocumentObject* pcObject, const bool clear)  // NOLINT
@@ -4677,6 +5422,40 @@ const std::vector<DocumentObject*>& Document::getObjects() const
     return d->objectArray;
 }
 
+std::uint64_t Document::getObjectChangeGeneration() const noexcept
+{
+    return d->objectChangeGeneration.load(std::memory_order_acquire);
+}
+
+void Document::advanceObjectChangeGeneration() noexcept
+{
+    advanceObjectChangeGeneration(nullptr);
+}
+
+std::uint64_t Document::getObjectStructureGeneration() const noexcept
+{
+    return d->objectStructureGeneration.load(std::memory_order_acquire);
+}
+
+std::uint64_t Document::getObjectRemovalGeneration() const noexcept
+{
+    return d->objectRemovalGeneration.load(std::memory_order_acquire);
+}
+
+void Document::advanceObjectChangeGeneration(const Property* changedValue) noexcept
+{
+    d->objectChangeGeneration.fetch_add(1, std::memory_order_release);
+    if (changedValue) {
+        const auto* object = dynamic_cast<const DocumentObject*>(changedValue->getContainer());
+        if ((object && changedValue == &object->Visibility)
+            || dynamic_cast<const PropertyPlacement*>(changedValue)
+            || dynamic_cast<const PropertyComplexGeoData*>(changedValue)) {
+            return;
+        }
+    }
+    d->objectStructureGeneration.fetch_add(1, std::memory_order_release);
+}
+
 std::vector<DocumentObject*> Document::getObjectsOfType(const Base::Type& typeId) const
 {
     std::vector<DocumentObject*> Objects;
@@ -4724,6 +5503,16 @@ std::vector<DocumentObject*> Document::findObjects(
     const char* label
 ) const
 {
+    return findObjects(typeId, objname, label, nullptr);
+}
+
+std::vector<DocumentObject*> Document::findObjects(
+    const Base::Type& typeId,
+    const char* objname,
+    const char* label,
+    const char* property
+) const
+{
     boost::cmatch what;
     boost::regex rx_name;
     boost::regex rx_label;
@@ -4739,7 +5528,7 @@ std::vector<DocumentObject*> Document::findObjects(
     std::vector<DocumentObject*> Objects;
     DocumentObject* found = nullptr;
     for (const auto it : d->objectArray) {
-        if (it->isDerivedFrom(typeId)) {
+        if (it->isDerivedFrom(typeId) && (!property || it->getPropertyByName(property))) {
             found = it;
 
             if (!rx_name.empty() && !boost::regex_search(it->getNameInDocument(), what, rx_name)) {

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -43,6 +43,7 @@
 #include <utility>
 #include <list>
 #include <cstdint>
+#include <stop_token>
 #include <string>
 #include <string_view>
 
@@ -297,6 +298,11 @@ public:
     App::MainThreadSignal<void(const Document&)> signalTransactionLockChanged;
     /// Signal when the outermost cooperative document mutation begins or ends.
     App::MainThreadSignal<void(const Document&, bool)> signalCooperativeMutationChanged;
+    /// Signal when asynchronous presentation work transitions between idle and active.
+    App::MainThreadSignal<void(const Document&, bool)> signalPresentationUpdateChanged;
+    /// Completed property-schema or extension change. The immutable object ID
+    /// avoids exposing a removed property to deferred projection consumers.
+    App::MainThreadSignal<void(long)> signalObjectSchemaChanged;
     /// Signal after document recompute/transaction state has fully unwound and
     /// observers may treat the document as stable again.
     App::MainThreadSignal<void(const Document&)> signalBecameStable;
@@ -941,6 +947,14 @@ public:
         const char* label
     ) const;
 
+    /** Match the existing criteria and require a named native property. */
+    std::vector<DocumentObject*> findObjects(
+        const Base::Type& typeId,
+        const char* objname,
+        const char* label,
+        const char* property
+    ) const;
+
     /**
      * @brief Get all objects of a given type.
      *
@@ -1028,6 +1042,15 @@ public:
         int options = 0
     );
 
+    /** Recompute with cooperative cancellation between dependency operations. */
+    int recomputeCancellable(
+        const std::vector<DocumentObject*>& objs,
+        bool force,
+        bool* hasError,
+        int options,
+        std::stop_token stopToken
+    );
+
     /**
      * @brief Recompute a single object.
      *
@@ -1049,6 +1072,16 @@ public:
 
     /// Generation and structured errors produced by the latest recompute.
     std::uint64_t getRecomputeDiagnosticGeneration() const;
+    /// Monotonic invalidation token for captured object structure and values.
+    /// This is not a lock: capture still requires document-owner access.
+    std::uint64_t getObjectChangeGeneration() const noexcept;
+    /// Structural snapshot token; excludes geometry/placement values and the
+    /// built-in Visibility value. Schema, links, and other metadata still count.
+    /// Consumers reading excluded values must use getObjectChangeGeneration().
+    std::uint64_t getObjectStructureGeneration() const noexcept;
+    /// Invalidates owner-thread identity caches on object removal/clear, but
+    /// not additions or property edits. This token does not grant read access.
+    std::uint64_t getObjectRemovalGeneration() const noexcept;
     const std::vector<RecomputeDiagnostic>& getRecomputeDiagnostics() const;
 
     /**
@@ -1136,6 +1169,18 @@ public:
     void beginCooperativeMutation();
     void endCooperativeMutation();
     bool isCooperativeMutationActive() const;
+
+    /** Track asynchronous GUI presentation work belonging to a document change.
+     *
+     * Presentation owners acquire a nested update before scheduling work and
+     * release it only after their final GUI-owned slice. Background callers
+     * can then await the complete model-and-presentation boundary without
+     * polling or an arbitrary timeout.
+     */
+    void beginPresentationUpdate() const;
+    void endPresentationUpdate() const;
+    bool isPresentationUpdateActive() const;
+    void waitForPresentationReady() const;
 
     bool transacting() const;
 
@@ -1537,6 +1582,7 @@ public:
     // because of transaction handling
     friend class TransactionalObject;
     friend class DocumentObject;
+    friend class ExtensionContainer;
     friend class Transaction;
     friend class TransactionDocumentObject;
 
@@ -1713,6 +1759,13 @@ protected:
     void _abortTransaction();
 
 private:
+    void advanceObjectChangeGeneration() noexcept;
+    void advanceObjectChangeGeneration(const Property* changedValue) noexcept;
+    // Application calls this only after an interrupted restore worker has
+    // unwound, immediately before removing its incomplete document.
+    void abandonRestore();
+    void invalidateTimelineVisibilityResources(const char* propertyName);
+    void notifyBecameStable() const;
     void setBookedTransaction(int transactionId) const;
     bool isBreakingDependency() const noexcept;
     void changePropertyOfObject(

--- a/src/App/Document.pyi
+++ b/src/App/Document.pyi
@@ -87,6 +87,9 @@ class Document(PropertyContainer):
     CooperativeMutationActive: Final[bool] = False
     """Indicate whether a resumable document-thread mutation is active."""
 
+    PresentationUpdateActive: Final[bool] = False
+    """Indicate whether asynchronous document presentation is still updating."""
+
     OldLabel: Final[str] = ""
     """Contains the old label before change"""
 
@@ -209,6 +212,10 @@ class Document(PropertyContainer):
 
     def endCooperativeMutation(self) -> None:
         """End a nested resumable document-thread mutation."""
+        ...
+
+    def waitForPresentationReady(self) -> None:
+        """Wait off the GUI thread for document mutation and presentation to finish."""
         ...
 
     @overload
@@ -453,6 +460,22 @@ class Document(PropertyContainer):
         """
         ...
 
+    def getObjectStructureGeneration(self) -> int:
+        """Return the structural invalidation token for owner-thread caches.
+
+        Placements, geometry values and built-in visibility do not change it.
+        This token is not a lock and does not authorize off-thread document reads.
+        """
+        ...
+
+    def getObjectRemovalGeneration(self) -> int:
+        """Return an owner-thread identity-cache token changed by removal/clear.
+
+        Additions and property changes do not advance it. It is not a lock and
+        does not authorize off-thread document reads.
+        """
+        ...
+
     def getRecomputeDiagnostics(self) -> dict:
         """
         Return the generation and structured diagnostics from the latest recompute.
@@ -496,6 +519,7 @@ class Document(PropertyContainer):
         Type: str = None,
         Name: str = None,
         Label: str = None,
+        Property: str = None,
     ) -> list[DocumentObject]:
         """
         Return a list of objects that match the specified type, name or label.
@@ -506,6 +530,7 @@ class Document(PropertyContainer):
             Type: Type of the feature.
             Name: Name
             Label: Label
+            Property: Require this named native property, without reading its value.
         """
         ...
 
@@ -609,6 +634,20 @@ class Document(PropertyContainer):
 
         Returns:
             True when the order changed, or False when it already matched.
+        """
+        ...
+
+    def reorderTimelineOperationDependentClosuresAfter(
+        self,
+        operations: Sequence[DocumentObject],
+        target: DocumentObject,
+        /,
+    ) -> bool:
+        """Move several operations and their shared downstream closure once.
+
+        Requires the same owned transaction and full-history boundary as the
+        single-operation entry. Complete semantic blocks and state are retained;
+        duplicate roots, cycles and invalid chronology are rejected atomically.
         """
         ...
 

--- a/src/App/DocumentObject.cpp
+++ b/src/App/DocumentObject.cpp
@@ -486,6 +486,23 @@ const std::vector<DocumentObject*>& DocumentObject::getOutList() const
     return _outList;
 }
 
+bool DocumentObject::hasPropertyLinkTo(const DocumentObject* target) const
+{
+    if (!_propertyLinkTargetsCached) {
+        _propertyLinkTargets.clear();
+        std::vector<Property*> properties;
+        getPropertyList(properties);
+        for (auto* property : properties) {
+            if (auto* link = freecad_cast<PropertyLinkBase*>(property)) {
+                link->getLinks(_propertyLinkTargets, true);
+            }
+        }
+        _propertyLinkTargetsCached = true;
+    }
+    return std::find(_propertyLinkTargets.begin(), _propertyLinkTargets.end(), target)
+        != _propertyLinkTargets.end();
+}
+
 std::vector<DocumentObject*> DocumentObject::getOutList(int options) const
 {
     std::vector<DocumentObject*> res;
@@ -866,10 +883,21 @@ bool DocumentObject::removeDynamicProperty(const char* name)
         ExpressionEngine.setValue(it, std::shared_ptr<Expression>());
     }
 
-    if (bypassLock) {
-        return TransactionalObject::removeDynamicPropertyForTransaction(name);
+    // Removal callbacks run before the property disappears and may inspect
+    // visibility. Invalidate again afterward so that inspection cannot leave
+    // an ownership index containing the removed metadata.
+    const std::string removedName(name);
+    const bool removed = bypassLock
+        ? TransactionalObject::removeDynamicPropertyForTransaction(name)
+        : TransactionalObject::removeDynamicProperty(name);
+    if (removed && _pDoc) {
+        _pDoc->advanceObjectChangeGeneration();
+        _pDoc->invalidateTimelineVisibilityResources(removedName.c_str());
+        if (!_pDoc->signalObjectSchemaChanged.empty()) {
+            _pDoc->signalObjectSchemaChanged(getID());
+        }
     }
-    return TransactionalObject::removeDynamicProperty(name);
+    return removed;
 }
 
 bool DocumentObject::renameDynamicProperty(Property* prop, const char* name)
@@ -902,6 +930,9 @@ bool DocumentObject::renameDynamicProperty(Property* prop, const char* name)
         ExpressionEngine.setValue(idNewProp, exprToMove);
     }
 
+    if (renamed && _pDoc && !_pDoc->signalObjectSchemaChanged.empty()) {
+        _pDoc->signalObjectSchemaChanged(getID());
+    }
     return renamed;
 }
 
@@ -918,12 +949,18 @@ App::Property* DocumentObject::addDynamicProperty(
     auto prop = TransactionalObject::addDynamicProperty(type, name, group, doc, attr, ro, hidden);
     if (prop && _pDoc) {
         _pDoc->addOrRemovePropertyOfObject(this, prop, true);
+        if (!_pDoc->signalObjectSchemaChanged.empty()) {
+            _pDoc->signalObjectSchemaChanged(getID());
+        }
     }
     return prop;
 }
 
 void DocumentObject::onBeforeChange(const Property* prop)
 {
+    if (_pDoc) {
+        _pDoc->advanceObjectChangeGeneration(prop);
+    }
     // Frozen objects reject ordinary edits, but transaction replay and
     // document-owned dependency teardown still have to capture the value
     // being replaced. Without the dependency-teardown case, removing a link
@@ -1048,6 +1085,9 @@ void DocumentObject::onEarlyChange(const Property* prop)
 /// get called by the container when a Property was changed
 void DocumentObject::onChanged(const Property* prop)
 {
+    if (_pDoc) {
+        _pDoc->advanceObjectChangeGeneration(prop);
+    }
     const bool labelChanged = prop == &Label && _pDoc && oldLabel != Label.getStrValue();
     if (labelChanged && _pDoc->containsObject(this)) {
         _pDoc->unregisterLabel(oldLabel);
@@ -1141,6 +1181,8 @@ void DocumentObject::onChanged(const Property* prop)
 
 void DocumentObject::clearOutListCache() const
 {
+    _propertyLinkTargets.clear();
+    _propertyLinkTargetsCached = false;
     _outList.clear();
     _outListMap.clear();
     _outListCached = false;
@@ -1500,6 +1542,9 @@ void App::DocumentObject::_removeBackLink(DocumentObject* rmvObj)
     auto it = std::ranges::find(_inList, rmvObj);
     if (it != _inList.end()) {
         _inList.erase(it);
+        if (_pDoc) {
+            _pDoc->advanceObjectChangeGeneration();
+        }
     }
 }
 
@@ -1510,6 +1555,11 @@ void App::DocumentObject::_addBackLink(DocumentObject* newObj)
     // only once this removal would clear the object from the inlist, even though there may be other
     // link properties from this object that link to us.
     _inList.push_back(newObj);
+    if (_pDoc) {
+        // Incoming ownership may be changed by a property in another document.
+        // Invalidate this target's snapshots as well as the property owner's.
+        _pDoc->advanceObjectChangeGeneration();
+    }
 }
 
 // Fully mimics _removeBackLink()

--- a/src/App/DocumentObject.h
+++ b/src/App/DocumentObject.h
@@ -1086,6 +1086,7 @@ public:
     friend class Document;
     friend class Transaction;
     friend class ObjectExecution;
+    friend class PropertyLinkBase;
 
     /**
      * @brief The standard return object for document object execution.
@@ -1524,6 +1525,10 @@ private:
     mutable std::unordered_map<const char*, App::DocumentObject*, CStringHasher, CStringHasher> _outListMap;
     mutable bool _outListCached = false;
     mutable bool _outListCachedProp = false;
+    // Owner-confined deletion query; unlike the DAG cache, includes hidden links.
+    bool hasPropertyLinkTo(const DocumentObject* target) const;
+    mutable std::vector<App::DocumentObject*> _propertyLinkTargets;
+    mutable bool _propertyLinkTargetsCached = false;
 
 public:
     /**

--- a/src/App/DocumentObserverPython.cpp
+++ b/src/App/DocumentObserverPython.cpp
@@ -136,6 +136,7 @@ DocumentObserverPython::DocumentObserverPython(const Py::Object& obj)
     FC_PY_ELEMENT_ARG1(RecomputedObject, ObjectRecomputed)
     FC_PY_ELEMENT_ARG1(BeforeRecomputeDocument, BeforeRecomputeDocument)
     FC_PY_ELEMENT_ARG1(RecomputedDocument, Recomputed)
+    FC_PY_ELEMENT_ARG2(CooperativeMutationChanged, CooperativeMutationChanged)
     FC_PY_ELEMENT_ARG2(OpenTransaction, OpenTransaction)
     FC_PY_ELEMENT_ARG1(CommitTransaction, CommitTransaction)
     FC_PY_ELEMENT_ARG1(AbortTransaction, AbortTransaction)
@@ -443,6 +444,22 @@ void DocumentObserverPython::slotBeforeRecomputeDocument(const App::Document& do
     }
     catch (Py::Exception&) {
         Base::PyException e;  // extract the Python error text
+        e.reportException();
+    }
+}
+
+void DocumentObserverPython::slotCooperativeMutationChanged(const App::Document& doc, bool active)
+{
+    Base::PyGILStateLocker lock;
+    PendingPythonErrorScope pendingError;
+    try {
+        Py::Tuple args(2);
+        args.setItem(0, Py::asObject(const_cast<App::Document&>(doc).getPyObject()));
+        args.setItem(1, Py::Boolean(active));
+        Base::pyCall(pyCooperativeMutationChanged.ptr(), args.ptr());
+    }
+    catch (Py::Exception&) {
+        Base::PyException e;
         e.reportException();
     }
 }

--- a/src/App/DocumentObserverPython.h
+++ b/src/App/DocumentObserverPython.h
@@ -88,6 +88,8 @@ private:
     void slotBeforeRecomputeDocument(const App::Document& Doc);
     /** Called when an observed document is recomputed */
     void slotRecomputedDocument(const App::Document& Doc);
+    /** Called at the outermost native cooperative mutation boundary. */
+    void slotCooperativeMutationChanged(const App::Document& Doc, bool active);
     /** Called when an observed document opens a transaction */
     void slotOpenTransaction(const App::Document& Doc, std::string str);
     /** Called when an observed document commits a transaction */
@@ -147,6 +149,7 @@ private:
     Connection pyRecomputedObject;
     Connection pyBeforeRecomputeDocument;
     Connection pyRecomputedDocument;
+    Connection pyCooperativeMutationChanged;
     Connection pyOpenTransaction;
     Connection pyCommitTransaction;
     Connection pyAbortTransaction;

--- a/src/App/DocumentPyImp.cpp
+++ b/src/App/DocumentPyImp.cpp
@@ -76,7 +76,8 @@ void validateParsedDocumentObjects(
     }
 }
 
-PyObject* reorderTimelineOperationBlocks(Document* document, PyObject* args, const bool insertBefore)
+PyObject* reorderTimelineOperationBlocks(
+    Document* document, PyObject* args, const bool insertBefore, const bool dependentClosures = false)
 {
     PyObject* pyOperations = nullptr;
     PyObject* pyTarget = nullptr;
@@ -126,8 +127,9 @@ PyObject* reorderTimelineOperationBlocks(Document* document, PyObject* args, con
             throw Py::RuntimeError("This document has no native operation timeline");
         }
         return Py::new_reference_to(Py::Boolean(
-            insertBefore ? timeline->reorderOperationBlocksBefore(operations, target)
-                         : timeline->reorderOperationBlocksAfter(operations, target)
+            dependentClosures ? timeline->reorderOperationDependentClosuresAfter(operations, target)
+                : insertBefore ? timeline->reorderOperationBlocksBefore(operations, target)
+                               : timeline->reorderOperationBlocksAfter(operations, target)
         ));
     }
     PY_CATCH;
@@ -779,6 +781,28 @@ PyObject* DocumentPy::endCooperativeMutation(PyObject* args)
     Py_Return;
 }
 
+PyObject* DocumentPy::waitForPresentationReady(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    auto* document = getDocumentPtr();
+    if (MainThreadSignalConfig::hasHooks() && MainThreadSignalConfig::isMainThread()
+        && (document->isCooperativeMutationActive()
+            || document->isPresentationUpdateActive())) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "waitForPresentationReady() cannot block the GUI thread"
+        );
+        return nullptr;
+    }
+    {
+        Base::PyGILStateRelease release;
+        document->waitForPresentationReady();
+    }
+    Py_Return;
+}
+
 Py::Boolean DocumentPy::getHasPendingTransaction() const
 {
     return {getDocumentPtr()->hasPendingTransaction()};
@@ -959,40 +983,29 @@ PyObject* DocumentPy::recomputeAsync(PyObject* args)
         }
 
         Application& application = GetApplication();
-        std::vector<std::string> unsafeObjects;
-        for (const auto& request : requests) {
-            if (!application.canRecomputeRequestOnWorker(request)) {
-                unsafeObjects.push_back(
-                    request.documentObjectName.empty() ? std::string("<document>")
-                                                       : request.documentObjectName
-                );
-            }
-        }
-        if (!unsafeObjects.empty()) {
-            std::ostringstream message;
-            message << "Asynchronous recompute rejected thread-affine target";
-            if (unsafeObjects.size() != 1) {
-                message << 's';
-            }
-            message << ": ";
-            for (std::size_t index = 0; index < unsafeObjects.size(); ++index) {
-                if (index != 0) {
-                    message << ", ";
-                }
-                message << unsafeObjects[index];
-            }
-            throw Base::RuntimeError(message.str());
-        }
-
         const auto requestCount = requests.size();
         if (!application.tryQueueRecomputeRequests(std::move(requests))) {
-            throw Base::RuntimeError(
-                "Asynchronous recompute targets became worker-unsafe before they were queued"
-            );
+            throw Base::RuntimeError("Asynchronous recompute targets are no longer available");
         }
         return Py::new_reference_to(Py::Long(requestCount));
     }
     PY_CATCH;
+}
+
+PyObject* DocumentPy::getObjectStructureGeneration(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    return PyLong_FromUnsignedLongLong(getDocumentPtr()->getObjectStructureGeneration());
+}
+
+PyObject* DocumentPy::getObjectRemovalGeneration(PyObject* args)
+{
+    if (!PyArg_ParseTuple(args, "")) {
+        return nullptr;
+    }
+    return PyLong_FromUnsignedLongLong(getDocumentPtr()->getObjectRemovalGeneration());
 }
 
 PyObject* DocumentPy::getRecomputeDiagnostics(PyObject* args)
@@ -1111,9 +1124,11 @@ PyObject* DocumentPy::getObjectsByLabel(PyObject* args)
 
 PyObject* DocumentPy::findObjects(PyObject* args, PyObject* kwds)
 {
-    const char *sType = "App::DocumentObject", *sName = nullptr, *sLabel = nullptr;
-    static const std::array<const char*, 4> kwlist {"Type", "Name", "Label", nullptr};
-    if (!Base::Wrapped_ParseTupleAndKeywords(args, kwds, "|sss", kwlist, &sType, &sName, &sLabel)) {
+    const char *sType = "App::DocumentObject", *sName = nullptr, *sLabel = nullptr,
+               *sProperty = nullptr;
+    static const std::array<const char*, 5> kwlist {"Type", "Name", "Label", "Property", nullptr};
+    if (!Base::Wrapped_ParseTupleAndKeywords(
+            args, kwds, "|ssss", kwlist, &sType, &sName, &sLabel, &sProperty)) {
         return nullptr;
     }
 
@@ -1128,7 +1143,7 @@ PyObject* DocumentPy::findObjects(PyObject* args, PyObject* kwds)
     std::vector<DocumentObject*> res;
 
     try {
-        res = getDocumentPtr()->findObjects(type, sName, sLabel);
+        res = getDocumentPtr()->findObjects(type, sName, sLabel, sProperty);
     }
     catch (const boost::regex_error& e) {
         PyErr_SetString(PyExc_RuntimeError, e.what());
@@ -1476,6 +1491,11 @@ PyObject* DocumentPy::reorderTimelineOperationBlocksAfter(PyObject* args)
 PyObject* DocumentPy::reorderTimelineOperationBlocksBefore(PyObject* args)
 {
     return reorderTimelineOperationBlocks(getDocumentPtr(), args, true);
+}
+
+PyObject* DocumentPy::reorderTimelineOperationDependentClosuresAfter(PyObject* args)
+{
+    return reorderTimelineOperationBlocks(getDocumentPtr(), args, false, true);
 }
 
 PyObject* DocumentPy::reorderTimelineOperationDependentClosureAfter(PyObject* args)
@@ -2391,6 +2411,11 @@ Py::Boolean DocumentPy::getTransacting() const
 Py::Boolean DocumentPy::getCooperativeMutationActive() const
 {
     return {getDocumentPtr()->isCooperativeMutationActive()};
+}
+
+Py::Boolean DocumentPy::getPresentationUpdateActive() const
+{
+    return {getDocumentPtr()->isPresentationUpdateActive()};
 }
 
 Py::String DocumentPy::getOldLabel() const

--- a/src/App/DocumentTimeline.cpp
+++ b/src/App/DocumentTimeline.cpp
@@ -13,6 +13,7 @@
  ***************************************************************************/
 
 #include "DocumentTimeline.h"
+#include "SemanticDependencyOrder.h"
 
 #include <algorithm>
 #include <cstring>
@@ -200,7 +201,8 @@ bool stableTopologicallyOrderSemanticBlocks(
     std::vector<DocumentObject*>& operations,
     std::vector<bool>& visibility,
     std::vector<bool>& suppression,
-    const long position
+    const long position,
+    const std::unordered_set<DocumentObject*>* retiredResources = nullptr
 )
 {
     if (!document || operations.size() != visibility.size()
@@ -238,73 +240,42 @@ bool stableTopologicallyOrderSemanticBlocks(
         blocks[existing->second].push_back(index);
     }
 
-    std::vector<std::vector<std::size_t>> consumers(roots.size());
-    std::vector<std::size_t> indegree(roots.size(), 0);
-    std::unordered_set<std::string> edges;
-    edges.reserve(operations.size());
-    for (std::size_t consumerIndex = 0; consumerIndex < roots.size(); ++consumerIndex) {
-        for (const auto operationIndex : blocks[consumerIndex]) {
-            const auto* operation = operations[operationIndex];
-            std::vector<const DocumentObject*> pending {operation};
-            std::unordered_set<const DocumentObject*> visited {operation};
-            while (!pending.empty()) {
-                const auto* current = pending.back();
-                pending.pop_back();
-                for (const auto* dependency : current->getOutList()) {
-                    if (!dependency || !document->containsObject(dependency)
-                        || dependency->getDocument() != document
-                        || isStructuralTimelineLink(current, dependency)
-                        || !visited.insert(dependency).second) {
-                        continue;
-                    }
-                    const auto* dependencyRoot = semanticOperationRoot(dependency, document);
-                    if (!dependencyRoot) {
-                        throw Base::RuntimeError(
-                            "Semantic History dependency ordering found a malformed dependency"
-                        );
-                    }
-                    const auto dependencyPosition = rootIndices.find(dependencyRoot);
-                    if (dependencyRoot != roots[consumerIndex]
-                        && dependencyPosition != rootIndices.end()) {
-                        const std::string edge = std::to_string(dependencyPosition->second) + ":"
-                            + std::to_string(consumerIndex);
-                        if (edges.insert(edge).second) {
-                            consumers[dependencyPosition->second].push_back(consumerIndex);
-                            ++indegree[consumerIndex];
-                        }
-                    }
-                    pending.push_back(dependency);
-                }
-            }
+    // Read each reachable object's native dependencies once. The ordering
+    // kernel below consumes only detached indices, not document pointers.
+    detail::SemanticDependencyGraph graph;
+    graph.members = blocks;
+    std::vector<const DocumentObject*> nodes(operations.begin(), operations.end());
+    std::unordered_map<const DocumentObject*, std::size_t> nodeIndices;
+    nodeIndices.reserve(nodes.size());
+    for (std::size_t index = 0; index < nodes.size(); ++index)
+        nodeIndices.emplace(nodes[index], index);
+    for (std::size_t index = 0; index < nodes.size(); ++index) {
+        const auto* current = nodes[index];
+        const auto* root = semanticOperationRoot(current, document);
+        if (!root)
+            throw Base::RuntimeError("Semantic History dependency ordering found a malformed dependency");
+        const auto rootIndex = rootIndices.find(root);
+        graph.block.push_back(rootIndex == rootIndices.end()
+            ? detail::SemanticDependencyGraph::untracked : rootIndex->second);
+        std::vector<std::size_t> inputs;
+        for (const auto* dependency : current->getOutList()) {
+            if (!dependency || !document->containsObject(dependency)
+                || dependency->getDocument() != document
+                || isStructuralTimelineLink(current, dependency)) continue;
+            if (retiredResources && retiredResources->contains(const_cast<DocumentObject*>(dependency)))
+                throw Base::RuntimeError("A surviving final dependency still targets a retired resource");
+            const auto [entry, inserted] = nodeIndices.emplace(dependency, nodes.size());
+            if (inserted) nodes.push_back(dependency);
+            inputs.push_back(entry->second);
         }
+        graph.dependencies.push_back(std::move(inputs));
     }
-
     std::vector<std::size_t> orderedRoots;
-    std::vector<bool> emitted(roots.size(), false);
-    orderedRoots.reserve(roots.size());
-    while (orderedRoots.size() != roots.size()) {
-        std::size_t next = roots.size();
-        for (std::size_t index = 0; index < roots.size(); ++index) {
-            if (!emitted[index] && indegree[index] == 0) {
-                next = index;
-                break;
-            }
-        }
-        if (next == roots.size()) {
-            throw Base::RuntimeError(
-                "Semantic History dependency ordering detected a cycle"
-            );
-        }
-        emitted[next] = true;
-        orderedRoots.push_back(next);
-        for (const auto consumer : consumers[next]) {
-            if (indegree[consumer] == 0) {
-                throw Base::RuntimeError(
-                    "Semantic History dependency ordering has inconsistent edges"
-                );
-            }
-            --indegree[consumer];
-        }
+    try {
+        orderedRoots = detail::stableSemanticDependencyOrder(graph).order;
+    }
+    catch (const std::runtime_error& error) {
+        throw Base::RuntimeError(std::string("Semantic History dependency ordering ") + error.what());
     }
 
     bool changed = false;
@@ -435,11 +406,31 @@ bool bitAt(const boost::dynamic_bitset<>& values, std::size_t index, bool fallba
     return index < values.size() ? values.test(index) : fallback;
 }
 
+int visibilityOperationIndex(
+    const std::vector<DocumentObject*>& operations,
+    const DocumentObject* object
+)
+{
+    const auto found = std::find(operations.begin(), operations.end(), object);
+    return found == operations.end() ? -1 : static_cast<int>(found - operations.begin());
+}
+
+int visibilityOperationIndex(const PropertyLinkList& operations, const DocumentObject* object)
+{
+    int index = -1;
+    const char* name = object->getNameInDocument();
+    return name && operations.findUsingMap(name, &index) == object ? index : -1;
+}
+
+template<typename Operations>
 bool ownersPresentedAtEnd(
     const DocumentObject* object,
-    const std::vector<DocumentObject*>& operations,
+    const Operations& operations,
     const boost::dynamic_bitset<>& visibility,
-    const boost::dynamic_bitset<>& suppression
+    const boost::dynamic_bitset<>& suppression,
+    const DocumentObject* changedOperation = nullptr,
+    bool changedVisibility = false,
+    bool changedSuppression = false
 )
 {
     if (!hasValidTimelineOwnerChain(object)) {
@@ -448,14 +439,19 @@ bool ownersPresentedAtEnd(
 
     for (const auto* owner = DocumentTimeline::timelineOwner(object); owner;
          owner = DocumentTimeline::timelineOwner(owner)) {
-        const auto found = std::find(operations.begin(), operations.end(), owner);
-        if (found == operations.end()) {
+        if (owner == changedOperation) {
+            if (!changedVisibility || changedSuppression) {
+                return false;
+            }
+            continue;
+        }
+        const auto index = visibilityOperationIndex(operations, owner);
+        if (index < 0) {
             if (!owner->Visibility.getValue() || operationSuppressed(owner)) {
                 return false;
             }
             continue;
         }
-        const auto index = static_cast<std::size_t>(std::distance(operations.begin(), found));
         if (!bitAt(visibility, index, owner->Visibility.getValue())
             || bitAt(suppression, index, operationSuppressed(owner))) {
             return false;
@@ -1319,8 +1315,18 @@ void DocumentTimeline::pruneProvisionalTransactionCreations()
 
 void DocumentTimeline::pruneProvisionalPublications()
 {
-    std::erase_if(_provisionalPublications, [this](const ProvisionalPublication& publication) {
-        return !publicationMatchesLiveState(publication, nullptr);
+    if (_provisionalPublications.empty()) {
+        return;
+    }
+    const auto counts = detail::countSemanticMembers(
+        Operations.getValues(), [document = getDocument()](const DocumentObject* object) {
+            return semanticOperationRoot(object, document);
+        });
+    // These checks only read live native state and emit no callbacks. Sharing
+    // this census within this call preserves exact validation without scanning
+    // the entire history once for every previously published block.
+    std::erase_if(_provisionalPublications, [this, &counts](const ProvisionalPublication& publication) {
+        return !publicationMatchesLiveState(publication, nullptr, &counts);
     });
 }
 
@@ -1638,7 +1644,8 @@ bool DocumentTimeline::isProvisionallyEnrolledByCurrentTransaction(
 
 bool DocumentTimeline::publicationMatchesLiveState(
     const ProvisionalPublication& publication,
-    const std::vector<DocumentObject*>* expectedBlock
+    const std::vector<DocumentObject*>* expectedBlock,
+    const std::unordered_map<const DocumentObject*, std::size_t>* memberCounts
 ) const noexcept
 {
     try {
@@ -1742,17 +1749,18 @@ bool DocumentTimeline::publicationMatchesLiveState(
             return false;
         }
 
-        std::size_t semanticMemberCount = 0;
-        for (auto* candidate : operations) {
-            if (semanticOperationRoot(candidate, document) != operation) {
-                continue;
-            }
-            ++semanticMemberCount;
-            if (!indices.contains(candidate)) {
-                return false;
-            }
+        std::unordered_map<const DocumentObject*, std::size_t> localCounts;
+        if (!memberCounts) {
+            localCounts = detail::countSemanticMembers(operations, [document](const DocumentObject* object) {
+                return semanticOperationRoot(object, document);
+            });
+            memberCounts = &localCounts;
         }
-        return semanticMemberCount == block.size();
+        // Each distinct declared member already resolves through its validated
+        // owner chain to this operation. Equality therefore also proves that
+        // no additional enrolled member was omitted from the declared block.
+        const auto count = memberCounts->find(operation);
+        return count != memberCounts->end() && count->second == block.size();
     }
     catch (...) {
         return false;
@@ -3195,7 +3203,13 @@ void DocumentTimeline::publishProvisionalOperationBlock(
                         + "' is later at history position " + std::to_string(dependencyOrder->second)
                     );
                 }
-                pending.push_back(dependency);
+                // Every final operation is validated by this outer loop. Once
+                // its own history order is checked above, its dependencies are
+                // checked there, rather than re-walking the entire ancestry for
+                // every descendant. Untracked bridge objects still need walking.
+                if (!finalIndices.contains(const_cast<DocumentObject*>(dependency))) {
+                    pending.push_back(dependency);
+                }
             }
         }
     }
@@ -4426,9 +4440,17 @@ bool DocumentTimeline::reorderOperationDependentClosureAfter(
     DocumentObject* target
 )
 {
+    return reorderOperationDependentClosuresAfter({operation}, target);
+}
+
+bool DocumentTimeline::reorderOperationDependentClosuresAfter(
+    const std::vector<DocumentObject*>& requestedOperations,
+    DocumentObject* target
+)
+{
     auto* document = getDocument();
     const auto operations = Operations.getValues();
-    if (!document || !operation || !target || operation == target || operations.empty()) {
+    if (!document || requestedOperations.empty() || !target || operations.empty()) {
         throw Base::ValueError(
             "Timeline dependency rebase requires one operation and one "
             "distinct target"
@@ -4452,17 +4474,24 @@ bool DocumentTimeline::reorderOperationDependentClosureAfter(
         }
     }
 
-    auto* operationRoot = const_cast<DocumentObject*>(semanticOperationRoot(operation, document));
     auto* targetRoot = const_cast<DocumentObject*>(semanticOperationRoot(target, document));
-    if (!operationRoot || !targetRoot || operationRoot == targetRoot
-        || !blocks.contains(operationRoot) || !blocks.contains(targetRoot)) {
+    if (!targetRoot || !blocks.contains(targetRoot)) {
         throw Base::ValueError(
             "Timeline dependency rebase inputs must identify two distinct "
             "tracked semantic operations"
         );
     }
 
-    std::unordered_set<const DocumentObject*> movingRoots {operationRoot};
+    std::unordered_set<const DocumentObject*> movingRoots;
+    for (const auto* operation : requestedOperations) {
+        const auto* root = semanticOperationRoot(operation, document);
+        if (!root || root == targetRoot || !blocks.contains(root)
+            || !movingRoots.insert(root).second) {
+            throw Base::ValueError(
+                "Timeline dependency rebase inputs must identify distinct tracked operations"
+            );
+        }
+    }
     const auto blockDependsOnMovingRoot = [&](const DocumentObject* candidateRoot) {
         std::vector<const DocumentObject*> pending;
         std::unordered_set<const DocumentObject*> visited;
@@ -8204,7 +8233,8 @@ void DocumentTimeline::finalizeProvisionalOperationResourceReconciliation(
         finalOperations,
         finalVisibilityValues,
         finalSuppressionValues,
-        finalPosition
+        finalPosition,
+        &retiredLiveSet
     );
 
     struct FinalBlock
@@ -8293,47 +8323,10 @@ void DocumentTimeline::finalizeProvisionalOperationResourceReconciliation(
             }
         }
 
-        std::vector<const DocumentObject*> pending {candidate};
-        std::unordered_set<const DocumentObject*> visited {candidate};
-        while (!pending.empty()) {
-            const auto* current = pending.back();
-            pending.pop_back();
-            for (const auto* dependency : current->getOutList()) {
-                if (!dependency || !document->containsObject(dependency)
-                    || dependency->getDocument() != document
-                    || isStructuralTimelineLink(current, dependency)
-                    || !visited.insert(dependency).second) {
-                    continue;
-                }
-                if (retiredLiveSet.contains(const_cast<DocumentObject*>(dependency))) {
-                    throw Base::RuntimeError(
-                        "A surviving final dependency still targets a "
-                        "retired resource"
-                    );
-                }
-                const auto* dependencyRoot = semanticOperationRoot(dependency, document);
-                if (!dependencyRoot) {
-                    throw Base::RuntimeError(
-                        "The final resource graph contains a malformed "
-                        "dependency"
-                    );
-                }
-                const auto dependencyOrder = rootOrder.find(dependencyRoot);
-                if (dependencyRoot != candidateRoot && dependencyOrder != rootOrder.end()
-                    && dependencyOrder->second > candidateOrder->second) {
-                    throw Base::RuntimeError(
-                        std::string("Final History consumer '")
-                        + candidate->getNameInDocument() + "' (semantic root '"
-                        + candidateRoot->getNameInDocument() + "', index "
-                        + std::to_string(candidateOrder->second) + ") precedes dependency '"
-                        + dependency->getNameInDocument() + "' (semantic root '"
-                        + dependencyRoot->getNameInDocument() + "', index "
-                        + std::to_string(dependencyOrder->second) + ")"
-                    );
-                }
-                pending.push_back(dependency);
-            }
-        }
+        // The value graph used to order the blocks has already visited every
+        // reachable dependency, rejected retired/malformed targets, and proved
+        // this order. No document mutation occurs between that capture and here.
+        // Rewalking each operation's transitive closure adds no new evidence.
     }
 
     std::unordered_set<const DocumentObject*> finalSet(finalOperations.begin(), finalOperations.end());
@@ -8705,8 +8698,137 @@ void DocumentTimeline::finalizeProvisionalOperationResourceReconciliation(
     _stagedResourceReconciliations.clear();
 }
 
+void DocumentTimeline::invalidateVisibilityResources() noexcept
+{
+    _visibilityResourcesValid = false;
+}
+
+void DocumentTimeline::indexVisibilityResources()
+{
+    if (_visibilityResourcesValid) {
+        return;
+    }
+    _visibilityResources.clear();
+    const auto& operations = Operations.getValues();
+    auto* document = getDocument();
+    for (std::size_t index = 0; index < operations.size(); ++index) {
+        auto* resource = operations[index];
+        if (!resource || !document || !document->containsObject(resource)
+            || !hasTimelineResourceRole(resource)) {
+            continue;
+        }
+        std::unordered_set<const DocumentObject*> visited;
+        for (auto* owner = timelineOwner(resource); owner; owner = timelineOwner(owner)) {
+            if (!document->containsObject(owner) || !visited.insert(owner).second) {
+                break;
+            }
+            _visibilityResources[owner->getID()].push_back(index);
+        }
+    }
+    _visibilityResourcesValid = true;
+}
+
+void DocumentTimeline::captureVisibility(DocumentObject* changedOperation)
+{
+    if (!changedOperation || isApplying()) {
+        return;
+    }
+
+    const auto& operations = Operations.getValues();
+    if (Position.getValue() != static_cast<long>(operations.size())) {
+        return;
+    }
+    int operationPosition = -1;
+    const char* operationName = changedOperation->getNameInDocument();
+    if (!operationName || Operations.findUsingMap(operationName, &operationPosition) != changedOperation) {
+        return;
+    }
+
+    auto* document = getDocument();
+    if (!document || changedOperation->getDocument() != document
+        || !document->containsObject(changedOperation)) {
+        return;
+    }
+    if (VisibilityAtEnd.getSize() != static_cast<int>(operations.size())
+        || SuppressionAtEnd.getSize() != static_cast<int>(operations.size())) {
+        // A malformed persisted parallel array requires one authoritative
+        // normalization. Normal steady-state visibility changes never enter
+        // this path.
+        captureVisibility();
+        return;
+    }
+
+    const auto& visibility = VisibilityAtEnd.getValues();
+    const auto& suppression = SuppressionAtEnd.getValues();
+    const auto index = static_cast<std::size_t>(operationPosition);
+    bool acceptedVisibility = changedOperation->Visibility.getValue();
+    const bool acceptedSuppression = operationSuppressed(changedOperation);
+    if (hasTimelineResourceRole(changedOperation)
+        && !ownersPresentedAtEnd(changedOperation, Operations, visibility, suppression)) {
+        acceptedVisibility = visibility.test(index);
+    }
+
+    struct ResourceVisibilityTarget
+    {
+        TimelineObjectIdentity object;
+        bool visible {false};
+    };
+    std::vector<ResourceVisibilityTarget> resourceTargets;
+    indexVisibilityResources();
+    std::vector<std::size_t> affected;
+    if (const auto found = _visibilityResources.find(changedOperation->getID());
+        found != _visibilityResources.end()) {
+        affected = found->second;
+    }
+    if (hasTimelineResourceRole(changedOperation)) {
+        affected.push_back(index);
+        std::sort(affected.begin(), affected.end());
+        affected.erase(std::unique(affected.begin(), affected.end()), affected.end());
+    }
+    for (const auto operationIndex : affected) {
+        auto* operation = operations[operationIndex];
+        if (!operation || !document->containsObject(operation)
+            || !hasTimelineResourceRole(operation)) {
+            continue;
+        }
+        resourceTargets.push_back(
+            {
+                {
+                    .objectId = operation->getID(),
+                    .objectName = operation->getNameInDocument(),
+                },
+                (operationIndex == index ? acceptedVisibility : bitAt(visibility, operationIndex, false))
+                    && ownersPresentedAtEnd(
+                        operation, Operations, visibility, suppression,
+                        changedOperation, acceptedVisibility, acceptedSuppression
+                    ),
+            }
+        );
+    }
+
+    ApplyingScope applying(*this);
+    if (acceptedVisibility != VisibilityAtEnd.getValues().test(index)) {
+        VisibilityAtEnd.set1Value(static_cast<int>(index), acceptedVisibility);
+    }
+    if (acceptedSuppression != SuppressionAtEnd.getValues().test(index)) {
+        SuppressionAtEnd.set1Value(static_cast<int>(index), acceptedSuppression);
+    }
+    for (const auto& target : resourceTargets) {
+        auto* operation = resolveExactTimelineIdentity(
+            document,
+            target.object.objectId,
+            target.object.objectName
+        );
+        if (operation && hasTimelineResourceRole(operation)
+            && operation->Visibility.getValue() != target.visible) {
+            operation->Visibility.setValue(target.visible);
+        }
+    }
+}
+
 void DocumentTimeline::captureVisibility()
 {
+    invalidateVisibilityResources();
     if (isApplying()) {
         return;
     }
@@ -8754,7 +8876,7 @@ void DocumentTimeline::captureVisibility()
         if (!isLiveOperation(operation) || !hasTimelineResourceRole(operation)) {
             continue;
         }
-        if (!ownersPresentedAtEnd(operation, operations, previousVisibility, previousSuppression)) {
+        if (!ownersPresentedAtEnd(operation, Operations, previousVisibility, previousSuppression)) {
             visibility.set(index, bitAt(previousVisibility, index, operation->Visibility.getValue()));
         }
     }
@@ -8771,7 +8893,7 @@ void DocumentTimeline::captureVisibility()
             continue;
         }
         const bool shouldShow = bitAt(visibility, index, false)
-            && ownersPresentedAtEnd(operation, operations, visibility, suppression);
+            && ownersPresentedAtEnd(operation, Operations, visibility, suppression);
         resourceVisibilityTargets.push_back(
             ResourceVisibilityTarget {
                 .object = {
@@ -8822,6 +8944,9 @@ void DocumentTimeline::setApplying(bool applying) noexcept
 
 void DocumentTimeline::onBeforeChange(const Property* property)
 {
+    if (property == &Operations) {
+        invalidateVisibilityResources();
+    }
     const auto* document = getDocument();
     if (property == &Operations && !isApplying()
         && (!document || !document->isPerformingTransaction())) {
@@ -8836,6 +8961,9 @@ void DocumentTimeline::onBeforeChange(const Property* property)
 
 void DocumentTimeline::onChanged(const Property* property)
 {
+    if (property == &Operations) {
+        invalidateVisibilityResources();
+    }
     auto* document = getDocument();
     if (!isApplying() && document && document->isPerformingTransaction()) {
         // Undo/redo replays the controller and its operations in transaction
@@ -9140,7 +9268,7 @@ void DocumentTimeline::reconcileEndStatePresentation()
                 operation->getNameInDocument(),
             },
             visibility.test(index)
-                && ownersPresentedAtEnd(operation, operations, visibility, suppression),
+                && ownersPresentedAtEnd(operation, Operations, visibility, suppression),
             suppression.test(index),
         });
     }
@@ -9171,6 +9299,7 @@ void DocumentTimeline::reconcileEndStatePresentation()
 
 void DocumentTimeline::onUndoRedoFinished()
 {
+    invalidateVisibilityResources();
     normalizeStoredState(false);
     reconcileEndStatePresentation();
     DocumentObject::onUndoRedoFinished();

--- a/src/App/DocumentTimeline.h
+++ b/src/App/DocumentTimeline.h
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "DocumentObject.h"
@@ -266,6 +267,15 @@ public:
      * requirements as reorderOperationBlocksAfter() apply.
      */
     bool reorderOperationDependentClosureAfter(DocumentObject* operation, DocumentObject* target);
+
+    /** Rebase several operations and their shared downstream closure once.
+     * Uses the single-root entry's ownership and chronology validation.
+     * Duplicate/overlapping roots and dependency cycles reject atomically.
+     */
+    bool reorderOperationDependentClosuresAfter(
+        const std::vector<DocumentObject*>& operations,
+        DocumentObject* target
+    );
 
     /**
      * Return the complete tracked semantic closure required to copy objects.
@@ -634,6 +644,11 @@ public:
      * is intentionally disabled while the marker is rolled back.
      */
     void captureVisibility();
+    /**
+     * Update the accepted end-state for one exact changed operation and any
+     * owned resources whose effective presentation depends on it.
+     */
+    void captureVisibility(DocumentObject* changedOperation);
 
     /**
      * Suppress baseline capture and automatic normalization while a timeline
@@ -674,6 +689,11 @@ protected:
 
 private:
     friend class Document;
+
+    void invalidateVisibilityResources() noexcept;
+    void indexVisibilityResources();
+    bool _visibilityResourcesValid {false};
+    std::unordered_map<long, std::vector<std::size_t>> _visibilityResources;
 
     struct ProvisionalEnrollment
     {
@@ -815,7 +835,8 @@ private:
     [[nodiscard]] bool isCreatedByCurrentTransaction(const DocumentObject* object) const noexcept;
     [[nodiscard]] bool publicationMatchesLiveState(
         const ProvisionalPublication& publication,
-        const std::vector<DocumentObject*>* expectedBlock
+        const std::vector<DocumentObject*>* expectedBlock,
+        const std::unordered_map<const DocumentObject*, std::size_t>* memberCounts = nullptr
     ) const noexcept;
     void discardTransactionProvenance(int transactionId) noexcept;
     void normalizeStoredState(bool migrateLegacy);

--- a/src/App/ExtensionContainer.cpp
+++ b/src/App/ExtensionContainer.cpp
@@ -33,6 +33,8 @@
 
 #include "Extension.h"
 #include "ExtensionContainer.h"
+#include "Document.h"
+#include "DocumentObject.h"
 
 
 using namespace App;
@@ -59,6 +61,15 @@ void ExtensionContainer::registerExtension(Base::Type extension, Extension* ext)
             "ExtensionContainer::registerExtension: Extension has not this as base object");
     }
 
+    // Attached objects can acquire extensions without setting any property.
+    // Invalidate captures on both sides of that structural change. Ordinary
+    // construction has no document yet and is covered by object insertion.
+    auto* object = dynamic_cast<DocumentObject*>(this);
+    auto* document = object ? object->getDocument() : nullptr;
+    if (document) {
+        document->advanceObjectChangeGeneration();
+    }
+
     // no duplicate extensions (including base classes)
     if (hasExtension(extension)) {
         for (const auto& entry : _extensions) {
@@ -70,6 +81,12 @@ void ExtensionContainer::registerExtension(Base::Type extension, Extension* ext)
     }
 
     _extensions[extension] = ext;
+    if (document) {
+        document->advanceObjectChangeGeneration();
+        if (!document->signalObjectSchemaChanged.empty()) {
+            document->signalObjectSchemaChanged(object->getID());
+        }
+    }
 }
 
 bool ExtensionContainer::hasExtension(Base::Type type, bool derived) const

--- a/src/App/FeaturePython.h
+++ b/src/App/FeaturePython.h
@@ -348,11 +348,12 @@ public:
 
     bool canRecomputeOnWorker() const override
     {
-        if (!FeatureT::canRecomputeOnWorker()) {
-            return false;
-        }
-
-        return imp->supportsAsyncRecompute() == FeaturePythonImp::Accepted;
+        // Python-backed model execution acquires the interpreter lock inside
+        // FeaturePythonImp. Missing declarations use the worker runtime by
+        // default; an explicit rejection remains authoritative. GUI APIs
+        // separately enforce GUI-thread affinity.
+        return FeatureT::canRecomputeOnWorker()
+            && imp->supportsAsyncRecompute() != FeaturePythonImp::Rejected;
     }
 
     /**

--- a/src/App/FeatureTest.cpp
+++ b/src/App/FeatureTest.cpp
@@ -52,7 +52,7 @@ struct AsyncBlockerState
 {
     std::mutex mutex;
     std::condition_variable changed;
-    bool started = false;
+    std::size_t started = 0;
     bool proceed = false;
 };
 
@@ -397,7 +397,16 @@ DocumentObjectExecReturn* FeatureTestAttribute::execute()
 PROPERTY_SOURCE(App::FeatureTestAsyncBlocker, App::DocumentObject)
 
 
-FeatureTestAsyncBlocker::FeatureTestAsyncBlocker() = default;
+FeatureTestAsyncBlocker::FeatureTestAsyncBlocker()
+{
+    ADD_PROPERTY_TYPE(
+        ExecutionCount,
+        (0),
+        "Test",
+        PropertyType(Prop_Output | Prop_ReadOnly),
+        "Number of completed test executions"
+    );
+}
 
 FeatureTestAsyncBlocker::~FeatureTestAsyncBlocker() = default;
 
@@ -405,15 +414,23 @@ void FeatureTestAsyncBlocker::resetBlocker()
 {
     auto& state = getAsyncBlockerState();
     std::lock_guard<std::mutex> lock(state.mutex);
-    state.started = false;
+    state.started = 0;
     state.proceed = false;
 }
 
 bool FeatureTestAsyncBlocker::waitUntilStarted(std::chrono::milliseconds timeout)
 {
+    return waitUntilStarted(1, timeout);
+}
+
+bool FeatureTestAsyncBlocker::waitUntilStarted(
+    std::size_t count,
+    std::chrono::milliseconds timeout
+)
+{
     auto& state = getAsyncBlockerState();
     std::unique_lock<std::mutex> lock(state.mutex);
-    return state.changed.wait_for(lock, timeout, [&state] { return state.started; });
+    return state.changed.wait_for(lock, timeout, [&state, count] { return state.started >= count; });
 }
 
 void FeatureTestAsyncBlocker::releaseBlocker()
@@ -430,8 +447,10 @@ DocumentObjectExecReturn* FeatureTestAsyncBlocker::execute()
 {
     auto& state = getAsyncBlockerState();
     std::unique_lock<std::mutex> lock(state.mutex);
-    state.started = true;
+    ++state.started;
     state.changed.notify_all();
     state.changed.wait(lock, [&state] { return state.proceed; });
+    lock.unlock();
+    ExecutionCount.setValue(ExecutionCount.getValue() + 1);
     return StdReturn;
 }

--- a/src/App/FeatureTest.h
+++ b/src/App/FeatureTest.h
@@ -216,7 +216,7 @@ public:
     FeatureTestAttribute();
     ~FeatureTestAttribute() override;
     DocumentObjectExecReturn* execute() override;
-    bool canRecomputeOnWorker() const override { return false; }
+    bool canRecomputeOnWorker() const override { return true; }
 
     App::PropertyPythonObject Object;
     App::PropertyString Attribute;
@@ -234,7 +234,10 @@ public:
 
     static void resetBlocker();
     static bool waitUntilStarted(std::chrono::milliseconds timeout);
+    static bool waitUntilStarted(std::size_t count, std::chrono::milliseconds timeout);
     static void releaseBlocker();
+
+    App::PropertyInteger ExecutionCount;
 };
 
 

--- a/src/App/GroupExtension.cpp
+++ b/src/App/GroupExtension.cpp
@@ -208,6 +208,15 @@ bool GroupExtension::hasObject(const DocumentObject* obj, bool recursive) const
     }
 
     try {
+        if (!recursive) {
+            const int member = obj ? Group.findObject(obj) : -1;
+            const int cycle = Group.findObject(getExtendedObject());
+            if (cycle >= 0 && (member < 0 || cycle < member)) {
+                throw Base::RuntimeError(
+                    "Cyclic dependencies detected: Search cannot be performed");
+            }
+            return member >= 0;
+        }
         const std::vector<DocumentObject*>& grp = Group.getValues();
         for (auto child : grp) {
 
@@ -330,8 +339,7 @@ DocumentObject* GroupExtension::getGroupOfObject(const DocumentObject* obj)
             ext = o->getExtension(GroupExtensionPython::getExtensionClassTypeId(), false, true);
         }
         if (ext) {
-            auto grp = static_cast<GroupExtension*>(ext)->Group.getValues();
-            if (std::find(grp.begin(), grp.end(), obj) != grp.end()) {
+            if (static_cast<GroupExtension*>(ext)->Group.findObject(obj) >= 0) {
                 return o;
             }
         }
@@ -369,8 +377,7 @@ void GroupExtension::extensionOnChanged(const Property* p)
                 for (auto in : list) {
                     auto ext = in->getExtension(GroupExtension::getExtensionClassTypeId(), false, true);
                     if (ext && (in != getExtendedObject())) {
-                        auto grp = static_cast<GroupExtension*>(ext)->Group.getValues();
-                        if (std::find(grp.begin(), grp.end(), obj) != grp.end()) {
+                        if (static_cast<GroupExtension*>(ext)->Group.findObject(obj) >= 0) {
                             error = true;
                             corrected.erase(std::remove(corrected.begin(), corrected.end(), obj),
                                             corrected.end());

--- a/src/App/HostRuntime.cpp
+++ b/src/App/HostRuntime.cpp
@@ -1,0 +1,1078 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "HostRuntime.h"
+#include "private/CpuBudget.h"
+
+#include <algorithm>
+#include <atomic>
+#include <condition_variable>
+#include <cstdint>
+#include <deque>
+#include <fstream>
+#include <latch>
+#include <mutex>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+#include <Base/Console.h>
+
+#include <QByteArray>
+#include <QProcess>
+#include <QProcessEnvironment>
+#include <QString>
+#include <QStringList>
+
+#ifdef Q_OS_WIN
+# include <windows.h>
+# include <psapi.h>
+#elif defined(Q_OS_MACOS)
+# include <libproc.h>
+#endif
+
+using namespace App;
+
+namespace
+{
+
+constexpr auto isolationProtocol = "VIBECAD-ISOLATION/1";
+constexpr qsizetype isolationOutputTailBytes = 64 * 1024;
+
+using App::detail::CpuBudget;
+
+class CpuLease
+{
+public:
+    CpuLease(CpuBudget& budget, std::size_t slots)
+        : budget_(&budget)
+        , slots_(slots)
+    {}
+
+    ~CpuLease()
+    {
+        budget_->release(slots_);
+    }
+
+    CpuLease(const CpuLease&) = delete;
+    CpuLease& operator=(const CpuLease&) = delete;
+
+private:
+    CpuBudget* budget_;
+    std::size_t slots_;
+};
+
+struct IsolationJob
+{
+    IsolationJob(
+        std::uint64_t jobId,
+        std::string jobRequest,
+        std::size_t jobMemoryLimitBytes,
+        std::size_t jobCpuSlots
+    )
+        : id(jobId)
+        , request(std::move(jobRequest))
+        , memoryLimitBytes(jobMemoryLimitBytes)
+        , cpuSlots(jobCpuSlots)
+    {}
+
+    void finish(HostRuntime::IsolationResult result)
+    {
+        bool expected = false;
+        if (finished.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+            completion.set_value(std::move(result));
+        }
+    }
+
+    const std::uint64_t id;
+    const std::string request;
+    const std::size_t memoryLimitBytes;
+    const std::size_t cpuSlots;
+    std::promise<HostRuntime::IsolationResult> completion;
+    std::stop_source cancellation;
+    std::atomic_bool finished {false};
+    std::atomic_bool memoryExceeded {false};
+    std::atomic_size_t observedMemoryBytes {0};
+};
+
+bool sameConfiguration(
+    const HostRuntime::IsolationConfiguration& left,
+    const HostRuntime::IsolationConfiguration& right
+)
+{
+    return left.executable == right.executable && left.arguments == right.arguments
+        && left.workingDirectory == right.workingDirectory
+        && left.environment == right.environment && left.workerCount == right.workerCount;
+}
+
+void appendOutputTail(QByteArray& tail, const QByteArray& bytes)
+{
+    tail.append(bytes);
+    if (tail.size() > isolationOutputTailBytes) {
+        tail.remove(0, tail.size() - isolationOutputTailBytes);
+    }
+}
+
+std::size_t processMemoryBytes(qint64 processId)
+{
+    if (processId <= 0) {
+        return 0;
+    }
+#ifdef Q_OS_WIN
+    const HANDLE process = OpenProcess(
+        PROCESS_QUERY_INFORMATION | PROCESS_VM_READ,
+        FALSE,
+        static_cast<DWORD>(processId)
+    );
+    if (!process) {
+        return 0;
+    }
+    PROCESS_MEMORY_COUNTERS counters {};
+    counters.cb = sizeof(counters);
+    const bool read = GetProcessMemoryInfo(process, &counters, sizeof(counters)) != FALSE;
+    CloseHandle(process);
+    return read ? static_cast<std::size_t>(counters.WorkingSetSize) : 0;
+#elif defined(Q_OS_MACOS)
+    rusage_info_v2 usage {};
+    if (proc_pid_rusage(
+            static_cast<int>(processId),
+            RUSAGE_INFO_V2,
+            reinterpret_cast<rusage_info_t*>(&usage)
+        ) != 0) {
+        return 0;
+    }
+    return static_cast<std::size_t>(usage.ri_resident_size);
+#elif defined(Q_OS_LINUX)
+    std::ifstream status("/proc/" + std::to_string(processId) + "/status");
+    std::string line;
+    while (std::getline(status, line)) {
+        if (line.starts_with("VmRSS:")) {
+            std::istringstream fields(line.substr(6));
+            std::size_t kibibytes = 0;
+            fields >> kibibytes;
+            return kibibytes * 1024;
+        }
+    }
+    return 0;
+#else
+    return 0;
+#endif
+}
+
+}  // namespace
+
+class HostRuntime::Private
+{
+public:
+    struct LaneState
+    {
+        LaneState(std::size_t initialWorkers, std::size_t capacity)
+            : workerLimit(initialWorkers)
+            , workerCapacity(capacity)
+        {
+            workers.reserve(capacity);
+        }
+
+        std::atomic_size_t workerLimit;
+        const std::size_t workerCapacity;
+        std::atomic_size_t ready {0};
+        std::atomic_size_t queued {0};
+        std::atomic_size_t active {0};
+        std::mutex queueMutex;
+        std::condition_variable workAvailable;
+        std::deque<Work> queue;
+        std::mutex workersMutex;
+        std::vector<std::thread> workers;
+    };
+
+    explicit Private(
+        std::size_t requestedLogicalProcessors,
+        bool isolationChild
+    )
+        : logicalProcessors(normalizeLogicalProcessors(requestedLogicalProcessors))
+        , compute(
+              isolationChild ? 1 : HostRuntime::workerBudget(logicalProcessors),
+              HostRuntime::workerBudget(logicalProcessors)
+          )
+        , io(
+              isolationChild ? 1 : HostRuntime::ioWorkerBudget(logicalProcessors),
+              HostRuntime::ioWorkerBudget(logicalProcessors)
+          )
+        , document(
+              isolationChild ? 1 : HostRuntime::documentWorkerBudget(logicalProcessors),
+              HostRuntime::documentWorkerBudget(logicalProcessors)
+          )
+        , cpuBudget(compute.workerCapacity)
+    {
+        std::latch workersStarted(
+            compute.workerLimit.load() + io.workerLimit.load() + document.workerLimit.load()
+        );
+        try {
+            startLane(Lane::Compute, compute, compute.workerLimit.load(), &workersStarted);
+            startLane(Lane::Io, io, io.workerLimit.load(), &workersStarted);
+            startLane(Lane::Document, document, document.workerLimit.load(), &workersStarted);
+        }
+        catch (...) {
+            stopAndJoin();
+            throw;
+        }
+        workersStarted.wait();
+    }
+
+    ~Private()
+    {
+        shutdown();
+    }
+
+    static std::size_t normalizeLogicalProcessors(std::size_t requested)
+    {
+        if (requested != 0) {
+            return requested;
+        }
+        return std::max<std::size_t>(1, std::thread::hardware_concurrency());
+    }
+
+    void enqueue(Lane lane, Work work)
+    {
+        if (!work) {
+            throw std::invalid_argument("HostRuntime cannot submit empty work");
+        }
+        auto& target = laneState(lane);
+        {
+            std::lock_guard lock(target.queueMutex);
+            if (!accepting.load(std::memory_order_acquire)) {
+                throw std::runtime_error("HostRuntime is shutting down");
+            }
+            if (lane == Lane::Compute && activeRuntime == this && activeLane == Lane::Compute) {
+                target.queue.emplace_front(std::move(work));
+            }
+            else {
+                target.queue.emplace_back(std::move(work));
+            }
+            target.queued.fetch_add(1, std::memory_order_release);
+        }
+        target.workAvailable.notify_one();
+    }
+
+    void startLane(
+        Lane laneKind,
+        LaneState& lane,
+        std::size_t count,
+        std::latch* workersStarted
+    )
+    {
+        for (std::size_t index = 0; index < count; ++index) {
+            lane.workers.emplace_back([this, laneKind, &lane, workersStarted] {
+                workerLoop(laneKind, lane, workersStarted);
+            });
+        }
+    }
+
+    void workerLoop(Lane laneKind, LaneState& lane, std::latch* workersStarted)
+    {
+        activeRuntime = this;
+        activeLane = laneKind;
+        lane.ready.fetch_add(1, std::memory_order_release);
+        if (workersStarted) {
+            workersStarted->count_down();
+        }
+
+        while (true) {
+            Work work;
+            {
+                std::unique_lock lock(lane.queueMutex);
+                lane.workAvailable.wait(lock, [this, &lane] {
+                    return !lane.queue.empty() || !accepting.load(std::memory_order_acquire);
+                });
+                if (!accepting.load(std::memory_order_acquire)) {
+                    break;
+                }
+                work = std::move(lane.queue.front());
+                lane.queue.pop_front();
+                lane.queued.fetch_sub(1, std::memory_order_release);
+                lane.active.fetch_add(1, std::memory_order_release);
+            }
+
+            if (laneKind == Lane::Compute) {
+                if (cpuBudget.acquire(1, stopSource.get_token())) {
+                    CpuLease permit(cpuBudget, 1);
+                    work(stopSource.get_token());
+                }
+                else {
+                    work.abandon();
+                }
+            }
+            else {
+                work(stopSource.get_token());
+            }
+            lane.active.fetch_sub(1, std::memory_order_release);
+        }
+
+        lane.ready.fetch_sub(1, std::memory_order_release);
+        activeRuntime = nullptr;
+    }
+
+    void ensureComputeWorkers(std::size_t requested)
+    {
+        const auto target = std::clamp<std::size_t>(requested, 1, compute.workerCapacity);
+        std::unique_lock lock(compute.workersMutex);
+        const auto current = compute.workers.size();
+        if (target <= current) {
+            return;
+        }
+        std::latch workersStarted(target - current);
+        startLane(Lane::Compute, compute, target - current, &workersStarted);
+        compute.workerLimit.store(target, std::memory_order_release);
+        lock.unlock();
+        workersStarted.wait();
+    }
+
+    [[nodiscard]] bool tryRunOnePendingComputeTask()
+    {
+        if (activeRuntime != this || activeLane != Lane::Compute) {
+            return false;
+        }
+
+        Work work;
+        {
+            std::lock_guard lock(compute.queueMutex);
+            if (compute.queue.empty()) {
+                return false;
+            }
+            work = std::move(compute.queue.front());
+            compute.queue.pop_front();
+            compute.queued.fetch_sub(1, std::memory_order_release);
+        }
+        work(stopSource.get_token());
+        return true;
+    }
+
+    void shutdown()
+    {
+        std::call_once(shutdownOnce, [this] {
+            stopAndJoin();
+        });
+    }
+
+    void stopAndJoin()
+    {
+        accepting.store(false, std::memory_order_release);
+        stopSource.request_stop();
+        clearQueue(compute);
+        clearQueue(io);
+        clearQueue(document);
+        compute.workAvailable.notify_all();
+        io.workAvailable.notify_all();
+        document.workAvailable.notify_all();
+        stopIsolationWorkers();
+        joinLane(compute);
+        joinLane(io);
+        joinLane(document);
+    }
+
+    static void clearQueue(LaneState& lane)
+    {
+        std::deque<Work> cancelled;
+        {
+            std::lock_guard lock(lane.queueMutex);
+            cancelled.swap(lane.queue);
+            lane.queued.store(0, std::memory_order_release);
+        }
+        for (const auto& work : cancelled) {
+            work.abandon();
+        }
+    }
+
+    static void joinLane(LaneState& lane)
+    {
+        std::lock_guard lock(lane.workersMutex);
+        for (auto& worker : lane.workers) {
+            if (worker.joinable()) {
+                worker.join();
+            }
+        }
+        lane.workers.clear();
+    }
+
+    LaneState& laneState(Lane lane)
+    {
+        switch (lane) {
+            case Lane::Compute:
+                return compute;
+            case Lane::Io:
+                return io;
+            case Lane::Document:
+                return document;
+        }
+        throw std::logic_error("Unknown HostRuntime lane");
+    }
+
+    const LaneState& laneState(Lane lane) const
+    {
+        switch (lane) {
+            case Lane::Compute:
+                return compute;
+            case Lane::Io:
+                return io;
+            case Lane::Document:
+                return document;
+        }
+        throw std::logic_error("Unknown HostRuntime lane");
+    }
+
+    void startIsolationWorkers(IsolationConfiguration requested)
+    {
+        if (requested.executable.empty()) {
+            throw std::invalid_argument("Isolation worker executable cannot be empty");
+        }
+        if (requested.workerCount == 0) {
+            requested.workerCount = HostRuntime::isolationWorkerBudget(logicalProcessors);
+        }
+        std::lock_guard lock(isolationMutex);
+        if (isolationConfiguration) {
+            if (!sameConfiguration(*isolationConfiguration, requested)) {
+                throw std::logic_error(
+                    "HostRuntime isolation workers are already configured differently"
+                );
+            }
+            return;
+        }
+        if (!accepting.load(std::memory_order_acquire)) {
+            throw std::runtime_error("HostRuntime is shutting down");
+        }
+        isolationConfiguration = std::move(requested);
+        isolationWorkers.reserve(isolationConfiguration->workerCount);
+        for (std::size_t index = 0; index < isolationConfiguration->workerCount; ++index) {
+            isolationWorkers.emplace_back([this] { isolationWorkerLoop(); });
+        }
+    }
+
+    IsolationSubmission submitIsolation(
+        std::string request,
+        std::size_t memoryLimitBytes,
+        std::size_t cpuSlots
+    )
+    {
+        if (request.empty() || request.find_first_of("\r\n") != std::string::npos) {
+            throw std::invalid_argument(
+                "Isolation request must be one non-empty protocol-safe line"
+            );
+        }
+        std::shared_ptr<IsolationJob> job;
+        {
+            std::lock_guard configurationLock(isolationMutex);
+            if (!isolationConfiguration) {
+                throw std::logic_error("HostRuntime isolation workers are not configured");
+            }
+        }
+        {
+            std::lock_guard lock(isolationQueueMutex);
+            if (!accepting.load(std::memory_order_acquire)) {
+                throw std::runtime_error("HostRuntime is shutting down");
+            }
+            const auto id = nextIsolationId.fetch_add(1, std::memory_order_relaxed);
+            job = std::make_shared<IsolationJob>(
+                id,
+                std::move(request),
+                memoryLimitBytes,
+                std::clamp<std::size_t>(cpuSlots, 1, cpuBudget.capacity())
+            );
+            isolationJobs.emplace(id, job);
+            isolationQueue.push_back(job);
+            isolationQueued.fetch_add(1, std::memory_order_release);
+        }
+        auto future = job->completion.get_future();
+        isolationAvailable.notify_one();
+        return IsolationSubmission {job->id, std::move(future)};
+    }
+
+    bool cancelIsolation(std::uint64_t id)
+    {
+        std::shared_ptr<IsolationJob> job;
+        {
+            std::lock_guard lock(isolationQueueMutex);
+            const auto iterator = isolationJobs.find(id);
+            if (iterator == isolationJobs.end() || iterator->second->finished.load()) {
+                return false;
+            }
+            job = iterator->second;
+        }
+        // Stop callbacks run synchronously; never invoke them under the queue
+        // mutex that completion uses to remove this job.
+        job->cancellation.request_stop();
+        isolationAvailable.notify_all();
+        return true;
+    }
+
+    void stopIsolationWorkers()
+    {
+        std::deque<std::shared_ptr<IsolationJob>> queued;
+        decltype(isolationJobs) jobs;
+        {
+            std::lock_guard lock(isolationQueueMutex);
+            queued.swap(isolationQueue);
+            jobs.swap(isolationJobs);
+            isolationQueued.store(0, std::memory_order_release);
+        }
+        for (const auto& [id, job] : jobs) {
+            (void)id;
+            job->cancellation.request_stop();
+        }
+        for (const auto& job : queued) {
+            job->finish(IsolationResult {
+                IsolationStatus::Cancelled,
+                {},
+                "HostRuntime shut down before the isolation job started",
+                {},
+            });
+        }
+        isolationAvailable.notify_all();
+        for (auto& worker : isolationWorkers) {
+            if (worker.joinable()) {
+                worker.join();
+            }
+        }
+        isolationWorkers.clear();
+    }
+
+    std::optional<std::string> waitForProtocolLine(
+        QProcess& process,
+        const std::string& prefix,
+        QByteArray& outputTail,
+        const std::shared_ptr<IsolationJob>& job = {}
+    )
+    {
+        while (accepting.load(std::memory_order_acquire)
+               && (!job || !job->cancellation.stop_requested())) {
+            std::size_t linesRead = 0;
+            while (process.canReadLine() && linesRead < 256) {
+                const QByteArray line = process.readLine();
+                ++linesRead;
+                const std::string text = line.trimmed().toStdString();
+                if (text.starts_with(prefix)) {
+                    return text.substr(prefix.size());
+                }
+                appendOutputTail(outputTail, line);
+            }
+            if (process.state() == QProcess::NotRunning) {
+                appendOutputTail(outputTail, process.readAll());
+                return std::nullopt;
+            }
+            if (job && job->memoryLimitBytes > 0) {
+                const auto observed = processMemoryBytes(process.processId());
+                job->observedMemoryBytes.store(observed, std::memory_order_release);
+                if (observed > job->memoryLimitBytes) {
+                    job->memoryExceeded.store(true, std::memory_order_release);
+                    return std::nullopt;
+                }
+            }
+            process.waitForReadyRead(100);
+        }
+        return std::nullopt;
+    }
+
+    bool startIsolationProcess(QProcess& process, QByteArray& outputTail)
+    {
+        const auto& configuration = *isolationConfiguration;
+        process.setProgram(QString::fromUtf8(configuration.executable));
+        QStringList arguments;
+        for (const auto& argument : configuration.arguments) {
+            arguments.push_back(QString::fromUtf8(argument));
+        }
+        process.setArguments(arguments);
+        if (!configuration.workingDirectory.empty()) {
+            process.setWorkingDirectory(QString::fromUtf8(configuration.workingDirectory));
+        }
+        auto environment = QProcessEnvironment::systemEnvironment();
+        for (const auto& [name, value] : configuration.environment) {
+            environment.insert(QString::fromUtf8(name), QString::fromUtf8(value));
+        }
+        process.setProcessEnvironment(environment);
+        process.setProcessChannelMode(QProcess::MergedChannels);
+#ifdef Q_OS_WIN
+        process.setCreateProcessArgumentsModifier([](QProcess::CreateProcessArguments* args) {
+            args->flags |= CREATE_NO_WINDOW;
+        });
+#endif
+        process.start(QIODevice::ReadWrite);
+        if (!process.waitForStarted(-1)) {
+            appendOutputTail(outputTail, process.errorString().toUtf8());
+            return false;
+        }
+        return waitForProtocolLine(
+                   process,
+                   std::string(isolationProtocol) + " READY",
+                   outputTail
+               )
+            .has_value();
+    }
+
+    void finishIsolationJob(
+        const std::shared_ptr<IsolationJob>& job,
+        IsolationResult result
+    )
+    {
+        job->finish(std::move(result));
+        std::lock_guard lock(isolationQueueMutex);
+        isolationJobs.erase(job->id);
+    }
+
+    void isolationWorkerLoop()
+    {
+        QProcess process;
+        QByteArray startupOutput;
+        bool processReady = startIsolationProcess(process, startupOutput);
+        if (processReady) {
+            isolationReady.fetch_add(1, std::memory_order_release);
+        }
+
+        while (accepting.load(std::memory_order_acquire)) {
+            std::shared_ptr<IsolationJob> job;
+            {
+                std::unique_lock lock(isolationQueueMutex);
+                isolationAvailable.wait(lock, [this] {
+                    return !isolationQueue.empty()
+                        || !accepting.load(std::memory_order_acquire);
+                });
+                if (!accepting.load(std::memory_order_acquire)) {
+                    break;
+                }
+                job = std::move(isolationQueue.front());
+                isolationQueue.pop_front();
+                isolationQueued.fetch_sub(1, std::memory_order_release);
+            }
+
+            if (job->cancellation.stop_requested()) {
+                finishIsolationJob(
+                    job,
+                    IsolationResult {
+                        IsolationStatus::Cancelled,
+                        {},
+                        "Isolation job was cancelled before execution",
+                        {},
+                    }
+                );
+                continue;
+            }
+            if (!processReady) {
+                startupOutput.clear();
+                processReady = startIsolationProcess(process, startupOutput);
+                if (processReady) {
+                    isolationReady.fetch_add(1, std::memory_order_release);
+                }
+            }
+            if (!processReady) {
+                finishIsolationJob(
+                    job,
+                    IsolationResult {
+                        IsolationStatus::Failed,
+                        {},
+                        "Isolation worker failed to start",
+                        startupOutput.toStdString(),
+                        false,
+                        0,
+                    }
+                );
+                continue;
+            }
+
+            std::stop_callback stopWithRuntime(stopSource.get_token(), [&job] {
+                job->cancellation.request_stop();
+            });
+            const bool admitted = cpuBudget.acquire(job->cpuSlots, job->cancellation.get_token());
+            if (!admitted) {
+                finishIsolationJob(
+                    job,
+                    IsolationResult {
+                        IsolationStatus::Cancelled,
+                        {},
+                        "Isolation job was cancelled before CPU admission",
+                        {},
+                    }
+                );
+                continue;
+            }
+            CpuLease cpuPermit(cpuBudget, job->cpuSlots);
+
+            isolationActive.fetch_add(1, std::memory_order_release);
+            QByteArray outputTail;
+            const std::string command = std::string(isolationProtocol) + " JOB "
+                + std::to_string(job->id) + " " + std::to_string(job->cpuSlots) + " "
+                + job->request + "\n";
+            process.write(QByteArray::fromStdString(command));
+            while (process.bytesToWrite() > 0 && process.state() != QProcess::NotRunning
+                   && accepting.load(std::memory_order_acquire)
+                   && !job->cancellation.stop_requested()) {
+                process.waitForBytesWritten(100);
+            }
+
+            const std::string responsePrefix = std::string(isolationProtocol) + " RESULT "
+                + std::to_string(job->id) + " ";
+            const auto response = waitForProtocolLine(
+                process,
+                responsePrefix,
+                outputTail,
+                job
+            );
+            isolationActive.fetch_sub(1, std::memory_order_release);
+
+            if (job->cancellation.stop_requested()
+                || !accepting.load(std::memory_order_acquire)) {
+                process.kill();
+                process.waitForFinished(-1);
+                isolationReady.fetch_sub(1, std::memory_order_release);
+                processReady = false;
+                finishIsolationJob(
+                    job,
+                    IsolationResult {
+                        IsolationStatus::Cancelled,
+                        {},
+                        "Isolation job was cancelled",
+                        outputTail.toStdString(),
+                        false,
+                        job->observedMemoryBytes.load(std::memory_order_acquire),
+                    }
+                );
+                if (accepting.load(std::memory_order_acquire)) {
+                    startupOutput.clear();
+                    processReady = startIsolationProcess(process, startupOutput);
+                    if (processReady) {
+                        isolationReady.fetch_add(1, std::memory_order_release);
+                    }
+                }
+                continue;
+            }
+            if (job->memoryExceeded.load(std::memory_order_acquire)) {
+                process.kill();
+                process.waitForFinished(-1);
+                isolationReady.fetch_sub(1, std::memory_order_release);
+                processReady = false;
+                finishIsolationJob(
+                    job,
+                    IsolationResult {
+                        IsolationStatus::Failed,
+                        {},
+                        "Isolation job exceeded its memory limit",
+                        outputTail.toStdString(),
+                        true,
+                        job->observedMemoryBytes.load(std::memory_order_acquire),
+                    }
+                );
+                startupOutput.clear();
+                processReady = startIsolationProcess(process, startupOutput);
+                if (processReady) {
+                    isolationReady.fetch_add(1, std::memory_order_release);
+                }
+                continue;
+            }
+            if (!response) {
+                if (processReady) {
+                    isolationReady.fetch_sub(1, std::memory_order_release);
+                }
+                processReady = false;
+                finishIsolationJob(
+                    job,
+                    IsolationResult {
+                        IsolationStatus::Failed,
+                        {},
+                        "Isolation worker exited before returning a result",
+                        outputTail.toStdString(),
+                        false,
+                        job->observedMemoryBytes.load(std::memory_order_acquire),
+                    }
+                );
+                startupOutput.clear();
+                processReady = startIsolationProcess(process, startupOutput);
+                if (processReady) {
+                    isolationReady.fetch_add(1, std::memory_order_release);
+                }
+                continue;
+            }
+            finishIsolationJob(
+                job,
+                IsolationResult {
+                    IsolationStatus::Completed,
+                    *response,
+                    {},
+                    outputTail.toStdString(),
+                    false,
+                    job->observedMemoryBytes.load(std::memory_order_acquire),
+                }
+            );
+        }
+
+        if (process.state() != QProcess::NotRunning) {
+            process.write(QByteArray(isolationProtocol) + " SHUTDOWN\n");
+            process.waitForBytesWritten(250);
+            process.terminate();
+            if (!process.waitForFinished(1000)) {
+                process.kill();
+                process.waitForFinished(-1);
+            }
+        }
+        if (processReady) {
+            isolationReady.fetch_sub(1, std::memory_order_release);
+        }
+    }
+
+    const std::size_t logicalProcessors;
+    LaneState compute;
+    LaneState io;
+    LaneState document;
+    CpuBudget cpuBudget;
+    std::atomic_bool accepting {true};
+    std::stop_source stopSource;
+    std::once_flag shutdownOnce;
+
+    std::mutex isolationMutex;
+    std::optional<IsolationConfiguration> isolationConfiguration;
+    std::vector<std::thread> isolationWorkers;
+    std::mutex isolationQueueMutex;
+    std::condition_variable isolationAvailable;
+    std::deque<std::shared_ptr<IsolationJob>> isolationQueue;
+    std::unordered_map<std::uint64_t, std::shared_ptr<IsolationJob>> isolationJobs;
+    std::atomic_uint64_t nextIsolationId {1};
+    std::atomic_size_t isolationReady {0};
+    std::atomic_size_t isolationQueued {0};
+    std::atomic_size_t isolationActive {0};
+
+    static thread_local Private* activeRuntime;
+    static thread_local Lane activeLane;
+};
+
+thread_local HostRuntime::Private* HostRuntime::Private::activeRuntime = nullptr;
+thread_local HostRuntime::Lane HostRuntime::Private::activeLane = HostRuntime::Lane::Io;
+
+HostRuntime::HostRuntime(std::size_t logicalProcessors, bool isolationChild)
+    : d(std::make_unique<Private>(logicalProcessors, isolationChild))
+{}
+
+HostRuntime::~HostRuntime() = default;
+
+void HostRuntime::shutdown()
+{
+    d->shutdown();
+}
+
+bool HostRuntime::isAccepting() const
+{
+    return d->accepting.load(std::memory_order_acquire);
+}
+
+std::size_t HostRuntime::logicalProcessorCount() const
+{
+    return d->logicalProcessors;
+}
+
+std::size_t HostRuntime::workerCount() const
+{
+    return workerCount(Lane::Compute);
+}
+
+std::size_t HostRuntime::workerCount(Lane lane) const
+{
+    return d->laneState(lane).workerLimit.load(std::memory_order_acquire);
+}
+
+std::size_t HostRuntime::readyWorkerCount() const
+{
+    return readyWorkerCount(Lane::Compute);
+}
+
+std::size_t HostRuntime::readyWorkerCount(Lane lane) const
+{
+    return d->laneState(lane).ready.load(std::memory_order_acquire);
+}
+
+std::size_t HostRuntime::queuedTaskCount() const
+{
+    return queuedTaskCount(Lane::Compute);
+}
+
+std::size_t HostRuntime::queuedTaskCount(Lane lane) const
+{
+    return d->laneState(lane).queued.load(std::memory_order_acquire);
+}
+
+std::size_t HostRuntime::activeTaskCount() const
+{
+    return activeTaskCount(Lane::Compute);
+}
+
+std::size_t HostRuntime::activeTaskCount(Lane lane) const
+{
+    return d->laneState(lane).active.load(std::memory_order_acquire);
+}
+
+void HostRuntime::parallelFor(
+    std::size_t count,
+    const std::function<void(std::size_t)>& function,
+    std::size_t concurrency
+)
+{
+    if (!function) {
+        throw std::invalid_argument("HostRuntime cannot execute empty parallel work");
+    }
+    if (count == 0) {
+        return;
+    }
+
+    const auto requested = concurrency == 0 ? workerCount(Lane::Compute) : concurrency;
+    const auto width = std::min(
+        count,
+        std::clamp<std::size_t>(requested, 1, d->compute.workerCapacity)
+    );
+    d->ensureComputeWorkers(width);
+
+    std::atomic_size_t next {0};
+    std::atomic_size_t completed {0};
+    const auto grain = std::max<std::size_t>(1, count / (width * 4));
+    std::vector<std::future<void>> work;
+    work.reserve(width);
+    std::exception_ptr failure;
+    try {
+        for (std::size_t worker = 0; worker < width; ++worker) {
+            work.push_back(submit(Lane::Compute, [&, grain](std::stop_token stopToken) {
+                std::size_t processed = 0;
+                while (!stopToken.stop_requested()) {
+                    const auto begin = next.fetch_add(grain, std::memory_order_relaxed);
+                    if (begin >= count) {
+                        break;
+                    }
+                    const auto end = std::min(count, begin + grain);
+                    for (auto index = begin; index < end; ++index) {
+                        if (stopToken.stop_requested()) {
+                            break;
+                        }
+                        Base::CancellationScope::check();
+                        function(index);
+                        ++processed;
+                    }
+                }
+                completed.fetch_add(processed, std::memory_order_relaxed);
+            }));
+        }
+    }
+    catch (...) {
+        // Submission can fail after earlier callbacks started (shutdown or
+        // allocation failure). Those callbacks borrow next and function:
+        // retain this frame and join them before propagating the admission
+        // error. A packaged-task future's destructor does not join its work.
+        failure = std::current_exception();
+    }
+
+    for (auto& item : work) {
+        try {
+            wait(item);
+        }
+        catch (...) {
+            if (!failure) {
+                failure = std::current_exception();
+            }
+        }
+    }
+    if (failure) {
+        std::rethrow_exception(failure);
+    }
+    // A running packaged task can return normally after observing shutdown.
+    // Its ready future is not proof that every input was computed. Never let
+    // a caller adopt partially filled geometry/projection buffers as success.
+    if (completed.load(std::memory_order_relaxed) != count) {
+        throw std::runtime_error("Parallel computation was cancelled before all items completed");
+    }
+}
+
+void HostRuntime::startIsolationWorkers(IsolationConfiguration configuration)
+{
+    d->startIsolationWorkers(std::move(configuration));
+}
+
+HostRuntime::IsolationSubmission HostRuntime::submitIsolation(
+    std::string request,
+    std::size_t memoryLimitBytes,
+    std::size_t cpuSlots
+)
+{
+    return d->submitIsolation(std::move(request), memoryLimitBytes, cpuSlots);
+}
+
+bool HostRuntime::cancelIsolation(std::uint64_t id)
+{
+    return d->cancelIsolation(id);
+}
+
+std::size_t HostRuntime::isolationWorkerCount() const
+{
+    std::lock_guard lock(d->isolationMutex);
+    return d->isolationConfiguration ? d->isolationConfiguration->workerCount : 0;
+}
+
+std::size_t HostRuntime::readyIsolationWorkerCount() const
+{
+    return d->isolationReady.load(std::memory_order_acquire);
+}
+
+std::size_t HostRuntime::queuedIsolationTaskCount() const
+{
+    return d->isolationQueued.load(std::memory_order_acquire);
+}
+
+std::size_t HostRuntime::activeIsolationTaskCount() const
+{
+    return d->isolationActive.load(std::memory_order_acquire);
+}
+
+std::size_t HostRuntime::workerBudget(std::size_t logicalProcessors)
+{
+    const auto normalized = std::max<std::size_t>(1, logicalProcessors);
+    const auto wholeGroups = (normalized / 4) * 3;
+    const auto remainder = ((normalized % 4) * 3) / 4;
+    return std::max<std::size_t>(1, wholeGroups + remainder);
+}
+
+std::size_t HostRuntime::ioWorkerBudget(std::size_t logicalProcessors)
+{
+    const auto normalized = std::max<std::size_t>(1, logicalProcessors);
+    return std::max<std::size_t>(1, normalized - workerBudget(normalized));
+}
+
+std::size_t HostRuntime::documentWorkerBudget(std::size_t logicalProcessors)
+{
+    return ioWorkerBudget(logicalProcessors);
+}
+
+std::size_t HostRuntime::isolationWorkerBudget(std::size_t logicalProcessors)
+{
+    return ioWorkerBudget(logicalProcessors);
+}
+
+void HostRuntime::Work::operator()(std::stop_token stop) const noexcept
+{
+    try { execute(stop); }
+    catch (const std::exception& error) {
+        Base::Console().error("HostRuntime completion failed: %s\n", error.what());
+    }
+    catch (...) { Base::Console().error("HostRuntime completion failed\n"); }
+}
+
+void HostRuntime::Work::abandon() const noexcept
+{
+    try { if (cancelled) { cancelled(); } }
+    catch (const std::exception& error) {
+        Base::Console().error("HostRuntime cancellation completion failed: %s\n", error.what());
+    }
+    catch (...) { Base::Console().error("HostRuntime cancellation completion failed\n"); }
+}
+
+void HostRuntime::enqueue(Lane lane, Work work)
+{
+    d->enqueue(lane, std::move(work));
+}
+
+bool HostRuntime::tryRunOnePendingComputeTask()
+{
+    return d->tryRunOnePendingComputeTask();
+}

--- a/src/App/HostRuntime.h
+++ b/src/App/HostRuntime.h
@@ -1,0 +1,277 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <future>
+#include <memory>
+#include <stop_token>
+#include <stdexcept>
+#include <string>
+#include <thread>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include <Base/Interpreter.h>
+#include <Base/CancellationScope.h>
+#include <FCGlobal.h>
+
+namespace App
+{
+
+/**
+ * Process-lifetime executor for CPU work that must not run on the GUI thread.
+ *
+ * Application owns exactly one HostRuntime. Its workers are created eagerly
+ * during application startup and remain alive until application shutdown.
+ * Submitted functions must accept a stop token and cooperate with shutdown.
+ * Submission also captures the caller's CancellationScope tokens. Each job
+ * installs its own context, including when a waiting worker helps other jobs;
+ * thread-local scope pointers never cross threads.
+ */
+class AppExport HostRuntime final
+{
+public:
+    enum class Lane
+    {
+        Compute,
+        Io,
+        Document
+    };
+
+    enum class IsolationStatus
+    {
+        Completed,
+        Cancelled,
+        Failed
+    };
+
+    struct IsolationConfiguration
+    {
+        std::string executable;
+        std::vector<std::string> arguments;
+        std::string workingDirectory;
+        std::vector<std::pair<std::string, std::string>> environment;
+        std::size_t workerCount {};
+    };
+
+    struct IsolationResult
+    {
+        IsolationStatus status {IsolationStatus::Failed};
+        std::string response;
+        std::string diagnostic;
+        std::string outputTail;
+        bool memoryExceeded {false};
+        std::size_t observedMemoryBytes {};
+    };
+
+    struct IsolationSubmission
+    {
+        std::uint64_t id {};
+        std::future<IsolationResult> completion;
+    };
+
+    explicit HostRuntime(
+        std::size_t logicalProcessors = 0,
+        bool isolationChild = false
+    );
+    ~HostRuntime();
+
+    HostRuntime(const HostRuntime&) = delete;
+    HostRuntime& operator=(const HostRuntime&) = delete;
+    HostRuntime(HostRuntime&&) = delete;
+    HostRuntime& operator=(HostRuntime&&) = delete;
+
+    template<typename Function>
+    [[nodiscard]] auto submit(Function&& function)
+        -> std::future<std::invoke_result_t<std::decay_t<Function>&, std::stop_token>>
+    {
+        return submit(Lane::Compute, std::forward<Function>(function));
+    }
+
+    template<typename Function>
+    [[nodiscard]] auto submit(Lane lane, Function&& function)
+        -> std::future<std::invoke_result_t<std::decay_t<Function>&, std::stop_token>>
+    {
+        using Callable = std::decay_t<Function>;
+        using Result = std::invoke_result_t<Callable&, std::stop_token>;
+        static_assert(
+            std::is_invocable_v<Callable&, std::stop_token>,
+            "HostRuntime work must accept a std::stop_token"
+        );
+
+        auto task = std::make_shared<std::packaged_task<Result(std::stop_token)>>(
+            [function = std::forward<Function>(function),
+             inherited = Base::CancellationScope::capture()](std::stop_token stop) mutable -> Result {
+                Base::CancellationScope context(std::move(inherited));
+                return std::invoke(function, stop);
+            }
+        );
+        auto result = task->get_future();
+        enqueue(lane, Work {[task = std::move(task)](std::stop_token stopToken) {
+            (*task)(stopToken);
+        }});
+        return result;
+    }
+
+    /**
+     * Notify exactly once for accepted work, including cancellation before it
+     * starts. The supplied future is already ready: reading it never waits.
+     * Completion runs on the finishing/cancelling lane and must only dispatch
+     * owner work, not access GUI state. Admission failure still throws.
+     */
+    template<typename Function, typename Completion>
+    void submitWithCompletion(Lane lane, Function&& function, Completion&& completion)
+    {
+        using Callable = std::decay_t<Function>;
+        using Result = std::invoke_result_t<Callable&, std::stop_token>;
+        using Callback = std::decay_t<Completion>;
+        struct Pending
+        {
+            Callable function;
+            Callback completion;
+            std::promise<Result> promise;
+            Base::CancellationScope::Captured inherited;
+
+            Pending(Callable function, Callback completion)
+                : function(std::move(function)), completion(std::move(completion)),
+                  inherited(Base::CancellationScope::capture()) {}
+
+            void run(std::stop_token stop)
+            {
+                try {
+                    Base::CancellationScope context(std::move(inherited));
+                    if constexpr (std::is_void_v<Result>) {
+                        std::invoke(function, stop);
+                        promise.set_value();
+                    }
+                    else {
+                        promise.set_value(std::invoke(function, stop));
+                    }
+                }
+                catch (...) { promise.set_exception(std::current_exception()); }
+                // Completion must be able to schedule cleanup, even when work
+                // was cancelled. Nor may a helping worker leak its outer job's
+                // context into this unrelated completion.
+                Base::CancellationScope context(Base::CancellationScope::Captured {});
+                std::invoke(completion, promise.get_future());
+            }
+
+            void cancel()
+            {
+                promise.set_exception(std::make_exception_ptr(
+                    std::runtime_error("HostRuntime shut down before this job started")));
+                Base::CancellationScope context(Base::CancellationScope::Captured {});
+                std::invoke(completion, promise.get_future());
+            }
+        };
+        auto pending = std::make_shared<Pending>(
+            std::forward<Function>(function), std::forward<Completion>(completion));
+        enqueue(lane, Work {
+            [pending](std::stop_token stop) { pending->run(stop); },
+            [pending] { pending->cancel(); }
+        });
+    }
+
+    /**
+     * Wait for runtime work without starving nested compute submissions.
+     *
+     * A compute task may itself fan work out onto the compute lane. While it
+     * waits, its physical worker executes pending compute work so a saturated
+     * pool cannot deadlock on its own child tasks.
+     */
+    template<typename Result>
+    Result wait(std::future<Result>& future)
+    {
+        using namespace std::chrono_literals;
+        // Python entry points commonly invoke synchronous public APIs while
+        // holding the interpreter lock. Release it for the duration of the
+        // wait so Python-backed work in the shared runtime can acquire it.
+        std::unique_ptr<Base::PyGILStateRelease> release;
+        if (Py_IsInitialized() && PyGILState_Check()) {
+            release = std::make_unique<Base::PyGILStateRelease>();
+        }
+        while (future.wait_for(0ms) != std::future_status::ready) {
+            if (!tryRunOnePendingComputeTask()) {
+                future.wait_for(1ms);
+            }
+        }
+        release.reset();
+        return future.get();
+    }
+
+    /** Stop admission, cancel queued work, request cancellation, and join. */
+    void shutdown();
+
+    [[nodiscard]] bool isAccepting() const;
+    [[nodiscard]] std::size_t logicalProcessorCount() const;
+    [[nodiscard]] std::size_t workerCount() const;
+    [[nodiscard]] std::size_t workerCount(Lane lane) const;
+    [[nodiscard]] std::size_t readyWorkerCount() const;
+    [[nodiscard]] std::size_t readyWorkerCount(Lane lane) const;
+    [[nodiscard]] std::size_t queuedTaskCount() const;
+    [[nodiscard]] std::size_t queuedTaskCount(Lane lane) const;
+    [[nodiscard]] std::size_t activeTaskCount() const;
+    [[nodiscard]] std::size_t activeTaskCount(Lane lane) const;
+
+    /**
+     * Execute independent indexed work on the application-owned compute lane.
+     *
+     * The call joins the submitted group before returning and propagates the
+     * first worker exception after every member has stopped using the supplied
+     * callable. A zero concurrency uses the runtime's current compute width.
+     * Shutdown is observed between items and incomplete work throws; a normal
+     * return means every indexed invocation completed, not merely that the
+     * worker futures became ready.
+     */
+    void parallelFor(
+        std::size_t count,
+        const std::function<void(std::size_t)>& function,
+        std::size_t concurrency = 0
+    );
+
+    /**
+     * Start the process-lifetime isolation workers.
+     *
+     * Configuration is single-assignment. Repeating the identical request is
+     * harmless; attempting to replace a live pool is an explicit error.
+     */
+    void startIsolationWorkers(IsolationConfiguration configuration);
+    [[nodiscard]] IsolationSubmission submitIsolation(
+        std::string request,
+        std::size_t memoryLimitBytes = 0,
+        std::size_t cpuSlots = 1
+    );
+    [[nodiscard]] bool cancelIsolation(std::uint64_t id);
+    [[nodiscard]] std::size_t isolationWorkerCount() const;
+    [[nodiscard]] std::size_t readyIsolationWorkerCount() const;
+    [[nodiscard]] std::size_t queuedIsolationTaskCount() const;
+    [[nodiscard]] std::size_t activeIsolationTaskCount() const;
+
+    [[nodiscard]] static std::size_t workerBudget(std::size_t logicalProcessors);
+    [[nodiscard]] static std::size_t ioWorkerBudget(std::size_t logicalProcessors);
+    [[nodiscard]] static std::size_t documentWorkerBudget(std::size_t logicalProcessors);
+    [[nodiscard]] static std::size_t isolationWorkerBudget(std::size_t logicalProcessors);
+
+private:
+    struct Work
+    {
+        std::function<void(std::stop_token)> execute;
+        std::function<void()> cancelled {};
+        explicit operator bool() const { return bool(execute); }
+        void operator()(std::stop_token stop) const noexcept;
+        void abandon() const noexcept;
+    };
+
+    void enqueue(Lane lane, Work work);
+    [[nodiscard]] bool tryRunOnePendingComputeTask();
+
+    class Private;
+    std::unique_ptr<Private> d;
+};
+
+}  // namespace App

--- a/src/App/HostWorkflow.h
+++ b/src/App/HostWorkflow.h
@@ -1,0 +1,205 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <coroutine>
+#include <exception>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+#include "HostRuntime.h"
+#include <Base/CancellationScope.h>
+
+namespace App
+{
+
+struct HostWorkflowStep
+{
+    HostRuntime::Lane lane;
+    std::function<void(std::stop_token)> work;
+};
+
+/** An owner-driven sequence of worker phases.
+ *
+ * The coordinator resumes on its owner only after the previous phase finishes.
+ * A phase exception is rethrown at its yield, preserving the document routine's
+ * existing recovery and cleanup scopes. The frame owns all local state across
+ * suspension; worker steps must finish before the coordinator is destroyed.
+ * Scheduling belongs to HostRuntime's driver, not to individual workbenches.
+ */
+template<typename Result>
+class HostWorkflow
+{
+public:
+    using Step = HostWorkflowStep;
+
+    struct promise_type
+    {
+        Step step;
+        std::optional<Result> result;
+        std::exception_ptr failure;
+        std::exception_ptr stepFailure;
+
+        HostWorkflow get_return_object()
+        {
+            return HostWorkflow(std::coroutine_handle<promise_type>::from_promise(*this));
+        }
+        std::suspend_always initial_suspend() noexcept { return {}; }
+        std::suspend_always final_suspend() noexcept { return {}; }
+        void return_value(Result value) { result.emplace(std::move(value)); }
+        void unhandled_exception() noexcept { failure = std::current_exception(); }
+
+        auto yield_value(Step next)
+        {
+            step = std::move(next);
+            struct Suspension: std::suspend_always
+            {
+                promise_type& promise;
+                void await_resume()
+                {
+                    if (auto error = std::exchange(promise.stepFailure, {})) {
+                        std::rethrow_exception(error);
+                    }
+                }
+            };
+            return Suspension {{}, *this};
+        }
+    };
+
+    HostWorkflow(HostWorkflow&& other) noexcept
+        : frame(std::exchange(other.frame, {}))
+    {}
+    HostWorkflow(const HostWorkflow&) = delete;
+    HostWorkflow& operator=(const HostWorkflow&) = delete;
+    ~HostWorkflow() { if (frame) { frame.destroy(); } }
+
+    bool advance()
+    {
+        if (!frame.done()) {
+            frame.resume();
+        }
+        return !frame.done();
+    }
+    const Step& step() const { return frame.promise().step; }
+    void failStep(std::exception_ptr error) { frame.promise().stepFailure = std::move(error); }
+    Result takeResult()
+    {
+        auto& promise = frame.promise();
+        if (promise.failure) {
+            std::rethrow_exception(promise.failure);
+        }
+        if (!frame.done() || !promise.result) {
+            throw std::logic_error("Workflow result requested before completion");
+        }
+        return std::move(*promise.result);
+    }
+
+    // Explicit adapter for existing synchronous public APIs. An asynchronous
+    // driver must submit each step to HostRuntime; it never calls this adapter.
+    Result runSynchronously()
+    {
+        while (advance()) {
+            try {
+                step().work(std::stop_token {});
+            }
+            catch (...) {
+                failStep(std::current_exception());
+            }
+        }
+        return takeResult();
+    }
+
+    /** Start on the coordinator owner and return without waiting for a worker.
+     * dispatchOwner must enqueue onto that same owner, which must remain alive
+     * until the returned future is ready. Both coroutine resumption and frame
+     * destruction stay there. Worker failures re-enter the suspended phase;
+     * submission failure is never replaced by caller-thread execution.
+     * finished runs once on the owner after the frame is destroyed and the
+     * future is ready (success or failure); it must not throw. Dispatch must
+     * enqueue, never invoke inline, including the initial coordinator step.
+     */
+    std::future<Result> runAsync(
+        HostRuntime& runtime,
+        std::function<void(std::function<void()>)> dispatchOwner,
+        std::function<void()> finished = {},
+        std::stop_token cancellation = {}) &&
+    {
+        struct Driver: std::enable_shared_from_this<Driver>
+        {
+            std::optional<HostWorkflow> workflow;
+            HostRuntime& runtime;
+            std::function<void(std::function<void()>)> dispatchOwner;
+            std::promise<Result> completion;
+            std::function<void()> finished;
+            std::stop_token cancellation;
+
+            Driver(HostWorkflow&& workflow, HostRuntime& runtime,
+                   std::function<void(std::function<void()>)> dispatchOwner,
+                   std::function<void()> finished,
+                   std::stop_token cancellation)
+                : workflow(std::move(workflow)), runtime(runtime),
+                  dispatchOwner(std::move(dispatchOwner)), finished(std::move(finished)),
+                  cancellation(std::move(cancellation))
+            {}
+
+            void resume(std::exception_ptr failure = {})
+            {
+                workflow->failStep(std::move(failure));
+                if (!workflow->advance()) {
+                    try {
+                        auto result = workflow->takeResult();
+                        workflow.reset();
+                        completion.set_value(std::move(result));
+                    }
+                    catch (...) {
+                        workflow.reset();
+                        completion.set_exception(std::current_exception());
+                    }
+                    // Release owner-affine callback captures here. The worker
+                    // submitting this dispatch may still hold the driver.
+                    if (auto notify = std::move(finished)) {
+                        notify();
+                    }
+                    return;
+                }
+
+                auto self = this->shared_from_this();
+                try {
+                    const auto next = workflow->step();
+                    runtime.submitWithCompletion(next.lane,
+                        [self, work = next.work](std::stop_token stop) {
+                            Base::CancellationScope shutdown(stop);
+                            Base::CancellationScope operation(self->cancellation);
+                            Base::CancellationScope::check();
+                            work(stop);
+                        },
+                        [self](std::future<void> result) {
+                            std::exception_ptr failure;
+                            try { result.get(); }
+                            catch (...) { failure = std::current_exception(); }
+                            self->dispatchOwner([self, failure] { self->resume(failure); });
+                        });
+                }
+                catch (...) {
+                    // Let the coroutine run its own cleanup/recovery at the
+                    // failed yield, on a later owner dispatch (no recursion).
+                    auto failure = std::current_exception();
+                    dispatchOwner([self, failure] { self->resume(failure); });
+                }
+            }
+        };
+        auto driver = std::make_shared<Driver>(std::move(*this), runtime,
+                                              std::move(dispatchOwner), std::move(finished),
+                                              std::move(cancellation));
+        auto result = driver->completion.get_future();
+        driver->dispatchOwner([driver] { driver->resume(); });
+        return result;
+    }
+
+private:
+    explicit HostWorkflow(std::coroutine_handle<promise_type> frame) : frame(frame) {}
+    std::coroutine_handle<promise_type> frame;
+};
+
+}  // namespace App

--- a/src/App/Link.cpp
+++ b/src/App/Link.cpp
@@ -1663,7 +1663,20 @@ DocumentObject* LinkBaseExtension::getTrueLinkedObject(bool recurse,
         return nullptr;
     }
     bool transform = linkTransform();
-    const char* subname = getSubName();
+    // Resolving an unchanged link is also used by background recompute.
+    // getSubName() reparses shared presentation caches and returns a pointer
+    // into mutable storage. A simultaneous display read can clear that string
+    // between this call and getSubObject(), losing a valid linked source.
+    // Keep the traversal path local; this read must not mutate those caches.
+    std::string objectPath;
+    const auto* xlink = freecad_cast<const PropertyXLink*>(getLinkedObjectProperty());
+    if (xlink && !xlink->getSubValues().empty()) {
+        const auto& fullPath = xlink->getSubValues().front();
+        const char* element = Data::findElementName(fullPath.c_str());
+        objectPath = element && element[0]
+            ? std::string(fullPath.c_str(), element) : fullPath;
+    }
+    const char* subname = objectPath.empty() ? nullptr : objectPath.c_str();
     if (subname || (mat && transform)) {
         ret = ret->getSubObject(subname, nullptr, mat, transform, depth + 1);
         transform = false;

--- a/src/App/MainThreadSignal.h
+++ b/src/App/MainThreadSignal.h
@@ -22,6 +22,8 @@
 #ifndef APP_MAINTHREADSIGNAL_H
 #define APP_MAINTHREADSIGNAL_H
 
+#include <FCGlobal.h>
+
 #include <Base/Interpreter.h>
 #include <fastsignals/signal.h>
 #include <functional>
@@ -42,51 +44,18 @@ namespace App
 // may observe while recompute can run on a worker thread. Raw
 // App::DocumentObject signals intentionally remain plain fastsignals with
 // same-thread semantics.
-class MainThreadSignalConfig
+class AppExport MainThreadSignalConfig
 {
 public:
     using IsMainThreadFn = bool (*)();  // true iff currently on GUI/main thread
     using InvokeFn = void (*)(std::function<void()>&& fn, bool blocking);
 
-    static void setHooks(IsMainThreadFn isMainThread, InvokeFn invoke)
-    {
-        isMainThreadSlot() = isMainThread;
-        invokeSlot() = invoke;
-    }
-
-    static inline bool isMainThread()
-    {
-        auto* f = isMainThreadSlot();
-        return f ? f() : true;  // no hooks, treat current thread as "main"
-    }
-
-    static inline bool hasHooks()
-    {
-        return isMainThreadSlot() && invokeSlot();
-    }
-
-    static inline void invoke(std::function<void()>&& fn, bool blocking)
-    {
-        auto* f = invokeSlot();
-        if (f) {
-            f(std::move(fn), blocking);
-        }
-        else {
-            fn();  // no hooks, run inline
-        }
-    }
-
-private:
-    static IsMainThreadFn& isMainThreadSlot()
-    {
-        static IsMainThreadFn fn = nullptr;
-        return fn;
-    }
-    static InvokeFn& invokeSlot()
-    {
-        static InvokeFn fn = nullptr;
-        return fn;
-    }
+    // Implemented by FreeCADApp rather than inline so Windows DLLs and PYDs
+    // all observe the same process-wide hook pair.
+    static void setHooks(IsMainThreadFn isMainThread, InvokeFn invoke);
+    static bool isMainThread();
+    static bool hasHooks();
+    static void invoke(std::function<void()>&& fn, bool blocking);
 };
 
 namespace detail
@@ -234,7 +203,13 @@ private:
             return self->sig_(std::forward<typename ::fastsignals::signal_arg_t<Arguments>>(args)...);
         }
 
-        Base::PyGILStateRelease release;
+        // Native worker tasks do not necessarily hold Python's GIL. Release
+        // it only for Python-backed callers before synchronously entering the
+        // GUI owner thread; PyEval_SaveThread is invalid without ownership.
+        std::unique_ptr<Base::PyGILStateRelease> release;
+        if (Py_IsInitialized() && PyGILState_Check()) {
+            release = std::make_unique<Base::PyGILStateRelease>();
+        }
 
         auto caps = std::make_tuple(
             detail::captureSignalArg<typename ::fastsignals::signal_arg_t<Arguments>>(args)...

--- a/src/App/PropertyLinks.cpp
+++ b/src/App/PropertyLinks.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <mutex>
 
 #include <QDir>
 #include <QFileInfo>
@@ -943,6 +944,19 @@ PropertyLinkList::~PropertyLinkList()
 
 void PropertyLinkList::setSize(int newSize)
 {
+    resizeValues(newSize, nullptr);
+}
+
+void PropertyLinkList::setSize(int newSize, const_reference def)
+{
+    resizeValues(newSize, def);
+}
+
+void PropertyLinkList::resizeValues(int newSize, DocumentObject* fill)
+{
+    if (newSize < 0) {
+        throw Base::ValueError("PropertyLinkList: negative size");
+    }
     for (int i = newSize; i < (int)_lValueList.size(); ++i) {
         auto obj = _lValueList[i];
         if (!obj || !obj->isAttachedToDocument()) {
@@ -955,16 +969,11 @@ void PropertyLinkList::setSize(int newSize)
             obj->_removeBackLinkProp(getName(), static_cast<DocumentObject*>(getContainer()));
         }
     }
-    _lValueList.resize(newSize);
-}
-
-void PropertyLinkList::setSize(int newSize, const_reference def)
-{
-    auto oldSize = getSize();
-    setSize(newSize);
-    for (auto i = oldSize; i < newSize; ++i) {
-        _lValueList[i] = def;
-    }
+    std::unique_lock lock(_objectIndexMutex);
+    // Fill under the same lock as resizing: a concurrent membership query must
+    // not see temporary null slots, and fill may alias the previous storage.
+    _lValueList.resize(newSize, fill);
+    _objectIndexValid = false;
 }
 
 void PropertyLinkList::set1Value(int idx, DocumentObject* const& value)
@@ -981,6 +990,10 @@ void PropertyLinkList::set1Value(int idx, DocumentObject* const& value)
         throw Base::ValueError("invalid document object");
     }
 
+    const int size = getSize();
+    if (idx < -1 || idx > size) {
+        throw Base::RuntimeError("index out of bound");
+    }
     _nameMap.clear();
 
     if (getContainer() && getContainer()->isDerivedFrom<App::DocumentObject>()) {
@@ -999,7 +1012,19 @@ void PropertyLinkList::set1Value(int idx, DocumentObject* const& value)
         }
     }
 
-    inherited::set1Value(idx, value);
+    atomic_change change(*this);
+    if (idx == -1 || idx == size) {
+        idx = size;
+        setSize(size + 1, value);
+    }
+    else {
+        std::unique_lock lock(_objectIndexMutex);
+        _lValueList[idx] = value;
+        _objectIndexValid = false;
+    }
+    _touchList.insert(idx);
+    // Never hold the lookup lock across property observers or GUI handoffs.
+    change.tryInvoke();
 }
 
 void PropertyLinkList::setValues(const std::vector<DocumentObject*>& value)
@@ -1041,7 +1066,15 @@ void PropertyLinkList::setValues(const std::vector<DocumentObject*>& value)
         }
     }
 
-    inherited::setValues(value);
+    atomic_change change(*this);
+    {
+        std::unique_lock lock(_objectIndexMutex);
+        // The outer atomic change owns notifications; the nested setter only
+        // updates storage here and cannot notify while this lock is held.
+        inherited::setValues(value);
+        _objectIndexValid = false;
+    }
+    change.tryInvoke();
 }
 
 PyObject* PropertyLinkList::getPyObject()
@@ -1192,6 +1225,30 @@ unsigned int PropertyLinkList::getMemSize() const
     return static_cast<unsigned int>(_lValueList.size() * sizeof(App::DocumentObject*));
 }
 
+
+int PropertyLinkList::findObject(const DocumentObject* object) const
+{
+    const auto lookup = [&] {
+        const auto found = _objectIndex.find(object);
+        return found == _objectIndex.end() ? -1 : found->second;
+    };
+    {
+        std::shared_lock lock(_objectIndexMutex);
+        if (_objectIndexValid) {
+            return lookup();
+        }
+    }
+    std::unique_lock lock(_objectIndexMutex);
+    if (!_objectIndexValid) {
+        _objectIndex.clear();
+        _objectIndex.reserve(_lValueList.size());
+        for (int index = 0; index < static_cast<int>(_lValueList.size()); ++index) {
+            _objectIndex.emplace(_lValueList[index], index);
+        }
+        _objectIndexValid = true;
+    }
+    return lookup();
+}
 
 DocumentObject* PropertyLinkList::find(const char* name, int* pindex) const
 {
@@ -3759,6 +3816,12 @@ void PropertyLinkBase::breakLinks(App::DocumentObject* link,
 {
     std::vector<Property*> props;
     for (auto obj : objs) {
+        // getLinks() enumerates attached targets only. Preserve the general
+        // detached-target contract, and always clear the removed owner's links.
+        if (link && link->isAttachedToDocument() && obj != link
+            && !obj->hasPropertyLinkTo(link)) {
+            continue;
+        }
         props.clear();
         obj->getPropertyList(props);
         for (auto prop : props) {

--- a/src/App/PropertyLinks.h
+++ b/src/App/PropertyLinks.h
@@ -31,6 +31,7 @@
 #include <vector>
 #include <unordered_set>
 #include <unordered_map>
+#include <shared_mutex>
 
 #include "Property.h"
 
@@ -857,11 +858,21 @@ public:
     DocumentObject* findUsingMap(const std::string&, int* pindex = nullptr) const;
     DocumentObject* find(const char* sub, int* pindex = nullptr) const;
 
+    /// Exact first-occurrence membership, independent of labels or object names.
+    /// Concurrent lookups are supported; property mutation remains document-owned.
+    int findObject(const DocumentObject* object) const;
+
 protected:
     DocumentObject* getPyValue(PyObject* item) const override;
 
 protected:
     mutable std::map<std::string, int> _nameMap;
+
+private:
+    void resizeValues(int newSize, DocumentObject* fill);
+    mutable std::shared_mutex _objectIndexMutex;
+    mutable std::unordered_map<const DocumentObject*, int> _objectIndex;
+    mutable bool _objectIndexValid {false};
 };
 
 /** The general Link Property with Child scope

--- a/src/App/SemanticDependencyOrder.h
+++ b/src/App/SemanticDependencyOrder.h
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+
+#include <functional>
+#include <limits>
+#include <queue>
+#include <stdexcept>
+#include <type_traits>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace App::detail
+{
+// One call-scoped ownership census can validate many publication blocks. Do
+// not retain it across document changes: ownership is part of the live contract.
+template<typename Node, typename ResolveRoot>
+auto countSemanticMembers(const std::vector<Node>& members, ResolveRoot resolveRoot)
+{
+    using Root = std::decay_t<decltype(resolveRoot(std::declval<Node>()))>;
+    std::unordered_map<Root, std::size_t> counts;
+    counts.reserve(members.size());
+    for (const auto member : members) {
+        ++counts[resolveRoot(member)];
+    }
+    return counts;
+}
+
+// Value-only graph: safe to prepare/consume without document or GUI pointers.
+struct SemanticDependencyGraph
+{
+    static constexpr std::size_t untracked = std::numeric_limits<std::size_t>::max();
+    std::vector<std::vector<std::size_t>> members;
+    std::vector<std::vector<std::size_t>> dependencies;
+    std::vector<std::size_t> block;
+};
+
+struct SemanticDependencyOrder
+{
+    std::vector<std::size_t> order;
+    std::size_t visitedEdges = 0;
+};
+
+inline SemanticDependencyOrder stableSemanticDependencyOrder(const SemanticDependencyGraph& graph)
+{
+    if (graph.block.size() != graph.dependencies.size())
+        throw std::runtime_error("received mismatched graph state");
+    std::vector<bool> enrolled(graph.block.size(), false);
+    for (std::size_t block = 0; block < graph.members.size(); ++block) {
+        for (const auto node : graph.members[block]) {
+            if (node >= graph.block.size() || graph.block[node] != block || enrolled[node])
+                throw std::runtime_error("received malformed block membership");
+            enrolled[node] = true;
+        }
+    }
+    std::vector<std::vector<std::size_t>> consumers(graph.members.size());
+    std::vector<std::size_t> indegree(graph.members.size(), 0);
+    std::vector<std::size_t> visited(graph.block.size(), SemanticDependencyGraph::untracked);
+    SemanticDependencyOrder result;
+    for (std::size_t block = 0; block < graph.members.size(); ++block) {
+        auto pending = graph.members[block];
+        for (const auto node : pending) visited[node] = block;
+        std::unordered_set<std::size_t> inputs;
+        while (!pending.empty()) {
+            const auto node = pending.back();
+            pending.pop_back();
+            for (const auto dependency : graph.dependencies[node]) {
+                ++result.visitedEdges;
+                if (dependency >= graph.block.size())
+                    throw std::runtime_error("received an invalid dependency index");
+                if (visited[dependency] == block) continue;
+                visited[dependency] = block;
+                const auto owner = graph.block[dependency];
+                if (owner != SemanticDependencyGraph::untracked && owner != block) {
+                    if (owner >= graph.members.size())
+                        throw std::runtime_error("received an invalid semantic root");
+                    if (inputs.insert(owner).second) {
+                        consumers[owner].push_back(block);
+                        ++indegree[block];
+                    }
+                    // Every enrolled block is processed independently. Its
+                    // transitive dependencies do not need duplicate edges here.
+                    if (enrolled[dependency]) continue;
+                }
+                pending.push_back(dependency);
+            }
+        }
+    }
+    std::priority_queue<std::size_t, std::vector<std::size_t>, std::greater<>> ready;
+    for (std::size_t block = 0; block < indegree.size(); ++block)
+        if (indegree[block] == 0) ready.push(block);
+    result.order.reserve(indegree.size());
+    while (!ready.empty()) {
+        const auto next = ready.top();
+        ready.pop();
+        result.order.push_back(next);
+        for (const auto consumer : consumers[next])
+            if (--indegree[consumer] == 0) ready.push(consumer);
+    }
+    if (result.order.size() != indegree.size())
+        throw std::runtime_error("detected a cycle");
+    return result;
+}
+} // namespace App::detail

--- a/src/App/StringHasher.cpp
+++ b/src/App/StringHasher.cpp
@@ -24,6 +24,7 @@
 #include <QCryptographicHash>
 #include <QHash>
 #include <deque>
+#include <mutex>
 
 #include <Base/Console.h>
 #include <Base/Reader.h>
@@ -80,6 +81,9 @@ using HashMapBase =
 class StringHasher::HashMap: public HashMapBase
 {
 public:
+    // Independent feature workers share this table. Hold the lock across lookup,
+    // ID allocation and insertion, including nested prefix/postfix interning.
+    mutable std::recursive_mutex mutex;
     bool SaveAll = false;
     int Threshold = 0;
 };
@@ -91,6 +95,7 @@ TYPESYSTEM_SOURCE_ABSTRACT(App::StringID, Base::BaseClass)
 StringID::~StringID()
 {
     if (_hasher) {
+        std::lock_guard lock(_hasher->_hashes->mutex);
         _hasher->_hashes->right.erase(_id);
     }
 }
@@ -182,6 +187,7 @@ StringHasher::~StringHasher()
 
 void StringHasher::setSaveAll(bool enable)
 {
+    std::lock_guard lock(_hashes->mutex);
     if (_hashes->SaveAll == enable) {
         return;
     }
@@ -191,6 +197,7 @@ void StringHasher::setSaveAll(bool enable)
 
 void StringHasher::compact()
 {
+    std::lock_guard lock(_hashes->mutex);
     if (_hashes->SaveAll) {
         return;
     }
@@ -228,21 +235,25 @@ void StringHasher::compact()
 
 bool StringHasher::getSaveAll() const
 {
+    std::lock_guard lock(_hashes->mutex);
     return _hashes->SaveAll;
 }
 
 void StringHasher::setThreshold(int threshold)
 {
+    std::lock_guard lock(_hashes->mutex);
     _hashes->Threshold = threshold;
 }
 
 int StringHasher::getThreshold() const
 {
+    std::lock_guard lock(_hashes->mutex);
     return _hashes->Threshold;
 }
 
 long StringHasher::lastID() const
 {
+    std::lock_guard lock(_hashes->mutex);
     if (_hashes->right.empty()) {
         return 0;
     }
@@ -261,6 +272,7 @@ StringIDRef StringHasher::getID(const char* text, int len, bool hashable)
 
 StringIDRef StringHasher::getID(const QByteArray& data, Options options)
 {
+    std::lock_guard lock(_hashes->mutex);
     bool binary = options.testFlag(Option::Binary);
     bool hashable = options.testFlag(Option::Hashable);
     bool nocopy = options.testFlag(Option::NoCopy);
@@ -300,6 +312,7 @@ StringIDRef StringHasher::getID(const QByteArray& data, Options options)
 
 StringIDRef StringHasher::getID(const Data::MappedName& name, const QVector<StringIDRef>& sids)
 {
+    std::lock_guard lock(_hashes->mutex);
     StringID tempID;
     tempID._postfix = name.postfixBytes();
 
@@ -434,6 +447,7 @@ StringIDRef StringHasher::getID(const Data::MappedName& name, const QVector<Stri
 
 StringIDRef StringHasher::getID(long id, int index) const
 {
+    std::lock_guard lock(_hashes->mutex);
     if (id <= 0) {
         return {};
     }
@@ -448,6 +462,7 @@ StringIDRef StringHasher::getID(long id, int index) const
 
 void StringHasher::setPersistenceFileName(const char* filename) const
 {
+    std::lock_guard lock(_hashes->mutex);
     if (!filename) {
         filename = "";
     }
@@ -461,6 +476,7 @@ const std::string& StringHasher::getPersistenceFileName() const
 
 void StringHasher::Save(Base::Writer& writer) const
 {
+    std::lock_guard lock(_hashes->mutex);
 
     std::size_t count = _hashes->SaveAll ? _hashes->size() : this->count();
 
@@ -489,6 +505,7 @@ void StringHasher::Save(Base::Writer& writer) const
 
 void StringHasher::SaveDocFile(Base::Writer& writer) const
 {
+    std::lock_guard lock(_hashes->mutex);
     std::size_t count = _hashes->SaveAll ? this->size() : this->count();
     writer.Stream() << "StringTableStart v1 " << count << '\n';
     saveStream(writer.Stream());
@@ -496,6 +513,7 @@ void StringHasher::SaveDocFile(Base::Writer& writer) const
 
 void StringHasher::saveStream(std::ostream& stream) const
 {
+    std::lock_guard lock(_hashes->mutex);
     Base::TextOutputStream textStreamWrapper(stream);
     boost::io::ios_flags_saver ifs(stream);
     stream << std::hex;
@@ -593,6 +611,7 @@ void StringHasher::saveStream(std::ostream& stream) const
 
 void StringHasher::RestoreDocFile(Base::Reader& reader)
 {
+    std::lock_guard lock(_hashes->mutex);
     std::string marker;
     std::string ver;
     reader >> marker;
@@ -612,6 +631,7 @@ void StringHasher::RestoreDocFile(Base::Reader& reader)
 
 void StringHasher::restoreStreamNew(std::istream& stream, std::size_t count)
 {
+    std::lock_guard lock(_hashes->mutex);
     Base::TextInputStream asciiStream(stream);
     _hashes->clear();
     std::string content;
@@ -728,6 +748,7 @@ void StringHasher::restoreStreamNew(std::istream& stream, std::size_t count)
 
 StringID* StringHasher::insert(const StringIDRef& sid)
 {
+    std::lock_guard lock(_hashes->mutex);
     assert(sid && sid._sid->_hasher == nullptr);
     auto& hasher = *sid._sid;
     hasher._hasher = this;
@@ -743,6 +764,7 @@ StringID* StringHasher::insert(const StringIDRef& sid)
 
 void StringHasher::restoreStream(std::istream& stream, std::size_t count)
 {
+    std::lock_guard lock(_hashes->mutex);
     _hashes->clear();
     std::string content;
     for (uint32_t i = 0; i < count; ++i) {
@@ -762,6 +784,7 @@ void StringHasher::restoreStream(std::istream& stream, std::size_t count)
 
 void StringHasher::clear()
 {
+    std::lock_guard lock(_hashes->mutex);
     for (auto& hasher : _hashes->right) {
         hasher.second->_hasher = nullptr;
         hasher.second->unref();
@@ -771,11 +794,13 @@ void StringHasher::clear()
 
 size_t StringHasher::size() const
 {
+    std::lock_guard lock(_hashes->mutex);
     return _hashes->size();
 }
 
 size_t StringHasher::count() const
 {
+    std::lock_guard lock(_hashes->mutex);
     size_t count = 0;
     for (auto& hasher : _hashes->right) {
         if (hasher.second->isMarked() || hasher.second->isPersistent()) {
@@ -787,6 +812,7 @@ size_t StringHasher::count() const
 
 void StringHasher::Restore(Base::XMLReader& reader)
 {
+    std::lock_guard lock(_hashes->mutex);
     clear();
     reader.readElement("StringHasher");
     _hashes->SaveAll = reader.getAttribute<long>("saveall") != 0L;
@@ -843,6 +869,7 @@ void StringHasher::Restore(Base::XMLReader& reader)
 
 unsigned int StringHasher::getMemSize() const
 {
+    std::lock_guard lock(_hashes->mutex);
     return (_hashes->SaveAll ? size() : count()) * 10;
 }
 
@@ -853,6 +880,7 @@ PyObject* StringHasher::getPyObject()
 
 std::map<long, StringIDRef> StringHasher::getIDMap() const
 {
+    std::lock_guard lock(_hashes->mutex);
     std::map<long, StringIDRef> ret;
     for (auto& hasher : _hashes->right) {
         ret.emplace_hint(ret.end(), hasher.first, StringIDRef(hasher.second));
@@ -862,6 +890,7 @@ std::map<long, StringIDRef> StringHasher::getIDMap() const
 
 void StringHasher::clearMarks() const
 {
+    std::lock_guard lock(_hashes->mutex);
     for (auto& hasher : _hashes->right) {
         hasher.second->_flags.setFlag(StringID::Flag::Marked, false);
     }

--- a/src/App/private/CpuBudget.h
+++ b/src/App/private/CpuBudget.h
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <algorithm>
+#include <condition_variable>
+#include <cstddef>
+#include <cstdint>
+#include <deque>
+#include <mutex>
+#include <stop_token>
+
+namespace App::detail
+{
+
+// One FIFO budget shared by native compute and isolated geometry workers.
+// This is an internal scheduler primitive, not another executor or pool.
+class CpuBudget
+{
+public:
+    explicit CpuBudget(std::size_t capacity)
+        : capacity_(std::max<std::size_t>(1, capacity)), available_(capacity_)
+    {}
+
+    bool acquire(std::size_t requested, std::stop_token stop)
+    {
+        const auto slots = std::clamp<std::size_t>(requested, 1, capacity_);
+        std::unique_lock lock(mutex_);
+        const auto ticket = nextTicket_++;
+        waiters_.push_back(ticket);
+        const bool ready = changed_.wait(lock, stop, [&] {
+            return waiters_.front() == ticket && available_ >= slots;
+        });
+        if (!ready || stop.stop_requested()) {
+            waiters_.erase(std::find(waiters_.begin(), waiters_.end(), ticket));
+            lock.unlock();
+            changed_.notify_all();
+            return false;
+        }
+        waiters_.pop_front();
+        available_ -= slots;
+        lock.unlock();
+        changed_.notify_all();
+        return true;
+    }
+
+    void release(std::size_t slots)
+    {
+        {
+            std::lock_guard lock(mutex_);
+            available_ = std::min(capacity_, available_ + slots);
+        }
+        changed_.notify_all();
+    }
+
+    [[nodiscard]] std::size_t capacity() const { return capacity_; }
+
+private:
+    const std::size_t capacity_;
+    std::size_t available_;
+    std::uint64_t nextTicket_ {0};
+    std::mutex mutex_;
+    std::condition_variable_any changed_;
+    std::deque<std::uint64_t> waiters_;
+};
+
+}  // namespace App::detail

--- a/src/App/private/DocumentP.h
+++ b/src/App/private/DocumentP.h
@@ -28,7 +28,10 @@
 #pragma warning(disable : 4834)
 #endif
 
+#include <atomic>
+#include <condition_variable>
 #include <map>
+#include <mutex>
 #include <string>
 #include <memory>
 #include <vector>
@@ -74,6 +77,8 @@ struct DocumentP
 {
     // Array to preserve the creation order of created objects
     std::vector<DocumentObject*> objectArray;
+    // Exact membership without dereferencing possibly retired candidate pointers.
+    std::unordered_set<const DocumentObject*> objectAddresses;
     std::unordered_set<App::DocumentObject*> touchedObjs;
     std::unordered_map<std::string, DocumentObject*> objectMap;
     Base::UniqueNameManager objectNameManager;
@@ -82,6 +87,9 @@ struct DocumentP
     std::unordered_map<std::string, bool> partialLoadObjects;
     std::vector<DocumentObjectT> pendingRemove;
     long lastObjectId {};
+    std::atomic_uint64_t objectChangeGeneration {0};
+    std::atomic_uint64_t objectStructureGeneration {0};
+    std::atomic_uint64_t objectRemovalGeneration {0};
     DocumentObject* activeObject {nullptr};
     Transaction* activeUndoTransaction {nullptr};
     // pointer to the python class
@@ -99,7 +107,17 @@ struct DocumentP
     unsigned int UndoMemSize {0};
     unsigned int UndoMaxStackSize {20};
     unsigned int TransactionLock {0};
-    unsigned int cooperativeMutationDepth {0};
+    std::atomic_uint cooperativeMutationDepth {0};
+    // Non-null only while the archive writer consumes live document properties.
+    std::atomic<const void*> archiveWriter {nullptr};
+    std::atomic_uint presentationUpdateDepth {0};
+    unsigned int restorePresentationDepth {0};
+    unsigned int presentationWaiterCount {0};
+    mutable std::mutex presentationUpdateMutex;
+    // A final presentation observer may close the document. Notification must
+    // retain its own lifetime after that callback, independently of DocumentP.
+    std::shared_ptr<std::condition_variable> presentationUpdateChanged {
+        std::make_shared<std::condition_variable>()};
     // Id and name that the next transaction will take
     // as soon as there is a change to the document
     int bookedTransaction { 0 }; 
@@ -108,6 +126,8 @@ struct DocumentP
     mutable HasherMap hashers;
     std::multimap<const App::DocumentObject*, std::unique_ptr<App::DocumentObjectExecReturn>>
         _RecomputeLog;
+    mutable std::recursive_mutex recomputeLogMutex;
+    mutable std::recursive_mutex propertyChangeMutex;
     std::uint64_t recomputeDiagnosticGeneration {0};
     std::vector<RecomputeDiagnostic> recomputeDiagnostics;
     ExportInfo exportInfo;
@@ -118,6 +138,7 @@ struct DocumentP
 
     void beginRecomputeDiagnostics()
     {
+        std::lock_guard lock(recomputeLogMutex);
         ++recomputeDiagnosticGeneration;
         recomputeDiagnostics.clear();
     }
@@ -129,6 +150,7 @@ struct DocumentP
                                 std::string_view property = {},
                                 std::string_view subelement = {})
     {
+        std::lock_guard lock(recomputeLogMutex);
         RecomputeDiagnostic diagnostic;
         diagnostic.generation = recomputeDiagnosticGeneration;
         diagnostic.severity = "error";
@@ -150,6 +172,7 @@ struct DocumentP
                          std::string_view property = {},
                          std::string_view subelement = {})
     {
+        std::lock_guard lock(recomputeLogMutex);
         addRecomputeLog(
             new DocumentObjectExecReturn(why, obj),
             code,
@@ -166,6 +189,7 @@ struct DocumentP
                          std::string_view property = {},
                          std::string_view subelement = {})
     {
+        std::lock_guard lock(recomputeLogMutex);
         addRecomputeLog(
             new DocumentObjectExecReturn(why, obj),
             code,
@@ -181,6 +205,7 @@ struct DocumentP
                          std::string_view property = {},
                          std::string_view subelement = {})
     {
+        std::lock_guard lock(recomputeLogMutex);
         if (!returnCode->Which) {
             delete returnCode;
             return;
@@ -200,6 +225,7 @@ struct DocumentP
 
     void clearRecomputeLog(const App::DocumentObject* obj = nullptr)
     {
+        std::lock_guard lock(recomputeLogMutex);
         if (!obj) {
             _RecomputeLog.clear();
         }
@@ -210,8 +236,11 @@ struct DocumentP
 
     void clearDocument()
     {
+        objectRemovalGeneration.fetch_add(1, std::memory_order_release);
+        objectChangeGeneration.fetch_add(1, std::memory_order_release);
         objectLabelManager.clear();
         objectArray.clear();
+        objectAddresses.clear();
         for (auto& v : objectMap) {
             v.second->setStatus(ObjectStatus::Destroy, true);
             delete (v.second);
@@ -220,15 +249,30 @@ struct DocumentP
         objectMap.clear();
         objectNameManager.clear();
         objectIdMap.clear();
+        objectChangeGeneration.fetch_add(1, std::memory_order_release);
+        objectRemovalGeneration.fetch_add(1, std::memory_order_release);
     }
 
     const char* findRecomputeLog(const App::DocumentObject* obj)
     {
+        std::lock_guard lock(recomputeLogMutex);
         auto range = _RecomputeLog.equal_range(obj);
         if (range.first == range.second) {
             return nullptr;
         }
         return (--range.second)->second->Why.c_str();
+    }
+
+    [[nodiscard]] bool hasRecomputeLog() const
+    {
+        std::lock_guard lock(recomputeLogMutex);
+        return !_RecomputeLog.empty();
+    }
+
+    [[nodiscard]] std::uint64_t getRecomputeDiagnosticGeneration() const
+    {
+        std::lock_guard lock(recomputeLogMutex);
+        return recomputeDiagnosticGeneration;
     }
 
     static void findAllPathsAt(const std::vector<Node>& all_nodes,

--- a/src/Base/Base64Filter.h
+++ b/src/Base/Base64Filter.h
@@ -136,7 +136,7 @@ struct base64_encoder
         pos += end - buf;
         bio::write(dev, buf, end - buf);
         buffer.clear();
-        return n;
+        return res;
     }
 
     std::size_t line_size;

--- a/src/Base/CMakeLists.txt
+++ b/src/Base/CMakeLists.txt
@@ -211,6 +211,7 @@ SET(FreeCADBase_CPP_SRCS
     PyObjectBase.cpp
     PythonTypeExt.cpp
     Reader.cpp
+    CancellationScope.cpp
     Rotation.cpp
     RotationPyImp.cpp
     Sequencer.cpp
@@ -280,6 +281,7 @@ SET(FreeCADBase_HPP_SRCS
     PyWrapParseTupleAndKeywords.h
     PythonTypeExt.h
     Reader.h
+    CancellationScope.h
     Rotation.h
     ServiceProvider.h
     Sequencer.h

--- a/src/Base/CancellationScope.cpp
+++ b/src/Base/CancellationScope.cpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "CancellationScope.h"
+#include "Exception.h"
+#include <algorithm>
+#include <utility>
+
+namespace Base
+{
+
+namespace
+{
+// Keep TLS inside FreeCADBase rather than exporting a TLS data member, which
+// MSVC does not support. Every module accesses it through the exported methods.
+thread_local CancellationScope* current = nullptr;
+}
+
+CancellationScope::CancellationScope(std::stop_token token) noexcept
+    : previous(current), token(std::move(token))
+{
+    current = this;
+}
+
+CancellationScope::~CancellationScope()
+{
+    current = previous;
+}
+
+CancellationScope::CancellationScope(Captured context) noexcept
+    : previous(current), inherited(std::move(context)), boundary(true)
+{
+    current = this;
+}
+
+void CancellationScope::check()
+{
+    for (auto* scope = current; scope; scope = scope->previous) {
+        if (scope->token.stop_requested()) {
+            throw AbortException();
+        }
+        for (const auto& token : scope->inherited.tokens) {
+            if (token.stop_requested()) {
+                throw AbortException();
+            }
+        }
+        if (scope->boundary) {
+            break;
+        }
+    }
+}
+
+CancellationScope::Captured CancellationScope::capture()
+{
+    Captured result;
+    const auto append = [&result](const std::stop_token& token) {
+        if (token.stop_possible()
+            && std::find(result.tokens.begin(), result.tokens.end(), token) == result.tokens.end()) {
+            result.tokens.push_back(token);
+        }
+    };
+    for (auto* scope = current; scope; scope = scope->previous) {
+        append(scope->token);
+        for (const auto& token : scope->inherited.tokens) {
+            append(token);
+        }
+        if (scope->boundary) {
+            break;
+        }
+    }
+    return result;
+}
+
+}  // namespace Base

--- a/src/Base/CancellationScope.h
+++ b/src/Base/CancellationScope.h
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <stop_token>
+#include <vector>
+#include <FCGlobal.h>
+
+namespace Base
+{
+
+/** Cancellation inherited by synchronous callees within one worker phase.
+ *
+ * Scopes never cross threads; captured tokens travel with submitted work.
+ * Nested scopes check every parent, allowing both operation cancellation
+ * and runtime shutdown to stop shared parsing/compute routines. Storage and
+ * checks live in FreeCADBase so all Windows modules observe the same scope.
+ */
+class BaseExport CancellationScope final
+{
+public:
+    struct Captured
+    {
+        std::vector<std::stop_token> tokens;
+    };
+
+    explicit CancellationScope(std::stop_token token) noexcept;
+    /// Install a captured job context, isolating it from this worker's caller.
+    explicit CancellationScope(Captured context) noexcept;
+    ~CancellationScope();
+    CancellationScope(const CancellationScope&) = delete;
+    CancellationScope& operator=(const CancellationScope&) = delete;
+
+    static void check();
+    [[nodiscard]] static Captured capture();
+
+private:
+    CancellationScope* previous;
+    std::stop_token token;
+    Captured inherited;
+    bool boundary {false};
+};
+
+}  // namespace Base

--- a/src/Base/Reader.cpp
+++ b/src/Base/Reader.cpp
@@ -22,6 +22,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <chrono>
+#include <cstdlib>
 #include <map>
 #include <vector>
 #include <iostream>
@@ -32,6 +34,7 @@
 #include <locale>
 
 #include "Reader.h"
+#include "CancellationScope.h"
 #include "Base64.h"
 #include "Base64Filter.h"
 #include "Console.h"
@@ -59,6 +62,7 @@ using namespace XERCES_CPP_NAMESPACE;
 Base::XMLReader::XMLReader(const char* FileName, std::istream& str)
     : _File(FileName)
 {
+    CancellationScope::check();
     str.imbue(std::locale::classic());
 
     // create the parser
@@ -71,6 +75,12 @@ Base::XMLReader::XMLReader(const char* FileName, std::istream& str)
     try {
         StdInputSource file(str, _File.filePath().c_str());
         _valid = parser->parseFirst(file, token);
+    }
+    catch (const Base::AbortException&) {
+        // A failed constructor does not run ~XMLReader(). Cancellation must
+        // retain its type without leaking the parser allocated above.
+        delete parser;
+        throw;
     }
     catch (const XMLException& toCatch) {
         char* message = XMLString::transcode(toCatch.getMessage());
@@ -195,10 +205,14 @@ bool Base::XMLReader::hasAttribute(const char* AttrName) const
 
 bool Base::XMLReader::read()
 {
+    CancellationScope::check();
     ReadType = None;
 
     try {
         parser->parseNext(token);
+    }
+    catch (const Base::AbortException&) {
+        throw;
     }
     catch (const XMLException& toCatch) {
 
@@ -332,6 +346,7 @@ void Base::XMLReader::readCharacters(const char* filename, CharStreamFormat form
 
 std::streamsize Base::XMLReader::read(char_type* s, std::streamsize n)
 {
+    CancellationScope::check();
 
     char_type* buf = s;
     if (CharacterOffset < 0) {
@@ -435,6 +450,10 @@ void Base::XMLReader::readBinFile(const char* filename)
 
 void Base::XMLReader::readFiles(zipios::ZipInputStream& zipstream) const
 {
+    CancellationScope::check();
+    const bool traceRestore = std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
+    const auto filesStarted = std::chrono::steady_clock::now();
+    std::size_t restoredFileCount = 0;
     // It's possible that not all objects inside the document could be created, e.g. if a module
     // is missing that would know these object types. So, there may be data files inside the zip
     // file that cannot be read. We simply ignore these files.
@@ -455,6 +474,7 @@ void Base::XMLReader::readFiles(zipios::ZipInputStream& zipstream) const
     std::vector<FileEntry>::const_iterator it = FileList.begin();
     Base::SequencerLauncher seq("Importing project files...", FileList.size());
     while (entry->isValid() && it != FileList.end()) {
+        CancellationScope::check();
         std::vector<FileEntry>::const_iterator jt = it;
         // Check if the current entry is registered, otherwise check the next registered files as
         // soon as both file names match
@@ -464,12 +484,16 @@ void Base::XMLReader::readFiles(zipios::ZipInputStream& zipstream) const
         // If this condition is true both file names match and we can read-in the data, otherwise
         // no file name for the current entry in the zip was registered.
         if (jt != FileList.end()) {
+            const auto fileStarted = std::chrono::steady_clock::now();
             try {
                 Base::Reader reader(zipstream, jt->FileName, FileVersion);
-                jt->Object->RestoreDocFile(reader);
+                restoreFile(*jt->Object, reader);
                 if (reader.getLocalReader()) {
                     reader.getLocalReader()->readFiles(zipstream);
                 }
+            }
+            catch (const Base::AbortException&) {
+                throw;
             }
             catch (...) {
                 // For any exception we just continue with the next file.
@@ -488,6 +512,20 @@ void Base::XMLReader::readFiles(zipios::ZipInputStream& zipstream) const
                     FailedFiles.push_back(jt->FileName);
                 }
             }
+            ++restoredFileCount;
+            if (traceRestore) {
+                const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - fileStarted
+                ).count();
+                if (elapsed >= 20) {
+                    Base::Console().message(
+                        "VIBECAD_RESTORE_DETAIL embedded_file name=%s size=%lld elapsed_ms=%lld\n",
+                        jt->FileName.c_str(),
+                        static_cast<long long>(entry->getSize()),
+                        static_cast<long long>(elapsed)
+                    );
+                }
+            }
             // Go to the next registered file name
             it = jt + 1;
         }
@@ -503,6 +541,21 @@ void Base::XMLReader::readFiles(zipios::ZipInputStream& zipstream) const
             break;
         }
     }
+    if (traceRestore) {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - filesStarted
+        ).count();
+        Base::Console().message(
+            "VIBECAD_RESTORE_DETAIL embedded_files count=%llu elapsed_ms=%lld\n",
+            static_cast<unsigned long long>(restoredFileCount),
+            static_cast<long long>(elapsed)
+        );
+    }
+}
+
+void Base::XMLReader::restoreFile(Persistence& object, Reader& reader) const
+{
+    object.RestoreDocFile(reader);
 }
 
 const char* Base::XMLReader::addFile(const char* Name, Base::Persistence* Object)
@@ -610,6 +663,11 @@ void Base::XMLReader::endCDATA()
 void Base::XMLReader::characters(const XMLCh* const chars, const XMLSize_t length)
 {
     Characters = StrX(chars).c_str();
+    if (CharacterOffset >= 0) {
+        // A SAX character callback replaces the current buffer. Reset here,
+        // not after parseNext: the same parse step may also end a CDATA section.
+        CharacterOffset = 0;
+    }
     ReadType = Chars;
     CharacterCount += length;
 }

--- a/src/Base/Reader.h
+++ b/src/Base/Reader.h
@@ -53,6 +53,7 @@ class SAX2XMLReader;
 namespace Base
 {
 class Persistence;
+class Reader;
 
 /** The XML reader class
  * This is an important helper class for the store and retrieval system
@@ -307,6 +308,13 @@ public:
     void setStatus(ReaderStatus pos, bool on);
 
 protected:
+    /** Restore one registered embedded file. Specialized readers can adopt
+     * thread-affine persistent state on its owner while archive traversal
+     * stays on the reading thread. Must finish (or throw) before returning;
+     * the reader and persistence target are borrowed for this call only.
+     */
+    virtual void restoreFile(Persistence& object, Reader& reader) const;
+
     /// read the next element
     bool read();
 

--- a/src/Base/Sequencer.cpp
+++ b/src/Base/Sequencer.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include <mutex>
+#include <unordered_map>
 #include <vector>
 #include <algorithm>
 #include <cstdio>
@@ -35,10 +36,17 @@ namespace Base
 {
 struct SequencerP
 {
+    struct ProgressPulse
+    {
+        void (*handler)(void*) {nullptr};
+        void* context {nullptr};
+    };
+
     // members
     static std::vector<SequencerBase*> _instances; /**< A vector of all created instances */
     static SequencerLauncher* _topLauncher;        /**< The outermost launcher */
     static std::recursive_mutex mutex;             /**< A mutex-locker for the launcher */
+    static std::unordered_map<SequencerBase*, ProgressPulse> progressPulses;
     /** Sets a global sequencer object.
      * Access to the last registered object is performed by @see Sequencer().
      */
@@ -48,6 +56,7 @@ struct SequencerP
     }
     static void removeInstance(SequencerBase* sb)
     {
+        progressPulses.erase(sb);
         const auto it = std::ranges::find(_instances, sb);
         _instances.erase(it);
     }
@@ -64,10 +73,12 @@ struct SequencerP
 std::vector<SequencerBase*> SequencerP::_instances;
 SequencerLauncher* SequencerP::_topLauncher = nullptr;
 std::recursive_mutex SequencerP::mutex;
+std::unordered_map<SequencerBase*, SequencerP::ProgressPulse> SequencerP::progressPulses;
 }  // namespace Base
 
 SequencerBase& SequencerBase::Instance()
 {
+    std::lock_guard<std::recursive_mutex> locker(SequencerP::mutex);
     // not initialized?
     if (SequencerP::_instances.empty()) {
         new ConsoleSequencer();
@@ -78,11 +89,13 @@ SequencerBase& SequencerBase::Instance()
 
 SequencerBase::SequencerBase()
 {
+    std::lock_guard<std::recursive_mutex> locker(SequencerP::mutex);
     SequencerP::appendInstance(this);
 }
 
 SequencerBase::~SequencerBase()
 {
+    std::lock_guard<std::recursive_mutex> locker(SequencerP::mutex);
     SequencerP::removeInstance(this);
 }
 
@@ -119,6 +132,9 @@ void SequencerBase::stopStep()
 bool SequencerBase::next(bool canAbort)
 {
     this->nProgress++;
+
+    pulse();
+
     float fDiv = this->nTotalSteps > 0 ? static_cast<float>(this->nTotalSteps) : 1000.0F;
     int perc = int((float(this->nProgress) * (100.0F / fDiv)));
 
@@ -135,8 +151,36 @@ bool SequencerBase::next(bool canAbort)
     return this->nProgress < this->nTotalSteps;
 }
 
+void SequencerBase::pulse()
+{
+    SequencerP::ProgressPulse progressPulse;
+    {
+        std::lock_guard<std::recursive_mutex> locker(SequencerP::mutex);
+        if (!this->_bLocked) {
+            const auto pulse = SequencerP::progressPulses.find(this);
+            if (pulse != SequencerP::progressPulses.end()) {
+                progressPulse = pulse->second;
+            }
+        }
+    }
+    if (progressPulse.handler) {
+        progressPulse.handler(progressPulse.context);
+    }
+}
+
 void SequencerBase::nextStep(bool /*next*/)
 {}
+
+void SequencerBase::setProgressPulseHandler(ProgressPulseHandler handler, void* context)
+{
+    std::lock_guard<std::recursive_mutex> locker(SequencerP::mutex);
+    if (handler) {
+        SequencerP::progressPulses[this] = {handler, context};
+    }
+    else {
+        SequencerP::progressPulses.erase(this);
+    }
+}
 
 void SequencerBase::setProgress(size_t /*value*/)
 {}
@@ -187,11 +231,13 @@ bool SequencerBase::wasCanceled() const
 
 void SequencerBase::tryToCancel()
 {
+    std::lock_guard<std::recursive_mutex> locker(SequencerP::mutex);
     this->_bCanceled = true;
 }
 
 void SequencerBase::rejectCancel()
 {
+    std::lock_guard<std::recursive_mutex> locker(SequencerP::mutex);
     this->_bCanceled = false;
 }
 
@@ -202,6 +248,7 @@ int SequencerBase::progressInPercent() const
 
 void SequencerBase::resetData()
 {
+    std::lock_guard<std::recursive_mutex> locker(SequencerP::mutex);
     this->_bCanceled = false;
 }
 
@@ -264,7 +311,8 @@ bool SequencerLauncher::next(bool canAbort)
 {
     std::lock_guard<std::recursive_mutex> locker(SequencerP::mutex);
     if (SequencerP::_topLauncher != this) {
-        return true;  // ignore
+        SequencerBase::Instance().pulse();
+        return true;  // percentage presentation belongs to the outer launcher
     }
     return SequencerBase::Instance().next(canAbort);
 }

--- a/src/Base/Sequencer.h
+++ b/src/Base/Sequencer.h
@@ -177,6 +177,13 @@ protected:
      */
     bool next(bool canAbort = false);
     /**
+     * Services owner-specific liveness work without advancing the visible
+     * progress value. Nested launchers use this because only the outermost
+     * launcher owns percentage presentation, while every nested unit of work
+     * must still keep the host responsive.
+     */
+    void pulse();
+    /**
      * Stops the sequencer if all operations are finished. It returns false if
      * there are still pending operations, otherwise it returns true.
      */
@@ -205,6 +212,8 @@ protected:
     void rejectCancel();
 
 protected:
+    using ProgressPulseHandler = void (*)(void* context);
+
     /** construction */
     SequencerBase();
     SequencerBase(const SequencerBase&) = default;
@@ -233,6 +242,13 @@ protected:
      * re-implementation this method can throw an AbortException if canAbort is true.
      */
     virtual void nextStep(bool canAbort);
+    /**
+     * Installs an owner-specific callback invoked for every unlocked progress
+     * advance, independently of percentage presentation. The callback is kept
+     * outside the object layout so adding GUI heartbeat service does not alter
+     * the ABI of SequencerBase. Passing nullptr removes the callback.
+     */
+    void setProgressPulseHandler(ProgressPulseHandler handler, void* context);
     /**
      * Sets the progress indicator to a certain position.
      */

--- a/src/Base/Writer.cpp
+++ b/src/Base/Writer.cpp
@@ -27,6 +27,7 @@
 #include <set>
 #include <vector>
 #include <string>
+#include <utility>
 
 #include <limits>
 #include <locale>
@@ -303,12 +304,66 @@ std::string Writer::addFile(const char* Name, const Base::Persistence* Object)
         temp.FileName = FileNameManager.makeUniqueName(temp.FileName);
     }
     temp.Object = Object;
+    temp.captureDispatcher = fileCaptureDispatcher;
 
     FileList.push_back(temp);
     FileNameManager.addExactName(temp.FileName);
 
     // return the unique file name
     return temp.FileName;
+}
+
+void Writer::captureOnOwner(const CaptureDispatcher& dispatch, const std::function<void()>& capture)
+{
+    if (!dispatch || CharStream) {
+        throw Base::RuntimeError("Invalid owner persistence capture state");
+    }
+    auto& output = Stream();
+    if (!output.good()) {
+        throw Base::RuntimeError("Cannot capture into a failed persistence stream");
+    }
+    // Allocate dispatcher copies before redirecting the stream: allocation
+    // failure must never leave it pointing at a destroyed temporary buffer.
+    auto nextDispatcher = dispatch;
+    std::stringbuf captured;
+    auto previousDispatcher = std::move(fileCaptureDispatcher);
+    const auto firstFile = FileList.size();
+    auto* destination = output.rdbuf(&captured);
+    fileCaptureDispatcher = std::move(nextDispatcher);
+    try {
+        dispatch([&] {
+            capture();
+            if (CharStream || !output.good()) {
+                throw Base::RuntimeError("Incomplete owner persistence capture");
+            }
+        });
+    }
+    catch (...) {
+        // A failed character encoder must release its reference to the temporary
+        // buffer before that buffer dies. Never flush partial output to disk.
+        CharStream.reset();
+        output.rdbuf(destination);
+        fileCaptureDispatcher = std::move(previousDispatcher);
+        while (FileList.size() > firstFile) {
+            FileNameManager.removeExactName(FileList.back().FileName);
+            FileList.pop_back();
+        }
+        throw;
+    }
+    output.rdbuf(destination);
+    fileCaptureDispatcher = std::move(previousDispatcher);
+    const auto bytes = captured.view();
+    output.write(bytes.data(), static_cast<std::streamsize>(bytes.size()));
+}
+
+void Writer::writeFile(const FileEntry& entry)
+{
+    if (entry.captureDispatcher) {
+        captureOnOwner(entry.captureDispatcher, [&] { entry.Object->SaveDocFile(*this); });
+    }
+    else {
+        entry.Object->SaveDocFile(*this);
+    }
 }
 
 void Writer::incInd()
@@ -336,6 +391,9 @@ void Writer::decInd()
 
 void Writer::putNextEntry(const char* file, const char* obj)
 {
+    if (fileCaptureDispatcher) {
+        throw Base::RuntimeError("An owner capture cannot change archive entries");
+    }
     ObjectName = obj ? obj : file;
 }
 
@@ -376,7 +434,7 @@ void ZipWriter::writeFiles()
         putNextEntry(entry.FileName.c_str());
         indent = 0;
         indBuf[0] = 0;
-        entry.Object->SaveDocFile(*this);
+        writeFile(entry);
         index++;
     }
 }
@@ -431,7 +489,7 @@ void FileWriter::writeFiles()
             putNextEntry(entry.FileName.c_str());
             indent = 0;
             indBuf[0] = 0;
-            entry.Object->SaveDocFile(*this);
+            writeFile(entry);
             this->FileStream.close();
         }
 

--- a/src/Base/Writer.h
+++ b/src/Base/Writer.h
@@ -30,6 +30,7 @@
 #include <sstream>
 #include <vector>
 #include <memory>
+#include <functional>
 
 #include <zipios++/zipoutputstream.h>
 
@@ -97,6 +98,15 @@ public:
     //@{
     /// add a write request of a persistent object
     std::string addFile(const char* Name, const Base::Persistence* Object);
+    /** Capture owner-affine persistence without writing the destination there.
+     * The dispatcher must complete the callback (or propagate its exception)
+     * before returning. The writer remains exclusively owned by its caller;
+     * no other task may use it during capture. Files registered by the callback
+     * inherit the dispatcher, including recursively registered binary files.
+     * Destination I/O and compression occur only after dispatch returns.
+     */
+    using CaptureDispatcher = std::function<void(std::function<void()>)>;
+    void captureOnOwner(const CaptureDispatcher& dispatch, const std::function<void()>& capture);
     /// process the requested file storing
     virtual void writeFiles() = 0;
     /// Set mode
@@ -184,7 +194,9 @@ protected:
     {
         std::string FileName;
         const Base::Persistence* Object;
+        CaptureDispatcher captureDispatcher;
     };
+    void writeFile(const FileEntry& entry);
     std::vector<FileEntry> FileList;
     UniqueFileNameManager FileNameManager;
     std::vector<std::string> Errors;
@@ -204,6 +216,7 @@ public:
     Writer& operator=(Writer&&) = delete;
 
 private:
+    CaptureDispatcher fileCaptureDispatcher;
     std::unique_ptr<std::ostream> CharStream;
     CharStreamFormat charStreamFormat;
 };

--- a/src/Doc/AsyncRecompute.dox
+++ b/src/Doc/AsyncRecompute.dox
@@ -17,11 +17,8 @@ App::DocumentObject::canRecomputeOnWorker().
 
 A recursive object request is worker-safe only when both its target and every
 object in the target's dependency closure are worker-safe. A batch containing
-any unsafe request is rejected atomically before work is queued.
-
-Objects that are not known to be worker-safe are expected to return false. In
-that case the recompute request falls back to the main thread instead of being
-queued to the worker.
+any unsafe request is rejected atomically before work is queued. Rejection is
+reported to the caller; recompute never falls back to the caller or GUI thread.
 
 \section asyncrecompute_cpp Rules for C++ code
 
@@ -44,8 +41,8 @@ Python-backed features may execute from the recompute worker. The GIL is kept
 for the duration of document recompute so Python execution stays serialized, but
 that does not make GUI access worker-safe.
 
-- App::FeaturePython objects default to worker-unsafe and therefore stay on the
-  main thread unless they explicitly opt in.
+- App::FeaturePython objects use the worker runtime unless their proxy
+  explicitly rejects asynchronous recompute.
 - Python execute() implementations must not access Qt UI or FreeCADGui objects
   from a worker thread.
 - Worker-thread GUI access should fail fast through the guarded FreeCADGui and

--- a/src/Gui/Action.cpp
+++ b/src/Gui/Action.cpp
@@ -1064,7 +1064,7 @@ void RecentFilesAction::activateFile(int id)
         save();
     }
     else {
-        ModuleIO::openFile(filename);
+        ModuleIO::openFileFromGui(filename);
     }
 }
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -52,8 +52,11 @@
 #include <cstring>
 #include <list>
 #include <ranges>
+#include <optional>
+#include <boost/scope_exit.hpp>
 
 #include <App/Document.h>
+#include <App/DocumentObserver.h>
 #include <App/DocumentObjectPy.h>
 #include <App/MainThreadSignal.h>
 #include <Base/Console.h>
@@ -84,6 +87,7 @@
 #include "EditorView.h"
 #include "ExpressionBindingPy.h"
 #include "FileDialog.h"
+#include "FrameBudget.h"
 #include "GuiApplication.h"
 #include "GuiInitScript.h"
 #include "GuiTestScript.h"
@@ -348,6 +352,11 @@ struct ApplicationP
     /// List of all registered views
     std::list<Gui::BaseView*> passive;
     bool isClosing {false};
+    bool closeAfterDocumentOpen {false};
+    bool closePreparationPending {false};
+    bool documentCloseWakeQueued {false};
+    fastsignals::scoped_connection documentOpenIdleConnection;
+    std::vector<fastsignals::scoped_connection> documentOpenCompletionConnections;
     bool startingUp {true};
     /// Handles all commands
     CommandManager commandManager;
@@ -490,27 +499,6 @@ struct PyMethodDef FreeCADGui_methods[] = {
     {nullptr, nullptr, 0, nullptr} /* sentinel */
 };
 
-class MainThreadInvoker final: public QObject
-{
-public:
-    static MainThreadInvoker* instance()
-    {
-        static MainThreadInvoker* inst = [] {
-            auto* obj = new MainThreadInvoker();
-            // Ensure the object lives on the GUI thread
-            if (qApp && qApp->thread() && QThread::currentThread() != qApp->thread()) {
-                obj->moveToThread(qApp->thread());
-            }
-            return obj;
-        }();
-        return inst;
-    }
-
-private:
-    MainThreadInvoker() = default;
-    ~MainThreadInvoker() override = default;
-};
-
 // Hook: are we currently on the GUI (main) thread?
 bool qtIsMainThread()
 {
@@ -525,11 +513,16 @@ void qtInvokeOnMain(std::function<void()>&& fn, bool blocking)
         return;
     }
 
-    QMetaObject::invokeMethod(
-        MainThreadInvoker::instance(),
-        [f = std::move(fn)]() mutable { f(); },
-        blocking ? Qt::BlockingQueuedConnection : Qt::QueuedConnection
-    );
+    if (blocking) {
+        if (!dispatchToGuiFrameAndWait(std::move(fn))) {
+            throw Base::RuntimeError("Failed to queue synchronous GUI-owned work");
+        }
+        return;
+    }
+
+    if (!dispatchToGuiFrame(std::move(fn))) {
+        throw Base::RuntimeError("Failed to queue asynchronous GUI-owned work");
+    }
 }
 
 }  // namespace Gui
@@ -618,6 +611,7 @@ Application::Application(bool GUIenabled)
 {
     // App::GetApplication().Attach(this);
     if (GUIenabled) {
+        initializeGuiFrameDispatcher();
         App::MainThreadSignalConfig::setHooks(&qtIsMainThread, &qtInvokeOnMain);
 
         // NOLINTBEGIN
@@ -838,6 +832,10 @@ Application::Application(bool GUIenabled)
     _pcWorkbenchDictionary = PyDict_New();
 
     if (GUIenabled) {
+        d->documentOpenIdleConnection =
+            App::GetApplication().signalDocumentOpenQueueIdle.connect([this] {
+                resumeCloseAfterDocumentOpen();
+            });
         createStandardOperations();
         MacroCommand::load();
     }
@@ -879,6 +877,142 @@ Application::~Application()
 // creating std commands
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+
+void Application::openFileFromGui(const char* filename, const char* module)
+{
+    const Base::FileInfo file(filename);
+    if (module && (file.hasExtension("FCStd") || file.hasExtension("FCBak"))) {
+        openNativeDocumentAsync(filename);
+        return;
+    }
+    // Foreign-format importers retain their existing module contract. They
+    // are not substitutes for a failed or unavailable native restore.
+    const bool previous = testStatus(UserInitiatedOpenDocument);
+    setStatus(UserInitiatedOpenDocument, true);
+    BOOST_SCOPE_EXIT_ALL(this, previous) {
+        setStatus(UserInitiatedOpenDocument, previous);
+    };
+    open(filename, module);
+    setStatus(UserInitiatedOpenDocument, previous);
+    auto* document = App::GetApplication().getActiveDocument();
+    checkPartialRestore(document);
+    checkRestoreError(document);
+}
+
+std::stop_source Application::openNativeDocumentAsync(
+    const char* filename, bool userInitiated,
+    std::function<void(App::OpenDocumentsResult)> completed)
+{
+    requireMainThread("Gui::Application::openNativeDocumentAsync");
+    if (Base::Tools::isNullOrEmpty(filename)) {
+        throw Base::ValueError("A native document filename is required");
+    }
+    const std::string path = Base::FileInfo(filename).filePath();
+    // An empty optional means preparation never ran. Restore the previous
+    // notification policy even when admission, parsing, or finalization fails.
+    auto previousPolicy = std::make_shared<std::optional<bool>>();
+    App::OpenDocumentsRequest request;
+    request.filenames = {path};
+    request.prepare = [this, path, userInitiated, previousPolicy](App::OpenDocumentsRequest& pending) {
+        *previousPolicy = testStatus(UserInitiatedOpenDocument);
+        setStatus(UserInitiatedOpenDocument, userInitiated);
+
+        auto& app = App::GetApplication();
+        auto* active = app.getActiveDocument();
+        auto* gui = getDocument(active);
+        if (active && active->countObjects() == 0 && gui && !gui->isModified()
+            && active->isAutoCreated()) {
+            Command::doCommand(Command::App, "App.closeDocument('%s')", active->getName());
+        }
+
+        // Reopening a fully loaded file also resolves its partially loaded
+        // dependencies, as the synchronous reopen API does. Keep those inputs
+        // viewless; only the explicitly opened file should gain a canvas.
+        pending.inputFlags = {{.createView = true}};
+        auto* existing = app.getDocumentByPath(path.c_str());
+        if (existing && !existing->testStatus(App::Document::PartialDoc)
+            && !existing->testStatus(App::Document::PartialRestore)) {
+            for (auto* dependency : existing->getDependentDocuments(true)) {
+                if (dependency != existing
+                    && (dependency->testStatus(App::Document::PartialDoc)
+                        || dependency->testStatus(App::Document::PartialRestore))) {
+                    pending.filenames.emplace_back(dependency->FileName.getValue());
+                    pending.inputFlags.push_back({.createView = false});
+                }
+            }
+        }
+
+        auto escaped = Base::Tools::escapedUnicodeFromUtf8(path.c_str());
+        escaped = Base::Tools::escapeEncodeFilename(escaped);
+        macroManager()->addLine(MacroManager::App,
+            fmt::format("FreeCAD.openDocument('{}')", escaped).c_str());
+    };
+    request.callback = [this, path, previousPolicy, completed = std::move(completed)](
+                           App::OpenDocumentsResult result) mutable {
+        if (previousPolicy->has_value()) {
+            setStatus(UserInitiatedOpenDocument, previousPolicy->value());
+        }
+        std::vector<std::pair<App::DocumentT, std::string>> identities(result.documents.size());
+        for (std::size_t index = 0; index < result.documents.size(); ++index) {
+            if (auto* document = result.documents[index]) {
+                identities[index] = {App::DocumentT(document), document->Uid.getValueStr()};
+            }
+        }
+        const auto resolve = [&](std::size_t index) -> App::Document* {
+            auto* document = identities[index].first.getDocument();
+            return document && document->Uid.getValueStr() == identities[index].second
+                ? document : nullptr;
+        };
+        try {
+            if (result.failure) {
+                std::rethrow_exception(result.failure);
+            }
+            if (!result.documents.empty() && result.documents.front()) {
+                auto* document = result.documents.front();
+                auto* gui = getDocument(document);
+                if (gui) {
+                    setActiveDocument(gui);
+                    if (!gui->setActiveView()) {
+                        gui->setActiveView(nullptr, View3DInventor::getClassTypeId());
+                    }
+                }
+                const auto name = QString::fromUtf8(path.c_str());
+                getMainWindow()->appendRecentFile(name);
+                FileDialog::setWorkingDirectory(name);
+                checkForRecomputes(true);
+                checkPartialRestore(resolve(0));
+                checkRestoreError(resolve(0));
+            }
+        }
+        catch (const Base::AbortException&) {
+            result.failure = std::current_exception();
+            Base::Console().message("Document open cancelled: %s\n", path.c_str());
+        }
+        catch (const Base::Exception& error) {
+            result.failure = std::current_exception();
+            error.reportException();
+        }
+        catch (const std::exception& error) {
+            result.failure = std::current_exception();
+            Base::Console().error("Document open failed: %s\n", error.what());
+        }
+        catch (...) {
+            result.failure = std::current_exception();
+            Base::Console().error("Document open failed with an unknown exception\n");
+        }
+        // Completion dialogs can run events that close documents. Do not
+        // hand their former pointers to an embedding caller afterwards.
+        for (std::size_t index = 0; index < result.documents.size(); ++index) {
+            result.documents[index] = resolve(index);
+        }
+        if (completed) {
+            completed(std::move(result));
+        }
+    };
+    auto cancellation = request.cancellation;
+    App::GetApplication().openDocumentsAsync(std::move(request));
+    return cancellation;
+}
 
 void Application::open(const char* FileName, const char* Module)
 {
@@ -1199,6 +1333,7 @@ void Application::slotNewDocument(const App::Document& Doc, bool isMainDoc)
 
 void Application::slotDeleteDocument(const App::Document& Doc)
 {
+    PerformanceScope closeTiming("Gui::Application delete-document notification");
     // Capture dependencies and their CURRENT view state before the document is destroyed.
     struct Candidate
     {
@@ -1328,6 +1463,11 @@ void Application::slotShowHidden(const App::Document& Doc)
 
 void Application::checkForRecomputes()
 {
+    checkForRecomputes(false);
+}
+
+void Application::checkForRecomputes(bool queue)
+{
     std::vector<App::Document*> docs;
     for (auto doc : App::GetApplication().getDocuments()) {
         if (doc->testStatus(App::Document::RecomputeOnRestore)) {
@@ -1362,6 +1502,20 @@ void Application::checkForRecomputes()
     }
     bool hasError = false;
     for (auto doc : App::Document::getDependentDocuments(docs, true)) {
+        if (queue) {
+            auto request = App::RecomputeRequest::fromDocument(*doc);
+            request.callback = [](App::RecomputeRequest&, App::RecomputeResult& result) {
+                if (!result.success) {
+                    QMetaObject::invokeMethod(getMainWindow(), [] {
+                        QMessageBox::critical(getMainWindow(), QObject::tr("Recompute error"),
+                            QObject::tr("Failed to recompute a restored document.\n"
+                                        "Check the report view for more details."));
+                    }, Qt::QueuedConnection);
+                }
+            };
+            App::GetApplication().queueRecomputeRequest(request);
+            continue;
+        }
         try {
             doc->recompute({}, false, &hasError);
         }
@@ -1896,19 +2050,90 @@ void Application::updateActions(bool delay)
     getMainWindow()->updateActions(delay);
 }
 
+void Application::resumeCloseAfterDocumentOpen()
+{
+    auto& application = App::GetApplication();
+    if (!d->closeAfterDocumentOpen || application.hasPendingDocumentOpens()) {
+        return;
+    }
+    d->documentOpenCompletionConnections.clear();
+    const auto changed = [this](const App::Document&, bool active) {
+        if (!active && !d->documentCloseWakeQueued) {
+            // Never reconnect a document signal while it is being emitted.
+            // Presentation waiters cannot release until the emitter returns;
+            // rebuilding these subscriptions inline can repeatedly invoke the
+            // newly connected slot and prevent that release forever.
+            d->documentCloseWakeQueued = true;
+            if (!dispatchToGuiFrame(getMainWindow(), [this] {
+                    d->documentCloseWakeQueued = false;
+                    resumeCloseAfterDocumentOpen();
+                })) {
+                d->documentCloseWakeQueued = false;
+            }
+        }
+    };
+    for (auto* document : application.getDocuments()) {
+        if (document->isCooperativeMutationActive() || document->isPresentationUpdateActive()) {
+            d->documentOpenCompletionConnections.emplace_back(
+                document->signalCooperativeMutationChanged.connect(changed));
+            d->documentOpenCompletionConnections.emplace_back(
+                document->signalPresentationUpdateChanged.connect(changed));
+        }
+    }
+    if (!d->documentOpenCompletionConnections.empty()) {
+        getMainWindow()->statusBar()->showMessage(
+            QObject::tr("Waiting for document work to finish before closing..."));
+        return;
+    }
+    d->closeAfterDocumentOpen = false;
+    auto* window = getMainWindow();
+    QMetaObject::invokeMethod(window, [window] { window->close(); }, Qt::QueuedConnection);
+}
+
 void Application::tryClose(QCloseEvent* e)
 {
-    e->setAccepted(getMainWindow()->closeAllDocuments(false));
-    if (!e->isAccepted()) {
+    // Keep the owner dispatcher alive until the native restore coordinator has
+    // delivered its final event, including the interval before its first
+    // document exists. Destroying it earlier strands worker-to-GUI handoffs.
+    if (App::GetApplication().hasPendingDocumentOpens()) {
+        d->closeAfterDocumentOpen = true;
+        App::GetApplication().cancelPendingDocumentOpens();
+        getMainWindow()->statusBar()->showMessage(
+            QObject::tr("Cancelling document restore before closing...")
+        );
+        e->ignore();
+        return;
+    }
+    if (d->closeAfterDocumentOpen) {
+        resumeCloseAfterDocumentOpen();
+        e->ignore();
+        return;
+    }
+    if (d->closePreparationPending) {
+        e->ignore();
         return;
     }
 
     // ask all passive views if closable
+    e->accept();
     for (std::list<Gui::BaseView*>::iterator It = d->passive.begin(); It != d->passive.end(); ++It) {
         e->setAccepted((*It)->canClose());
         if (!e->isAccepted()) {
             return;
         }
+    }
+
+    if (!App::GetApplication().getDocuments().empty()) {
+        e->ignore();
+        d->closePreparationPending = true;
+        getMainWindow()->closeAllDocumentsAsync([this](bool closed) {
+            d->closePreparationPending = false;
+            if (closed) {
+                auto* window = getMainWindow();
+                QMetaObject::invokeMethod(window, [window] { window->close(); }, Qt::QueuedConnection);
+            }
+        });
+        return;
     }
 
     if (e->isAccepted()) {
@@ -1924,7 +2149,14 @@ void Application::tryClose(QCloseEvent* e)
             itp = d->passive.begin();
         }
 
-        App::GetApplication().closeAllDocuments();
+        // Passive close callbacks can create documents. They were not part of
+        // the approved close request and must not be discarded during exit.
+        if (!App::GetApplication().getDocuments().empty()) {
+            // A close observer may have acquired asynchronous finalization
+            // after canClose() succeeded. Keep the GUI dispatcher alive.
+            d->isClosing = false;
+            e->ignore();
+        }
     }
 }
 

--- a/src/Gui/Application.h
+++ b/src/Gui/Application.h
@@ -78,6 +78,12 @@ public:
     //@{
     /// open a file
     void open(const char* FileName, const char* Module);
+    /// Interactive entry point; native restore is queued, not executed inline.
+    void openFileFromGui(const char* filename, const char* module);
+    /// Queue a native file open and report completion on the GUI owner.
+    std::stop_source openNativeDocumentAsync(
+        const char* filename, bool userInitiated = true,
+        std::function<void(App::OpenDocumentsResult)> completed = {});
     /// import a file into the document DocName
     void importFrom(const char* FileName, const char* DocName, const char* Module);
     /// Export objects from the document DocName to a single file
@@ -86,6 +92,8 @@ public:
     App::Document* reopen(App::Document* doc);
     /// Prompt about recomputing if needed
     static void checkForRecomputes();
+    /// The queued form uses the same prompt and the shared recompute runtime.
+    static void checkForRecomputes(bool queue);
     /// Prompt about PartialRestore
     void checkPartialRestore(App::Document* doc);
     /// Prompt for Errors on open
@@ -388,10 +396,11 @@ public:
     //@}
 
 private:
+    void resumeCloseAfterDocumentOpen();
     struct ApplicationP* d;
     /// workbench python dictionary
     PyObject* _pcWorkbenchDictionary;
-    NavlibInterface* pNavlibInterface;
+    NavlibInterface* pNavlibInterface {};
     static void init3DMouse(MainWindow* mainWindow, QApplication* qtApp);
 
     friend class ApplicationPy;

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -58,6 +58,7 @@
 #include "DownloadManager.h"
 #include "EditorView.h"
 #include "FileHandler.h"
+#include "FrameBudget.h"
 #include "Macro.h"
 #include "MainWindow.h"
 #include "MainWindowPy.h"
@@ -81,6 +82,43 @@ using namespace Gui;
 
 namespace
 {
+// Python errors belong to a thread state. All Python-owned presentation
+// handoffs use this transport so exception types and tracebacks survive the
+// worker/owner boundary, and no GUI callback waits for the worker's GIL.
+PyObject* runPythonOnMainThread(const std::function<PyObject*()>& call)
+{
+    PyObject* result = nullptr;
+    PyObject* errorType = nullptr;
+    PyObject* errorValue = nullptr;
+    PyObject* errorTrace = nullptr;
+    try {
+        if (!dispatchToGuiFrameAndWait([&] {
+                Base::PyGILStateLocker python;
+                result = call();
+                if (!result) {
+                    PyErr_Fetch(&errorType, &errorValue, &errorTrace);
+                }
+            })) {
+            PyErr_SetString(PyExc_RuntimeError, "The GUI presentation dispatcher is unavailable");
+        }
+    }
+    catch (const std::exception& error) {
+        PyErr_SetString(PyExc_RuntimeError, error.what());
+    }
+    catch (...) {
+        PyErr_SetString(PyExc_RuntimeError, "GUI presentation dispatch failed");
+    }
+    // dispatchToGuiFrameAndWait has reacquired the caller's GIL here.
+    if (errorType) {
+        PyErr_Restore(errorType, errorValue, errorTrace);
+    }
+    if (PyErr_Occurred()) {
+        Py_XDECREF(result);
+        return nullptr;
+    }
+    return result;
+}
+
 bool requirePythonMainThread(const char* api) noexcept
 {
     try {
@@ -560,6 +598,15 @@ PyMethodDef ApplicationPy::Methods[] = {
      "Get a document.\n"
      "\n"
      "doc : str, App.Document\n    `App.Document` name or `App.Document` object."},
+    {"runOnMainThread",
+     (PyCFunction)ApplicationPy::sRunOnMainThread,
+     METH_VARARGS,
+     "runOnMainThread(callable, *args) -> object\n"
+     "\n"
+     "Run a small presentation update on the GUI owner using the shared frame dispatcher.\n"
+     "Worker callers release the GIL while waiting. Return values and Python exceptions\n"
+     "are delivered to the caller. Geometry, document computation and I/O belong on workers;\n"
+     "this call cannot interrupt an expensive callback."},
     {"doCommand",
      (PyCFunction)ApplicationPy::sDoCommand,
      METH_VARARGS,
@@ -912,6 +959,22 @@ PyObject* Gui::ApplicationPy::sSetActiveDocument(PyObject* /*self*/, PyObject* a
     }
 
     Py_Return;
+}
+
+PyObject* ApplicationPy::sRunOnMainThread(PyObject* /*self*/, PyObject* args)
+{
+    if (PyTuple_Size(args) == 0 || !PyCallable_Check(PyTuple_GetItem(args, 0))) {
+        PyErr_SetString(PyExc_TypeError, "runOnMainThread requires a callable followed by its arguments");
+        return nullptr;
+    }
+    PyObject* callable = PyTuple_GetItem(args, 0);
+    PyObject* arguments = PyTuple_GetSlice(args, 1, PyTuple_Size(args));
+    if (!arguments) {
+        return nullptr;
+    }
+    PyObject* result = runPythonOnMainThread([&] { return PyObject_CallObject(callable, arguments); });
+    Py_DECREF(arguments);
+    return result;
 }
 
 PyObject* ApplicationPy::sGetDocument(PyObject* /*self*/, PyObject* args)
@@ -1714,10 +1777,6 @@ PyObject* ApplicationPy::sAddCommand(PyObject* /*self*/, PyObject* args)
         return nullptr;
     }
 
-    if (!requirePythonMainThread("FreeCADGui.addCommand")) {
-        return nullptr;
-    }
-
     // get the call stack to find the Python module name
     //
     std::string module;
@@ -1767,12 +1826,14 @@ PyObject* ApplicationPy::sAddCommand(PyObject* /*self*/, PyObject* args)
     catch (Py::Exception& e) {
         e.clear();
     }
-    try {
-        Base::PyGILStateLocker lock;
-
-        Py::Object cmd(pcCmdObj);
-        if (cmd.hasAttr("GetCommands")) {
-            Command* cmd = new PythonGroupCommand(pName, pcCmdObj);
+    // Preserve caller-module discovery on the importing worker. Only command
+    // construction and registry notification belong to the GUI owner.
+    return runPythonOnMainThread([&]() -> PyObject* {
+        try {
+            Py::Object object(pcCmdObj);
+            Command* cmd = object.hasAttr("GetCommands")
+                ? static_cast<Command*>(new PythonGroupCommand(pName, pcCmdObj))
+                : static_cast<Command*>(new PythonCommand(pName, pcCmdObj, pSource));
             if (!module.empty()) {
                 cmd->setAppModuleName(module.c_str());
             }
@@ -1781,30 +1842,19 @@ PyObject* ApplicationPy::sAddCommand(PyObject* /*self*/, PyObject* args)
             }
             Application::Instance->commandManager().addCommand(cmd);
         }
-        else {
-            Command* cmd = new PythonCommand(pName, pcCmdObj, pSource);
-            if (!module.empty()) {
-                cmd->setAppModuleName(module.c_str());
-            }
-            if (!group.empty()) {
-                cmd->setGroupName(group.c_str());
-            }
-            Application::Instance->commandManager().addCommand(cmd);
+        catch (const Base::Exception& e) {
+            e.setPyException();
+            return nullptr;
         }
-    }
-    catch (const Base::Exception& e) {
-        e.setPyException();
-        return nullptr;
-    }
-    catch (...) {
-        PyErr_SetString(
-            Base::PyExc_FC_GeneralError,
-            "Unknown C++ exception raised in ApplicationPy::sAddCommand()"
-        );
-        return nullptr;
-    }
-
-    Py_Return;
+        catch (...) {
+            PyErr_SetString(
+                Base::PyExc_FC_GeneralError,
+                "Unknown C++ exception raised in ApplicationPy::sAddCommand()"
+            );
+            return nullptr;
+        }
+        Py_Return;
+    });
 }
 
 PyObject* ApplicationPy::sRunCommand(PyObject* /*self*/, PyObject* args)

--- a/src/Gui/ApplicationPy.h
+++ b/src/Gui/ApplicationPy.h
@@ -89,6 +89,7 @@ public:
     static PyObject* sActiveView               (PyObject *self,PyObject *args);
     static PyObject* sActivateView             (PyObject *self,PyObject *args);
     static PyObject* sGetDocument              (PyObject *self,PyObject *args);
+    static PyObject* sRunOnMainThread          (PyObject *self,PyObject *args);
     static PyObject* sEditDocument             (PyObject *self,PyObject *args);
 
     static PyObject* sDoCommand                (PyObject *self,PyObject *args);

--- a/src/Gui/AsyncImageExport.h
+++ b/src/Gui/AsyncImageExport.h
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+
+#include <App/HostRuntime.h>
+#include <QImage>
+#include <QSaveFile>
+#include <chrono>
+#include <exception>
+#include <future>
+#include <optional>
+#include <stop_token>
+
+namespace Gui::detail
+{
+/// Detached image processing; no QWidget, viewer or scene-graph references.
+/// The owner polls completion, never waits. Destruction requests cancellation.
+class AsyncImageExport final
+{
+public:
+    AsyncImageExport(App::HostRuntime& runtime, QImage image, QString path,
+                     int width, int height, bool flipVertically)
+    {
+        if (image.isNull() || path.isEmpty() || width <= 0 || height <= 0) {
+            throw std::invalid_argument("Frame export requires pixels, a destination and positive dimensions");
+        }
+        future = runtime.submit(
+            [image = std::move(image), path = std::move(path), width, height,
+             flipVertically, cancellation = stop.get_token()](std::stop_token shutdown) mutable {
+                const auto check = [&] {
+                    Base::CancellationScope::check();
+                    if (cancellation.stop_requested() || shutdown.stop_requested()) {
+                        throw std::runtime_error("Frame export cancelled");
+                    }
+                };
+                check();
+                if (flipVertically) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
+                    image = image.mirrored();
+#else
+                    image = image.flipped(Qt::Vertical);
+#endif
+                }
+                if (image.width() != width || image.height() != height) {
+                    image = image.scaled(width, height, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
+                }
+                check();
+                QSaveFile destination(path);
+                destination.setDirectWriteFallback(false);
+                if (!destination.open(QIODevice::WriteOnly)) {
+                    throw std::runtime_error(destination.errorString().toStdString());
+                }
+                if (!image.save(&destination, "PNG")) {
+                    throw std::runtime_error("Could not encode the captured frame as PNG");
+                }
+                check();
+                if (!destination.commit()) {
+                    throw std::runtime_error(destination.errorString().toStdString());
+                }
+            });
+    }
+
+    ~AsyncImageExport() { cancel(); }
+    AsyncImageExport(const AsyncImageExport&) = delete;
+    AsyncImageExport& operator=(const AsyncImageExport&) = delete;
+
+    void cancel() { stop.request_stop(); }
+
+    bool isReady() const
+    {
+        return completion.has_value()
+            || future.wait_for(std::chrono::seconds(0)) == std::future_status::ready;
+    }
+
+    bool finish()
+    {
+        if (!isReady()) {
+            return false;
+        }
+        if (!completion.has_value()) {
+            try {
+                future.get();
+                completion = std::exception_ptr {};
+            }
+            catch (...) {
+                completion = std::current_exception();
+            }
+        }
+        if (*completion) {
+            std::rethrow_exception(*completion);
+        }
+        return true;
+    }
+
+private:
+    std::stop_source stop;
+    std::future<void> future;
+    std::optional<std::exception_ptr> completion;
+};
+}

--- a/src/Gui/CMakeLists.txt
+++ b/src/Gui/CMakeLists.txt
@@ -951,6 +951,7 @@ SET(View3D_SRCS
     View3DSettings.h
     CoinRiftWidget.h
     View3DViewerPy.h
+    AsyncImageExport.h
     NaviCube.h
 )
 SOURCE_GROUP("View3D" FILES ${View3D_SRCS})
@@ -1182,6 +1183,7 @@ SOURCE_GROUP("View3D\\Inventor" FILES ${Inventor_SRCS})
 SET(Widget_CPP_SRCS
     ComboLinks.cpp
     FeatureTimeline.cpp
+    FrameBudget.cpp
     FileDialog.cpp
     MainWindow.cpp
     MainWindowPy.cpp
@@ -1214,6 +1216,8 @@ endif(WIN32)
 SET(Widget_HPP_SRCS
     ComboLinks.h
     FeatureTimeline.h
+    FrameBudget.h
+    FrameSequence.h
     FileDialog.h
     FileDialogInternal.h
     MainWindow.h

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -653,7 +653,9 @@ bool Command::canInvoke()
     }
 
     App::Document* document = getDocument();
-    if (document && document->isCooperativeMutationActive()) {
+    if (document
+        && (document->isCooperativeMutationActive()
+            || document->isPresentationUpdateActive())) {
         const std::string_view name(getName());
         if ((eType & AlterDoc) || name == "Std_Undo" || name == "Std_Redo"
             || name == "Std_Refresh") {

--- a/src/Gui/CommandDoc.cpp
+++ b/src/Gui/CommandDoc.cpp
@@ -153,13 +153,7 @@ void StdCmdOpen::activated(int iMsg)
             continue;
         }
 
-        getGuiApplication()->setStatus(Gui::Application::UserInitiatedOpenDocument, true);
-        getGuiApplication()->open(file.toUtf8(), "FreeCAD");
-        getGuiApplication()->setStatus(Gui::Application::UserInitiatedOpenDocument, false);
-
-        App::Document* doc = App::GetApplication().getActiveDocument();
-        getGuiApplication()->checkPartialRestore(doc);
-        getGuiApplication()->checkRestoreError(doc);
+        getGuiApplication()->openFileFromGui(file.toUtf8(), "FreeCAD");
     }
 
     fileList.erase(
@@ -189,17 +183,7 @@ void StdCmdOpen::activated(int iMsg)
     else {
         for (SelectModule::Dict::iterator it = dict.begin(); it != dict.end(); ++it) {
 
-            // Set flag indicating that this load/restore has been initiated by the user (not by a macro)
-            getGuiApplication()->setStatus(Gui::Application::UserInitiatedOpenDocument, true);
-
-            getGuiApplication()->open(it.key().toUtf8(), it.value().toLatin1());
-
-            getGuiApplication()->setStatus(Gui::Application::UserInitiatedOpenDocument, false);
-
-            App::Document* doc = App::GetApplication().getActiveDocument();
-
-            getGuiApplication()->checkPartialRestore(doc);
-            getGuiApplication()->checkRestoreError(doc);
+            getGuiApplication()->openFileFromGui(it.key().toUtf8(), it.value().toLatin1());
         }
     }
 }
@@ -899,7 +883,7 @@ StdCmdSaveAll::StdCmdSaveAll()
 void StdCmdSaveAll::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    Gui::Document::saveAll();
+    Gui::Document::saveAllAsync();
 }
 
 bool StdCmdSaveAll::isActive()
@@ -2616,21 +2600,6 @@ void handleDocumentRecomputeResult(const std::string& documentName, App::Recompu
     App::GetApplication().queueRecomputeRequest(newRequest);
 }
 
-void refreshDocumentSynchronously(App::Document& document)
-{
-    try {
-        document.recompute({}, true, nullptr, App::Document::DepNoCycle);
-    }
-    catch (Base::BadGraphError&) {
-        if (shouldProceedAfterDependencyCycle()) {
-            document.recompute({}, true);
-        }
-    }
-    catch (Base::Exception& exception) {
-        exception.reportException();
-    }
-}
-
 }  // namespace
 
 void StdCmdRefresh::activated([[maybe_unused]] int iMsg)
@@ -2645,12 +2614,6 @@ void StdCmdRefresh::activated([[maybe_unused]] int iMsg)
     App::RecomputeRequest request
         = App::RecomputeRequest::fromDocument(*doc, true, App::Document::DepNoCycle);
 
-    if (!App::GetApplication().isAsyncRecomputeEnabled()
-        || !App::GetApplication().canRecomputeRequestOnWorker(request)) {
-        refreshDocumentSynchronously(*doc);
-        return;
-    }
-
     request.callback = [](App::RecomputeRequest& request, App::RecomputeResult& result) {
         // Handle the result in the UI thread.
         QMetaObject::invokeMethod(
@@ -2662,6 +2625,8 @@ void StdCmdRefresh::activated([[maybe_unused]] int iMsg)
         );
     };
 
+    // The worker must never race the GUI command's transaction teardown.
+    trans.close();
     App::GetApplication().queueRecomputeRequest(request);
 }
 

--- a/src/Gui/CommandWindow.cpp
+++ b/src/Gui/CommandWindow.cpp
@@ -148,7 +148,7 @@ StdCmdCloseAllWindows::StdCmdCloseAllWindows()
 void StdCmdCloseAllWindows::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    getMainWindow()->closeAllDocuments();
+    getMainWindow()->closeAllDocumentsAsync();
 }
 
 bool StdCmdCloseAllWindows::isActive()

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -21,23 +21,29 @@
  ***************************************************************************/
 
 #include <tuple>
+#include <chrono>
+#include <deque>
+#include <utility>
 #include <memory>
 #include <list>
 #include <string>
+#include <sstream>
 #include <map>
 #include <set>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 #include <cctype>
 #include <mutex>
 #include <QApplication>
 #include <QCheckBox>
-#include <QElapsedTimer>
-#include <QEventLoop>
 #include <QFileInfo>
 #include <QMessageBox>
+#include <QObject>
 #include <QOpenGLWidget>
+#include <QPointer>
 #include <QTextStream>
+#include <QTimer>
 #include <QStatusBar>
 #include <Inventor/actions/SoSearchAction.h>
 #include <Inventor/nodes/SoSeparator.h>
@@ -48,20 +54,25 @@
 #include <App/DocumentObjectGroup.h>
 #include <App/Transactions.h>
 #include <App/ElementNamingUtils.h>
+#include <App/HostWorkflow.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Base/Matrix.h>
 #include <Base/Reader.h>
+#include <Base/Sequencer.h>
 #include <Base/Writer.h>
 #include <Base/Tools.h>
 
 #include "Document.h"
+#include "FrameBudget.h"
+#include "ModelTreeBrowser.h"
 #include "DocumentPy.h"
 #include "Application.h"
 #include "Command.h"
 #include "Control.h"
 #include "FileDialog.h"
 #include "MainWindow.h"
+#include "Macro.h"
 #include "MDIView.h"
 #include "NotificationArea.h"
 #include "Selection.h"
@@ -85,6 +96,75 @@ namespace Gui
 
 namespace
 {
+void restoreOnGui(std::function<void()> step)
+{
+    if (!dispatchToGuiFrameAndWait(std::move(step))) {
+        throw Base::RuntimeError("Unable to dispatch document presentation restore");
+    }
+}
+
+void captureOnGui(Base::Writer& writer, const std::function<void()>& capture)
+{
+    writer.captureOnOwner(
+        [](std::function<void()> step) {
+            if (!dispatchToGuiFrameAndWait(std::move(step))) {
+                throw Base::RuntimeError("Unable to dispatch document presentation save");
+            }
+        },
+        capture
+    );
+}
+
+std::shared_ptr<std::istream> bufferRestoreInput(std::istream& source)
+{
+    std::ostringstream buffer;
+    buffer << source.rdbuf();
+    return std::make_shared<std::istringstream>(std::move(buffer).str());
+}
+
+// The archive belongs to the document worker. Its GUI XML and binary payloads
+// are read there before the owner is asked to adopt persistent presentation
+// state. Retaining the XML input also keeps Xerces' stream alive while its
+// registered embedded files are being restored.
+struct GuiRestoreInput
+{
+    explicit GuiRestoreInput(std::istream& source)
+        : input(bufferRestoreInput(source))
+    {}
+
+    std::shared_ptr<std::istream> input;
+};
+
+class GuiRestoreReader final: private GuiRestoreInput, public Base::XMLReader
+{
+public:
+    explicit GuiRestoreReader(Base::Reader& reader)
+        : GuiRestoreInput(reader)
+        , Base::XMLReader("GuiDocument.xml", *input)
+    {
+        FileVersion = reader.getFileVersion();
+    }
+
+protected:
+    void restoreFile(Base::Persistence& object, Base::Reader& reader) const override
+    {
+        auto input = bufferRestoreInput(reader);
+        Base::Reader buffered(*input, reader.getFileName(), reader.getFileVersion());
+        restoreOnGui([&] { object.RestoreDocFile(buffered); });
+        if (auto child = buffered.getLocalReader()) {
+            // Preserve stream lifetime for any nested parser registered by
+            // the persistence callback, not just the built-in GUI properties.
+            struct NestedInput
+            {
+                std::shared_ptr<std::istream> input;
+                std::shared_ptr<Base::XMLReader> parser;
+            };
+            auto lifetime = std::make_shared<NestedInput>(NestedInput {input, child});
+            reader.initLocalReader(std::shared_ptr<Base::XMLReader>(lifetime, child.get()));
+        }
+    }
+};
+
 struct DetachedExactAbort
 {
     int transactionId {App::NullTransaction};
@@ -172,6 +252,28 @@ void retainDetachedExactAbort(
         );
     detachedExactAborts().insert_or_assign(transactionId, state);
 }
+
+template<typename Callable>
+void runViewProviderUpdate(const std::string& objectName, Callable&& callable)
+{
+    try {
+        std::forward<Callable>(callable)();
+    }
+    catch (const Base::MemoryException& error) {
+        FC_ERR("Memory exception in " << objectName << " thrown: " << error.what());
+    }
+    catch (Base::Exception& error) {
+        error.reportException();
+    }
+    catch (const std::exception& error) {
+        FC_ERR("C++ exception in " << objectName << " thrown " << error.what());
+    }
+#ifndef FC_DEBUG
+    catch (...) {
+        FC_ERR("Unknown exception in Feature " << objectName << " thrown");
+    }
+#endif
+}
 }
 
 // Pimpl class
@@ -184,7 +286,10 @@ struct DocumentP
     int _iWinCount;
     int _iDocId;
     bool _isClosing;
+    bool closeQueryActive {false};
     bool _isModified;
+    std::uint64_t modificationGeneration {0};
+    std::optional<std::uint64_t> savedModificationGeneration;
     bool _isTransacting;
     bool _isActive;
     bool _changeViewTouchDocument;
@@ -222,6 +327,32 @@ struct DocumentP
     std::map<std::string, ViewProvider*> _ViewProviderMapAnnotation;
     std::list<ViewProviderDocumentObject*> _redoViewProviders;
 
+    struct DeferredNewViewProvider
+    {
+        long objectId;
+        bool updateView;
+        bool recordRedo;
+    };
+    struct DeferredViewUpdate
+    {
+        std::set<std::string> propertyNames;
+        bool refreshAll {false};
+    };
+    std::deque<long> deferredNewViewProviderOrder;
+    std::unordered_map<long, DeferredNewViewProvider> deferredNewViewProviders;
+    std::deque<long> deferredViewUpdateOrder;
+    std::unordered_map<long, DeferredViewUpdate> deferredViewUpdates;
+    std::deque<long> deferredRelabelOrder;
+    std::unordered_set<long> deferredRelabels;
+    long deferredActivatedObjectId {0};
+    bool deferredActionUpdate {false};
+    bool bulkViewAdoptionLease {false};
+    bool bulkViewAdoptionScheduled {false};
+    bool bulkViewAdoptionFinishing {false};
+    std::unique_ptr<QObject> bulkViewDispatchContext;
+    std::unique_ptr<ModelTreeBrowserCache> modelBrowserCache;
+    std::unordered_map<BaseView*, QPointer<QWidget>> presentationSuspendedViews;
+
     Connection connectNewObject;
     Connection connectDelObject;
     Connection connectCngObject;
@@ -245,6 +376,8 @@ struct DocumentP
     Connection connectTransactionRemove;
     Connection connectBookedTransactionChanged;
     Connection connectTransactionLockChanged;
+    Connection connectCooperativeMutationChanged;
+    Connection connectPresentationUpdateChanged;
     Connection connectTouchedObject;
     Connection connectChangePropertyEditor;
     AdvancedConnection connectChangeDocument;
@@ -556,6 +689,7 @@ Document::Document(App::Document* pcDocument, Application* app)
     d->_editTransactionClosePending = false;
     d->_editTransactionClosing = false;
     d->_editTransactionId = App::NullTransaction;
+    d->bulkViewDispatchContext = std::make_unique<QObject>();
 
     // NOLINTBEGIN
     //  Setup the connections
@@ -653,6 +787,24 @@ Document::Document(App::Document* pcDocument, Application* app)
         pcDocument->signalTransactionLockChanged.connect(
             updateTransactionSensitiveActions
         );
+    d->connectCooperativeMutationChanged =
+        pcDocument->signalCooperativeMutationChanged.connect(
+            std::bind(
+                &Gui::Document::slotCooperativeMutationChanged,
+                this,
+                sp::_1,
+                sp::_2
+            )
+        );
+    d->connectPresentationUpdateChanged =
+        pcDocument->signalPresentationUpdateChanged.connect(
+            std::bind(
+                &Gui::Document::slotPresentationUpdateChanged,
+                this,
+                sp::_1,
+                sp::_2
+            )
+        );
     // NOLINTEND
 
     // pointer to the python class
@@ -675,6 +827,8 @@ Document::Document(App::Document* pcDocument, Application* app)
 
 Document::~Document()
 {
+    PerformanceScope closeTiming("Gui::Document destruction");
+    d->modelBrowserCache.reset();
     // A retained no-panel command checkpoint is keyed by this GUI document.
     // Remove it before the pointer can become stale, and resolve the exact
     // adopted transaction while the App document is still alive.
@@ -734,9 +888,11 @@ Document::~Document()
     d->connectTransactionRemove.disconnect();
     d->connectBookedTransactionChanged.disconnect();
     d->connectTransactionLockChanged.disconnect();
+    d->connectCooperativeMutationChanged.disconnect();
     d->connectTouchedObject.disconnect();
     d->connectChangePropertyEditor.disconnect();
     d->connectChangeDocument.disconnect();
+    d->bulkViewDispatchContext.reset();
 
     // e.g. if document gets closed from within a Python command
     d->_isClosing = true;
@@ -746,8 +902,11 @@ Document::~Document()
         it->deleteSelf();
     }
 
-    for (const auto& vp : d->_ViewProviderMap) {
-        delete vp.second;
+    {
+        PerformanceScope providerTiming("Gui::Document view-provider destruction");
+        for (const auto& vp : d->_ViewProviderMap) {
+            delete vp.second;
+        }
     }
 
     for (const auto& va : d->_ViewProviderMapAnnotation) {
@@ -1417,6 +1576,15 @@ ViewProvider* Document::getViewProviderByName(const char* name) const
     return nullptr;
 }
 
+ModelTreeBrowserCache& Document::modelBrowserProjectionCache()
+{
+    requireMainThread("Gui::Document::modelBrowserProjectionCache");
+    if (!d->modelBrowserCache) {
+        d->modelBrowserCache = std::make_unique<ModelTreeBrowserCache>(d->_pcDocument);
+    }
+    return *d->modelBrowserCache;
+}
+
 bool Document::projectionRefreshBlocked(const App::Document* document)
 {
     return document
@@ -1475,8 +1643,366 @@ void Document::setPos(const char* name, const Base::Matrix4D& rclMtrx)
 //*****************************************************************************************************
 // Document
 //*****************************************************************************************************
+bool Document::hasDeferredViewProviderWork() const
+{
+    return !d->deferredNewViewProviders.empty()
+        || !d->deferredViewUpdates.empty()
+        || !d->deferredRelabels.empty()
+        || d->deferredActivatedObjectId != 0
+        || d->deferredActionUpdate;
+}
+
+void Document::queueDeferredNewViewProvider(
+    const App::DocumentObject& object,
+    bool updateView,
+    bool recordRedo
+)
+{
+    const long objectId = object.getID();
+    const auto [found, inserted] = d->deferredNewViewProviders.try_emplace(
+        objectId,
+        DocumentP::DeferredNewViewProvider {objectId, updateView, recordRedo}
+    );
+    if (inserted) {
+        d->deferredNewViewProviderOrder.push_back(objectId);
+    }
+    else {
+        found->second.updateView = found->second.updateView || updateView;
+        found->second.recordRedo = found->second.recordRedo || recordRedo;
+    }
+
+    // A provider's first full update observes the final state of every App
+    // property. Earlier incremental notifications for that same new object
+    // would only repeat work and expose a half-constructed representation.
+    d->deferredViewUpdates.erase(objectId);
+    d->deferredRelabels.erase(objectId);
+    d->deferredActionUpdate = true;
+}
+
+void Document::slotCooperativeMutationChanged(
+    const App::Document& document,
+    bool active
+)
+{
+    if (&document != d->_pcDocument || active
+        || d->bulkViewAdoptionLease
+        || d->bulkViewAdoptionFinishing
+        || !hasDeferredViewProviderWork()) {
+        return;
+    }
+
+    // Keep the document's existing cooperative-mutation contract active
+    // through GUI adoption. The originating mutation has reached depth zero,
+    // so this is a distinct GUI-owned lease, released after the last bounded
+    // slice. Tree, History, undo, close, and recompute therefore observe one
+    // coherent operation instead of the partially attached object graph.
+    d->bulkViewAdoptionLease = true;
+    d->_pcDocument->beginCooperativeMutation();
+    scheduleDeferredViewProviderWork();
+}
+
+void Document::slotPresentationUpdateChanged(
+    const App::Document& document,
+    bool active
+)
+{
+    if (&document != d->_pcDocument) {
+        return;
+    }
+
+    if (active) {
+        for (auto* view : getMDIViews(true)) {
+            synchronizePresentationView(*view);
+        }
+        return;
+    }
+
+    auto suspended = std::move(d->presentationSuspendedViews);
+    d->presentationSuspendedViews.clear();
+    for (const auto& [view, widget] : suspended) {
+        (void)view;
+        if (widget) {
+            widget->setUpdatesEnabled(true);
+        }
+    }
+}
+
+void Document::synchronizePresentationView(MDIView& view)
+{
+    if (!d->_pcDocument->isPresentationUpdateActive() || !view.updatesEnabled()) {
+        return;
+    }
+    view.setUpdatesEnabled(false);
+    d->presentationSuspendedViews.try_emplace(&view, &view);
+}
+
+void Document::scheduleDeferredViewProviderWork()
+{
+    if (d->bulkViewAdoptionScheduled) {
+        return;
+    }
+    Q_ASSERT(d->bulkViewDispatchContext);
+    d->bulkViewAdoptionScheduled = true;
+    if (!dispatchToGuiFrame(
+        d->bulkViewDispatchContext.get(),
+        [this] { drainDeferredViewProviderWork(); }
+    )) {
+        d->bulkViewAdoptionScheduled = false;
+        FC_ERR("Cannot schedule deferred view-provider adoption");
+    }
+}
+
+void Document::finishNewViewProvider(
+    long objectId,
+    bool updateView,
+    bool recordRedo
+)
+{
+    auto* object = d->_pcDocument->getObjectByID(objectId);
+    auto* provider = object
+        ? freecad_cast<ViewProviderDocumentObject*>(getViewProvider(object))
+        : nullptr;
+    if (!object || !provider || provider->getObject() != object) {
+        return;
+    }
+
+    const std::string objectName = object->getFullName();
+    if (updateView) {
+        runViewProviderUpdate(objectName, [provider] {
+            provider->updateView();
+            provider->setActiveMode();
+        });
+    }
+
+    object = d->_pcDocument->getObjectByID(objectId);
+    provider = object
+        ? freecad_cast<ViewProviderDocumentObject*>(getViewProvider(object))
+        : nullptr;
+    if (!object || !provider || provider->getObject() != object) {
+        return;
+    }
+
+    // From this point onward deletion must follow the ordinary exposed-view
+    // path so a callback can remove the provider from viewers and observers.
+    d->deferredNewViewProviders.erase(objectId);
+    for (auto* view : d->baseViews) {
+        if (auto* activeView = dynamic_cast<View3DInventor*>(view)) {
+            activeView->getViewer()->addViewProvider(provider);
+        }
+    }
+
+    signalNewObject(*provider);
+
+    object = d->_pcDocument->getObjectByID(objectId);
+    provider = object
+        ? freecad_cast<ViewProviderDocumentObject*>(getViewProvider(object))
+        : nullptr;
+    if (!object || !provider || provider->getObject() != object) {
+        return;
+    }
+    provider->pcDocument = this;
+    handleChildren3D(provider);
+    if (recordRedo) {
+        d->_redoViewProviders.push_back(provider);
+    }
+}
+
+void Document::finishDeferredViewUpdate(
+    long objectId,
+    const std::set<std::string>& propertyNames,
+    bool refreshAll
+)
+{
+    auto* object = d->_pcDocument->getObjectByID(objectId);
+    auto* provider = object ? getViewProvider(object) : nullptr;
+    if (!object || !provider) {
+        return;
+    }
+    const std::string objectName = object->getFullName();
+    bool editingTransformChanged = refreshAll;
+
+    if (refreshAll) {
+        auto* documentProvider = freecad_cast<ViewProviderDocumentObject*>(provider);
+        if (documentProvider) {
+            runViewProviderUpdate(objectName, [documentProvider] {
+                documentProvider->updateView();
+            });
+        }
+    }
+    else {
+        for (const auto& propertyName : propertyNames) {
+            object = d->_pcDocument->getObjectByID(objectId);
+            provider = object ? getViewProvider(object) : nullptr;
+            auto* property = object
+                ? object->getPropertyByName(propertyName.c_str())
+                : nullptr;
+            if (!object || !provider || !property) {
+                continue;
+            }
+            editingTransformChanged = editingTransformChanged
+                || property->isDerivedFrom<App::PropertyPlacement>()
+                || propertyName.find("Scale") != std::string::npos;
+            runViewProviderUpdate(objectName, [provider, property] {
+                provider->update(property);
+            });
+        }
+    }
+
+    object = d->_pcDocument->getObjectByID(objectId);
+    provider = object ? getViewProvider(object) : nullptr;
+    if (!object || !provider) {
+        return;
+    }
+    if (editingTransformChanged
+        && d->_editingViewer
+        && d->_editingObject
+        && d->_editViewProviderParent
+        && d->_editObjs.contains(object)) {
+        Base::Matrix4D matrix;
+        auto* editedObject = d->_editViewProviderParent->getObject()->getSubObject(
+            d->_editSubname.c_str(),
+            nullptr,
+            &matrix
+        );
+        if (editedObject == d->_editingObject && d->_editingTransform != matrix) {
+            d->_editingTransform = matrix;
+            d->_editingViewer->setEditingTransform(d->_editingTransform);
+        }
+    }
+
+    handleChildren3D(provider);
+    for (const auto& propertyName : propertyNames) {
+        object = d->_pcDocument->getObjectByID(objectId);
+        auto* documentProvider = object
+            ? freecad_cast<ViewProviderDocumentObject*>(getViewProvider(object))
+            : nullptr;
+        auto* property = object
+            ? object->getPropertyByName(propertyName.c_str())
+            : nullptr;
+        if (!object || !documentProvider || !property) {
+            continue;
+        }
+        signalChangedObject(*documentProvider, *property);
+    }
+}
+
+void Document::drainDeferredViewProviderWork()
+{
+    d->bulkViewAdoptionScheduled = false;
+    FrameBudget budget;
+
+    while (!budget.exhausted()) {
+        bool consumedWork = false;
+
+        while (!d->deferredNewViewProviderOrder.empty()) {
+            const long objectId = d->deferredNewViewProviderOrder.front();
+            d->deferredNewViewProviderOrder.pop_front();
+            const auto found = d->deferredNewViewProviders.find(objectId);
+            if (found == d->deferredNewViewProviders.end()) {
+                continue;
+            }
+            const auto work = found->second;
+            finishNewViewProvider(work.objectId, work.updateView, work.recordRedo);
+            d->deferredNewViewProviders.erase(objectId);
+            consumedWork = true;
+            break;
+        }
+        if (consumedWork) {
+            continue;
+        }
+
+        while (!d->deferredViewUpdateOrder.empty()) {
+            const long objectId = d->deferredViewUpdateOrder.front();
+            d->deferredViewUpdateOrder.pop_front();
+            const auto found = d->deferredViewUpdates.find(objectId);
+            if (found == d->deferredViewUpdates.end()) {
+                continue;
+            }
+            const auto work = std::move(found->second);
+            d->deferredViewUpdates.erase(found);
+            finishDeferredViewUpdate(objectId, work.propertyNames, work.refreshAll);
+            consumedWork = true;
+            break;
+        }
+        if (consumedWork) {
+            continue;
+        }
+
+        while (!d->deferredRelabelOrder.empty()) {
+            const long objectId = d->deferredRelabelOrder.front();
+            d->deferredRelabelOrder.pop_front();
+            if (d->deferredRelabels.erase(objectId) == 0) {
+                continue;
+            }
+            auto* object = d->_pcDocument->getObjectByID(objectId);
+            auto* provider = object
+                ? freecad_cast<ViewProviderDocumentObject*>(getViewProvider(object))
+                : nullptr;
+            if (provider) {
+                signalRelabelObject(*provider);
+            }
+            consumedWork = true;
+            break;
+        }
+        if (consumedWork) {
+            continue;
+        }
+
+        if (d->deferredActivatedObjectId != 0) {
+            const long objectId = d->deferredActivatedObjectId;
+            d->deferredActivatedObjectId = 0;
+            auto* object = d->_pcDocument->getObjectByID(objectId);
+            auto* provider = object
+                ? freecad_cast<ViewProviderDocumentObject*>(getViewProvider(object))
+                : nullptr;
+            if (provider) {
+                signalActivatedObject(*provider);
+            }
+            continue;
+        }
+
+        break;
+    }
+
+    const bool hasQueuedProjectionWork =
+        !d->deferredNewViewProviders.empty()
+        || !d->deferredViewUpdates.empty()
+        || !d->deferredRelabels.empty()
+        || d->deferredActivatedObjectId != 0;
+    if (hasQueuedProjectionWork) {
+        scheduleDeferredViewProviderWork();
+        return;
+    }
+
+    if (d->deferredActionUpdate) {
+        d->deferredActionUpdate = false;
+        getMainWindow()->updateActions(true);
+        if (hasDeferredViewProviderWork()) {
+            scheduleDeferredViewProviderWork();
+            return;
+        }
+    }
+
+    if (d->bulkViewAdoptionLease) {
+        d->bulkViewAdoptionFinishing = true;
+        d->bulkViewAdoptionLease = false;
+        d->_pcDocument->endCooperativeMutation();
+        d->bulkViewAdoptionFinishing = false;
+    }
+}
+
 void Document::slotNewObject(const App::DocumentObject& Obj)
 {
+    const bool traceRestore = d->_pcDocument->testStatus(App::Document::Status::Restoring)
+        && qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE");
+    const auto traceStart = std::chrono::steady_clock::now();
+    auto providerTypeReady = traceStart;
+    auto providerCreated = traceStart;
+    auto providerAttached = traceStart;
+    auto providerUpdated = traceStart;
+    auto providerPublished = traceStart;
+    const bool deferViewAdoption = d->_pcDocument->isCooperativeMutationActive();
+    bool createdProvider = false;
     auto pcProvider = static_cast<ViewProviderDocumentObject*>(getViewProvider(&Obj));
     if (!pcProvider) {
         std::string_view cName {Obj.getViewProviderNameStored()};
@@ -1491,7 +2017,9 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
                 ViewProviderDocumentObject::getClassTypeId(),
                 true
             );
+            providerTypeReady = std::chrono::steady_clock::now();
             pcProvider = static_cast<ViewProviderDocumentObject*>(type.createInstance());
+            providerCreated = std::chrono::steady_clock::now();
             // createInstance could return a null pointer
             if (!pcProvider) {
                 // type not derived from ViewProviderDocumentObject!!!
@@ -1505,6 +2033,7 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
                 cName = Obj.getViewProviderName();
             }
             else {
+                createdProvider = true;
                 break;
             }
         }
@@ -1518,8 +2047,12 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
             // if successfully created set the right name and calculate the view
             // FIXME: Consider to change argument of attach() to const pointer
             pcProvider->attach(const_cast<App::DocumentObject*>(&Obj));
-            pcProvider->updateView();
-            pcProvider->setActiveMode();
+            providerAttached = std::chrono::steady_clock::now();
+            if (!deferViewAdoption) {
+                pcProvider->updateView();
+                pcProvider->setActiveMode();
+            }
+            providerUpdated = std::chrono::steady_clock::now();
         }
         catch (const Base::MemoryException& e) {
             FC_ERR("Memory exception in " << Obj.getFullName() << " thrown: " << e.what());
@@ -1543,6 +2076,15 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
     }
 
     if (pcProvider) {
+        if (deferViewAdoption) {
+            queueDeferredNewViewProvider(
+                Obj,
+                createdProvider,
+                d->_isTransacting
+            );
+            return;
+        }
+
         // cycling to all views of the document
         for (auto* v : d->baseViews) {
             auto activeView = dynamic_cast<View3DInventor*>(v);
@@ -1557,8 +2099,33 @@ void Document::slotNewObject(const App::DocumentObject& Obj)
 
         // it is possible that a new viewprovider already claims children
         handleChildren3D(pcProvider);
+        providerPublished = std::chrono::steady_clock::now();
         if (d->_isTransacting) {
             d->_redoViewProviders.push_back(pcProvider);
+        }
+    }
+
+    if (traceRestore) {
+        const auto elapsed = [](auto begin, auto end) {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count();
+        };
+        const auto end = std::chrono::steady_clock::now();
+        const auto total = elapsed(traceStart, end);
+        if (total >= 20) {
+            Base::Console().message(
+                "VIBECAD_RESTORE_DETAIL new_view_provider object=%s stored_type=%s "
+                "type_lookup_ms=%lld create_ms=%lld attach_ms=%lld update_ms=%lld "
+                "publish_ms=%lld remainder_ms=%lld total_ms=%lld\n",
+                Obj.getNameInDocument(),
+                Obj.getViewProviderNameStored(),
+                static_cast<long long>(elapsed(traceStart, providerTypeReady)),
+                static_cast<long long>(elapsed(providerTypeReady, providerCreated)),
+                static_cast<long long>(elapsed(providerCreated, providerAttached)),
+                static_cast<long long>(elapsed(providerAttached, providerUpdated)),
+                static_cast<long long>(elapsed(providerUpdated, providerPublished)),
+                static_cast<long long>(elapsed(providerPublished, end)),
+                static_cast<long long>(total)
+            );
         }
     }
 }
@@ -1570,6 +2137,21 @@ void Document::slotDeletedObject(const App::DocumentObject& Obj)
     // cycling to all views of the document
     ViewProvider* viewProvider = getViewProvider(&Obj);
     if (!viewProvider) {
+        return;
+    }
+
+    const long objectId = Obj.getID();
+    if (d->deferredNewViewProviders.erase(objectId) != 0) {
+        d->deferredViewUpdates.erase(objectId);
+        d->deferredRelabels.erase(objectId);
+        if (d->deferredActivatedObjectId == objectId) {
+            d->deferredActivatedObjectId = 0;
+        }
+        // The provider was reserved for transaction identity but was never
+        // published to a viewer or projection, so no inverse GUI notification
+        // is valid. slotTransactionRemove() owns its transfer or deletion.
+        viewProvider->beforeDelete();
+        d->deferredActionUpdate = true;
         return;
     }
 
@@ -1603,6 +2185,7 @@ void Document::slotDeletedObject(const App::DocumentObject& Obj)
 
 void Document::beforeDelete()
 {
+    PerformanceScope closeTiming("Gui::Document beforeDelete");
     Application::Instance->unsetEditDocumentIf([this](Gui::Document* editDoc) {
         auto vp = freecad_cast<ViewProviderDocumentObject*>(editDoc->d->_editViewProvider);
         auto vpp = freecad_cast<ViewProviderDocumentObject*>(editDoc->d->_editViewProviderParent);
@@ -1617,6 +2200,31 @@ void Document::beforeDelete()
 
 void Document::slotChangedObject(const App::DocumentObject& Obj, const App::Property& Prop)
 {
+    if (d->_pcDocument->isCooperativeMutationActive()) {
+        if (!Prop.testStatus(App::Property::NoModify)) {
+            FC_LOG(Prop.getFullName() << " modified");
+            setModified(true);
+        }
+        d->deferredActionUpdate = true;
+
+        const long objectId = Obj.getID();
+        if (getViewProvider(&Obj)
+            && !d->deferredNewViewProviders.contains(objectId)) {
+            const auto [found, inserted] =
+                d->deferredViewUpdates.try_emplace(objectId);
+            if (inserted) {
+                d->deferredViewUpdateOrder.push_back(objectId);
+            }
+            if (const char* propertyName = Prop.getName()) {
+                found->second.propertyNames.emplace(propertyName);
+            }
+            else {
+                found->second.refreshAll = true;
+            }
+        }
+        return;
+    }
+
     ViewProvider* viewProvider = getViewProvider(&Obj);
     if (viewProvider) {
         try {
@@ -1656,7 +2264,7 @@ void Document::slotChangedObject(const App::DocumentObject& Obj, const App::Prop
     }
 
     // a property of an object has changed
-    if (!Prop.testStatus(App::Property::NoModify) && !isModified()) {
+    if (!Prop.testStatus(App::Property::NoModify)) {
         FC_LOG(Prop.getFullName() << " modified");
         setModified(true);
     }
@@ -1666,6 +2274,16 @@ void Document::slotChangedObject(const App::DocumentObject& Obj, const App::Prop
 
 void Document::slotRelabelObject(const App::DocumentObject& Obj)
 {
+    if (d->_pcDocument->isCooperativeMutationActive()) {
+        const long objectId = Obj.getID();
+        if (!d->deferredNewViewProviders.contains(objectId)
+            && d->deferredRelabels.insert(objectId).second) {
+            d->deferredRelabelOrder.push_back(objectId);
+        }
+        d->deferredActionUpdate = true;
+        return;
+    }
+
     ViewProvider* viewProvider = getViewProvider(&Obj);
     if (viewProvider && viewProvider->isDerivedFrom<ViewProviderDocumentObject>()) {
         signalRelabelObject(*(static_cast<ViewProviderDocumentObject*>(viewProvider)));
@@ -1682,6 +2300,14 @@ void Document::slotTransactionAppend(const App::DocumentObject& obj, App::Transa
 
 void Document::slotTransactionRemove(const App::DocumentObject& obj, App::Transaction* transaction)
 {
+    const long objectId = obj.getID();
+    d->deferredNewViewProviders.erase(objectId);
+    d->deferredViewUpdates.erase(objectId);
+    d->deferredRelabels.erase(objectId);
+    if (d->deferredActivatedObjectId == objectId) {
+        d->deferredActivatedObjectId = 0;
+    }
+
     std::map<const App::DocumentObject*, ViewProviderDocumentObject*>::const_iterator it
         = d->_ViewProviderMap.find(&obj);
     if (it != d->_ViewProviderMap.end()) {
@@ -1706,6 +2332,12 @@ void Document::slotTransactionRemove(const App::DocumentObject& obj, App::Transa
 
 void Document::slotActivatedObject(const App::DocumentObject& Obj)
 {
+    if (d->_pcDocument->isCooperativeMutationActive()) {
+        d->deferredActivatedObjectId = Obj.getID();
+        d->deferredActionUpdate = true;
+        return;
+    }
+
     ViewProvider* viewProvider = getViewProvider(&Obj);
     if (viewProvider && viewProvider->isDerivedFrom<ViewProviderDocumentObject>()) {
         signalActivatedObject(*(static_cast<ViewProviderDocumentObject*>(viewProvider)));
@@ -1786,11 +2418,13 @@ void Document::slotSkipRecompute(const App::Document& doc, const std::vector<App
 
 void Document::slotTouchedObject(const App::DocumentObject& Obj)
 {
-    getMainWindow()->updateActions(true);
-    if (!isModified()) {
-        FC_LOG(Obj.getFullName() << " touched");
-        setModified(true);
+    FC_LOG(Obj.getFullName() << " touched");
+    setModified(true);
+    if (d->_pcDocument->isCooperativeMutationActive()) {
+        d->deferredActionUpdate = true;
+        return;
     }
+    getMainWindow()->updateActions(true);
 }
 
 void Document::addViewProvider(Gui::ViewProviderDocumentObject* vp)
@@ -1808,6 +2442,9 @@ void Document::addViewProvider(Gui::ViewProviderDocumentObject* vp)
 
 void Document::setModified(bool b)
 {
+    if (b) {
+        ++d->modificationGeneration;
+    }
     if (d->_isModified == b) {
         return;
     }
@@ -1822,6 +2459,13 @@ void Document::setModified(bool b)
 bool Document::isModified() const
 {
     return d->_isModified;
+}
+
+void Document::clearModifiedAfterSave()
+{
+    if (d->savedModificationGeneration == d->modificationGeneration) {
+        setModified(false);
+    }
 }
 void Document::setWorkbench(const std::string& name)
 {
@@ -1991,18 +2635,245 @@ static bool checkCanonicalPath(const std::map<App::Document*, bool>& docs)
     return ret == QMessageBox::Yes;
 }
 
+namespace
+{
+enum class SaveAction
+{
+    Save,
+    SaveAs,
+    Copy
+};
+
+QString chooseDocumentSaveFilename(const App::Document& document, bool useLabel)
+{
+    const auto applicationName = qApp->applicationName();
+    QString name = QString::fromUtf8(document.FileName.getValue());
+    if (name.isEmpty() && useLabel) {
+        name = QString::fromUtf8(document.Label.getValue());
+    }
+    if (name.endsWith(QStringLiteral(".FCBak"), Qt::CaseInsensitive)) {
+        name.chop(QStringLiteral(".FCBak").size());
+        if (!name.endsWith(QStringLiteral(".FCStd"), Qt::CaseInsensitive)) {
+            name += QStringLiteral(".FCStd");
+        }
+    }
+    return FileDialog::getSaveFileName(
+        getMainWindow(),
+        QObject::tr("Save %1 Document").arg(applicationName),
+        name,
+        FileDialog::FilterList {{QObject::tr("%1 document").arg(applicationName), {"*.FCStd"}}}
+    );
+}
+
+struct SaveTarget
+{
+    App::Document* document;
+    std::string name;
+    bool neededRecompute;
+    SaveAction action;
+    std::string filename;
+
+    SaveTarget(
+        App::Document* document,
+        bool neededRecompute,
+        SaveAction action = SaveAction::Save,
+        std::string filename = {}
+    )
+        : document(document)
+        , name(document->getName())
+        , neededRecompute(neededRecompute)
+        , action(action)
+        , filename(std::move(filename))
+    {}
+};
+
+struct PendingSave
+{
+    std::vector<SaveTarget> targets;
+    std::size_t leased = 0;
+    std::future<bool> result;
+
+    void release()
+    {
+        // Release on the owner, before invoking any user completion callback.
+        // Observers may close a document at the idle notification, so do not
+        // dereference it again after releasing its lease.
+        std::exception_ptr failure;
+        while (leased) {
+            const auto& target = targets[--leased];
+            if (App::GetApplication().getDocument(target.name.c_str()) == target.document) {
+                try {
+                    target.document->endCooperativeMutation();
+                }
+                catch (...) {
+                    if (!failure) {
+                        failure = std::current_exception();
+                    }
+                }
+            }
+        }
+        if (failure) {
+            std::rethrow_exception(failure);
+        }
+    }
+};
+
+App::HostWorkflow<bool> saveDocuments(std::shared_ptr<PendingSave> pending)
+{
+    for (const auto& target : pending->targets) {
+        if (App::GetApplication().getDocument(target.name.c_str()) != target.document) {
+            throw Base::RuntimeError("The document selected for saving no longer exists");
+        }
+        const auto method = target.action == SaveAction::Copy ? "saveCopy"
+            : target.action == SaveAction::SaveAs             ? "saveAs"
+                                                              : "save";
+        const auto escaped = Base::Tools::escapeEncodeFilename(
+            Base::Tools::escapedUnicodeFromUtf8(target.filename.c_str()));
+        const auto argument = target.filename.empty() ? std::string {} : "u\"" + escaped + "\"";
+        Application::Instance->macroManager()->addLine(
+            MacroManager::App,
+            ("App.getDocument(\"" + target.name + "\")." + method + "(" + argument + ")").c_str()
+        );
+
+        co_yield App::HostWorkflowStep {
+            App::HostRuntime::Lane::Document,
+            [&](std::stop_token stop) {
+                Base::SequencerLauncher progress("Saving document...", 1);
+                // External document saves can dirty their dependants. Retain the
+                // existing save-order recompute policy, but execute it on a worker.
+                if (!target.neededRecompute && target.document->mustExecute()) {
+                    App::AutoTransaction transaction(target.document, "Recompute");
+                    bool failed = false;
+                    target.document->recomputeCancellable({}, false, &failed, 0, stop);
+                    if (failed) {
+                        throw Base::RuntimeError("Cannot save: dependent document recompute failed");
+                    }
+                }
+                const bool saved = target.action == SaveAction::Copy
+                    ? target.document->saveCopy(target.filename.c_str())
+                    : target.action == SaveAction::SaveAs
+                    ? target.document->saveAs(target.filename.c_str())
+                    : target.document->save();
+                if (!saved) {
+                    throw Base::RuntimeError("Document save did not complete");
+                }
+                progress.next(false);
+            }
+        };
+
+        if (target.action != SaveAction::Copy) {
+            if (auto* gui = Application::Instance->getDocument(target.document)) {
+                gui->clearModifiedAfterSave();
+            }
+            if (target.action == SaveAction::SaveAs) {
+                getMainWindow()->appendRecentFile(
+                    QString::fromUtf8(target.document->FileName.getValue())
+                );
+            }
+        }
+    }
+    co_return true;
+}
+
+bool queueDocumentSave(std::vector<SaveTarget> targets, Document::SaveCallback finished)
+{
+    if (targets.empty()) {
+        return false;
+    }
+    for (const auto& target : targets) {
+        if (App::GetApplication().getDocument(target.name.c_str()) != target.document
+            || Document::historyMutationBlocked(target.document)
+            || target.document->isPresentationUpdateActive()) {
+            getMainWindow()->showMessage(QObject::tr("Cannot save while document work is active"));
+            return false;
+        }
+    }
+    auto pending = std::make_shared<PendingSave>();
+    pending->targets = std::move(targets);
+    try {
+        for (const auto& target : pending->targets) {
+            ++pending->leased;
+            target.document->beginCooperativeMutation();
+        }
+        getMainWindow()->showMessage(QObject::tr("Saving document…"));
+        pending->result = saveDocuments(pending).runAsync(
+            App::GetApplication().hostRuntime(),
+            [](std::function<void()> resume) {
+                if (!dispatchToGuiFrame(std::move(resume))) {
+                    throw Base::RuntimeError("Unable to dispatch document save completion");
+                }
+            },
+            [pending, finished = std::move(finished)] {
+                bool success = false;
+                std::string error;
+                try {
+                    success = pending->result.get();
+                }
+                catch (const Base::Exception& failure) {
+                    error = failure.what();
+                }
+                catch (const std::exception& failure) {
+                    error = failure.what();
+                }
+                catch (...) {
+                    error = "Unknown document save failure";
+                }
+                try {
+                    pending->release();
+                }
+                catch (const std::exception& failure) {
+                    success = false;
+                    error = failure.what();
+                }
+                catch (...) {
+                    success = false;
+                    error = "Document save cleanup failed";
+                }
+                if (success) {
+                    getMainWindow()->showMessage(QObject::tr("Document saved"), 3000);
+                }
+                else {
+                    Base::Console().error("Document save failed: %s\n", error.c_str());
+                    getMainWindow()->showMessage(
+                        QObject::tr("Document save failed: %1").arg(QString::fromStdString(error))
+                    );
+                }
+                if (finished) {
+                    try {
+                        finished(success);
+                    }
+                    catch (...) {
+                        Base::Console().error("Document save completion callback failed\n");
+                    }
+                }
+                else if (!success) {
+                    QMessageBox::critical(
+                        getMainWindow(),
+                        QObject::tr("Saving document failed"),
+                        QString::fromStdString(error)
+                    );
+                }
+            }
+        );
+    }
+    catch (...) {
+        pending->release();
+        throw;
+    }
+    return true;
+}
+}  // namespace
+
 bool Document::askIfSavingFailed(const QString& error)
 {
     int ret = QMessageBox::question(
         getMainWindow(),
         QObject::tr("Could not save document"),
-        QObject::tr(
-            "There was an issue trying to save the file. "
-            "This may be because some of the parent folders do not exist, "
-            "or you do not have sufficient permissions, "
-            "or for other reasons. Error details:\n\n\"%1\"\n\n"
-            "Would you like to save the file with a different name?"
-        )
+        QObject::tr("There was an issue trying to save the file. "
+                    "This may be because some of the parent folders do not exist, "
+                    "or you do not have sufficient permissions, "
+                    "or for other reasons. Error details:\n\n\"%1\"\n\n"
+                    "Would you like to save the file with a different name?")
             .arg(error),
         QMessageBox::Yes,
         QMessageBox::No
@@ -2020,7 +2891,7 @@ bool Document::askIfSavingFailed(const QString& error)
     return false;
 }
 
-bool Document::warnIfOlderVersion()
+bool Document::warnIfOlderVersion(bool asynchronous, SaveCallback finished, bool* queuedSaveAs)
 {
     // Skip warning if no GUI (headless/scripted mode)
     if (!getMainWindow()) {
@@ -2060,10 +2931,11 @@ bool Document::warnIfOlderVersion()
     // Warn if the document was created with an older version or has no version info
     if (!hasVersion || (docMajor < currentMajor)
         || (docMajor == currentMajor && docMinor < currentMinor)) {
-        QMessageBox msgBox(getMainWindow());
-        msgBox.setWindowTitle(QObject::tr("File Created with Older FreeCAD Version"));
-        msgBox.setIcon(QMessageBox::Warning);
-        msgBox.setText(
+        auto msgBox = std::make_unique<QMessageBox>(getMainWindow());
+        msgBox->setObjectName(QStringLiteral("confirmVersionUpgrade"));
+        msgBox->setWindowTitle(QObject::tr("File Created with Older FreeCAD Version"));
+        msgBox->setIcon(QMessageBox::Warning);
+        msgBox->setText(
             QObject::tr(
                 "This file was created with %1, but you are using v%2.%3.\n\n"
                 "Saving will upgrade the file format. The file may not be readable "
@@ -2079,25 +2951,73 @@ bool Document::warnIfOlderVersion()
                 .arg(currentMajor)
                 .arg(currentMinor)
         );
-        QPushButton* saveButton = msgBox.addButton(QObject::tr("Save"), QMessageBox::AcceptRole);
-        QPushButton* saveAsButton = msgBox.addButton(QObject::tr("Save As…"), QMessageBox::ActionRole);
-        msgBox.addButton(QMessageBox::Cancel);
-        msgBox.setDefaultButton(QMessageBox::Cancel);
+        QPushButton* saveButton = msgBox->addButton(QObject::tr("Save"), QMessageBox::AcceptRole);
+        QPushButton* saveAsButton = msgBox->addButton(QObject::tr("Save As…"), QMessageBox::ActionRole);
+        msgBox->addButton(QMessageBox::Cancel);
+        msgBox->setDefaultButton(QMessageBox::Cancel);
 
-        QCheckBox dontShowCheckBox(QObject::tr("Do not show this warning again"), &msgBox);
-        msgBox.setCheckBox(&dontShowCheckBox);
+        auto* dontShowCheckBox = new QCheckBox(QObject::tr("Do not show this warning again"), msgBox.get());
+        msgBox->setCheckBox(dontShowCheckBox);
 
-        int ret = msgBox.exec();
+        if (asynchronous) {
+            // A prompt is preparation, not a running save. Do not nest the Qt
+            // event loop or retain a document pointer while the user decides.
+            const std::string name = getDocument()->getName();
+            const std::string filename = getDocument()->FileName.getStrValue();
+            const int identity = d->_iDocId;
+            auto completion = std::make_shared<SaveCallback>(std::move(finished));
+            auto* prompt = msgBox.release();
+            prompt->setAttribute(Qt::WA_DeleteOnClose);
+            QObject::connect(prompt, &QObject::destroyed, getMainWindow(), [completion] {
+                if (auto callback = std::exchange(*completion, {})) { callback(false); }
+            });
+            QObject::connect(prompt, &QDialog::finished, getMainWindow(),
+                [prompt, saveButton, saveAsButton, dontShowCheckBox, name, filename,
+                 identity, completion](int) {
+                    auto callback = std::exchange(*completion, {});
+                    auto* app = App::GetApplication().getDocument(name.c_str());
+                    auto* gui = app ? Application::Instance->getDocument(app) : nullptr;
+                    if (!gui || gui->d->_iDocId != identity
+                        || app->FileName.getStrValue() != filename) {
+                        if (callback) { callback(false); }
+                        return;
+                    }
+                    bool queued = false;
+                    try {
+                        if (prompt->clickedButton() == saveButton) {
+                            if (dontShowCheckBox->isChecked()) {
+                                App::GetApplication().GetParameterGroupByPath(
+                                    "User parameter:BaseApp/Preferences/Document")
+                                    ->SetBool("DisableVersionCheckOnSave", true);
+                            }
+                            queued = gui->saveImpl(true, callback, true);
+                        }
+                        else if (prompt->clickedButton() == saveAsButton) {
+                            queued = gui->saveAsImpl(true, callback);
+                        }
+                    }
+                    catch (const Base::Exception& error) {
+                        error.reportException();
+                    }
+                    if (!queued && callback) { callback(false); }
+                });
+            prompt->open();
+            if (queuedSaveAs) { *queuedSaveAs = true; }
+            return false;
+        }
 
-        if (msgBox.clickedButton() == saveButton) {
-            if (dontShowCheckBox.isChecked()) {
+        int ret = msgBox->exec();
+
+        if (msgBox->clickedButton() == saveButton) {
+            if (dontShowCheckBox->isChecked()) {
                 App::GetApplication()
                     .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
                     ->SetBool("DisableVersionCheckOnSave", true);
             }
         }
-        else if (msgBox.clickedButton() == saveAsButton) {
-            saveAs();
+        else if (msgBox->clickedButton() == saveAsButton) {
+            const bool accepted = saveAsImpl(asynchronous, std::move(finished));
+            if (asynchronous && queuedSaveAs) { *queuedSaveAs = accepted; }
             return false;
         }
 
@@ -2111,10 +3031,21 @@ bool Document::warnIfOlderVersion()
 /// Save the document
 bool Document::save()
 {
+    return saveImpl(false);
+}
+
+bool Document::saveAsync(SaveCallback finished)
+{
+    return saveImpl(true, std::move(finished));
+}
+
+bool Document::saveImpl(bool asynchronous, SaveCallback finished, bool versionApproved)
+{
     if (d->_pcDocument->isSaved()) {
         // Warn if this document was created with an older FreeCAD version
-        if (!warnIfOlderVersion()) {
-            return false;
+        bool queuedSaveAs = false;
+        if (!versionApproved && !warnIfOlderVersion(asynchronous, finished, &queuedSaveAs)) {
+            return queuedSaveAs;
         }
 
         try {
@@ -2150,10 +3081,8 @@ bool Document::save()
                 int ret = QMessageBox::question(
                     getMainWindow(),
                     QObject::tr("Save dependent files"),
-                    QObject::tr(
-                        "The file contains external dependencies. "
-                        "Do you want to save the dependent files, too?"
-                    ),
+                    QObject::tr("The file contains external dependencies. "
+                                "Do you want to save the dependent files, too?"),
                     QMessageBox::Yes,
                     QMessageBox::No
                 );
@@ -2167,6 +3096,28 @@ bool Document::save()
 
             if (!checkCanonicalPath(dmap)) {
                 return false;
+            }
+
+            if (asynchronous) {
+                std::vector<SaveTarget> targets;
+                for (auto* doc : docs) {
+                    if (!doc->isSaved()) {
+                        const auto filename = chooseDocumentSaveFilename(*doc, true);
+                        if (filename.isEmpty()) {
+                            return false;
+                        }
+                        targets.emplace_back(
+                            doc,
+                            dmap.at(doc),
+                            SaveAction::SaveAs,
+                            filename.toUtf8().toStdString()
+                        );
+                    }
+                    else {
+                        targets.emplace_back(doc, dmap.at(doc));
+                    }
+                }
+                return queueDocumentSave(std::move(targets), std::move(finished));
             }
 
             Gui::WaitCursor wc;
@@ -2204,36 +3155,35 @@ bool Document::save()
         return true;
     }
     else {
-        return saveAs();
+        return saveAsImpl(asynchronous, std::move(finished));
     }
 }
 
 /// Save the document under a new file name
 bool Document::saveAs()
 {
+    return saveAsImpl(false);
+}
+
+bool Document::saveAsAsync(SaveCallback finished)
+{
+    return saveAsImpl(true, std::move(finished));
+}
+
+bool Document::saveAsImpl(bool asynchronous, SaveCallback finished)
+{
     getMainWindow()->showMessage(QObject::tr("Save document under new filename…"));
 
-    QString exe = qApp->applicationName();
-    QString name = QString::fromUtf8(getDocument()->FileName.getValue());
-    if (name.isEmpty()) {
-        name = QString::fromUtf8(getDocument()->Label.getValue());
-    }
-    if (name.endsWith(QStringLiteral(".FCBak"), Qt::CaseInsensitive)) {
-        name.chop(QStringLiteral(".FCBak").size());
-        if (!name.endsWith(QStringLiteral(".FCStd"), Qt::CaseInsensitive)) {
-            name += QStringLiteral(".FCStd");
-        }
-    }
-    QString fn = FileDialog::getSaveFileName(
-        getMainWindow(),
-        QObject::tr("Save %1 Document").arg(exe),
-        name,
-        FileDialog::FilterList {{QObject::tr("%1 document").arg(exe), {"*.FCStd"}}}
-    );
+    const QString fn = chooseDocumentSaveFilename(*getDocument(), true);
 
     if (!fn.isEmpty()) {
         QFileInfo fi;
         fi.setFile(fn);
+
+        if (asynchronous) {
+            return queueDocumentSave({SaveTarget(getDocument(), getDocument()->mustExecute(),
+                SaveAction::SaveAs, fn.toUtf8().toStdString())}, std::move(finished));
+        }
 
         const char* DocName = App::GetApplication().getDocumentName(getDocument());
 
@@ -2274,6 +3224,16 @@ bool Document::saveAs()
 
 void Document::saveAll()
 {
+    saveAllImpl(false);
+}
+
+void Document::saveAllAsync()
+{
+    saveAllImpl(true);
+}
+
+void Document::saveAllImpl(bool asynchronous)
+{
     std::vector<App::Document*> docs;
     try {
         docs = App::Document::getDependentDocuments(App::GetApplication().getDocuments(), true);
@@ -2302,6 +3262,26 @@ void Document::saveAll()
     }
 
     if (!checkCanonicalPath(dmap)) {
+        return;
+    }
+
+    if (asynchronous) {
+        std::vector<SaveTarget> targets;
+        for (auto* doc : docs) {
+            if (!dmap.contains(doc) || !Application::Instance->getDocument(doc)) {
+                continue;
+            }
+            if (!doc->isSaved()) {
+                const auto filename = chooseDocumentSaveFilename(*doc, true);
+                if (filename.isEmpty()) { return; }
+                targets.emplace_back(doc, dmap.at(doc), SaveAction::SaveAs,
+                    filename.toUtf8().toStdString());
+            }
+            else {
+                targets.emplace_back(doc, dmap.at(doc));
+            }
+        }
+        queueDocumentSave(std::move(targets), {});
         return;
     }
 
@@ -2344,23 +3324,24 @@ void Document::saveAll()
 /// Save a copy of the document under a new file name
 bool Document::saveCopy()
 {
+    return saveCopyImpl(false);
+}
+
+bool Document::saveCopyAsync(SaveCallback finished)
+{
+    return saveCopyImpl(true, std::move(finished));
+}
+
+bool Document::saveCopyImpl(bool asynchronous, SaveCallback finished)
+{
     getMainWindow()->showMessage(QObject::tr("Save a copy of the document under new filename…"));
 
-    QString exe = qApp->applicationName();
-    QString name = QString::fromUtf8(getDocument()->FileName.getValue());
-    if (name.endsWith(QStringLiteral(".FCBak"), Qt::CaseInsensitive)) {
-        name.chop(QStringLiteral(".FCBak").size());
-        if (!name.endsWith(QStringLiteral(".FCStd"), Qt::CaseInsensitive)) {
-            name += QStringLiteral(".FCStd");
-        }
-    }
-    QString fn = FileDialog::getSaveFileName(
-        getMainWindow(),
-        QObject::tr("Save %1 Document").arg(exe),
-        name,
-        FileDialog::FilterList {{QObject::tr("%1 document").arg(exe), {"*.FCStd"}}}
-    );
+    const QString fn = chooseDocumentSaveFilename(*getDocument(), false);
     if (!fn.isEmpty()) {
+        if (asynchronous) {
+            return queueDocumentSave({SaveTarget(getDocument(), true,
+                SaveAction::Copy, fn.toUtf8().toStdString())}, std::move(finished));
+        }
         const char* DocName = App::GetApplication().getDocumentName(getDocument());
 
         // save as new file name
@@ -2447,25 +3428,27 @@ void Document::Restore(Base::XMLReader& reader)
  */
 void Document::RestoreDocFile(Base::Reader& reader)
 {
+    const bool traceRestore = qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE");
+    const auto restoreStarted = std::chrono::steady_clock::now();
     // We must create an XML parser to read from the input stream
-    std::shared_ptr<Base::XMLReader> localreader
-        = std::make_shared<Base::XMLReader>("GuiDocument.xml", reader);
-    localreader->FileVersion = reader.getFileVersion();
+    auto localreader = std::make_shared<GuiRestoreReader>(reader);
 
     localreader->readElement("Document");
     long scheme = localreader->getAttribute<long>("SchemaVersion");
     localreader->DocumentSchema = scheme;
-    localreader->ProgramVersion = d->_pcDocument->getProgramVersion();
+    restoreOnGui([&] { localreader->ProgramVersion = d->_pcDocument->getProgramVersion(); });
 
     bool hasExpansion = localreader->hasAttribute("HasExpansion");
     if (hasExpansion) {
-        auto tree = TreeWidget::instance();
-        if (tree) {
-            auto docItem = tree->getDocumentItem(this);
-            if (docItem) {
-                docItem->Restore(*localreader);
+        restoreOnGui([&] {
+            auto tree = TreeWidget::instance();
+            if (tree) {
+                auto docItem = tree->getDocumentItem(this);
+                if (docItem) {
+                    docItem->Restore(*localreader);
+                }
             }
-        }
+        });
     }
 
     // At this stage all the document objects and their associated view providers exist.
@@ -2476,9 +3459,10 @@ void Document::RestoreDocFile(Base::Reader& reader)
         // read the viewproviders itself
         localreader->readElement("ViewProviderData");
         int Cnt = localreader->getAttribute<long>("Count");
-        QElapsedTimer restoreEvents;
-        restoreEvents.start();
+        Base::SequencerLauncher restoreViews("Restoring document presentation...", Cnt);
         for (int i = 0; i < Cnt; i++) {
+            const auto viewStarted = std::chrono::steady_clock::now();
+            restoreViews.next();
             localreader->readElement("ViewProvider");
             std::string name = localreader->getAttribute<const char*>("name");
 
@@ -2495,58 +3479,78 @@ void Document::RestoreDocFile(Base::Reader& reader)
                 treeRank = localreader->getAttribute<int>("treeRank");
             }
 
-            auto pObj = freecad_cast<ViewProviderDocumentObject*>(getViewProviderByName(name.c_str()));
-            // check if this feature has been registered
-            if (pObj) {
-                pObj->Restore(*localreader);
-            }
+            restoreOnGui([&] {
+                auto pObj = freecad_cast<ViewProviderDocumentObject*>(
+                    getViewProviderByName(name.c_str())
+                );
+                // Resolve and consume the provider only on its owner thread.
+                if (pObj) {
+                    pObj->Restore(*localreader);
+                }
 
-            if (pObj && treeRank >= 0) {
-                pObj->setTreeRank(treeRank);
-            }
+                if (pObj && treeRank >= 0) {
+                    pObj->setTreeRank(treeRank);
+                }
 
-            if (pObj && expanded) {
-                this->signalExpandObject(*pObj, TreeItemMode::ExpandItem, 0, 0);
-            }
+                if (pObj && expanded) {
+                    this->signalExpandObject(*pObj, TreeItemMode::ExpandItem, 0, 0);
+                }
+            });
             localreader->readEndElement("ViewProvider");
 
-            // GuiDocument.xml is restored as one project-file step. Large
-            // documents can spend a long time in this loop without returning
-            // to Qt, making the application appear hung. Repaint periodically
-            // while excluding user input and socket activity so no command can
-            // observe or mutate the partially restored document.
-            if (restoreEvents.hasExpired(100)) {
-                qApp->processEvents(
-                    QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers
-                );
-                restoreEvents.restart();
+            if (traceRestore) {
+                const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                    std::chrono::steady_clock::now() - viewStarted
+                ).count();
+                if (elapsed >= 20) {
+                    Base::Console().message(
+                        "VIBECAD_RESTORE_DETAIL restore_view index=%d count=%d name=%s "
+                        "elapsed_ms=%lld\n",
+                        i + 1,
+                        Cnt,
+                        name.c_str(),
+                        static_cast<long long>(elapsed)
+                    );
+                }
             }
+
         }
         localreader->readEndElement("ViewProviderData");
 
         // read camera settings
         localreader->readElement("Camera");
-        const char* ppReturn = localreader->getAttribute<const char*>("settings");
-        cameraSettings.clear();
-        if (!Base::Tools::isNullOrEmpty(ppReturn)) {
-            saveCameraSettings(ppReturn);
-            try {
-                for (const auto& it : getMDIViews()) {
-                    if (auto* viewCamera = freecad_cast<MDIViewWithCamera*>(it)) {
-                        viewCamera->setCamera(cameraSettings.c_str());
+        const std::string settings = localreader->getAttribute<const char*>("settings");
+        restoreOnGui([&] {
+            cameraSettings.clear();
+            if (!settings.empty()) {
+                saveCameraSettings(settings.c_str());
+                try {
+                    for (const auto& it : getMDIViews()) {
+                        if (auto* viewCamera = freecad_cast<MDIViewWithCamera*>(it)) {
+                            viewCamera->setCamera(cameraSettings.c_str());
+                        }
                     }
                 }
+                catch (const Base::Exception& e) {
+                    Base::Console().error("%s\n", e.what());
+                }
             }
-            catch (const Base::Exception& e) {
-                Base::Console().error("%s\n", e.what());
-            }
-        }
+        });
     }
 
     reader.initLocalReader(localreader);
 
     // reset modified flag
-    setModified(false);
+    restoreOnGui([&] { setModified(false); });
+    if (traceRestore) {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - restoreStarted
+        ).count();
+        Base::Console().message(
+            "VIBECAD_RESTORE_DETAIL gui_document elapsed_ms=%lld\n",
+            static_cast<long long>(elapsed)
+        );
+    }
 }
 
 void Document::slotStartRestoreDocument(const App::Document& doc)
@@ -2602,50 +3606,59 @@ void Document::slotShowHidden(const App::Document& doc)
  */
 void Document::SaveDocFile(Base::Writer& writer) const
 {
-    writer.Stream() << "<?xml version='1.0' encoding='utf-8'?>" << std::endl
-                    << "<!--" << std::endl
-                    << " FreeCAD Document, see https://www.freecad.org for more information…"
-                    << std::endl
-                    << "-->" << std::endl;
+    // The archive/compressor stays on the caller. Only GUI-owned state capture
+    // enters the frame dispatcher; embedded property files inherit that owner.
+    std::vector<std::pair<const App::DocumentObject*, ViewProviderDocumentObject*>> providers;
+    captureOnGui(writer, [&] {
+        writer.Stream() << "<?xml version='1.0' encoding='utf-8'?>" << std::endl
+                        << "<!--" << std::endl
+                        << " FreeCAD Document, see https://www.freecad.org for more information…"
+                        << std::endl
+                        << "-->" << std::endl;
 
-    writer.Stream() << "<Document SchemaVersion=\"1\"";
+        writer.Stream() << "<Document SchemaVersion=\"1\"";
 
-    writer.incInd();
+        writer.incInd();
 
-    auto tree = TreeWidget::instance();
-    bool hasExpansion = false;
-    if (tree) {
-        auto docItem = tree->getDocumentItem(this);
-        if (docItem) {
-            hasExpansion = true;
-            writer.Stream() << " HasExpansion=\"1\">" << std::endl;
-            docItem->Save(writer);
+        auto tree = TreeWidget::instance();
+        bool hasExpansion = false;
+        if (tree) {
+            auto docItem = tree->getDocumentItem(this);
+            if (docItem) {
+                hasExpansion = true;
+                writer.Stream() << " HasExpansion=\"1\">" << std::endl;
+                docItem->Save(writer);
+            }
         }
-    }
-    if (!hasExpansion) {
-        writer.Stream() << ">" << std::endl;
-    }
+        if (!hasExpansion) {
+            writer.Stream() << ">" << std::endl;
+        }
 
-    // writing the view provider names itself
-    writer.Stream() << writer.ind() << "<ViewProviderData Count=\"" << d->_ViewProviderMap.size()
-                    << "\">" << std::endl;
+        // writing the view provider names itself
+        writer.Stream() << writer.ind() << "<ViewProviderData Count=\""
+                        << d->_ViewProviderMap.size() << "\">" << std::endl;
+        providers.assign(d->_ViewProviderMap.begin(), d->_ViewProviderMap.end());
+    });
 
     bool xml = writer.isForceXML();
     // writer.setForceXML(true);
     writer.incInd();  // indentation for 'ViewProvider name'
-    for (const auto& it : d->_ViewProviderMap) {
-        const App::DocumentObject* doc = it.first;
-        ViewProviderDocumentObject* obj = it.second;
-        writer.Stream() << writer.ind() << "<ViewProvider name=\"" << doc->getNameInDocument() << "\""
-                        << " expanded=\"" << (doc->testStatus(App::Expand) ? 1 : 0) << "\""
-                        << " treeRank=\"" << obj->getTreeRank() << "\"";
-        if (obj->hasExtensions()) {
-            writer.Stream() << " Extensions=\"True\"";
-        }
+    for (const auto& it : providers) {
+        captureOnGui(writer, [&] {
+            const App::DocumentObject* doc = it.first;
+            ViewProviderDocumentObject* obj = it.second;
+            writer.Stream() << writer.ind() << "<ViewProvider name=\"" << doc->getNameInDocument()
+                            << "\""
+                            << " expanded=\"" << (doc->testStatus(App::Expand) ? 1 : 0) << "\""
+                            << " treeRank=\"" << obj->getTreeRank() << "\"";
+            if (obj->hasExtensions()) {
+                writer.Stream() << " Extensions=\"True\"";
+            }
 
-        writer.Stream() << ">" << std::endl;
-        obj->Save(writer);
-        writer.Stream() << writer.ind() << "</ViewProvider>" << std::endl;
+            writer.Stream() << ">" << std::endl;
+            obj->Save(writer);
+            writer.Stream() << writer.ind() << "</ViewProvider>" << std::endl;
+        });
     }
     writer.setForceXML(xml);
 
@@ -2654,21 +3667,24 @@ void Document::SaveDocFile(Base::Writer& writer) const
     writer.decInd();  // indentation for 'ViewProviderData Count'
 
     // save camera settings
-    for (const auto& it : getMDIViews()) {
-        if (auto* viewCamera = freecad_cast<MDIViewWithCamera*>(it)) {
-            const std::string& camera = viewCamera->getCamera();
-            if (saveCameraSettings(camera.c_str())) {
-                break;
+    captureOnGui(writer, [&] {
+        for (const auto& it : getMDIViews()) {
+            if (auto* viewCamera = freecad_cast<MDIViewWithCamera*>(it)) {
+                const std::string& camera = viewCamera->getCamera();
+                if (saveCameraSettings(camera.c_str())) {
+                    break;
+                }
             }
         }
-    }
 
-    writer.incInd();  // indentation for camera settings
-    writer.Stream() << writer.ind() << "<Camera settings=\"" << encodeAttribute(getCameraSettings())
-                    << "\"/>\n";
-    writer.decInd();  // indentation for camera settings
+        writer.incInd();  // indentation for camera settings
+        writer.Stream() << writer.ind() << "<Camera settings=\""
+                        << encodeAttribute(getCameraSettings()) << "\"/>\n";
+        writer.decInd();  // indentation for camera settings
 
-    writer.Stream() << "</Document>" << std::endl;
+        writer.Stream() << "</Document>" << std::endl;
+        d->savedModificationGeneration = d->modificationGeneration;
+    });
 }
 
 void Document::exportObjects(const std::vector<App::DocumentObject*>& obj, Base::Writer& writer)
@@ -2727,8 +3743,7 @@ void Document::importObjects(
 )
 {
     // We must create an XML parser to read from the input stream
-    std::shared_ptr<Base::XMLReader> localreader
-        = std::make_shared<Base::XMLReader>("GuiDocument.xml", reader);
+    auto localreader = std::make_shared<GuiRestoreReader>(reader);
     localreader->readElement("Document");
     long scheme = localreader->getAttribute<long>("SchemaVersion");
 
@@ -2758,18 +3773,20 @@ void Document::importObjects(
                     expanded = true;
                 }
             }
-            Gui::ViewProvider* pObj = this->getViewProviderByName(name.c_str());
-            if (pObj) {
-                pObj->setStatus(Gui::isRestoring, true);
-                auto vpd = freecad_cast<ViewProviderDocumentObject*>(pObj);
-                if (vpd) {
-                    vpd->startRestoring();
+            restoreOnGui([&] {
+                Gui::ViewProvider* pObj = this->getViewProviderByName(name.c_str());
+                if (pObj) {
+                    pObj->setStatus(Gui::isRestoring, true);
+                    auto vpd = freecad_cast<ViewProviderDocumentObject*>(pObj);
+                    if (vpd) {
+                        vpd->startRestoring();
+                    }
+                    pObj->Restore(*localreader);
+                    if (expanded && vpd) {
+                        this->signalExpandObject(*vpd, TreeItemMode::ExpandItem, 0, 0);
+                    }
                 }
-                pObj->Restore(*localreader);
-                if (expanded && vpd) {
-                    this->signalExpandObject(*vpd, TreeItemMode::ExpandItem, 0, 0);
-                }
-            }
+            });
             localreader->readEndElement("ViewProvider");
             if (it == obj.end()) {
                 break;
@@ -2952,10 +3969,20 @@ void Document::attachView(Gui::BaseView* pcView, bool bPassiv)
     else {
         d->passiveViews.push_back(pcView);
     }
+    if (auto* mdiView = dynamic_cast<MDIView*>(pcView)) {
+        synchronizePresentationView(*mdiView);
+    }
 }
 
 void Document::detachView(Gui::BaseView* pcView, bool bPassiv)
 {
+    const auto suspended = d->presentationSuspendedViews.find(pcView);
+    if (suspended != d->presentationSuspendedViews.end()) {
+        if (suspended->second) {
+            suspended->second->setUpdatesEnabled(true);
+        }
+        d->presentationSuspendedViews.erase(suspended);
+    }
     if (bPassiv) {
         if (find(d->passiveViews.begin(), d->passiveViews.end(), pcView) != d->passiveViews.end()) {
             d->passiveViews.remove(pcView);
@@ -3119,6 +4146,259 @@ bool Document::canClose(bool checkModify, bool checkLink)
     }
 
     return ok;
+}
+
+class Document::ClosePreparation final : public QObject
+{
+    struct Target {
+        std::string name;
+        int id;
+        std::optional<std::uint64_t> approved;
+    };
+    std::vector<Target> targets;
+    std::vector<fastsignals::scoped_connection> waiters;
+    SaveCallback finished;
+    std::size_t index {0};
+    int policy {MainWindow::ConfirmSaveResult::Cancel}; // Ask each time until Apply to all.
+    std::optional<int> answer;
+    bool checkLinks;
+    bool queued {false};
+    bool complete {false};
+    bool waitingAfterSave {false};
+    bool ownsQueries {false};
+    bool closeDocuments;
+
+    Document* lookup(const Target& target) const
+    {
+        auto* app = App::GetApplication().getDocument(target.name.c_str());
+        auto* gui = app ? Application::Instance->getDocument(app) : nullptr;
+        return gui && gui->d->_iDocId == target.id ? gui : nullptr;
+    }
+
+    void finish(bool success)
+    {
+        if (complete) { return; }
+        complete = true;
+        waiters.clear();
+        for (const auto& target : targets) {
+            if (auto* gui = lookup(target)) {
+                if (success && (!target.approved
+                    || *target.approved != gui->d->modificationGeneration
+                    || !gui->getDocument()->isClosable())) {
+                    success = false;
+                }
+            }
+            else { success = false; }
+        }
+        if (success && closeDocuments) {
+            for (const auto& target : targets) {
+                auto* gui = lookup(target);
+                if (!gui) { continue; }
+                // Earlier close observers may edit another prepared document.
+                // Never discard edits which were not covered by its decision.
+                try {
+                    PerformanceScope closeTiming("App::Application closeDocument");
+                    if (*target.approved != gui->d->modificationGeneration
+                        || !gui->getDocument()->isClosable()
+                        || !App::GetApplication().closeDocument(target.name.c_str())) {
+                        success = false;
+                    }
+                }
+                catch (...) {
+                    Base::Console().error("Document close failed: %s\n", target.name.c_str());
+                    success = false;
+                }
+            }
+        }
+        releaseQueries();
+        auto callback = std::move(finished);
+        deleteLater();
+        if (callback) { callback(success); }
+    }
+
+    void releaseQueries()
+    {
+        if (!ownsQueries) { return; }
+        ownsQueries = false;
+        for (const auto& target : targets) {
+            if (auto* gui = lookup(target)) { gui->d->closeQueryActive = false; }
+        }
+    }
+
+    void approve(Document& document)
+    {
+        targets[index].approved = document.d->modificationGeneration;
+        ++index;
+        answer.reset();
+        queue();
+    }
+
+    void saveFailed()
+    {
+        auto* box = new QMessageBox(QMessageBox::Question,
+            QObject::tr("Unable to save document"),
+            QObject::tr("Document saving failed. Would you like to cancel the closure?"),
+            QMessageBox::Discard | QMessageBox::Cancel, getMainWindow());
+        box->setDefaultButton(QMessageBox::Discard);
+        box->setAttribute(Qt::WA_DeleteOnClose);
+        connect(box, &QDialog::finished, this, [this](int decision) {
+            if (decision != QMessageBox::Discard) { finish(false); return; }
+            answer = MainWindow::ConfirmSaveResult::Discard;
+            queue();
+        });
+        box->open();
+    }
+
+    void step()
+    {
+        if (complete) { return; }
+        if (index == targets.size()) { finish(true); return; }
+        auto* gui = lookup(targets[index]);
+        if (!gui) { finish(false); return; }
+        auto* document = gui->getDocument();
+        if (waitingAfterSave) {
+            if (document->isCooperativeMutationActive() || document->isPresentationUpdateActive()) {
+                if (waiters.empty()) {
+                    const auto changed = [this](const App::Document&, bool active) {
+                        if (!active) { queue(); }
+                    };
+                    waiters.emplace_back(document->signalCooperativeMutationChanged.connect(changed));
+                    waiters.emplace_back(document->signalPresentationUpdateChanged.connect(changed));
+                    waiters.emplace_back(App::GetApplication().signalDeleteDocument.connect(
+                        [this](const App::Document&) { queue(); }));
+                }
+                getMainWindow()->showMessage(QObject::tr("Finishing document display before closing..."));
+                return;
+            }
+            waiters.clear();
+            waitingAfterSave = false;
+            if (gui->isModified()) {
+                getMainWindow()->showMessage(QObject::tr("Document changed after saving; close cancelled"));
+                finish(false);
+                return;
+            }
+            approve(*gui);
+            return;
+        }
+        if (!document->isClosable()) {
+            getMainWindow()->showMessage(QObject::tr("Document work is active; close cancelled"));
+            finish(false);
+            return;
+        }
+        const bool needsSave = gui->isModified()
+            && !document->testStatus(App::Document::PartialDoc)
+            && !document->testStatus(App::Document::TempDoc)
+            && !(checkLinks && !App::PropertyXLink::getDocumentInList(document).empty());
+        if (!needsSave) {
+            const bool wasModified = gui->isModified();
+            if (!gui->canClose(false, checkLinks)) { finish(false); return; }
+            gui = lookup(targets[index]);
+            if (!gui) { finish(false); }
+            else if (!wasModified && gui->isModified()) { queue(); }
+            else { approve(*gui); }
+            return;
+        }
+        if (!answer) {
+            if (policy == MainWindow::ConfirmSaveResult::SaveAll
+                || policy == MainWindow::ConfirmSaveResult::DiscardAll) {
+                answer = policy;
+            }
+            else {
+                QPointer<ClosePreparation> guard(this);
+                getMainWindow()->confirmSaveAsync(document, [guard](int decision) {
+                    if (!guard || guard->complete) { return; }
+                    guard->answer = decision;
+                    guard->queue();
+                }, getMainWindow(), targets.size() > 1);
+                return;
+            }
+        }
+        const int decision = *answer;
+        if (decision == MainWindow::ConfirmSaveResult::Cancel) { finish(false); return; }
+        if (decision == MainWindow::ConfirmSaveResult::SaveAll
+            || decision == MainWindow::ConfirmSaveResult::DiscardAll) {
+            policy = decision;
+        }
+        if (!gui->canClose(false, checkLinks)) { finish(false); return; }
+        gui = lookup(targets[index]);
+        if (!gui) { finish(false); return; }
+        if (decision == MainWindow::ConfirmSaveResult::Discard
+            || decision == MainWindow::ConfirmSaveResult::DiscardAll) {
+            approve(*gui);
+            return;
+        }
+        QPointer<ClosePreparation> guard(this);
+        if (!gui->saveAsync([guard](bool saved) {
+                if (!guard || guard->complete) { return; }
+                if (!saved) { guard->saveFailed(); return; }
+                guard->waitingAfterSave = true;
+                guard->queue();
+            })) {
+            finish(false);
+        }
+    }
+
+public:
+    ClosePreparation(const std::vector<Document*>& documents, SaveCallback callback,
+                     bool checkLinks, bool closeDocuments = false)
+        : QObject(getMainWindow()), finished(std::move(callback)), checkLinks(checkLinks),
+          closeDocuments(closeDocuments)
+    {
+        for (auto* document : documents) {
+            if (document && std::none_of(targets.begin(), targets.end(), [&](const Target& target) {
+                    return target.id == document->d->_iDocId;
+                })) {
+                targets.push_back({document->getDocument()->getName(), document->d->_iDocId, {}});
+            }
+        }
+    }
+
+    ~ClosePreparation() override { releaseQueries(); }
+
+    void start()
+    {
+        for (const auto& target : targets) {
+            if (auto* gui = lookup(target); gui && gui->d->closeQueryActive) {
+                finish(false);
+                return;
+            }
+        }
+        for (const auto& target : targets) {
+            if (auto* gui = lookup(target)) { gui->d->closeQueryActive = true; }
+        }
+        ownsQueries = true;
+        queue();
+    }
+
+    void queue()
+    {
+        if (complete || queued) { return; }
+        queued = true;
+        // Always resume after the signal emitter returns; reconnecting from
+        // inside a completion signal can otherwise prevent its final release.
+        if (!dispatchToGuiFrame(this, [this] {
+                queued = false;
+                try { step(); }
+                catch (const std::exception& error) {
+                    Base::Console().error("Document close preparation failed: %s\n", error.what());
+                    finish(false);
+                }
+                catch (...) { finish(false); }
+            })) {
+            finish(false);
+        }
+    }
+};
+
+void Document::prepareCloseAsync(const std::vector<Document*>& documents,
+                                 SaveCallback finished, bool checkLinks)
+{
+    (new ClosePreparation(documents, std::move(finished), checkLinks))->start();
+}
+
+void Document::closeDocumentsAsync(const std::vector<Document*>& documents, SaveCallback finished)
+{
+    (new ClosePreparation(documents, std::move(finished), false, true))->start();
 }
 
 std::list<MDIView*> Document::getMDIViews(bool includePassive) const

--- a/src/Gui/Document.h
+++ b/src/Gui/Document.h
@@ -24,7 +24,9 @@
 
 #include <list>
 #include <map>
+#include <set>
 #include <string>
+#include <functional>
 #include <fastsignals/signal.h>
 #include <QString>
 
@@ -58,6 +60,7 @@ class ViewProvider;
 class ViewProviderDocumentObject;
 class Application;
 class DocumentPy;
+class ModelTreeBrowserCache;
 class TransactionViewProvider;
 namespace TaskView
 {
@@ -94,6 +97,8 @@ protected:
     void slotRelabelObject(const App::DocumentObject&);
     void slotTransactionAppend(const App::DocumentObject&, App::Transaction*);
     void slotTransactionRemove(const App::DocumentObject&, App::Transaction*);
+    void slotCooperativeMutationChanged(const App::Document&, bool active);
+    void slotPresentationUpdateChanged(const App::Document&, bool active);
     void slotActivatedObject(const App::DocumentObject&);
     void slotStartRestoreDocument(const App::Document&);
     void slotFinishRestoreDocument(const App::Document&);
@@ -170,8 +175,16 @@ public:
     bool saveAs();
     /// Save a copy of the document under a new file name
     bool saveCopy();
+    /// Queue interactive persistence. Returns false if no request was admitted.
+    /// An admitted request calls finished once on the GUI owner, after lease
+    /// release. Existing synchronous save APIs remain available to scripts.
+    using SaveCallback = std::function<void(bool)>;
+    bool saveAsync(SaveCallback finished = {});
+    bool saveAsAsync(SaveCallback finished = {});
+    bool saveCopyAsync(SaveCallback finished = {});
     /// Save all open document
     static void saveAll();
+    static void saveAllAsync();
     /// This method is used to save properties or very small amounts of data to an XML document.
     void Save(Base::Writer& writer) const override;
     /// This method is used to restore properties from an XML document.
@@ -193,6 +206,8 @@ public:
     /// Observer message from the App doc
     void setModified(bool);
     bool isModified() const;
+    /// Clear the dirty flag only if no edit followed the last archive capture.
+    void clearModifiedAfterSave();
 
     /// getter-setter for workbench name
     void setWorkbench(const std::string& name);
@@ -372,6 +387,13 @@ public:
 
     /// handles the application close event
     bool canClose(bool checkModify = true, bool checkLink = false);
+    /// Prepare the exact documents for closing without waiting for Save on Qt.
+    /// The callback runs on Qt after save and presentation, without closing them.
+    static void prepareCloseAsync(const std::vector<Document*>& documents,
+                                  SaveCallback finished, bool checkLinks = false);
+    /// Prepare and close only these exact document instances, never replacements.
+    static void closeDocumentsAsync(const std::vector<Document*>& documents,
+                                    SaveCallback finished = {});
     bool isLastView();
 
     /// called by Application before being deleted
@@ -392,6 +414,7 @@ public:
      * once signalBecameStable() is emitted.
      */
     static bool projectionRefreshBlocked(const App::Document* document);
+    ModelTreeBrowserCache& modelBrowserProjectionCache();
 
     /** Return true while user-driven History mutations must remain disabled.
      *
@@ -406,6 +429,11 @@ protected:
     Gui::DocumentPy* _pcDocPy;
 
 private:
+    class ClosePreparation;
+    bool saveImpl(bool asynchronous, SaveCallback finished = {}, bool versionApproved = false);
+    bool saveAsImpl(bool asynchronous, SaveCallback finished = {});
+    bool saveCopyImpl(bool asynchronous, SaveCallback finished = {});
+    static void saveAllImpl(bool asynchronous);
     bool trySetEdit(Gui::ViewProvider* p, int ModNum, const char* subname);
     /**
      * Transfer one exact application transaction to the active edit session.
@@ -420,6 +448,25 @@ private:
     void retryPendingEditTransaction();
     void completePendingEditTransaction(int transactionId, bool commit);
     void resetIfEditing();
+    void queueDeferredNewViewProvider(
+        const App::DocumentObject& object,
+        bool updateView,
+        bool recordRedo
+    );
+    void scheduleDeferredViewProviderWork();
+    void drainDeferredViewProviderWork();
+    bool hasDeferredViewProviderWork() const;
+    void finishNewViewProvider(
+        long objectId,
+        bool updateView,
+        bool recordRedo
+    );
+    void finishDeferredViewUpdate(
+        long objectId,
+        const std::set<std::string>& propertyNames,
+        bool refreshAll
+    );
+    void synchronizePresentationView(MDIView& view);
     // handles the scene graph nodes to correctly group child and parents
     void handleChildren3D(ViewProvider* viewProvider, bool deleting = false);
 
@@ -428,7 +475,8 @@ private:
     /// Ask for user interaction if saving has failed
     bool askIfSavingFailed(const QString&);
     /// Warn if saving a document from an older FreeCAD version (returns false if user cancels)
-    bool warnIfOlderVersion();
+    bool warnIfOlderVersion(bool asynchronous = false, SaveCallback finished = {},
+                           bool* queuedSaveAs = nullptr);
 
     struct DocumentP* d;
     static int _iDocCount;
@@ -445,6 +493,7 @@ private:
     //@}
 
     friend class TransactionViewProvider;
+    friend class MDIView;
     friend class TaskView::TaskDialog;
 };
 

--- a/src/Gui/FeatureTimeline.cpp
+++ b/src/Gui/FeatureTimeline.cpp
@@ -3,11 +3,13 @@
 #include "FeatureTimeline.h"
 
 #include <algorithm>
+#include <array>
 #include <functional>
 #include <iterator>
 #include <limits>
 #include <optional>
 #include <sstream>
+#include <span>
 #include <string_view>
 #include <unordered_map>
 #include <unordered_set>
@@ -18,10 +20,12 @@
 #include <QApplication>
 #include <QByteArray>
 #include <QColor>
+#include <QElapsedTimer>
 #include <QFrame>
 #include <QHBoxLayout>
 #include <QIcon>
 #include <QImage>
+#include <QItemSelectionModel>
 #include <QListView>
 #include <QListWidget>
 #include <QMenu>
@@ -29,12 +33,14 @@
 #include <QMouseEvent>
 #include <QPalette>
 #include <QPixmap>
+#include <QPointer>
 #include <QScopedValueRollback>
 #include <QScrollBar>
 #include <QSignalBlocker>
 #include <QSizePolicy>
 #include <QStyle>
 #include <QTimer>
+#include <QThread>
 #include <QToolButton>
 #include <QVariant>
 #include <QtGlobal>
@@ -43,10 +49,12 @@
 #include <App/Document.h>
 #include <App/DocumentTimeline.h>
 #include <App/DocumentObject.h>
+#include <App/HostRuntime.h>
 #include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
 #include <App/SuppressibleExtension.h>
 #include <Base/Console.h>
+#include <Base/CancellationScope.h>
 #include <Base/Exception.h>
 
 #include "ActiveObjectList.h"
@@ -56,6 +64,7 @@
 #include "Command.h"
 #include "Control.h"
 #include "Document.h"
+#include "FrameBudget.h"
 #include "Macro.h"
 #include "MDIView.h"
 #include "ModelTreeBrowser.h"
@@ -73,6 +82,42 @@ namespace
 constexpr int timelineHeight = 56;
 constexpr int timelineItemHeight = 34;
 constexpr int timelineItemWidth = 38;
+
+bool timelineStructureProperty(
+    const App::DocumentObject& object,
+    const App::Property& property
+)
+{
+    const std::string_view name = property.getName();
+    if (object.isDerivedFrom<App::DocumentTimeline>()) {
+        return name == "Operations" || name == "Position";
+    }
+
+    // These properties define membership, semantic ownership, or ordering in
+    // the shared Tree/History projection. Every other property can change an
+    // existing item's status or icon without rebuilding the operation list.
+    static constexpr std::array structuralProperties {
+        std::string_view("BaseFeature"),
+        std::string_view("Group"),
+        std::string_view("Originals"),
+        std::string_view("ProgramId"),
+        std::string_view("ProgramObjectName"),
+        std::string_view("Tip"),
+        std::string_view("TransformMode"),
+        std::string_view("Transformations"),
+        std::string_view("VibeCADPartDesignComponentOccurrenceNames"),
+        std::string_view("VibeCADPartDesignComponentOccurrences"),
+        std::string_view("VibeCADScriptedEngine"),
+        std::string_view("VibeCADScriptedModelId"),
+        std::string_view("VibeCADScriptedOutputKey"),
+        std::string_view("VibeCADScriptedRole"),
+        std::string_view("VibeCADVibeScriptOutputType"),
+        std::string_view(App::DocumentTimeline::EditorPropertyName),
+        std::string_view(App::DocumentTimeline::OwnerPropertyName),
+        std::string_view(App::DocumentTimeline::RolePropertyName),
+    };
+    return std::ranges::find(structuralProperties, name) != structuralProperties.end();
+}
 
 QPixmap desaturatePixmap(const QPixmap& source)
 {
@@ -432,7 +477,8 @@ bool isVisibleTimelineOperation(
 
 const App::DocumentObject* semanticTimelineRoot(
     const App::DocumentObject* object,
-    const App::Document* document
+    const App::Document* document,
+    std::unordered_map<const App::DocumentObject*, const App::DocumentObject*>& roots
 ) noexcept
 {
     if (!object || !document || !document->containsObject(object)
@@ -440,19 +486,28 @@ const App::DocumentObject* semanticTimelineRoot(
         return nullptr;
     }
 
-    std::unordered_set<const App::DocumentObject*> visited;
+    std::vector<const App::DocumentObject*> path;
     auto* current = object;
-    while (App::DocumentTimeline::hasTimelineResourceRole(current)) {
-        if (!visited.insert(current).second) {
-            return nullptr;
+    const App::DocumentObject* root = nullptr;
+    while (current && document->containsObject(current) && current->getDocument() == document) {
+        const auto [entry, inserted] = roots.emplace(current, nullptr);
+        if (!inserted) {
+            // A null entry denotes either a previously invalid chain or a
+            // cycle back into this walk. Neither can expose a history block.
+            root = entry->second;
+            break;
+        }
+        path.push_back(current);
+        if (!App::DocumentTimeline::hasTimelineResourceRole(current)) {
+            root = current;
+            break;
         }
         current = App::DocumentTimeline::timelineOwner(current);
-        if (!current || !document->containsObject(current)
-            || current->getDocument() != document) {
-            return nullptr;
-        }
     }
-    return current;
+    for (const auto* member : path) {
+        roots[member] = root;
+    }
+    return root;
 }
 
 struct SemanticTimelineBlock
@@ -471,8 +526,9 @@ class SemanticTimelineLayout
 public:
     SemanticTimelineLayout(
         const std::vector<App::DocumentObject*>& operations,
-        const App::Document* document
-    ) noexcept
+        const App::Document* document,
+        const ModelTreeBrowserProjection* snapshot = nullptr
+    )
         : document(document)
     {
         if (!document) {
@@ -482,44 +538,48 @@ public:
             valid = true;
             return;
         }
+        if (snapshot) {
+            roots = snapshot->timelineRoots();
+        }
 
         std::unordered_set<const App::DocumentObject*> operationIdentities;
         operationIdentities.reserve(operations.size());
         for (const auto* operation : operations) {
-            if (!operation || !document->containsObject(operation)
-                || operation->getDocument() != document
+            Base::CancellationScope::check();
+            const bool present = snapshot ? roots.contains(operation)
+                : operation && document->containsObject(operation)
+                    && operation->getDocument() == document;
+            if (!operation || !present
                 || !operationIdentities.insert(operation).second) {
                 return;
             }
         }
 
         blocks.reserve(operations.size());
+        roots.reserve(operations.size());
+        orderedBlocks.reserve(operations.size());
+        const App::DocumentObject* previousRoot = nullptr;
         for (std::size_t index = 0; index < operations.size(); ++index) {
-            const auto* root = semanticTimelineRoot(operations[index], document);
+            Base::CancellationScope::check();
+            const auto* root = snapshot ? roots.at(operations[index])
+                : semanticTimelineRoot(operations[index], document, roots);
             if (!root || !operationIdentities.contains(root)) {
                 return;
             }
             const auto position = static_cast<int>(index);
-            auto& block = blocks[root];
-            block.begin = block.begin < 0 ? position : std::min(block.begin, position);
-            block.end = std::max(block.end, position + 1);
-        }
-
-        orderedBlocks.reserve(blocks.size());
-        for (const auto& [root, block] : blocks) {
-            (void)root;
-            if (!block.isValid()) {
-                return;
+            if (root != previousRoot) {
+                const SemanticTimelineBlock block {position, position + 1};
+                if (!blocks.emplace(root, block).second) {
+                    // Returning to an earlier root interleaves its resources
+                    // with another operation, so no exact boundary exists.
+                    return;
+                }
+                orderedBlocks.push_back(block);
+                previousRoot = root;
             }
-            orderedBlocks.push_back(block);
-        }
-        std::ranges::sort(orderedBlocks, {}, &SemanticTimelineBlock::begin);
-        for (std::size_t index = 1; index < orderedBlocks.size(); ++index) {
-            if (orderedBlocks[index - 1].end > orderedBlocks[index].begin) {
-                // Interleaved semantic blocks cannot expose an exact state
-                // boundary. Refuse navigation instead of activating only part
-                // of either operation.
-                return;
+            else {
+                blocks.at(root).end = position + 1;
+                orderedBlocks.back().end = position + 1;
             }
         }
         valid = true;
@@ -537,7 +597,9 @@ public:
         if (!valid) {
             return {};
         }
-        const auto* root = semanticTimelineRoot(operation, document);
+        const auto cached = roots.find(operation);
+        const auto* root = cached != roots.end() ? cached->second
+            : semanticTimelineRoot(operation, document, roots);
         const auto found = blocks.find(root);
         return found == blocks.end() ? SemanticTimelineBlock {} : found->second;
     }
@@ -550,6 +612,7 @@ public:
 private:
     const App::Document* document {};
     std::unordered_map<const App::DocumentObject*, SemanticTimelineBlock> blocks;
+    mutable std::unordered_map<const App::DocumentObject*, const App::DocumentObject*> roots;
     std::vector<SemanticTimelineBlock> orderedBlocks;
     bool valid {false};
 };
@@ -936,6 +999,68 @@ private:
 
 }  // namespace
 
+struct FeatureTimeline::RebuildState
+{
+    enum class Phase
+    {
+        CaptureProjection,
+        WaitProjection,
+        Scan,
+        RemoveItems,
+        AddItems,
+        Finish,
+    };
+
+    struct VisibleOperation
+    {
+        TimelineObjectIdentity identity;
+        std::size_t operationIndex {};
+        SemanticTimelineBlock block;
+        bool active {false};
+    };
+
+    std::uint64_t requestGeneration {};
+    std::uint64_t documentGeneration {};
+    TimelineDocumentIdentity documentIdentity;
+    TimelineObjectIdentity controllerIdentity;
+    std::span<App::DocumentObject* const> operations;
+    std::shared_ptr<SemanticTimelineLayout> semanticLayout;
+    std::shared_ptr<const ModelTreeBrowserProjection> projection;
+    std::stop_source cancellation;
+    const std::unordered_set<App::DocumentObject*>* internalTransformations {};
+    std::vector<VisibleOperation> visibleOperations;
+    std::size_t scanIndex {};
+    std::size_t addIndex {};
+    int position {};
+    int lastActiveVisible {-1};
+    int activeVisibleCount {};
+    bool historyEnabled {false};
+    bool recomputeEnabled {false};
+    bool previousEnabled {false};
+    bool nextEnabled {false};
+    bool endEnabled {false};
+    bool markerAdded {false};
+    QListWidgetItem* stateMarker {};
+    QString emptyMessage;
+    QString toolTip;
+    QElapsedTimer elapsed;
+    Phase phase {Phase::Scan};
+
+    ~RebuildState() { cancellation.request_stop(); }
+};
+
+struct FeatureTimeline::PresentationRefreshState
+{
+    std::uint64_t documentGeneration {};
+    TimelineDocumentIdentity documentIdentity;
+    std::unordered_set<long> objectIds;
+    std::unordered_set<QListWidgetItem*> refreshedItems;
+    std::unordered_set<QListWidgetItem*>::const_iterator item;
+    bool iteratingItems {false};
+    std::size_t dirtyObjectCount {};
+    QElapsedTimer elapsed;
+};
+
 FeatureTimeline::FeatureTimeline(QWidget* parent)
     : QWidget(parent)
     , SelectionObserver(true, ResolveMode::OldStyleElement)
@@ -1073,7 +1198,7 @@ FeatureTimeline::FeatureTimeline(QWidget* parent)
     refreshTimer->setSingleShot(true);
     refreshTimer->setInterval(0);
 
-    connect(refreshTimer, &QTimer::timeout, this, &FeatureTimeline::rebuild);
+    connect(refreshTimer, &QTimer::timeout, this, &FeatureTimeline::processRefresh);
     connect(
         timeline,
         &QListWidget::itemSelectionChanged,
@@ -1104,11 +1229,31 @@ FeatureTimeline::FeatureTimeline(QWidget* parent)
     recomputeRequestFinishedConnection
         = App::GetApplication().signalRecomputeRequestFinished.connect(
             [this](const std::string& documentName) {
-                if (documentName == observedDocumentName) {
-                    scheduleRefresh();
-                }
+                dispatchToGuiFrame(this, [this, documentName] {
+                    if (documentName == observedDocumentName) {
+                        scheduleControlRefresh();
+                    }
+                });
             }
         );
+    finishRestoreDocumentConnection =
+        App::GetApplication().signalFinishRestoreDocument.connect(
+            [this](const App::Document& restored) {
+                if (&restored != observedAppDocument) {
+                    return;
+                }
+                // Record the refresh even if the worker's outer restore scope
+                // is still active. The idle connections below wake it again.
+                QTimer::singleShot(0, this, [this] { scheduleRefresh(); });
+            }
+        );
+    const auto restoreIdle = [this] {
+        dispatchToGuiFrame(this, [this] {
+            if (auto* document = activeAppDocument()) { scheduleStableRefresh(*document); }
+        });
+    };
+    restoreActivityIdleConnection = App::GetApplication().signalRestoreActivityIdle.connect(restoreIdle);
+    finishOpenDocumentConnection = App::GetApplication().signalFinishOpenDocument.connect(restoreIdle);
 
     if (Gui::Application::Instance) {
         activeDocumentConnection = Gui::Application::Instance->signalActiveDocument.connect(
@@ -1138,6 +1283,9 @@ FeatureTimeline::FeatureTimeline(QWidget* parent)
 
 FeatureTimeline::~FeatureTimeline()
 {
+    restoreActivityIdleConnection.disconnect();
+    finishOpenDocumentConnection.disconnect();
+    releasePresentationUpdate();
     detachDocument();
 }
 
@@ -1174,7 +1322,13 @@ void FeatureTimeline::setObservedDocument(Gui::Document* document)
     changedObjectConnection.disconnect();
     touchedObjectConnection.disconnect();
     recomputedObjectConnection.disconnect();
+    releasePresentationUpdate();
     detachDocument();
+    rebuildState.reset();
+    presentationRefreshState.reset();
+    pendingPresentationObjects.clear();
+    fullRefreshPending = false;
+    controlRefreshPending = false;
     observedAppDocument = nextDocument;
     observedDocumentName = nextName;
     ++observedDocumentGeneration;
@@ -1182,19 +1336,28 @@ void FeatureTimeline::setObservedDocument(Gui::Document* document)
     if (document && nextDocument) {
         attachDocument(document);
         bookedTransactionConnection = document->getDocument()->signalBookedTransactionChanged.connect(
-            [this](const App::Document&, int, int) { scheduleRefresh(); }
+            [this](const App::Document&, int, int) { scheduleControlRefresh(); }
         );
         stableDocumentConnection = document->getDocument()->signalBecameStable.connect(
-            [this](const App::Document&) { scheduleRefresh(); }
+            [this](const App::Document& stableDocument) {
+                scheduleStableRefresh(const_cast<App::Document&>(stableDocument));
+            }
         );
         changedObjectConnection = document->getDocument()->signalChangedObject.connect(
-            [this](const App::DocumentObject&, const App::Property&) { scheduleRefresh(); }
+            [this](const App::DocumentObject& object, const App::Property& property) {
+                if (timelineStructureProperty(object, property)) {
+                    scheduleRefresh();
+                }
+                else {
+                    scheduleObjectRefresh(object);
+                }
+            }
         );
         touchedObjectConnection = document->getDocument()->signalTouchedObject.connect(
-            [this](const App::DocumentObject&) { scheduleRefresh(); }
+            [this](const App::DocumentObject& object) { scheduleObjectRefresh(object); }
         );
         recomputedObjectConnection = document->getDocument()->signalRecomputedObject.connect(
-            [this](const App::DocumentObject&) { scheduleRefresh(); }
+            [this](const App::DocumentObject& object) { scheduleObjectRefresh(object); }
         );
     }
 
@@ -1203,9 +1366,138 @@ void FeatureTimeline::setObservedDocument(Gui::Document* document)
 
 void FeatureTimeline::scheduleRefresh()
 {
+    if (QThread::currentThread() != thread()) {
+        dispatchToGuiFrame(this, [this] { scheduleRefresh(); });
+        return;
+    }
+    fullRefreshPending = true;
+    ++requestedRefreshGeneration;
+    if (Gui::Document::projectionRefreshBlocked(activeAppDocument())) {
+        rebuildState.reset();
+        presentationRefreshState.reset();
+        return;
+    }
+    startRefreshTimer();
+}
+
+void FeatureTimeline::scheduleObjectRefresh(const App::DocumentObject& object)
+{
+    const long objectId = object.getID();
+    const std::string documentName = object.getDocument() ? object.getDocument()->getName() : "";
+    if (QThread::currentThread() != thread()) {
+        dispatchToGuiFrame(this, [this, documentName, objectId] {
+            auto* document = activeAppDocument();
+            if (document && document->getName() == documentName) {
+                scheduleObjectRefresh(objectId);
+            }
+        });
+        return;
+    }
+    auto* document = activeAppDocument();
+    if (document && document->getName() == documentName) {
+        scheduleObjectRefresh(objectId);
+    }
+}
+
+void FeatureTimeline::scheduleObjectRefresh(long objectId)
+{
+    if (objectId < 0) {
+        return;
+    }
+    pendingPresentationObjects.insert(objectId);
+    if (!Gui::Document::projectionRefreshBlocked(activeAppDocument())) {
+        startRefreshTimer();
+    }
+}
+
+void FeatureTimeline::scheduleControlRefresh()
+{
+    if (QThread::currentThread() != thread()) {
+        dispatchToGuiFrame(this, [this] { scheduleControlRefresh(); });
+        return;
+    }
+    controlRefreshPending = true;
+    if (!Gui::Document::projectionRefreshBlocked(activeAppDocument())) {
+        startRefreshTimer();
+    }
+}
+
+void FeatureTimeline::scheduleStableRefresh(App::Document& document)
+{
+    if (QThread::currentThread() != thread()) {
+        const std::string documentName = document.getName();
+        dispatchToGuiFrame(this, [this, documentName] {
+            auto* current = activeAppDocument();
+            if (current && current->getName() == documentName) {
+                scheduleStableRefresh(*current);
+            }
+        });
+        return;
+    }
+    if (&document != activeAppDocument()) {
+        return;
+    }
+    if (fullRefreshPending || rebuildState || presentationRefreshState
+        || !pendingPresentationObjects.empty() || controlRefreshPending) {
+        acquirePresentationUpdate(document);
+        startRefreshTimer();
+    }
+}
+
+void FeatureTimeline::startRefreshTimer()
+{
     if (refreshTimer && !refreshTimer->isActive()) {
         refreshTimer->start();
     }
+}
+
+void FeatureTimeline::processRefresh()
+{
+    auto* document = activeAppDocument();
+    if (Gui::Document::projectionRefreshBlocked(document)) {
+        if (rebuildState) {
+            fullRefreshPending = true;
+        }
+        if (presentationRefreshState) {
+            pendingPresentationObjects.merge(presentationRefreshState->objectIds);
+        }
+        rebuildState.reset();
+        presentationRefreshState.reset();
+        return;
+    }
+    if (rebuildState) {
+        rebuild();
+        return;
+    }
+    if (fullRefreshPending) {
+        fullRefreshPending = false;
+        controlRefreshPending = false;
+        pendingPresentationObjects.clear();
+        presentationRefreshState.reset();
+        rebuild();
+        return;
+    }
+    refreshPresentation();
+}
+
+void FeatureTimeline::acquirePresentationUpdate(App::Document& document)
+{
+    if (presentationUpdateDocument == &document) {
+        return;
+    }
+    releasePresentationUpdate();
+    document.beginPresentationUpdate();
+    presentationUpdateDocument = &document;
+}
+
+void FeatureTimeline::releasePresentationUpdate()
+{
+    if (!presentationUpdateDocument) {
+        return;
+    }
+    auto* document = presentationUpdateDocument;
+    presentationUpdateDocument = nullptr;
+    document->endPresentationUpdate();
 }
 
 bool FeatureTimeline::canChangeHistory() const
@@ -1224,6 +1516,198 @@ bool FeatureTimeline::canChangeHistory() const
         && editAllowsHistory && !Gui::Control().activeDialog(document);
 }
 
+void FeatureTimeline::updateTimelineItemPresentation(
+    QListWidgetItem* item,
+    App::DocumentObject* object,
+    App::DocumentObject* owner
+)
+{
+    if (!item || !object) {
+        return;
+    }
+
+    const bool isCurrent = item->data(IsCurrentRole).toBool();
+    const bool afterPosition = item->data(IsAfterPositionRole).toBool();
+    const auto presentationVisible = timelinePresentationVisibility(object, owner);
+    const QString label = objectLabel(object);
+    const QString ownerLabel = owner && owner != object ? objectLabel(owner) : QString();
+    const QString statusText = timelineStatusText(object);
+    item->setData(
+        Qt::AccessibleTextRole,
+        statusText.isEmpty() ? label : tr("%1, %2").arg(label, statusText)
+    );
+
+    if (Gui::Application::Instance) {
+        item->setIcon({});
+        const auto* editor = App::DocumentTimeline::timelineEditor(object);
+        const auto* iconObject = editor ? editor : object;
+        if (auto* viewProvider = dynamic_cast<Gui::ViewProviderDocumentObject*>(
+                Gui::Application::Instance->getViewProvider(iconObject)
+            )) {
+            item->setIcon(
+                timelineObjectIcon(
+                    viewProvider->getIcon(),
+                    object,
+                    afterPosition,
+                    presentationVisible
+                )
+            );
+        }
+    }
+
+    QFont font = timeline->font();
+    font.setBold(isCurrent);
+    if (object->hasExtension(App::SuppressibleExtension::getExtensionClassTypeId())) {
+        if (auto* suppressible = object->getExtensionByType<App::SuppressibleExtension>()) {
+            font.setStrikeOut(suppressible->Suppressed.getValue());
+        }
+    }
+    item->setFont(font);
+
+    const QString ownershipText = ownerLabel.isEmpty() ? QString()
+                                                       : tr("\nPart: %1").arg(ownerLabel);
+    const bool bodyOwned = ModelTreeBrowserProjection::isBody(owner);
+    const QString visibilityLabel = bodyOwned ? tr("Body visibility") : tr("Visibility");
+    const QString visibilityText = !presentationVisible.has_value()
+        ? QString()
+        : *presentationVisible ? tr("\n%1: Visible").arg(visibilityLabel)
+                               : tr("\n%1: Hidden").arg(visibilityLabel);
+    if (afterPosition) {
+        item->setForeground(palette().brush(QPalette::Disabled, QPalette::Text));
+        item->setToolTip(
+            statusText.isEmpty()
+                ? tr("%1%2%3\nAfter the current document state")
+                      .arg(label, ownershipText, visibilityText)
+                : tr("%1%2%3\n%4\nAfter the current document state")
+                      .arg(label, ownershipText, visibilityText, statusText)
+        );
+    }
+    else if (isCurrent) {
+        item->setForeground(palette().brush(QPalette::Active, QPalette::Link));
+        item->setToolTip(
+            statusText.isEmpty()
+                ? tr("%1%2%3\nCurrent document state")
+                      .arg(label, ownershipText, visibilityText)
+                : tr("%1%2%3\n%4\nCurrent document state")
+                      .arg(label, ownershipText, visibilityText, statusText)
+        );
+    }
+    else {
+        item->setData(Qt::ForegroundRole, QVariant());
+        item->setToolTip(
+            statusText.isEmpty()
+                ? tr("%1%2%3").arg(label, ownershipText, visibilityText)
+                : tr("%1%2%3\n%4").arg(label, ownershipText, visibilityText, statusText)
+        );
+    }
+}
+
+void FeatureTimeline::refreshPresentation()
+{
+    auto* document = activeAppDocument();
+    if (!document) {
+        pendingPresentationObjects.clear();
+        controlRefreshPending = false;
+        presentationRefreshState.reset();
+        releasePresentationUpdate();
+        return;
+    }
+    if (Gui::Document::projectionRefreshBlocked(document)) {
+        if (presentationRefreshState) {
+            pendingPresentationObjects.merge(presentationRefreshState->objectIds);
+        }
+        presentationRefreshState.reset();
+        return;
+    }
+
+    if (!presentationRefreshState) {
+        auto state = std::make_unique<PresentationRefreshState>();
+        state->documentGeneration = observedDocumentGeneration;
+        state->documentIdentity = documentIdentity(document);
+        state->objectIds = std::move(pendingPresentationObjects);
+        pendingPresentationObjects.clear();
+        controlRefreshPending = false;
+        state->dirtyObjectCount = state->objectIds.size();
+        state->elapsed.start();
+        presentationRefreshState = std::move(state);
+    }
+
+    QSignalBlocker timelineBlocker(timeline);
+    FrameBudget budget;
+    auto* state = presentationRefreshState.get();
+    while (!state->objectIds.empty() && !budget.exhausted()) {
+        const auto dirty = state->objectIds.begin();
+        const auto rows = itemsByObject.find(*dirty);
+        if (rows == itemsByObject.end()) {
+            state->objectIds.erase(dirty);
+            continue;
+        }
+        if (!state->iteratingItems) {
+            state->item = rows->second.begin();
+            state->iteratingItems = true;
+        }
+        if (state->item == rows->second.end()) {
+            state->objectIds.erase(dirty);
+            state->iteratingItems = false;
+            continue;
+        }
+        auto* item = *state->item++;
+        // Both an operation and its owner may be dirty in this epoch.
+        if (!state->refreshedItems.insert(item).second) {
+            continue;
+        }
+        const long objectId = item->data(ObjectIdRole).toLongLong();
+        const long ownerId = item->data(OwnerIdRole).toLongLong();
+
+        auto* currentDocument = resolveDocument(state->documentIdentity);
+        auto* object = resolveObject(
+            currentDocument,
+            item->data(ObjectNameRole).toString().toStdString(),
+            objectId
+        );
+        auto* owner = ownerId < 0
+            ? nullptr
+            : resolveObject(
+                  currentDocument,
+                  item->data(OwnerNameRole).toString().toStdString(),
+                  ownerId
+              );
+        if (!currentDocument || observedDocumentGeneration != state->documentGeneration || !object) {
+            presentationRefreshState.reset();
+            scheduleRefresh();
+            startRefreshTimer();
+            return;
+        }
+        updateTimelineItemPresentation(item, object, owner);
+    }
+    if (!state->objectIds.empty()) {
+        dispatchToGuiFrame(this, [this] { processRefresh(); });
+        return;
+    }
+
+    const qint64 elapsed = state->elapsed.elapsed();
+    const std::size_t projectedObjects = state->dirtyObjectCount;
+    presentationRefreshState.reset();
+    syncSelectionFromGui();
+    if (Gui::Application::Instance) {
+        auto* command = Gui::Application::Instance->commandManager().getCommandByName("Std_Refresh");
+        recomputeButton->setEnabled(canChangeHistory() && command && command->canInvoke());
+    }
+    if (qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE")) {
+        Base::Console().message(
+            "VIBECAD_PROJECTION history total_ms=%lld objects=%zu full=0\n",
+            static_cast<long long>(elapsed),
+            projectedObjects
+        );
+    }
+    if (fullRefreshPending || !pendingPresentationObjects.empty() || controlRefreshPending) {
+        startRefreshTimer();
+    }
+    else {
+        releasePresentationUpdate();
+    }
+}
+
 void FeatureTimeline::rebuild()
 {
     App::Document* document = activeAppDocument();
@@ -1236,91 +1720,231 @@ void FeatureTimeline::rebuild()
         previousButton->setEnabled(false);
         nextButton->setEnabled(false);
         endButton->setEnabled(false);
+        if (rebuildState) {
+            fullRefreshPending = true;
+            rebuildState.reset();
+        }
         return;
     }
 
-    if (auto* timelineList = dynamic_cast<TimelineListWidget*>(timeline)) {
-        timelineList->cancelMarkerDrag();
-    }
     QScopedValueRollback rebuildingGuard(rebuildingTimeline, true);
     QSignalBlocker timelineBlocker(timeline);
+    FrameBudget budget;
 
-    timeline->clear();
-    timeline->setEnabled(false);
-    recomputeButton->setEnabled(false);
-    previousButton->setEnabled(false);
-    nextButton->setEnabled(false);
-    endButton->setEnabled(false);
-
-    if (!document) {
-        auto* empty = new QListWidgetItem(tr("Open a document to see its feature history"));
-        empty->setFlags(Qt::NoItemFlags);
-        timeline->addItem(empty);
-        return;
+    if (rebuildState
+        && (rebuildState->requestGeneration != requestedRefreshGeneration
+            || rebuildState->documentGeneration != observedDocumentGeneration)) {
+        // A document notification arrived between cooperative slices. The
+        // partial list contains presentation data only, so discard its build
+        // state and rebuild from the newest authoritative document snapshot.
+        rebuildState.reset();
     }
 
-    if (Gui::Application::Instance) {
-        auto* command = Gui::Application::Instance->commandManager().getCommandByName(
-            "Std_Refresh"
-        );
-        recomputeButton->setEnabled(
-            canChangeHistory() && command && command->canInvoke()
-        );
+    if (!rebuildState) {
+        if (auto* timelineList = dynamic_cast<TimelineListWidget*>(timeline)) {
+            timelineList->cancelMarkerDrag();
+        }
+        timeline->setEnabled(false);
+        recomputeButton->setEnabled(false);
+        previousButton->setEnabled(false);
+        nextButton->setEnabled(false);
+        endButton->setEnabled(false);
+
+        auto state = std::make_unique<RebuildState>();
+        state->requestGeneration = requestedRefreshGeneration;
+        state->documentGeneration = observedDocumentGeneration;
+        state->documentIdentity = ::documentIdentity(document);
+        state->elapsed.start();
+
+        if (!document) {
+            state->emptyMessage = tr("Open a document to see its feature history");
+            state->phase = RebuildState::Phase::RemoveItems;
+        }
+        else {
+            if (Gui::Application::Instance) {
+                auto* command = Gui::Application::Instance->commandManager().getCommandByName(
+                    "Std_Refresh"
+                );
+                state->recomputeEnabled = canChangeHistory() && command && command->canInvoke();
+            }
+
+            auto* controller = App::DocumentTimeline::get(document);
+            if (!controller) {
+                state->emptyMessage = tr("Create a modeling operation to begin");
+                state->phase = RebuildState::Phase::RemoveItems;
+            }
+            else {
+                state->controllerIdentity = objectIdentity(controller);
+                state->position = static_cast<int>(std::clamp(
+                    controller->Position.getValue(),
+                    0L,
+                    static_cast<long>(controller->Operations.getValues().size())
+                ));
+                state->phase = RebuildState::Phase::CaptureProjection;
+            }
+        }
+        rebuildState = std::move(state);
     }
 
-    auto* controller = App::DocumentTimeline::get(document);
-    if (!controller) {
-        auto* empty = new QListWidgetItem(tr("Create a modeling operation to begin"));
-        empty->setFlags(Qt::NoItemFlags);
-        timeline->addItem(empty);
-        return;
-    }
-
-    const auto operations = controller->Operations.getValues();
-    const int position = static_cast<int>(
-        std::clamp(controller->Position.getValue(), 0L, static_cast<long>(operations.size()))
-    );
-    const SemanticTimelineLayout semanticLayout(operations, document);
-    ModelTreeBrowserProjection projection(document);
-    const auto internalTransformations = internalTransformationChildren(operations);
-    const bool historyEnabled = canChangeHistory() && semanticLayout.isValid();
-    timeline->setEnabled(historyEnabled);
-
-    const bool transactionBusy = document->getBookedTransactionID() != App::NullTransaction
-        || document->hasPendingTransaction() || document->isPerformingTransaction()
-        || document->isTransactionLocked();
-
-    struct VisibleSemanticBlock
-    {
-        SemanticTimelineBlock block;
-        bool active {false};
+    auto scheduleNextSlice = [this]() {
+        dispatchToGuiFrame(this, [this] { processRefresh(); });
     };
-    std::vector<VisibleSemanticBlock> visibleBlocks;
-    visibleBlocks.reserve(operations.size());
-    int lastActiveVisible = -1;
-    for (std::size_t index = 0; index < operations.size(); ++index) {
-        if (!isVisibleTimelineOperation(operations[index], internalTransformations, projection)) {
-            continue;
+    auto* state = rebuildState.get();
+
+    if (state->phase == RebuildState::Phase::WaitProjection) {
+        return; // Worker completion posts the next owner step; no polling.
+    }
+    if (state->phase == RebuildState::Phase::CaptureProjection) {
+        state->phase = RebuildState::Phase::WaitProjection;
+        const auto request = state->requestGeneration;
+        const auto generation = state->documentGeneration;
+        const auto cancellation = state->cancellation.get_token();
+        const QPointer<FeatureTimeline> lifetime(this);
+        auto ready = [lifetime, request, generation](
+                         std::shared_ptr<const ModelTreeBrowserProjection> projection,
+                         std::shared_ptr<SemanticTimelineLayout> layout,
+                         std::string failure) {
+            dispatchToGuiFrame([lifetime, request, generation,
+                                projection = std::move(projection),
+                                layout = std::move(layout),
+                                failure = std::move(failure)] {
+                if (!lifetime) {
+                    return;
+                }
+                auto* self = lifetime.data();
+                auto* current = self->rebuildState.get();
+                if (!current || current->requestGeneration != request
+                    || current->documentGeneration != generation
+                    || self->requestedRefreshGeneration != request
+                    || self->observedDocumentGeneration != generation) {
+                    return;
+                }
+                if (!projection) {
+                    current->historyEnabled = false;
+                    current->emptyMessage = tr("Could not prepare feature history: %1")
+                        .arg(QString::fromStdString(failure));
+                    current->phase = RebuildState::Phase::RemoveItems;
+                    Base::Console().error("Feature history preparation failed: %s\n", failure.c_str());
+                }
+                else {
+                    if (!projection->isCurrent()) {
+                        self->scheduleRefresh();
+                        self->rebuildState.reset();
+                        self->startRefreshTimer();
+                        return;
+                    }
+                    current->projection = std::move(projection);
+                    current->semanticLayout = std::move(layout);
+                    current->operations = current->projection->timelineOperations();
+                    current->internalTransformations = &current->projection->internalTransformations();
+                    current->historyEnabled = self->canChangeHistory()
+                        && current->semanticLayout->isValid();
+                    current->visibleOperations.reserve(current->operations.size());
+                    current->phase = RebuildState::Phase::Scan;
+                }
+                self->processRefresh();
+            });
+        };
+        try {
+            auto* guiDocument = Gui::Application::Instance
+                ? Gui::Application::Instance->getDocument(document) : nullptr;
+            if (!guiDocument) {
+                throw std::runtime_error("The feature history document was closed");
+            }
+            auto& cache = guiDocument->modelBrowserProjectionCache();
+            cache.observeInvalidation(this, [this, document] {
+                if (activeAppDocument() == document) { scheduleRefresh(); }
+            });
+            cache.request(this,
+                [lifetime, request, generation, ready, cancellation, document]
+                (auto projection, std::string failure) {
+                    if (!lifetime || lifetime->requestedRefreshGeneration != request
+                        || lifetime->observedDocumentGeneration != generation) {
+                        return;
+                    }
+                    if (!projection) {
+                        ready({}, {}, std::move(failure));
+                        return;
+                    }
+                    try {
+                        App::GetApplication().hostRuntime().submitWithCompletion(
+                            App::HostRuntime::Lane::Compute,
+                            [projection, cancellation, document](std::stop_token shutdown) {
+                                Base::CancellationScope shutdownScope(shutdown);
+                                Base::CancellationScope operationScope(cancellation);
+                                Base::CancellationScope::check();
+                                // document is opaque; read only the immutable projection.
+                                return std::make_shared<SemanticTimelineLayout>(
+                                    projection->timelineOperations(), document, projection.get());
+                            },
+                            [projection, ready](std::future<std::shared_ptr<SemanticTimelineLayout>> result) {
+                                try { ready(projection, result.get(), {}); }
+                                catch (const std::exception& error) { ready({}, {}, error.what()); }
+                                catch (...) { ready({}, {}, "History preparation cancelled or failed"); }
+                            });
+                    }
+                    catch (const std::exception& error) {
+                        ready({}, {}, error.what());
+                    }
+                });
         }
-        const auto block = semanticLayout.blockFor(operations[index]);
-        if (!block.isValid()) {
-            continue;
+        catch (const std::exception& failure) {
+            ready({}, {}, failure.what());
         }
-        const bool active = controller->isOperationActive(operations[index]);
-        visibleBlocks.push_back({block, active});
-        if (active) {
-            lastActiveVisible = static_cast<int>(index);
+        return;
+    }
+
+    while (state->phase == RebuildState::Phase::Scan
+           && state->scanIndex < state->operations.size()) {
+        const std::size_t index = state->scanIndex++;
+        auto* operation = state->operations[index];
+        if (operation && operation->isAttachedToDocument()
+            && isVisibleTimelineOperation(
+                operation,
+                *state->internalTransformations,
+                *state->projection
+            )) {
+            const auto block = state->semanticLayout->blockFor(operation);
+            if (block.isValid()) {
+                auto* currentDocument = resolveDocument(state->documentIdentity);
+                auto* controller = dynamic_cast<App::DocumentTimeline*>(
+                    resolveObject(currentDocument, state->controllerIdentity)
+                );
+                if (!controller) {
+                    scheduleRefresh();
+                    rebuildState.reset();
+                    scheduleNextSlice();
+                    return;
+                }
+                const bool active = controller->isOperationActive(operation);
+                state->visibleOperations.push_back(
+                    {objectIdentity(operation), index, block, active}
+                );
+                if (active) {
+                    state->lastActiveVisible = static_cast<int>(index);
+                    ++state->activeVisibleCount;
+                    state->previousEnabled |= block.begin < state->position;
+                }
+                else {
+                    state->nextEnabled |= block.end > state->position;
+                }
+            }
+        }
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
         }
     }
-    const auto activeVisibleCount = static_cast<int>(std::ranges::count_if(
-        visibleBlocks,
-        [](const VisibleSemanticBlock& visible) {
-            return visible.active;
-        }
-    ));
-    timeline->setToolTip(
-        !historyEnabled
-            ? !semanticLayout.isValid()
+
+    if (state->phase == RebuildState::Phase::Scan) {
+        auto* currentDocument = resolveDocument(state->documentIdentity);
+        const bool transactionBusy = currentDocument
+            && (currentDocument->getBookedTransactionID() != App::NullTransaction
+                || currentDocument->hasPendingTransaction()
+                || currentDocument->isPerformingTransaction()
+                || currentDocument->isTransactionLocked());
+        state->toolTip = !state->historyEnabled
+            ? !state->semanticLayout->isValid()
                 ? tr("Document history has invalid operation ownership")
                 : transactionBusy
                 ? tr("Wait for the current document operation to finish")
@@ -1328,38 +1952,52 @@ void FeatureTimeline::rebuild()
                 ? tr("Wait for the document to finish opening")
                 : tr("Finish or cancel the active task before changing model history")
             : tr("Document history: %1 of %2 operations active")
-                  .arg(activeVisibleCount)
-                  .arg(static_cast<int>(visibleBlocks.size()))
-    );
-    const bool hasPrevious = std::ranges::any_of(
-        visibleBlocks,
-        [position](const VisibleSemanticBlock& visible) {
-            return visible.active && visible.block.begin < position;
-        }
-    );
-    const bool hasNext = std::ranges::any_of(
-        visibleBlocks,
-        [position](const VisibleSemanticBlock& visible) {
-            return !visible.active && visible.block.end > position;
-        }
-    );
-    previousButton->setEnabled(historyEnabled && hasPrevious);
-    nextButton->setEnabled(historyEnabled && hasNext);
-    endButton->setEnabled(historyEnabled && position < static_cast<int>(operations.size()));
+                  .arg(state->activeVisibleCount)
+                  .arg(static_cast<int>(state->visibleOperations.size()));
+        state->previousEnabled &= state->historyEnabled;
+        state->nextEnabled &= state->historyEnabled;
+        state->endEnabled = state->historyEnabled
+            && state->position < static_cast<int>(state->operations.size());
+        state->phase = RebuildState::Phase::RemoveItems;
+    }
 
-    int operationCount = 0;
-    bool markerAdded = false;
-    QListWidgetItem* stateMarker = nullptr;
-    auto addCurrentStateMarker = [&]() {
-        auto* marker = new QListWidgetItem(tr("▮"));
-        marker->setData(DocumentNameRole, QString::fromStdString(document->getName()));
+    while (state->phase == RebuildState::Phase::RemoveItems && timeline->count() > 0) {
+        auto* item = timeline->takeItem(timeline->count() - 1);
+        if (item->data(ObjectIdRole).isValid()) {
+            for (const auto role : {ObjectIdRole, OwnerIdRole}) {
+                const auto found = itemsByObject.find(item->data(role).toLongLong());
+                if (found != itemsByObject.end()) {
+                    found->second.erase(item);
+                    if (found->second.empty()) {
+                        itemsByObject.erase(found);
+                    }
+                }
+            }
+        }
+        delete item;
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
+        }
+    }
+    if (state->phase == RebuildState::Phase::RemoveItems) {
+        state->phase = RebuildState::Phase::AddItems;
+    }
+
+    auto addCurrentStateMarker = [this, state]() {
+        auto* currentDocument = resolveDocument(state->documentIdentity);
+        if (!currentDocument) {
+            return false;
+        }
+        auto* marker = new QListWidgetItem(QString(QChar(0x25AE)));
+        marker->setData(DocumentNameRole, QString::fromStdString(currentDocument->getName()));
         marker->setData(
             DocumentGenerationRole,
-            QVariant::fromValue<qulonglong>(observedDocumentGeneration)
+            QVariant::fromValue<qulonglong>(state->documentGeneration)
         );
         marker->setData(IsCurrentRole, false);
         marker->setData(IsAfterPositionRole, false);
-        marker->setData(OperationIndexRole, position);
+        marker->setData(OperationIndexRole, state->position);
         marker->setData(IsMarkerRole, true);
         marker->setData(Qt::AccessibleTextRole, tr("Current document state"));
         marker->setFlags(Qt::ItemIsEnabled);
@@ -1371,29 +2009,44 @@ void FeatureTimeline::rebuild()
                               "Drag to roll the complete document backward or forward"));
         marker->setSizeHint(QSize(22, timelineItemHeight));
         timeline->addItem(marker);
-        stateMarker = marker;
-        markerAdded = true;
+        state->stateMarker = marker;
+        state->markerAdded = true;
+        return true;
     };
 
-    for (std::size_t index = 0; index < operations.size(); ++index) {
-        auto* object = operations[index];
-        if (!object || !object->isAttachedToDocument()
-            || !isVisibleTimelineOperation(object, internalTransformations, projection)) {
-            continue;
+    while (state->phase == RebuildState::Phase::AddItems
+           && state->addIndex < state->visibleOperations.size()) {
+        const auto& visible = state->visibleOperations[state->addIndex];
+        auto* currentDocument = resolveDocument(state->documentIdentity);
+        auto* controller = dynamic_cast<App::DocumentTimeline*>(
+            resolveObject(currentDocument, state->controllerIdentity)
+        );
+        auto* object = resolveObject(currentDocument, visible.identity);
+        if (!controller || !object) {
+            scheduleRefresh();
+            rebuildState.reset();
+            scheduleNextSlice();
+            return;
         }
 
-        if (!markerAdded && static_cast<int>(index) >= position) {
-            addCurrentStateMarker();
+        if (!state->markerAdded
+            && static_cast<int>(visible.operationIndex) >= state->position) {
+            if (!addCurrentStateMarker()) {
+                scheduleRefresh();
+                rebuildState.reset();
+                scheduleNextSlice();
+                return;
+            }
+            if (budget.exhausted()) {
+                scheduleNextSlice();
+                return;
+            }
         }
 
-        const bool isCurrent = static_cast<int>(index) == lastActiveVisible;
-        const bool afterPosition = !controller->isOperationActive(object);
-        auto* owner = operationOwner(object, projection);
-        const std::optional<bool> presentationVisible =
-            timelinePresentationVisibility(object, owner);
-        const QString label = objectLabel(object);
-        const QString ownerLabel = owner && owner != object ? objectLabel(owner) : QString();
-        const QString statusText = timelineStatusText(object);
+        const bool isCurrent = static_cast<int>(visible.operationIndex)
+            == state->lastActiveVisible;
+        const bool afterPosition = !visible.active;
+        auto* owner = operationOwner(object, *state->projection);
         auto* item = new QListWidgetItem;
         item->setData(ObjectNameRole, QString::fromUtf8(object->getNameInDocument()));
         item->setData(ObjectIdRole, QVariant::fromValue<qlonglong>(object->getID()));
@@ -1403,106 +2056,85 @@ void FeatureTimeline::rebuild()
                                                 : QString()
         );
         item->setData(OwnerIdRole, QVariant::fromValue<qlonglong>(owner ? owner->getID() : -1));
-        item->setData(DocumentNameRole, QString::fromStdString(document->getName()));
+        item->setData(DocumentNameRole, QString::fromStdString(currentDocument->getName()));
         item->setData(
             DocumentGenerationRole,
-            QVariant::fromValue<qulonglong>(observedDocumentGeneration)
+            QVariant::fromValue<qulonglong>(state->documentGeneration)
         );
         item->setData(IsCurrentRole, isCurrent);
         item->setData(IsAfterPositionRole, afterPosition);
-        item->setData(OperationIndexRole, static_cast<qlonglong>(index));
+        item->setData(OperationIndexRole, static_cast<qlonglong>(visible.operationIndex));
         item->setData(IsMarkerRole, false);
-        item->setData(
-            Qt::AccessibleTextRole,
-            statusText.isEmpty() ? label : tr("%1, %2").arg(label, statusText)
-        );
-
-        if (Gui::Application::Instance) {
-            const auto* editor = App::DocumentTimeline::timelineEditor(object);
-            const auto* iconObject = editor ? editor : object;
-            if (auto* viewProvider = dynamic_cast<Gui::ViewProviderDocumentObject*>(
-                    Gui::Application::Instance->getViewProvider(iconObject)
-                )) {
-                const QIcon icon = viewProvider->getIcon();
-                item->setIcon(
-                    timelineObjectIcon(
-                        icon,
-                        object,
-                        afterPosition,
-                        presentationVisible
-                    )
-                );
-            }
-        }
-
-        QFont font = timeline->font();
-        font.setBold(isCurrent);
-        if (object->hasExtension(App::SuppressibleExtension::getExtensionClassTypeId())) {
-            if (auto* suppressible = object->getExtensionByType<App::SuppressibleExtension>()) {
-                font.setStrikeOut(suppressible->Suppressed.getValue());
-            }
-        }
-        item->setFont(font);
-
-        const QString ownershipText = ownerLabel.isEmpty() ? QString()
-                                                           : tr("\nPart: %1").arg(ownerLabel);
-        const bool bodyOwned = ModelTreeBrowserProjection::isBody(owner);
-        const QString visibilityLabel = bodyOwned ? tr("Body visibility") : tr("Visibility");
-        const QString visibilityText = !presentationVisible.has_value()
-            ? QString()
-            : *presentationVisible ? tr("\n%1: Visible").arg(visibilityLabel)
-                                   : tr("\n%1: Hidden").arg(visibilityLabel);
-        if (afterPosition) {
-            item->setForeground(palette().brush(QPalette::Disabled, QPalette::Text));
-            item->setToolTip(
-                statusText.isEmpty()
-                    ? tr("%1%2%3\nAfter the current document state")
-                          .arg(label, ownershipText, visibilityText)
-                    : tr("%1%2%3\n%4\nAfter the current document state")
-                          .arg(label, ownershipText, visibilityText, statusText)
-            );
-        }
-        else if (isCurrent) {
-            item->setForeground(palette().brush(QPalette::Active, QPalette::Link));
-            item->setToolTip(
-                statusText.isEmpty()
-                    ? tr("%1%2%3\nCurrent document state")
-                          .arg(label, ownershipText, visibilityText)
-                    : tr("%1%2%3\n%4\nCurrent document state")
-                          .arg(label, ownershipText, visibilityText, statusText)
-            );
-        }
-        else {
-            item->setToolTip(
-                statusText.isEmpty()
-                    ? tr("%1%2%3").arg(label, ownershipText, visibilityText)
-                    : tr("%1%2%3\n%4").arg(label, ownershipText, visibilityText, statusText)
-            );
-        }
-
+        updateTimelineItemPresentation(item, object, owner);
         item->setSizeHint(QSize(timelineItemWidth, timelineItemHeight));
         timeline->addItem(item);
-        ++operationCount;
+        itemsByObject[object->getID()].insert(item);
+        if (owner) {
+            itemsByObject[owner->getID()].insert(item);
+        }
+        ++state->addIndex;
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
+        }
     }
 
-    if (!markerAdded) {
-        addCurrentStateMarker();
+    if (state->phase == RebuildState::Phase::AddItems) {
+        if (!state->emptyMessage.isEmpty()) {
+            auto* empty = new QListWidgetItem(state->emptyMessage);
+            empty->setFlags(Qt::NoItemFlags);
+            timeline->addItem(empty);
+        }
+        else {
+            if (!state->markerAdded && !addCurrentStateMarker()) {
+                scheduleRefresh();
+                rebuildState.reset();
+                scheduleNextSlice();
+                return;
+            }
+            if (state->visibleOperations.empty()) {
+                auto* empty = new QListWidgetItem(tr("No modeling operations in this document"));
+                empty->setFlags(Qt::NoItemFlags);
+                timeline->addItem(empty);
+            }
+        }
+        state->phase = RebuildState::Phase::Finish;
     }
 
-    if (operationCount == 0) {
-        auto* empty = new QListWidgetItem(tr("No modeling operations in this document"));
-        empty->setFlags(Qt::NoItemFlags);
-        timeline->addItem(empty);
-    }
-
-    timelineBlocker.unblock();
-    if (stateMarker) {
+    if (state->phase == RebuildState::Phase::Finish) {
+        timeline->setToolTip(state->toolTip);
+        timeline->setEnabled(state->historyEnabled);
+        recomputeButton->setEnabled(state->recomputeEnabled);
+        previousButton->setEnabled(state->previousEnabled);
+        nextButton->setEnabled(state->nextEnabled);
+        endButton->setEnabled(state->endEnabled);
+        auto* stateMarker = state->stateMarker;
+        const qint64 elapsed = state->elapsed.elapsed();
+        const std::size_t projectedObjects = state->visibleOperations.size();
+        timelineBlocker.unblock();
+        rebuildState.reset();
+        if (stateMarker) {
         // QListWidget resets its horizontal position when rebuilt. Reveal the
         // end-of-history marker first; syncSelectionFromGui() deliberately runs
         // afterward so an ordinary object selection still takes precedence.
-        timeline->scrollToItem(stateMarker, QAbstractItemView::EnsureVisible);
+            timeline->scrollToItem(stateMarker, QAbstractItemView::EnsureVisible);
+        }
+        syncSelectionFromGui();
+        if (qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE")) {
+            Base::Console().message(
+                "VIBECAD_PROJECTION history total_ms=%lld objects=%zu full=1\n",
+                static_cast<long long>(elapsed),
+                projectedObjects
+            );
+        }
+        if (fullRefreshPending || !pendingPresentationObjects.empty()
+            || controlRefreshPending) {
+            startRefreshTimer();
+        }
+        else {
+            releasePresentationUpdate();
+        }
     }
-    syncSelectionFromGui();
 }
 
 void FeatureTimeline::activateOwningBody(App::DocumentObject* object)
@@ -1602,35 +2234,58 @@ void FeatureTimeline::onTimelineSelectionChanged()
 
 void FeatureTimeline::syncSelectionFromGui()
 {
-    if (syncingSelection) {
+    if (syncingSelection || rebuildState
+        || Gui::Document::projectionRefreshBlocked(activeAppDocument())) {
         return;
     }
     App::Document* document = activeAppDocument();
     QScopedValueRollback syncingGuard(syncingSelection, true);
     QSignalBlocker blocker(timeline);
 
-    std::unordered_set<App::DocumentObject*> selectedObjects;
+    std::vector<int> selectedRows;
+    std::unordered_set<long> selectedIds;
     if (document) {
         for (const auto& selection :
              Gui::Selection().getSelection(document->getName(), ResolveMode::OldStyleElement)) {
-            if (selection.pObject) {
-                selectedObjects.insert(selection.pObject);
+            if (!selection.pObject) {
+                continue;
+            }
+            const auto id = selection.pObject->getID();
+            if (!selectedIds.insert(id).second) {
+                continue;
+            }
+            const auto found = itemsByObject.find(id);
+            if (found == itemsByObject.end()) {
+                continue;
+            }
+            for (auto* item : found->second) {
+                // The presentation index also includes owner dependencies.
+                // Selecting an owner must not select every operation it owns.
+                if (item->data(ObjectIdRole).toLongLong() == id
+                    && itemBelongsToObservedDocument(item)) {
+                    selectedRows.push_back(timeline->row(item));
+                }
             }
         }
     }
 
-    QListWidgetItem* firstSelected = nullptr;
-    for (int row = 0; row < timeline->count(); ++row) {
-        auto* item = timeline->item(row);
-        const bool selected = selectedObjects.contains(objectForItem(item));
-        item->setSelected(selected);
-        if (selected && !firstSelected) {
-            firstSelected = item;
+    std::ranges::sort(selectedRows);
+    selectedRows.erase(std::unique(selectedRows.begin(), selectedRows.end()), selectedRows.end());
+    QItemSelection selected;
+    for (std::size_t index = 0; index < selectedRows.size();) {
+        const int first = selectedRows[index];
+        int last = first;
+        while (++index < selectedRows.size() && selectedRows[index] == last + 1) {
+            last = selectedRows[index];
         }
+        selected.select(timeline->model()->index(first, 0), timeline->model()->index(last, 0));
     }
-    if (firstSelected) {
-        timeline->setCurrentItem(firstSelected);
-        timeline->scrollToItem(firstSelected, QAbstractItemView::EnsureVisible);
+    auto* selectionModel = timeline->selectionModel();
+    selectionModel->select(selected, QItemSelectionModel::ClearAndSelect);
+    if (!selectedRows.empty()) {
+        const auto first = timeline->model()->index(selectedRows.front(), 0);
+        selectionModel->setCurrentIndex(first, QItemSelectionModel::NoUpdate);
+        timeline->scrollTo(first, QAbstractItemView::EnsureVisible);
     }
 }
 
@@ -1644,12 +2299,9 @@ void FeatureTimeline::onSelectionChanged(const SelectionChanges& message)
         case SelectionChanges::SetSelection:
         case SelectionChanges::RmvSelection:
         case SelectionChanges::ClrSelection:
-            syncSelectionFromGui();
-            // Selection observers can be called before the singleton finishes
-            // publishing its new aggregate selection. Re-check once the event
-            // loop settles so clicks in the 3D view and tree always reach the
-            // same global timeline without changing its contents.
-            QTimer::singleShot(0, this, [this]() { syncSelectionFromGui(); });
+            // The existing single-shot projection scheduler coalesces the
+            // notification burst and reads selection after publication ends.
+            scheduleControlRefresh();
             break;
         default:
             break;
@@ -2961,24 +3613,31 @@ void FeatureTimeline::slotDeletedObject(const ViewProviderDocumentObject&)
     scheduleRefresh();
 }
 
-void FeatureTimeline::slotChangedObject(const ViewProviderDocumentObject&, const App::Property&)
+void FeatureTimeline::slotChangedObject(
+    const ViewProviderDocumentObject& viewProvider,
+    const App::Property&
+)
 {
-    scheduleRefresh();
+    if (auto* object = viewProvider.getObject()) {
+        scheduleObjectRefresh(*object);
+    }
 }
 
-void FeatureTimeline::slotRelabelObject(const ViewProviderDocumentObject&)
+void FeatureTimeline::slotRelabelObject(const ViewProviderDocumentObject& viewProvider)
 {
-    scheduleRefresh();
+    if (auto* object = viewProvider.getObject()) {
+        scheduleObjectRefresh(*object);
+    }
 }
 
 void FeatureTimeline::slotEnterEditObject(const ViewProviderDocumentObject&)
 {
-    scheduleRefresh();
+    scheduleControlRefresh();
 }
 
 void FeatureTimeline::slotResetEditObject(const ViewProviderDocumentObject&)
 {
-    scheduleRefresh();
+    scheduleControlRefresh();
 }
 
 void FeatureTimeline::slotUndoDocument(const Gui::Document&)

--- a/src/Gui/FeatureTimeline.h
+++ b/src/Gui/FeatureTimeline.h
@@ -3,7 +3,10 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
+#include <unordered_map>
+#include <unordered_set>
 
 #include <QWidget>
 #include <fastsignals/signal.h>
@@ -73,8 +76,12 @@ private Q_SLOTS:
     void onTimelineItemDoubleClicked(QListWidgetItem* item);
     void onTimelineContextMenu(const QPoint& position);
     void rebuild();
+    void processRefresh();
 
 private:
+    struct RebuildState;
+    struct PresentationRefreshState;
+
     enum ItemRole
     {
         ObjectNameRole = Qt::UserRole,
@@ -103,6 +110,19 @@ private:
 
     void setObservedDocument(Gui::Document* document);
     void scheduleRefresh();
+    void scheduleObjectRefresh(const App::DocumentObject& object);
+    void scheduleObjectRefresh(long objectId);
+    void scheduleControlRefresh();
+    void scheduleStableRefresh(App::Document& document);
+    void startRefreshTimer();
+    void refreshPresentation();
+    void updateTimelineItemPresentation(
+        QListWidgetItem* item,
+        App::DocumentObject* object,
+        App::DocumentObject* owner
+    );
+    void acquirePresentationUpdate(App::Document& document);
+    void releasePresentationUpdate();
     void syncSelectionFromGui();
     bool canChangeHistory() const;
     void activateOwningBody(App::DocumentObject* object);
@@ -127,6 +147,14 @@ private:
     std::string observedDocumentName;
     App::Document* observedAppDocument {};
     std::uint64_t observedDocumentGeneration {0};
+    std::uint64_t requestedRefreshGeneration {0};
+    std::unique_ptr<RebuildState> rebuildState;
+    std::unique_ptr<PresentationRefreshState> presentationRefreshState;
+    std::unordered_set<long> pendingPresentationObjects;
+    std::unordered_map<long, std::unordered_set<QListWidgetItem*>> itemsByObject;
+    App::Document* presentationUpdateDocument {};
+    bool fullRefreshPending {false};
+    bool controlRefreshPending {false};
     bool rebuildingTimeline {false};
     bool syncingSelection {false};
 
@@ -135,6 +163,9 @@ private:
     fastsignals::scoped_connection renamedDocumentConnection;
     fastsignals::scoped_connection bookedTransactionConnection;
     fastsignals::scoped_connection recomputeRequestFinishedConnection;
+    fastsignals::scoped_connection finishRestoreDocumentConnection;
+    fastsignals::scoped_connection restoreActivityIdleConnection;
+    fastsignals::scoped_connection finishOpenDocumentConnection;
     fastsignals::scoped_connection stableDocumentConnection;
     fastsignals::scoped_connection changedObjectConnection;
     fastsignals::scoped_connection touchedObjectConnection;

--- a/src/Gui/FrameBudget.cpp
+++ b/src/Gui/FrameBudget.cpp
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "FrameBudget.h"
+#include "GuiApplication.h"
+
+#include <deque>
+#include <future>
+#include <mutex>
+
+#include <QApplication>
+#include <QEvent>
+#include <QPointer>
+#include <QThread>
+#include <QTimer>
+
+#include <Base/Console.h>
+#include <Base/Exception.h>
+#include <Base/Interpreter.h>
+
+namespace Gui
+{
+namespace
+{
+
+class FrameDispatcher final: public QObject
+{
+public:
+    static FrameDispatcher* instance()
+    {
+        static FrameDispatcher* inst = [] {
+            auto* dispatcher = new FrameDispatcher();
+            if (qApp && qApp->thread() && QThread::currentThread() != qApp->thread()) {
+                dispatcher->moveToThread(qApp->thread());
+            }
+            QObject::connect(qApp, &QCoreApplication::aboutToQuit, dispatcher,
+                             [dispatcher] { dispatcher->stop(); }, Qt::DirectConnection);
+            QObject::connect(qApp, &QObject::destroyed, dispatcher,
+                             [dispatcher] { dispatcher->stop(); }, Qt::DirectConnection);
+            return dispatcher;
+        }();
+        return inst;
+    }
+
+    bool enqueue(std::function<void()> task)
+    {
+        if (!task || !qApp) {
+            return false;
+        }
+
+        bool schedule = false;
+        {
+            std::lock_guard lock(mutex);
+            if (stopped) {
+                return false;
+            }
+            queue.push_back(std::move(task));
+            if (!scheduled) {
+                scheduled = true;
+                schedule = true;
+            }
+        }
+        if (!schedule) {
+            return true;
+        }
+        scheduleDrain();
+        return true;
+    }
+
+private:
+    FrameDispatcher() = default;
+    ~FrameDispatcher() override = default;
+
+    void stop()
+    {
+        // Qt will no longer dispatch ordinary work after aboutToQuit. Release
+        // accepted captures on their owner now, including promises whose
+        // workers would otherwise wait forever during runtime shutdown.
+        // Destructors may submit again: reject before releasing, outside the
+        // queue lock, so cancellation cannot deadlock or revive the queue.
+        std::deque<std::function<void()>> cancelled;
+        {
+            std::lock_guard lock(mutex);
+            stopped = true;
+            scheduled = false;
+            cancelled.swap(queue);
+        }
+    }
+
+    static QEvent::Type drainEventType()
+    {
+        static const auto type = static_cast<QEvent::Type>(QEvent::registerEventType());
+        return type;
+    }
+
+    void scheduleDrain()
+    {
+        std::lock_guard lock(mutex);
+        if (stopped) {
+            return;
+        }
+        // Adoption is important but never more important than input, paint,
+        // timers, or status heartbeats already waiting in the Qt queue.
+        QCoreApplication::postEvent(
+            this,
+            new QEvent(drainEventType()),
+            Qt::LowEventPriority
+        );
+    }
+
+    bool event(QEvent* event) override
+    {
+        if (event->type() == drainEventType()) {
+            drain();
+            return true;
+        }
+        return QObject::event(event);
+    }
+
+    void drain()
+    {
+        FrameBudget budget;
+        do {
+            std::function<void()> task;
+            {
+                std::lock_guard lock(mutex);
+                if (queue.empty()) {
+                    scheduled = false;
+                    return;
+                }
+                task = std::move(queue.front());
+                queue.pop_front();
+            }
+
+            try {
+                task();
+            }
+            catch (const Base::Exception& exception) {
+                exception.reportException();
+            }
+            catch (const std::exception& exception) {
+                Base::Console().error(
+                    "GUI frame adoption failed: %s\n",
+                    exception.what()
+                );
+            }
+            catch (...) {
+                Base::Console().error("GUI frame adoption failed with an unknown exception\n");
+            }
+        } while (!budget.exhausted());
+
+        // Posting another event while Qt is draining posted events can let the
+        // continuation run immediately in the same event-loop pass. A zero
+        // timer is an event-loop yield, not a time delay: it gives input,
+        // paint, status, and other due timers one dispatch opportunity before
+        // the next bounded adoption frame is posted.
+        QTimer::singleShot(0, this, [this] { scheduleDrain(); });
+    }
+
+    std::mutex mutex;
+    std::deque<std::function<void()>> queue;
+    bool scheduled {false};
+    bool stopped {false};
+};
+
+}  // namespace
+
+PerformanceScope::PerformanceScope(const char* name) : name(name)
+{
+    static const bool enabled = qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE");
+    if (enabled && qApp && QThread::currentThread() == qApp->thread()) {
+        timer.start();
+    }
+}
+
+PerformanceScope::~PerformanceScope()
+{
+    if (!timer.isValid() || timer.elapsed() < FrameBudget::Milliseconds || !qApp) {
+        return;
+    }
+    // Native Qt fixtures may use plain QApplication rather than GUIApplication.
+    if (auto* application = qobject_cast<GUIApplication*>(qApp)) {
+        application->recordPerformancePhase(QString::fromLatin1(name), timer.nsecsElapsed());
+    }
+}
+
+void initializeGuiFrameDispatcher()
+{
+    if (!qApp || QThread::currentThread() != qApp->thread()) {
+        throw std::logic_error("GUI frame dispatcher initialization requires the Qt owner");
+    }
+    FrameDispatcher::instance();
+}
+
+bool dispatchToGuiFrame(std::function<void()> task)
+{
+    // Do not construct a QObject after QApplication has already disappeared.
+    if (!task || !qApp || QCoreApplication::closingDown()) {
+        return false;
+    }
+    return FrameDispatcher::instance()->enqueue(std::move(task));
+}
+
+bool dispatchToGuiFrame(QObject* context, std::function<void()> task)
+{
+    if (!context || !task) {
+        return false;
+    }
+    QPointer<QObject> lifetime(context);
+    return dispatchToGuiFrame(
+        [lifetime, task = std::move(task)]() mutable {
+            if (lifetime) {
+                task();
+            }
+        }
+    );
+}
+
+bool dispatchToGuiFrameAndWait(std::function<void()> task)
+{
+    if (!task || !qApp) {
+        return false;
+    }
+    if (QThread::currentThread() == qApp->thread()) {
+        task();
+        return true;
+    }
+
+    auto completion = std::make_shared<std::promise<void>>();
+    auto finished = completion->get_future();
+    const bool accepted = dispatchToGuiFrame(
+        [task = std::move(task), completion = std::move(completion)]() mutable {
+            try {
+                task();
+                completion->set_value();
+            }
+            catch (...) {
+                completion->set_exception(std::current_exception());
+            }
+        }
+    );
+    if (!accepted) {
+        return false;
+    }
+
+    // Python-backed document callers can own the GIL. Their GUI adoption may
+    // itself call Python, so release it for the wait, never on GUI execution.
+    std::unique_ptr<Base::PyGILStateRelease> release;
+    if (Py_IsInitialized() && PyGILState_Check()) {
+        release = std::make_unique<Base::PyGILStateRelease>();
+    }
+    finished.get();
+    return true;
+}
+
+}  // namespace Gui

--- a/src/Gui/FrameBudget.h
+++ b/src/Gui/FrameBudget.h
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <functional>
+
+#include <FCGlobal.h>
+#include <QElapsedTimer>
+
+class QObject;
+
+namespace Gui
+{
+
+/// Attribute a native owner-thread phase to the existing opt-in GUI trace.
+/// Disabled scopes do not start a timer; recording never performs file I/O.
+class GuiExport PerformanceScope
+{
+public:
+    explicit PerformanceScope(const char* name);
+    ~PerformanceScope();
+    PerformanceScope(const PerformanceScope&) = delete;
+    PerformanceScope& operator=(const PerformanceScope&) = delete;
+
+private:
+    const char* name;
+    QElapsedTimer timer;
+};
+
+/**
+ * A single GUI-event work budget.
+ *
+ * Native document work may prepare arbitrarily large results, but Qt and Coin
+ * state must still be adopted by their owning thread.  All cooperative GUI
+ * consumers use this one budget so no subsystem quietly invents a larger
+ * synchronous slice.
+ */
+class FrameBudget
+{
+public:
+    static constexpr qint64 Milliseconds = 8;
+
+    FrameBudget()
+    {
+        timer.start();
+    }
+
+    bool exhausted() const
+    {
+        return timer.elapsed() >= Milliseconds;
+    }
+
+private:
+    QElapsedTimer timer;
+};
+
+/**
+ * Queue one GUI-owned adoption step on the shared frame-budgeted dispatcher.
+ *
+ * Worker preparation may finish many results at once. Posting each result as
+ * an independent Qt event lets those callbacks monopolize the GUI queue. This
+ * dispatcher drains ready results for at most one shared frame budget and then
+ * yields to input, paint, timers, and status updates before continuing.
+ */
+// Install the application-lifetime shutdown hook on the Qt owner before any
+// document worker can submit GUI notifications.
+GuiExport void initializeGuiFrameDispatcher();
+// Returns false once Qt shutdown begins. Accepted, unexecuted callbacks are
+// released on the owner at shutdown; a waiting promise then reports cancellation
+// through std::future_error instead of retaining its worker indefinitely.
+GuiExport bool dispatchToGuiFrame(std::function<void()> task);
+GuiExport bool dispatchToGuiFrame(QObject* context, std::function<void()> task);
+
+/**
+ * Queue one GUI-owned step and block its worker caller until adoption finishes.
+ *
+ * This preserves synchronous document-notification semantics without posting an
+ * unbounded burst of normal-priority blocking Qt calls. The shared dispatcher
+ * admits the callback within the same elapsed-time frame budget used by every
+ * other native adoption path. Exceptions are rethrown on the calling worker.
+ */
+GuiExport bool dispatchToGuiFrameAndWait(std::function<void()> task);
+
+}  // namespace Gui

--- a/src/Gui/FrameSequence.h
+++ b/src/Gui/FrameSequence.h
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <coroutine>
+#include <exception>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+
+namespace Gui
+{
+namespace detail
+{
+struct FrameSequenceControl
+{
+    std::coroutine_handle<> active;
+};
+
+template<typename Result>
+struct FrameSequenceResult
+{
+    std::optional<Result> result;
+    void return_value(Result value) { result.emplace(std::move(value)); }
+    Result take() { return std::move(result.value()); }
+};
+
+template<>
+struct FrameSequenceResult<void>
+{
+    void return_void() noexcept {}
+    void take() noexcept {}
+};
+} // namespace detail
+
+/** Owner-thread presentation with explicit suspension points.
+ *
+ * advance() resumes the deepest suspended child until the next yield. The
+ * caller uses FrameBudget and the shared frame dispatcher; this type owns no
+ * executor, threads, timers, or event loop. Nested operations retain ordinary
+ * return values, exception handling, and scope destruction across frames.
+ * Creation, advance, and destruction belong to the same GUI owner. Only
+ * bounded Qt/Coin adoption belongs here; prepare expensive data on HostRuntime.
+ */
+template<typename Result = void>
+class FrameSequence
+{
+public:
+    struct promise_type: detail::FrameSequenceResult<Result>
+    {
+        detail::FrameSequenceControl* control {};
+        std::coroutine_handle<> parent;
+        std::exception_ptr failure;
+
+        FrameSequence get_return_object()
+        {
+            return FrameSequence(Handle::from_promise(*this));
+        }
+        std::suspend_always initial_suspend() noexcept { return {}; }
+        auto final_suspend() noexcept
+        {
+            struct Final
+            {
+                bool await_ready() const noexcept { return false; }
+                std::coroutine_handle<> await_suspend(Handle finished) const noexcept
+                {
+                    auto& promise = finished.promise();
+                    if (promise.parent) {
+                        promise.control->active = promise.parent;
+                        return promise.parent;
+                    }
+                    return std::noop_coroutine();
+                }
+                void await_resume() const noexcept {}
+            };
+            return Final {};
+        }
+        void unhandled_exception() noexcept { failure = std::current_exception(); }
+    };
+    using Handle = std::coroutine_handle<promise_type>;
+
+    FrameSequence(FrameSequence&& other) noexcept
+        : frame(std::exchange(other.frame, {})), control(std::move(other.control))
+    {}
+    FrameSequence(const FrameSequence&) = delete;
+    FrameSequence& operator=(const FrameSequence&) = delete;
+    ~FrameSequence() { if (frame) { frame.destroy(); } }
+
+    bool advance()
+    {
+        if (!frame || frame.done()) { return false; }
+        if (!control) {
+            control = std::make_unique<detail::FrameSequenceControl>();
+            control->active = frame;
+            frame.promise().control = control.get();
+        }
+        control->active.resume();
+        return !frame.done();
+    }
+
+    Result takeResult() { return take(frame); }
+
+    struct Awaiter
+    {
+        Handle child;
+        explicit Awaiter(Handle child) : child(child) {}
+        Awaiter(Awaiter&& other) noexcept : child(std::exchange(other.child, {})) {}
+        Awaiter(const Awaiter&) = delete;
+        ~Awaiter() { if (child) { child.destroy(); } }
+        bool await_ready() const noexcept { return false; }
+        template<typename Promise>
+        std::coroutine_handle<> await_suspend(std::coroutine_handle<Promise> parent) noexcept
+        {
+            child.promise().parent = parent;
+            child.promise().control = parent.promise().control;
+            child.promise().control->active = child;
+            return child;
+        }
+        Result await_resume() { return take(child); }
+    };
+
+    auto operator co_await() &&
+    {
+        if (control) { throw std::logic_error("Cannot nest an already-started presentation sequence"); }
+        return Awaiter {std::exchange(frame, {})};
+    }
+
+private:
+    explicit FrameSequence(Handle frame) : frame(frame) {}
+    static Result take(Handle frame)
+    {
+        if (!frame || !frame.done()) {
+            throw std::logic_error("Presentation result requested before completion");
+        }
+        if (frame.promise().failure) { std::rethrow_exception(frame.promise().failure); }
+        return frame.promise().take();
+    }
+    Handle frame;
+    std::unique_ptr<detail::FrameSequenceControl> control;
+};
+
+} // namespace Gui

--- a/src/Gui/GuiApplication.cpp
+++ b/src/Gui/GuiApplication.cpp
@@ -32,6 +32,7 @@
 #endif
 
 #include <sstream>
+#include <stdexcept>
 #include <QAbstractSpinBox>
 #include <QByteArray>
 #include <QComboBox>
@@ -41,6 +42,8 @@
 #include <QFileOpenEvent>
 #include <QSessionManager>
 #include <QTimer>
+#include <QScopeGuard>
+#include <QThread>
 
 
 #include <QLocalServer>
@@ -55,6 +58,7 @@
 #include "Application.h"
 #include "MainWindow.h"
 #include "SpaceballEvent.h"
+#include "FrameBudget.h"
 
 
 using namespace Gui;
@@ -72,9 +76,38 @@ GUIApplication::GUIApplication(int& argc, char** argv)
 #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     setFallbackSessionManagementEnabled(false);
 #endif
+    traceClock.start();
+    traceEvents = qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE");
 }
 
 GUIApplication::~GUIApplication() = default;
+
+QVariantMap GUIApplication::takePerformanceEvents()
+{
+    if (QThread::currentThread() != thread()) {
+        throw std::logic_error("GUI event timings must be drained on the GUI owner");
+    }
+    QVariantMap result {{"enabled", traceEvents}, {"events", eventTimings},
+                        {"clock_ms", traceClock.nsecsElapsed() / 1000000.0},
+                        {"dropped", QVariant::fromValue(droppedEventTimings)}};
+    eventTimings.clear();
+    droppedEventTimings = 0;
+    return result;
+}
+
+void GUIApplication::recordPerformancePhase(const QString& name, qint64 elapsedNanoseconds)
+{
+    if (!traceEvents || elapsedNanoseconds < FrameBudget::Milliseconds * 1000000) { return; }
+    if (QThread::currentThread() != thread()) {
+        throw std::logic_error("GUI phase timings must be recorded on the GUI owner");
+    }
+    if (eventTimings.size() >= 4096) { ++droppedEventTimings; return; }
+    eventTimings.append(QVariantMap {
+        {"start_ms", (traceClock.nsecsElapsed() - elapsedNanoseconds) / 1000000.0},
+        {"elapsed_ms", elapsedNanoseconds / 1000000.0}, {"phase", name},
+        {"event_type", -1}, {"receiver_class", "native_phase"},
+        {"receiver_name", name}, {"depth", eventTraceDepth}});
+}
 
 bool GUIApplication::notify(QObject* receiver, QEvent* event)
 {
@@ -85,6 +118,27 @@ bool GUIApplication::notify(QObject* receiver, QEvent* event)
         );
         return false;
     }
+
+    const bool tracing = traceEvents && QThread::currentThread() == thread();
+    const qint64 started = tracing ? traceClock.nsecsElapsed() : 0;
+    // The receiver and event can be destroyed by notify. Capture identity first.
+    const QByteArray receiverClass = tracing ? QByteArray(receiver->metaObject()->className()) : QByteArray();
+    const QString receiverName = tracing ? receiver->objectName() : QString();
+    const int eventType = tracing ? int(event->type()) : 0;
+    const int depth = tracing ? ++eventTraceDepth : 0;
+    const auto recordTiming = qScopeGuard([&] {
+        if (!tracing) { return; }
+        --eventTraceDepth;
+        const qint64 elapsed = traceClock.nsecsElapsed() - started;
+        if (elapsed < FrameBudget::Milliseconds * 1000000) { return; }
+        // Bound diagnostic memory if no consumer is attached. This limits
+        // retained trace records, never event execution; loss is reported.
+        if (eventTimings.size() >= 4096) { ++droppedEventTimings; return; }
+        eventTimings.append(QVariantMap {
+            {"start_ms", started / 1000000.0}, {"elapsed_ms", elapsed / 1000000.0},
+            {"event_type", eventType}, {"receiver_class", QString::fromLatin1(receiverClass)},
+            {"receiver_name", receiverName}, {"depth", depth}});
+    });
 
     // https://github.com/FreeCAD/FreeCAD/issues/16905
     std::string exceptionWarning =
@@ -201,7 +255,7 @@ bool GUIApplication::event(QEvent* ev)
         QFileInfo fi(file);
         if (fi.suffix().toLower() == QLatin1String("fcstd")) {
             QByteArray fn = file.toUtf8();
-            Application::Instance->open(fn, "FreeCAD");
+            Application::Instance->openFileFromGui(fn, "FreeCAD");
             return true;
         }
     }

--- a/src/Gui/GuiApplication.h
+++ b/src/Gui/GuiApplication.h
@@ -26,6 +26,8 @@
 #include "GuiApplicationNativeEventAware.h"
 #include <Base/Interpreter.h>  // For Base::SystemExitException
 #include <QList>
+#include <QElapsedTimer>
+#include <QVariantMap>
 #include <memory>
 
 class QSessionManager;
@@ -54,9 +56,19 @@ public:
 
 public Q_SLOTS:
     void commitData(QSessionManager& manager);
+    /// Drain opt-in event timings on the GUI owner; performs no filesystem I/O.
+    QVariantMap takePerformanceEvents();
+    void recordPerformancePhase(const QString& name, qint64 elapsedNanoseconds);
 
 protected:
     bool event(QEvent* event) override;
+
+private:
+    bool traceEvents {false};
+    QElapsedTimer traceClock;
+    QVariantList eventTimings;
+    quint64 droppedEventTimings {0};
+    int eventTraceDepth {0};
 };
 
 class GUISingleApplication: public GUIApplication

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -27,6 +27,7 @@
 #include <QEvent>
 #include <QCloseEvent>
 #include <QMdiSubWindow>
+#include <QPointer>
 #include <QPrintDialog>
 #include <QPrintPreviewDialog>
 #include <QPrinter>
@@ -71,6 +72,7 @@ MDIView::MDIView(Gui::Document* pcDocument, QWidget* parent, Qt::WindowFlags wfl
         );
         assert(connectDelObject.connected());
         // NOLINTEND
+        pcDocument->synchronizePresentationView(*this);
     }
 }
 
@@ -107,6 +109,10 @@ MDIView::~MDIView()
 
 void MDIView::deleteSelf()
 {
+    // This is terminal destruction (document teardown or view replacement),
+    // not a new user close request. Do not queue preparation against a document
+    // that the caller is already destroying and detach a still-open window.
+    closePrepared = true;
     // When using QMdiArea make sure to remove the QMdiSubWindow
     // this view is associated with.
     //
@@ -216,6 +222,7 @@ bool MDIView::onHasMsg(const char* pMsg) const
 
 bool MDIView::canClose()
 {
+    if (closePrepared) { return true; }
     if (getAppDocument() && getAppDocument()->testStatus(App::Document::TempDoc)) {
         return true;
     }
@@ -230,6 +237,23 @@ bool MDIView::canClose()
 
 void MDIView::closeEvent(QCloseEvent* e)
 {
+    if (!closePrepared && !bIsPassive && getGuiDocument() && getGuiDocument()->isLastView()
+        && !getAppDocument()->testStatus(App::Document::TempDoc)) {
+        e->ignore();
+        if (!closePreparationPending) {
+            closePreparationPending = true;
+            QPointer<MDIView> guard(this);
+            Document::prepareCloseAsync({getGuiDocument()}, [guard](bool ready) {
+                if (!guard) { return; }
+                guard->closePreparationPending = false;
+                if (!ready) { return; }
+                guard->closePrepared = true;
+                guard->close();
+                if (guard) { guard->closePrepared = false; }
+            }, true);
+        }
+        return;
+    }
     if (canClose()) {
         e->accept();
         Application::Instance->viewClosed(this);

--- a/src/Gui/MDIView.h
+++ b/src/Gui/MDIView.h
@@ -202,6 +202,8 @@ protected:
     PyObject* pythonObject;
 
 private:
+    bool closePreparationPending {false};
+    bool closePrepared {false};
     ViewMode currentMode;
     Qt::WindowStates wstate;
     // list of active objects of this view

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1246,9 +1246,10 @@ void MainWindow::closeActiveWindow()
     d->mdiArea->closeActiveSubWindow();
 }
 
-int MainWindow::confirmSave(App::Document* doc, QWidget* parent, bool addCheckbox)
+QMessageBox* MainWindow::createSaveConfirmation(App::Document* doc, QWidget* parent, bool addCheckbox)
 {
-    QMessageBox box(parent ? parent : this);
+    auto* message = new QMessageBox(parent ? parent : this);
+    auto& box = *message;
     box.setObjectName(QStringLiteral("confirmSave"));
     box.setIcon(QMessageBox::Question);
     box.setWindowFlags(box.windowFlags() | Qt::WindowStaysOnTopHint);
@@ -1266,7 +1267,10 @@ int MainWindow::confirmSave(App::Document* doc, QWidget* parent, bool addCheckbo
     box.setDefaultButton(QMessageBox::Save);
     box.setEscapeButton(QMessageBox::Cancel);
 
-    QCheckBox checkBox(QObject::tr("Apply to all"));
+    auto& checkBox = *new QCheckBox(QObject::tr("Apply to all"), message);
+    checkBox.setObjectName(QStringLiteral("applyToAll"));
+    checkBox.setVisible(addCheckbox);
+    checkBox.setEnabled(addCheckbox);
     ParameterGrp::handle hGrp;
     if (addCheckbox) {
         hGrp = App::GetApplication()
@@ -1294,7 +1298,6 @@ int MainWindow::confirmSave(App::Document* doc, QWidget* parent, bool addCheckbo
         discardBtn->setShortcut(QKeySequence::mnemonic(text));
     }
 
-    int res = ConfirmSaveResult::Cancel;
     box.adjustSize();  // Silence warnings from Qt on Windows
 
     // activates the last used MDI view of the closing document
@@ -1310,18 +1313,69 @@ int MainWindow::confirmSave(App::Document* doc, QWidget* parent, bool addCheckbo
         }
     }
 
-    switch (box.exec()) {
+    return message;
+}
+
+namespace
+{
+int saveConfirmationResult(QMessageBox& box, int answer)
+{
+    const auto* checkBox = box.findChild<QCheckBox*>(QStringLiteral("applyToAll"));
+    const bool all = checkBox && checkBox->isChecked();
+    int res = MainWindow::ConfirmSaveResult::Cancel;
+    switch (answer) {
         case QMessageBox::Save:
-            res = checkBox.isChecked() ? ConfirmSaveResult::SaveAll : ConfirmSaveResult::Save;
+            res = all ? MainWindow::ConfirmSaveResult::SaveAll : MainWindow::ConfirmSaveResult::Save;
             break;
         case QMessageBox::Discard:
-            res = checkBox.isChecked() ? ConfirmSaveResult::DiscardAll : ConfirmSaveResult::Discard;
+            res = all ? MainWindow::ConfirmSaveResult::DiscardAll : MainWindow::ConfirmSaveResult::Discard;
             break;
     }
-    if (addCheckbox && res) {
-        hGrp->SetBool("ConfirmAll", checkBox.isChecked());
+    if (checkBox && checkBox->isEnabled() && res) {
+        App::GetApplication().GetUserParameter().GetGroup("BaseApp")
+            ->GetGroup("Preferences")->GetGroup("General")->SetBool("ConfirmAll", all);
     }
     return res;
+}
+} // namespace
+
+int MainWindow::confirmSave(App::Document* doc, QWidget* parent, bool addCheckbox)
+{
+    std::unique_ptr<QMessageBox> box(createSaveConfirmation(doc, parent, addCheckbox));
+    return saveConfirmationResult(*box, box->exec());
+}
+
+void MainWindow::confirmSaveAsync(App::Document* doc, std::function<void(int)> finished,
+                                  QWidget* parent, bool addCheckbox)
+{
+    auto* box = createSaveConfirmation(doc, parent, addCheckbox);
+    connect(box, &QDialog::finished, this, [box, finished = std::move(finished)](int answer) {
+        const int result = saveConfirmationResult(*box, answer);
+        box->deleteLater();
+        finished(result);
+    });
+    box->open();
+}
+
+void MainWindow::closeAllDocumentsAsync(std::function<void(bool)> finished)
+{
+    auto documents = App::GetApplication().getDocuments();
+    try {
+        documents = App::Document::getDependentDocuments(documents, true);
+    }
+    catch (const Base::Exception& error) {
+        error.reportException();
+        if (finished) { finished(false); }
+        return;
+    }
+    std::vector<Gui::Document*> targets;
+    for (auto* document : documents) {
+        if (auto* gui = Application::Instance->getDocument(document)) { targets.push_back(gui); }
+    }
+    Gui::Document::closeDocumentsAsync(targets, [finished = std::move(finished)](bool closed) {
+        // Documents created during a modeless prompt were never approved.
+        if (finished) { finished(closed && App::GetApplication().getDocuments().empty()); }
+    });
 }
 
 bool MainWindow::closeAllDocuments(bool close)
@@ -1399,6 +1453,7 @@ bool MainWindow::closeAllDocuments(bool close)
 
     if (close) {
         App::GetApplication().closeAllDocuments();
+        return App::GetApplication().getDocuments().empty();
     }
 
     return true;
@@ -1855,8 +1910,12 @@ void MainWindow::setActiveWindow(MDIView* view)
             this->activateWorkbench(currWb);
         }
         else {
-            const std::string name = WorkbenchManager::instance()->active()->name();
-            view->setProperty("ownWB", QString::fromStdString(name));
+            // A native open may finish before the initial workbench activates.
+            // Leave ownership unset until there is an actual workbench to remember.
+            const std::string name = WorkbenchManager::instance()->activeName();
+            if (!name.empty()) {
+                view->setProperty("ownWB", QString::fromStdString(name));
+            }
         }
     }
 

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -28,6 +28,7 @@
 #include <QMainWindow>
 #include <QMdiArea>
 #include <QString>
+#include <functional>
 
 #include "Window.h"
 #include "InputHint.h"
@@ -36,6 +37,7 @@ class QMimeData;
 class QUrl;
 class QMdiSubWindow;
 class QMenu;
+class QMessageBox;
 
 namespace App
 {
@@ -283,9 +285,12 @@ public Q_SLOTS:
      * Closes all document window.
      */
     bool closeAllDocuments(bool close = true);
+    void closeAllDocumentsAsync(std::function<void(bool)> finished = {});
     /** Pop up a message box asking for saving document
      */
     int confirmSave(App::Document* doc, QWidget* parent = nullptr, bool addCheckBox = false);
+    void confirmSaveAsync(App::Document* doc, std::function<void(int)> finished,
+                          QWidget* parent = nullptr, bool addCheckBox = false);
     /**
      * Activates the next window in the child window chain.
      */
@@ -358,6 +363,7 @@ protected:
     void changeEvent(QEvent* e) override;
 
 private:
+    QMessageBox* createSaveConfirmation(App::Document*, QWidget*, bool);
     void setupDockWindows();
     bool setupTaskView();
     bool setupSelectionView();

--- a/src/Gui/ModelTreeBrowser.cpp
+++ b/src/Gui/ModelTreeBrowser.cpp
@@ -5,6 +5,8 @@
 #include <algorithm>
 #include <cstddef>
 #include <limits>
+#include <optional>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -12,15 +14,27 @@
 #include <vector>
 
 #include <App/Datums.h>
+#include <App/Application.h>
 #include <App/Document.h>
 #include <App/DocumentTimeline.h>
 #include <App/DocumentObject.h>
 #include <App/GeoFeatureGroupExtension.h>
 #include <App/GroupExtension.h>
+#include <App/HostRuntime.h>
+#include <App/MainThreadSignal.h>
 #include <App/Origin.h>
 #include <App/OriginGroupExtension.h>
 #include <App/PropertyLinks.h>
 #include <App/PropertyStandard.h>
+#include <Base/CancellationScope.h>
+#include <fastsignals/signal.h>
+#include <QObject>
+#include <QPointer>
+#include <QCoreApplication>
+#include <QThread>
+
+#include "Document.h"
+#include "FrameBudget.h"
 
 
 using namespace Gui;
@@ -158,14 +172,455 @@ App::DocumentObject* exactVibeScriptProgramFor(
 
 }  // namespace
 
-ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
+struct ModelTreeBrowserProjection::Preparation::Data
 {
-    if (!document) {
-        return;
+    struct Node
+    {
+        App::DocumentObject* object {};
+        App::DocumentObject* parent {};
+        App::DocumentObject* normalGroup {};
+        App::DocumentObject* origin {};
+        App::DocumentObject* program {};
+        App::DocumentObject* timelineOwner {};
+        App::DocumentObject* originObject {};
+        bool plainGroup {};
+        bool geoGroup {};
+        bool originGroup {};
+        bool datumElement {};
+        bool localCoordinateSystem {};
+        bool isOrigin {};
+        bool timelineResource {};
+        bool multiTransform {};
+        bool included {};
+        bool documentMember {};
+        bool body {};
+        bool component {};
+        bool assembly {};
+        Role baseRole {Role::Other};
+        bool fixedRole {};
+        std::optional<Role> assemblyRole;
+        std::string bodyIdentity;
+        std::string publicationIdentity;
+        std::string targetIdentity;
+        std::vector<App::DocumentObject*> occurrences;
+        std::vector<App::DocumentObject*> transformations;
+        std::vector<App::DocumentObject*> incoming;
+        std::vector<App::DocumentObject*> groupMembers;
+        std::vector<App::DocumentObject*> originFeatures;
+        std::unordered_map<const App::DocumentObject*, std::size_t> groupIndex;
+        std::unordered_set<const App::DocumentObject*> originFeatureIndex;
+        Ownership ownership;
+    };
+    App::Document* document {};
+    std::vector<App::DocumentObject*> pending;
+    std::unordered_set<App::DocumentObject*> queued;
+    std::size_t cursor {};
+    std::size_t documentObjects {};
+    std::optional<Node> capturing;
+    std::size_t occurrenceCursor {};
+    std::size_t transformationCursor {};
+    std::size_t incomingCursor {};
+    std::size_t groupCursor {};
+    std::size_t originFeatureCursor {};
+    bool operationsCaptured {};
+    App::DocumentTimeline* timeline {};
+    long timelineId {};
+    bool canonicalTimeline {};
+    std::vector<Node> nodes;
+    std::unordered_map<const App::DocumentObject*, std::size_t> index;
+    std::vector<App::DocumentObject*> operations;
+    std::unordered_map<const App::DocumentObject*, std::vector<App::DocumentObject*>> histories;
+    std::unordered_set<const App::Document*> sourceDocuments;
+    std::vector<SourceRevision> sourceRevisions;
+
+    void captureRevision(const App::Document* source)
+    {
+        if (source && sourceDocuments.insert(source).second) {
+            sourceRevisions.push_back(
+                {source->getName(), source->Uid.getValueStr(), source->getObjectStructureGeneration()});
+        }
     }
 
-    const auto& objects = document->getObjects();
-    _entries.reserve(objects.size());
+    void enqueue(App::DocumentObject* object)
+    {
+        if (object && object->getDocument() != document && queued.insert(object).second) {
+            captureRevision(object->getDocument());
+            pending.push_back(object);
+        }
+    }
+    const Node* find(const App::DocumentObject* object) const
+    {
+        const auto entry = index.find(object);
+        return entry == index.end() ? nullptr : &nodes[entry->second];
+    }
+    bool contains(const Node& group, const App::DocumentObject* object) const
+    {
+        if (group.localCoordinateSystem) {
+            return group.originFeatureIndex.contains(object);
+        }
+        if (group.originGroup && group.originObject) {
+            const auto* origin = find(group.originObject);
+            if (!origin || !origin->isOrigin) {
+                throw Base::RuntimeError("Invalid Origin in captured model-browser group");
+            }
+            if (group.originObject == object || origin->originFeatureIndex.contains(object)) {
+                return true;
+            }
+        }
+        const auto member = group.groupIndex.find(object);
+        if (object == group.object || member == group.groupIndex.end()) {
+            return false;
+        }
+        const auto cycle = group.groupIndex.find(group.object);
+        // Match nonrecursive GroupExtension::hasObject: a self-cycle before
+        // the member prevents finding it; a preceding member is still valid.
+        return cycle == group.groupIndex.end() || cycle->second >= member->second;
+    }
+    void resolveParents(Node& node) const
+    {
+        for (auto* incoming : node.incoming) {
+            Base::CancellationScope::check();
+            const auto* candidate = find(incoming);
+            if (!candidate) { continue; }
+            if (!node.normalGroup && candidate->plainGroup
+                && candidate->groupIndex.contains(node.object)) {
+                node.normalGroup = incoming;
+            }
+            if (node.datumElement) {
+                if (!node.origin && candidate->isOrigin) { node.origin = incoming; }
+                if (!node.parent && candidate->originGroup) { node.parent = incoming; }
+                if (!node.parent && candidate->localCoordinateSystem) {
+                    for (auto* ancestor : candidate->incoming) {
+                        Base::CancellationScope::check();
+                        const auto* owner = find(ancestor);
+                        if (owner && owner->originGroup) {
+                            node.parent = ancestor;
+                            break;
+                        }
+                    }
+                }
+            }
+            else if (!node.parent && candidate->geoGroup && contains(*candidate, node.object)) {
+                node.parent = incoming;
+            }
+        }
+        if (!node.parent) { node.parent = node.normalGroup; }
+        if (node.origin && !node.component && !node.body && !node.isOrigin) {
+            node.baseRole = Role::OriginFeature;
+            node.fixedRole = true;
+        }
+    }
+    Ownership ownership(const App::DocumentObject* object) const
+    {
+        Ownership result;
+        std::unordered_set<const App::DocumentObject*> visited;
+        for (auto* current = object; current && visited.insert(current).second;) {
+            Base::CancellationScope::check();
+            const auto* node = find(current);
+            const auto* parent = node ? find(node->parent) : nullptr;
+            if (!parent || parent->object == current) {
+                break;
+            }
+            if (!result.body && parent->body) {
+                result.body = parent->object;
+            }
+            else if (!result.component && parent->component) {
+                result.component = parent->object;
+            }
+            current = parent->object;
+        }
+        return result;
+    }
+    Role classifyNode(const Node& node, const Ownership& owner, bool published) const
+    {
+        if (node.fixedRole) {
+            return node.baseRole;
+        }
+        const auto* component = find(owner.component);
+        if (component && component->assembly && node.assemblyRole) {
+            return *node.assemblyRole;
+        }
+        if (published) {
+            return Role::VibeCADOutput;
+        }
+        if (owner.body && (node.baseRole == Role::Other || node.baseRole == Role::Geometry)) {
+            return Role::Feature;
+        }
+        return node.baseRole;
+    }
+};
+
+ModelTreeBrowserProjection::Preparation::Preparation(App::Document* document)
+    : data(std::make_unique<Data>())
+{
+    data->document = document;
+    data->captureRevision(document);
+    if (document) {
+        data->documentObjects = document->getObjects().size();
+    }
+}
+
+ModelTreeBrowserProjection::Preparation::~Preparation() = default;
+ModelTreeBrowserProjection::Preparation::Preparation(Preparation&&) noexcept = default;
+ModelTreeBrowserProjection::Preparation&
+ModelTreeBrowserProjection::Preparation::operator=(Preparation&&) noexcept = default;
+
+App::Document* ModelTreeBrowserProjection::SourceRevision::resolve() const
+{
+    auto* source = App::GetApplication().getDocument(name.c_str());
+    return source && source->Uid.getValueStr() == uid ? source : nullptr;
+}
+
+bool ModelTreeBrowserProjection::SourceRevision::isCurrent() const
+{
+    const auto* source = resolve();
+    return source
+        && !Gui::Document::projectionRefreshBlocked(source)
+        && source->getObjectStructureGeneration() == generation;
+}
+
+bool ModelTreeBrowserProjection::Preparation::isCurrent() const
+{
+    return std::ranges::all_of(data->sourceRevisions, [](const auto& source) {
+        return source.isCurrent();
+    });
+}
+
+bool ModelTreeBrowserProjection::isCurrent() const
+{
+    return std::ranges::all_of(_sourceRevisions, [](const auto& source) {
+        return source.isCurrent();
+    });
+}
+
+std::vector<App::Document*> ModelTreeBrowserProjection::Preparation::sourceDocuments() const
+{
+    std::vector<App::Document*> result;
+    for (const auto& source : data->sourceRevisions) {
+        if (auto* document = source.resolve()) {
+            result.push_back(document);
+        }
+    }
+    return result;
+}
+
+std::vector<App::Document*> ModelTreeBrowserProjection::sourceDocuments() const
+{
+    std::vector<App::Document*> result;
+    for (const auto& source : _sourceRevisions) {
+        if (auto* document = source.resolve()) {
+            result.push_back(document);
+        }
+    }
+    return result;
+}
+
+bool ModelTreeBrowserProjection::Preparation::captureNext()
+{
+    if (data->cursor == data->documentObjects + data->pending.size()) {
+        if (data->timeline
+            && data->operations.size() < data->timeline->Operations.getValues().size()) {
+            data->operations.push_back(
+                data->timeline->Operations.getValues()[data->operations.size()]);
+            return false;
+        }
+        data->operationsCaptured = true;
+        return true;
+    }
+    if (data->capturing) {
+        auto& node = *data->capturing;
+        auto* object = node.object;
+        if (data->incomingCursor < object->getInList().size()) {
+            auto* incoming = object->getInList()[data->incomingCursor++];
+            node.incoming.push_back(incoming);
+            data->enqueue(incoming);
+            return false;
+        }
+        if (auto* group = object->getExtensionByType<App::GroupExtension>(true)) {
+            if (data->groupCursor < group->Group.getValues().size()) {
+                node.groupMembers.push_back(group->Group.getValues()[data->groupCursor++]);
+                return false;
+            }
+        }
+        if (node.localCoordinateSystem) {
+            auto* coordinateSystem = static_cast<App::LocalCoordinateSystem*>(object);
+            if (data->originFeatureCursor < coordinateSystem->OriginFeatures.getValues().size()) {
+                node.originFeatures.push_back(
+                    coordinateSystem->OriginFeatures.getValues()[data->originFeatureCursor++]);
+                return false;
+            }
+        }
+        if (node.multiTransform) {
+            if (auto* children = dynamic_cast<const App::PropertyLinkList*>(
+                    object->getPropertyByName("Transformations"))) {
+                if (data->transformationCursor < children->getValues().size()) {
+                    node.transformations.push_back(
+                        children->getValues()[data->transformationCursor++]);
+                    return false;
+                }
+            }
+        }
+        if (node.component) {
+            if (auto* names = dynamic_cast<const App::PropertyStringList*>(
+                    object->getPropertyByName("VibeCADPartDesignComponentOccurrenceNames"))) {
+                if (data->occurrenceCursor < names->getValues().size()) {
+                    auto* owner = object->getDocument();
+                    const auto& name = names->getValues()[data->occurrenceCursor++];
+                    node.occurrences.push_back(owner ? owner->getObject(name.c_str()) : nullptr);
+                    return false;
+                }
+            }
+            else if (auto* legacy = dynamic_cast<const App::PropertyLinkList*>(
+                         object->getPropertyByName("VibeCADPartDesignComponentOccurrences"))) {
+                if (data->occurrenceCursor < legacy->getValues().size()) {
+                    node.occurrences.push_back(legacy->getValues()[data->occurrenceCursor++]);
+                    return false;
+                }
+            }
+        }
+        data->index.emplace(object, data->nodes.size());
+        data->nodes.push_back(std::move(node));
+        data->capturing.reset();
+        ++data->cursor;
+        return false;
+    }
+    auto* object = data->cursor < data->documentObjects
+        ? data->document->getObjects()[data->cursor]
+        : data->pending[data->cursor - data->documentObjects];
+    Data::Node node;
+    node.object = object;
+    node.documentMember = data->cursor < data->documentObjects;
+    if (node.documentMember && object->isDerivedFrom<App::DocumentTimeline>()) {
+        const bool canonical = std::string_view(object->getNameInDocument())
+            == App::DocumentTimeline::ObjectName;
+        if (canonical || (!data->canonicalTimeline
+                          && (!data->timeline || object->getID() < data->timelineId))) {
+            data->timeline = static_cast<App::DocumentTimeline*>(object);
+            data->timelineId = object->getID();
+            data->canonicalTimeline = canonical;
+        }
+    }
+    node.included = node.documentMember
+        && object->isAttachedToDocument() && !object->testStatus(App::PartialObject);
+    node.body = isBody(object);
+    node.component = isComponent(object);
+    node.assembly = isDerivedFrom(object, "Assembly::AssemblyObject")
+        || isDerivedFrom(object, "Assembly::AssemblyLink");
+    node.plainGroup = object->getExtension(App::GroupExtension::getExtensionClassTypeId(), false, true)
+        || object->getExtension(Base::Type::fromName("App::GroupExtensionPython"), false, true);
+    node.geoGroup = object->hasExtension(App::GeoFeatureGroupExtension::getExtensionClassTypeId());
+    node.originGroup = object->hasExtension(App::OriginGroupExtension::getExtensionClassTypeId());
+    node.datumElement = object->isDerivedFrom<App::DatumElement>();
+    node.localCoordinateSystem = object->isDerivedFrom<App::LocalCoordinateSystem>();
+    node.isOrigin = object->isDerivedFrom<App::Origin>();
+    if (node.originGroup) {
+        node.originObject = object->getExtensionByType<App::OriginGroupExtension>()->Origin.getValue();
+        data->enqueue(node.originObject);
+    }
+    node.program = exactVibeScriptProgramFor(data->document, object);
+    node.timelineResource = App::DocumentTimeline::hasTimelineResourceRole(object);
+    node.timelineOwner = node.timelineResource ? App::DocumentTimeline::timelineOwner(object) : nullptr;
+    data->enqueue(node.timelineOwner);
+    node.multiTransform = hasTypeNameFragment(object, "MultiTransform");
+    data->enqueue(node.program);
+    node.baseRole = classify(object, {}, false, false);
+    const auto outputType = vibeScriptOutputType(object);
+    node.fixedRole = node.component || node.body || object->isDerivedFrom<App::Origin>()
+        || node.origin || isDerivedFrom(object, "Assembly::BomObject")
+        || isParameterObject(object) || isSketch(object) || isReferenceGeometry(object)
+        || (outputType == "component_link" && isLink(object));
+    if (outputType == "component_link" || isDerivedFrom(object, "Assembly::AssemblyLink")
+        || isLink(object)) {
+        node.assemblyRole = Role::AssemblyOccurrence;
+    }
+    else if (outputType == "motion") {
+        node.assemblyRole = Role::AssemblyMotion;
+    }
+    else if (outputType == "joint" || outputType == "simulation"
+             || outputType == "mechanism_verification" || outputType == "exploded_view"
+             || outputType == "bom") {
+        node.assemblyRole = Role::AssemblyOperation;
+    }
+    if (node.body) {
+        node.bodyIdentity = scriptedOutputIdentity(object, "implementation");
+    }
+    if (isLink(object)) {
+        node.publicationIdentity = scriptedOutputIdentity(object, "publication");
+    }
+    node.targetIdentity = scriptedOutputIdentity(object, "publication_target");
+    data->capturing = std::move(node);
+    data->occurrenceCursor = 0;
+    data->transformationCursor = 0;
+    data->incomingCursor = 0;
+    data->groupCursor = 0;
+    data->originFeatureCursor = 0;
+    return false;
+}
+
+ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
+{
+    Preparation preparation(document);
+    while (!preparation.captureNext()) {}
+    *this = std::move(preparation).finish();
+}
+
+ModelTreeBrowserProjection ModelTreeBrowserProjection::Preparation::finish(
+    App::HostRuntime* runtime, std::stop_token cancellation) &&
+{
+    if (runtime && App::MainThreadSignalConfig::hasHooks()
+        && App::MainThreadSignalConfig::isMainThread()) {
+        throw std::logic_error("Parallel model browser preparation requires a worker caller");
+    }
+    Base::CancellationScope operationScope(cancellation);
+    Base::CancellationScope::check();
+    if (!data->operationsCaptured || data->capturing
+        || data->cursor != data->documentObjects + data->pending.size()) {
+        throw std::logic_error("Model browser preparation has uncaptured objects");
+    }
+    ModelTreeBrowserProjection result;
+    auto& _entries = result._entries;
+    auto& _index = result._index;
+
+    _entries.reserve(data->documentObjects);
+    const auto indexRelationships = [this, cancellation](std::size_t index) {
+        Base::CancellationScope childScope(cancellation);
+        auto& node = data->nodes[index];
+        for (std::size_t member = 0; member < node.groupMembers.size(); ++member) {
+            Base::CancellationScope::check();
+            node.groupIndex.try_emplace(node.groupMembers[member], member);
+        }
+        for (auto* feature : node.originFeatures) {
+            Base::CancellationScope::check();
+            node.originFeatureIndex.insert(feature);
+        }
+    };
+    const auto resolveParents = [this, cancellation](std::size_t index) {
+        Base::CancellationScope childScope(cancellation);
+        data->resolveParents(data->nodes[index]);
+    };
+    const auto resolve = [this, cancellation](std::size_t index) {
+        Base::CancellationScope childScope(cancellation);
+        Base::CancellationScope::check();
+        auto& node = data->nodes[index];
+        node.ownership = data->ownership(node.object);
+    };
+    if (runtime) {
+        runtime->parallelFor(data->nodes.size(), indexRelationships);
+        runtime->parallelFor(data->nodes.size(), resolveParents);
+        runtime->parallelFor(data->nodes.size(), resolve);
+    }
+    else {
+        // The existing synchronous constructor retains its public contract.
+        // Asynchronous consumers supply the shared runtime, never wait here
+        // on the GUI owner, and never select this adapter after a failure.
+        for (const auto& phase : {std::function<void(std::size_t)>(indexRelationships),
+                                  std::function<void(std::size_t)>(resolveParents),
+                                  std::function<void(std::size_t)>(resolve)}) {
+            for (std::size_t index = 0; index < data->nodes.size(); ++index) {
+                phase(index);
+            }
+        }
+    }
 
     // VibeScript publishes through stable root-level links so Assembly,
     // TechDraw, FEM, CAM, and other consumers never lose object identity when
@@ -190,24 +645,29 @@ ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
             iterator->second = nullptr;
         }
     };
-    for (auto* object : objects) {
-        if (isBody(object)) {
+    for (const auto& node : data->nodes) {
+        Base::CancellationScope::check();
+        auto* object = node.object;
+        if (!node.documentMember) {
+            continue;
+        }
+        if (node.body) {
             recordUnique(
                 scriptedBodies,
-                scriptedOutputIdentity(object, "implementation"),
+                node.bodyIdentity,
                 object
             );
         }
-        if (isLink(object)) {
+        if (!node.publicationIdentity.empty()) {
             recordUnique(
                 scriptedPublications,
-                scriptedOutputIdentity(object, "publication"),
+                node.publicationIdentity,
                 object
             );
         }
         recordUnique(
             scriptedPublicationTargets,
-            scriptedOutputIdentity(object, "publication_target"),
+            node.targetIdentity,
             object
         );
     }
@@ -255,52 +715,26 @@ ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
             pairedPublicationTargets.insert(target->second);
         }
     }
-    for (auto* object : objects) {
-        if (!isComponent(object)) {
+    for (const auto& node : data->nodes) {
+        if (!node.documentMember || !node.component) {
             continue;
         }
-        std::vector<App::DocumentObject*> occurrences;
-        const auto* occurrenceNames = dynamic_cast<const App::PropertyStringList*>(
-            object->getPropertyByName("VibeCADPartDesignComponentOccurrenceNames")
-        );
-        if (occurrenceNames) {
-            App::Document* document = object->getDocument();
-            const auto& names = occurrenceNames->getValues();
-            occurrences.reserve(names.size());
-            for (const std::string& name : names) {
-                if (document) {
-                    occurrences.push_back(document->getObject(name.c_str()));
-                }
-            }
-        }
-        else if (const auto* legacyOccurrences =
-                     dynamic_cast<const App::PropertyLinkList*>(
-                         object->getPropertyByName(
-                             "VibeCADPartDesignComponentOccurrences"
-                         )
-                     )) {
-            // Compatibility for documents loaded before the Python migration
-            // runs. New documents keep this property empty so it cannot create
-            // forward modeling dependencies.
-            occurrences = legacyOccurrences->getValues();
-        }
-        for (auto* occurrence : occurrences) {
+        for (auto* occurrence : node.occurrences) {
             if (!occurrence) {
                 continue;
             }
             const auto [iterator, inserted] =
-                modelOccurrenceOwners.emplace(occurrence, object);
-            if (!inserted && iterator->second != object) {
-                // Conflicting explicit owners are damage that must remain
-                // visible at document root rather than being guessed away.
+                modelOccurrenceOwners.emplace(occurrence, node.object);
+            if (!inserted && iterator->second != node.object) {
+                // Conflicting explicit owners stay visible at document root.
                 iterator->second = nullptr;
             }
         }
     }
 
-    for (auto* object : objects) {
-        if (!object || !object->isAttachedToDocument()
-            || object->testStatus(App::PartialObject)) {
+    for (const auto& node : data->nodes) {
+        auto* object = node.object;
+        if (!node.included) {
             continue;
         }
 
@@ -308,9 +742,9 @@ ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
         // Presentation ownership may place a root object below a semantic
         // component in the browser, but that virtual relationship is not a
         // valid getSubObject() path.
-        const Ownership selectionOwnership = resolveOwnership(object);
+        const Ownership selectionOwnership = node.ownership;
         Ownership ownership = selectionOwnership;
-        if (auto* program = exactVibeScriptProgramFor(document, object)) {
+        if (auto* program = node.program) {
             // DesignScriptOperation is deliberately Design-global and must
             // not enter the App::Part containment graph. Its exact persisted
             // program identity supplies presentation ownership only; logical
@@ -321,15 +755,7 @@ ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
             owner != modelOccurrenceOwners.end() && owner->second) {
             ownership.component = owner->second;
         }
-        App::DocumentObject* normalGroup = App::GroupExtension::getGroupOfObject(object);
-        if (normalGroup
-            && normalGroup->hasExtension(
-                App::GeoFeatureGroupExtension::getExtensionClassTypeId()
-            )) {
-            // Bodies and Parts also implement GroupExtension. They are ownership
-            // contexts, not user-created organizational groups.
-            normalGroup = nullptr;
-        }
+        App::DocumentObject* normalGroup = node.normalGroup;
         const bool publishedOutput =
             completePublicationLinks.contains(object);
         if (const auto body = bodyRepresentations.find(object);
@@ -338,13 +764,13 @@ ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
             // contract. Once that exact pair is established, present the
             // internal link in the Body's native ownership context. Never
             // derive publication status from an App::Link target or location.
-            ownership = resolveOwnership(body->second);
+            ownership = data->find(body->second)->ownership;
         }
         else if (const auto target = targetRepresentations.find(object);
                  target != targetRepresentations.end()) {
             // A publication without a native Body uses its exact persisted
             // target pair's component solely as its presentation context.
-            ownership = resolveOwnership(target->second);
+            ownership = data->find(target->second)->ownership;
         }
 
         Entry entry;
@@ -355,10 +781,10 @@ ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
         entry.publishedOutput = publishedOutput;
         entry.publishedImplementation =
             pairedPublicationTargets.contains(object);
-        entry.role = classify(object, ownership, publishedOutput);
+        entry.role = data->classifyNode(node, ownership, publishedOutput);
 
         if (entry.role == Role::OriginFeature) {
-            entry.logicalParent = findOriginParent(object);
+            entry.logicalParent = node.origin;
         }
         else if (publishedOutput) {
             // The internal link uses the paired Body's semantic component but
@@ -392,17 +818,62 @@ ModelTreeBrowserProjection::ModelTreeBrowserProjection(App::Document* document)
         _entries.push_back(entry);
     }
 
-    orderOperationsByTimeline(document);
-    orderFeaturesByBodyHistory();
+    // The membership snapshot already contains each Body's ordered Group.
+    // Transfer that storage after parent resolution instead of walking and
+    // copying the same live property a second time on the GUI owner.
+    for (auto& node : data->nodes) {
+        Base::CancellationScope::check();
+        if (node.body) {
+            data->histories.emplace(node.object, std::move(node.groupMembers));
+        }
+    }
+    result.orderOperationsByTimeline(data->operations);
+    result.orderFeaturesByBodyHistory(data->histories);
+    // Resolve semantic History ownership once from the same immutable graph.
+    // Null memo entries also break malformed resource cycles without walking
+    // them once per operation or ever consulting a live document on a worker.
+    for (const auto& node : data->nodes) {
+        if (!node.documentMember) {
+            continue;
+        }
+        Base::CancellationScope::check();
+        std::vector<const App::DocumentObject*> path;
+        const auto* current = &node;
+        const App::DocumentObject* root = nullptr;
+        while (current && current->documentMember) {
+            const auto [entry, inserted] = result._timelineRoots.emplace(current->object, nullptr);
+            if (!inserted) {
+                root = entry->second;
+                break;
+            }
+            path.push_back(current->object);
+            if (!current->timelineResource) {
+                root = current->object;
+                break;
+            }
+            current = data->find(current->timelineOwner);
+        }
+        for (const auto* object : path) {
+            result._timelineRoots[object] = root;
+        }
+    }
+    for (const auto* operation : data->operations) {
+        if (const auto* node = data->find(operation)) {
+            for (auto* child : node->transformations) {
+                if (child) {
+                    result._internalTransformations.insert(child);
+                }
+            }
+        }
+    }
+    result._operations = std::move(data->operations);
+    result._sourceRevisions = std::move(data->sourceRevisions);
+    return result;
 }
 
-void ModelTreeBrowserProjection::orderOperationsByTimeline(const App::Document* document)
+void ModelTreeBrowserProjection::orderOperationsByTimeline(
+    const std::vector<App::DocumentObject*>& operations)
 {
-    const auto* timeline = App::DocumentTimeline::get(document);
-    if (!timeline) {
-        return;
-    }
-
     std::vector<std::size_t> slots;
     for (std::size_t index = 0; index < _entries.size(); ++index) {
         if (_entries[index].role == Role::History) {
@@ -414,7 +885,6 @@ void ModelTreeBrowserProjection::orderOperationsByTimeline(const App::Document* 
     }
 
     std::unordered_map<const App::DocumentObject*, std::size_t> rank;
-    const auto& operations = timeline->Operations.getValues();
     rank.reserve(operations.size());
     for (std::size_t position = 0; position < operations.size(); ++position) {
         rank.emplace(operations[position], position);
@@ -448,7 +918,9 @@ void ModelTreeBrowserProjection::orderOperationsByTimeline(const App::Document* 
     }
 }
 
-void ModelTreeBrowserProjection::orderFeaturesByBodyHistory()
+void ModelTreeBrowserProjection::orderFeaturesByBodyHistory(
+    const std::unordered_map<const App::DocumentObject*,
+                             std::vector<App::DocumentObject*>>& histories)
 {
     // Collect each Body's user-facing operation entries in creation order.
     std::unordered_map<const App::DocumentObject*, std::vector<std::size_t>>
@@ -467,13 +939,12 @@ void ModelTreeBrowserProjection::orderFeaturesByBodyHistory()
         }
         // A Body's Group property is its feature history: move up/down and
         // similar edits reorder Group without changing creation order.
-        const auto* group = dynamic_cast<const App::PropertyLinkList*>(
-            body->getPropertyByName("Group"));
-        if (!group) {
+        const auto history = histories.find(body);
+        if (history == histories.end()) {
             continue;
         }
         std::unordered_map<const App::DocumentObject*, std::size_t> rank;
-        const auto& members = group->getValues();
+        const auto& members = history->second;
         rank.reserve(members.size());
         for (std::size_t position = 0; position < members.size(); ++position) {
             rank.emplace(members[position], position);
@@ -584,7 +1055,8 @@ ModelTreeBrowserProjection::findOriginParent(const App::DocumentObject* object)
 ModelTreeBrowserProjection::Role ModelTreeBrowserProjection::classify(
     const App::DocumentObject* object,
     const Ownership& ownership,
-    bool publishedOutput
+    bool publishedOutput,
+    bool inspectOrigin
 )
 {
     if (isComponent(object)) {
@@ -596,7 +1068,7 @@ ModelTreeBrowserProjection::Role ModelTreeBrowserProjection::classify(
     if (object->isDerivedFrom<App::Origin>()) {
         return Role::Origin;
     }
-    if (findOriginParent(object)) {
+    if (inspectOrigin && findOriginParent(object)) {
         return Role::OriginFeature;
     }
     // Assembly BOMs derive from Spreadsheet::Sheet for their tabular editor,
@@ -659,4 +1131,326 @@ ModelTreeBrowserProjection::Role ModelTreeBrowserProjection::classify(
         return Role::Geometry;
     }
     return Role::Other;
+}
+
+struct ModelTreeBrowserCache::Data: QObject
+{
+    struct Waiter
+    {
+        QPointer<QObject> receiver;
+        Completion completion;
+    };
+    struct Observer
+    {
+        QPointer<QObject> receiver;
+        std::function<void()> invalidated;
+    };
+    std::string documentUid;
+    Result cached;
+    std::unique_ptr<ModelTreeBrowserProjection::Preparation> preparation;
+    std::unordered_map<QObject*, Waiter> waiters;
+    std::unordered_map<QObject*, Observer> observers;
+    std::vector<fastsignals::scoped_connection> stableConnections;
+    std::vector<fastsignals::scoped_connection> sourceConnections;
+    std::stop_source cancellation;
+    bool scheduled {};
+    bool computing {};
+    bool invalidationPending {};
+    std::uint64_t invalidationGeneration {};
+
+    explicit Data(App::Document* document)
+        : documentUid(document ? document->Uid.getValueStr() : "")
+    {}
+    ~Data() override { cancellation.request_stop(); }
+
+    App::Document* document() const
+    {
+        for (auto* candidate : App::GetApplication().getDocuments()) {
+            if (candidate->Uid.getValueStr() == documentUid) {
+                return candidate;
+            }
+        }
+        return nullptr;
+    }
+
+    void request(QObject* receiver, Completion completion)
+    {
+        if (!receiver || !completion) {
+            return;
+        }
+        waiters.insert_or_assign(receiver, Waiter {receiver, std::move(completion)});
+        schedule();
+    }
+
+    void sourceChanged()
+    {
+        if (invalidationPending) {
+            return;
+        }
+        invalidationPending = true;
+        const auto generation = ++invalidationGeneration;
+        dispatchToGuiFrame(this, [this, generation] {
+            if (!invalidationPending || invalidationGeneration != generation) {
+                return;
+            }
+            std::erase_if(observers, [](const auto& entry) { return !entry.second.receiver; });
+            // Post separately: a subscriber may unregister, request again, or
+            // throw without invalidating iteration or starving other consumers.
+            const QPointer<Data> lifetime(this);
+            for (const auto& [key, observer] : observers) {
+                dispatchToGuiFrame([lifetime, observer, generation] {
+                    if (lifetime && lifetime->invalidationPending
+                        && lifetime->invalidationGeneration == generation && observer.receiver) {
+                        observer.invalidated();
+                    }
+                });
+            }
+        });
+    }
+
+    void observeSources()
+    {
+        sourceConnections.clear();
+        const auto sources = cached->sourceDocuments();
+        const auto* owner = document();
+        for (auto* source : sources) {
+            sourceConnections.emplace_back(source->signalObjectSchemaChanged.connect(
+                [this](long) { sourceChanged(); }));
+            // Tree/History already observe their own document with property-
+            // specific handlers. Do not turn local Visibility/Shape changes
+            // into unconditional hierarchy rebuilds through this shared cache.
+            if (source == owner) {
+                continue;
+            }
+            sourceConnections.emplace_back(source->signalNewObject.connect(
+                [this](const App::DocumentObject&) { sourceChanged(); }));
+            sourceConnections.emplace_back(source->signalDeletedObject.connect(
+                [this](const App::DocumentObject&) { sourceChanged(); }));
+            sourceConnections.emplace_back(source->signalChangedObject.connect(
+                [this, source, generation = source->getObjectStructureGeneration()]
+                (const App::DocumentObject&, const App::Property&) {
+                    if (source->getObjectStructureGeneration() != generation) { sourceChanged(); }
+                }));
+            sourceConnections.emplace_back(source->signalBecameStable.connect(
+                [this](const App::Document&) {
+                    if (cached && !cached->isCurrent()) { sourceChanged(); }
+                }));
+        }
+        sourceConnections.emplace_back(App::GetApplication().signalDeleteDocument.connect(
+            [this, sources](const App::Document& closing) {
+                if (std::ranges::find(sources, &closing) != sources.end()) {
+                    sourceChanged();
+                }
+            }));
+        invalidationPending = false;
+    }
+
+    void schedule()
+    {
+        if (!scheduled && !computing && !waiters.empty()) {
+            scheduled = true;
+            if (!dispatchToGuiFrame(this, [this] {
+                    try {
+                        drain();
+                    }
+                    catch (const std::exception& error) {
+                        preparation.reset();
+                        scheduled = false;
+                        deliver({}, error.what());
+                    }
+                    catch (...) {
+                        preparation.reset();
+                        scheduled = false;
+                        deliver({}, "Model browser capture cancelled or failed");
+                    }
+                })) {
+                scheduled = false;
+                throw std::runtime_error("Model browser owner dispatcher is unavailable");
+            }
+        }
+    }
+
+    bool waitForStableSources(const std::vector<App::Document*>& sources)
+    {
+        stableConnections.clear();
+        bool busy = false;
+        for (auto* source : sources) {
+            if (!Gui::Document::projectionRefreshBlocked(source)) {
+                continue;
+            }
+            busy = true;
+            stableConnections.emplace_back(source->signalBecameStable.connect(
+                [this](const App::Document&) { schedule(); }));
+            stableConnections.emplace_back(source->signalCooperativeMutationChanged.connect(
+                [this](const App::Document&, bool active) { if (!active) { schedule(); } }));
+            stableConnections.emplace_back(source->signalSkipRecompute.connect(
+                [this](const App::Document&, const std::vector<App::DocumentObject*>&) { schedule(); }));
+        }
+        if (busy) {
+            // Global restore activity and early-return recomputes can unblock
+            // a source without emitting that source's normal stable signal.
+            auto& app = App::GetApplication();
+            stableConnections.emplace_back(app.signalFinishRestoreDocument.connect(
+                [this](const App::Document&) { schedule(); }));
+            stableConnections.emplace_back(app.signalRestoreActivityIdle.connect(
+                [this] { schedule(); }));
+            stableConnections.emplace_back(app.signalFinishOpenDocument.connect(
+                [this] { schedule(); }));
+            stableConnections.emplace_back(app.signalRecomputeRequestFinished.connect(
+                [this](const std::string&) { schedule(); }));
+            stableConnections.emplace_back(app.signalDeleteDocument.connect(
+                [this](const App::Document&) { schedule(); }));
+        }
+        return busy;
+    }
+
+    void deliver(Result result, std::string failure)
+    {
+        auto recipients = std::move(waiters);
+        waiters.clear();
+        const QPointer<Data> lifetime(this);
+        for (auto& [key, waiter] : recipients) {
+            dispatchToGuiFrame([lifetime, waiter = std::move(waiter), result, failure]() mutable {
+                if (!lifetime || !waiter.receiver) {
+                    return;
+                }
+                if (result && !result->isCurrent()) {
+                    lifetime->request(waiter.receiver, std::move(waiter.completion));
+                    return;
+                }
+                waiter.completion(result, std::move(failure));
+            });
+        }
+    }
+
+    void drain()
+    {
+        scheduled = false;
+        std::erase_if(waiters, [](const auto& entry) { return !entry.second.receiver; });
+        if (waiters.empty() || computing) {
+            return;
+        }
+        auto* owner = document();
+        if (!owner) {
+            deliver({}, "The projection's source document was closed");
+            return;
+        }
+        const auto sources = preparation ? preparation->sourceDocuments()
+            : cached ? cached->sourceDocuments() : std::vector<App::Document*> {owner};
+        if (waitForStableSources(sources)) {
+            return;
+        }
+        if (cached && cached->isCurrent()) {
+            if (invalidationPending) {
+                // A notification may have been raised before the actual
+                // mutation; only a current capture can clear the dirty epoch.
+                observeSources();
+            }
+            deliver(cached, {});
+            return;
+        }
+        cached.reset();
+        if (!preparation || !preparation->isCurrent()) {
+            preparation = std::make_unique<ModelTreeBrowserProjection::Preparation>(owner);
+        }
+        FrameBudget budget;
+        bool captured = false;
+        do {
+            if (!preparation->isCurrent()) {
+                if (!waitForStableSources(preparation->sourceDocuments())) {
+                    preparation.reset();
+                    schedule();
+                }
+                return;
+            }
+            captured = preparation->captureNext();
+        } while (!captured && !budget.exhausted());
+        if (!captured) {
+            schedule();
+            return;
+        }
+        computing = true;
+        const QPointer<Data> lifetime(this);
+        auto complete = [lifetime](Result result, std::string failure) {
+            dispatchToGuiFrame([lifetime, result = std::move(result), failure = std::move(failure)] {
+                if (!lifetime) {
+                    return;
+                }
+                lifetime->computing = false;
+                try {
+                    if (!result) {
+                        lifetime->deliver({}, failure);
+                    }
+                    else {
+                        lifetime->cached = result;
+                        if (result->isCurrent()) {
+                            lifetime->observeSources();
+                        }
+                        lifetime->schedule();
+                    }
+                }
+                catch (const std::exception& error) {
+                    lifetime->cached.reset();
+                    lifetime->deliver({}, error.what());
+                }
+                catch (...) {
+                    lifetime->cached.reset();
+                    lifetime->deliver({}, "Model browser completion cancelled or failed");
+                }
+            });
+        };
+        auto& runtime = App::GetApplication().hostRuntime();
+        const auto stop = cancellation.get_token();
+        try {
+            runtime.submitWithCompletion(App::HostRuntime::Lane::Compute,
+                [input = std::move(preparation), &runtime, stop](std::stop_token shutdown) mutable {
+                    Base::CancellationScope shutdownScope(shutdown);
+                    return std::make_shared<ModelTreeBrowserProjection>(
+                        std::move(*input).finish(&runtime, stop));
+                },
+                [complete](std::future<std::shared_ptr<ModelTreeBrowserProjection>> result) {
+                    try { complete(result.get(), {}); }
+                    catch (const std::exception& error) { complete({}, error.what()); }
+                    catch (...) { complete({}, "Model browser preparation cancelled or failed"); }
+                });
+        }
+        catch (const std::exception& error) {
+            complete({}, error.what());
+        }
+    }
+};
+
+ModelTreeBrowserCache::ModelTreeBrowserCache(App::Document* document)
+{
+    if (!QCoreApplication::instance()
+        || QThread::currentThread() != QCoreApplication::instance()->thread()) {
+        throw std::runtime_error("Model browser cache must be created on the GUI owner");
+    }
+    data = std::make_unique<Data>(document);
+}
+
+ModelTreeBrowserCache::~ModelTreeBrowserCache() = default;
+
+void ModelTreeBrowserCache::request(QObject* receiver, Completion completion)
+{
+    if (QThread::currentThread() != data->thread()
+        || (receiver && receiver->thread() != data->thread())) {
+        throw std::runtime_error("Model browser requests must belong to the GUI owner");
+    }
+    data->request(receiver, std::move(completion));
+}
+
+void ModelTreeBrowserCache::observeInvalidation(QObject* receiver,
+                                              std::function<void()> invalidated)
+{
+    if (QThread::currentThread() != data->thread()
+        || (receiver && receiver->thread() != data->thread())) {
+        throw std::runtime_error("Model browser observers must belong to the GUI owner");
+    }
+    if (receiver && invalidated) {
+        data->observers.insert_or_assign(receiver, Data::Observer {receiver, std::move(invalidated)});
+    }
+    else {
+        data->observers.erase(receiver);
+    }
 }

--- a/src/Gui/ModelTreeBrowser.h
+++ b/src/Gui/ModelTreeBrowser.h
@@ -3,12 +3,22 @@
 #pragma once
 
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
+#include <memory>
+#include <string>
+#include <cstdint>
+#include <functional>
+#include <stop_token>
+#include <FCGlobal.h>
+
+class QObject;
 
 namespace App
 {
 class Document;
 class DocumentObject;
+class HostRuntime;
 }
 
 namespace Gui
@@ -23,7 +33,7 @@ namespace Gui
  * This projection derives a stable browser role and ownership context without
  * creating, moving, or modifying any document objects.
  */
-class ModelTreeBrowserProjection
+class GuiExport ModelTreeBrowserProjection
 {
 public:
     enum class Role
@@ -113,18 +123,62 @@ public:
 
     explicit ModelTreeBrowserProjection(App::Document* document);
 
+    /** Capture on the document owner, one metadata record or relation per call.
+     * Finish may run on
+     * a compute worker: it only consumes captured values and opaque identity
+     * tokens, never live document properties. The caller must reject results
+     * if its document generation changes during capture or before adoption.
+     */
+    class GuiExport Preparation
+    {
+    public:
+        explicit Preparation(App::Document* document);
+        ~Preparation();
+        Preparation(Preparation&&) noexcept;
+        Preparation& operator=(Preparation&&) noexcept;
+        bool captureNext();
+        bool isCurrent() const;
+        std::vector<App::Document*> sourceDocuments() const;
+        ModelTreeBrowserProjection finish(
+            App::HostRuntime* runtime = nullptr, std::stop_token cancellation = {}) &&;
+
+    private:
+        struct Data;
+        std::unique_ptr<Data> data;
+    };
+
     const std::vector<Entry>& entries() const
     {
         return _entries;
     }
 
     const Entry* find(const App::DocumentObject* object) const;
+    /// Owner-thread check before reusing or adopting captured identities.
+    bool isCurrent() const;
+    std::vector<App::Document*> sourceDocuments() const;
+
+    const std::vector<App::DocumentObject*>& timelineOperations() const { return _operations; }
+    const std::unordered_map<const App::DocumentObject*, const App::DocumentObject*>&
+    timelineRoots() const { return _timelineRoots; }
+    const std::unordered_set<App::DocumentObject*>& internalTransformations() const
+    {
+        return _internalTransformations;
+    }
 
     static bool isBody(const App::DocumentObject* object);
     static bool isComponent(const App::DocumentObject* object);
     static bool isVibeScriptProgram(const App::DocumentObject* object);
 
 private:
+    struct SourceRevision
+    {
+        std::string name;
+        std::string uid;
+        std::uint64_t generation {};
+        bool isCurrent() const;
+        App::Document* resolve() const;
+    };
+    ModelTreeBrowserProjection() = default;
     struct Ownership
     {
         App::DocumentObject* component {};
@@ -136,19 +190,47 @@ private:
 
     // History edits reorder the persisted document timeline independently of
     // creation order. Preserve that chronology inside every ownership folder.
-    void orderOperationsByTimeline(const App::Document* document);
+    void orderOperationsByTimeline(const std::vector<App::DocumentObject*>& operations);
 
     // PartDesign move up/down edits the Body's Group order, so Group order --
     // not creation order -- is the feature history the browser must present.
-    void orderFeaturesByBodyHistory();
+    void orderFeaturesByBodyHistory(
+        const std::unordered_map<const App::DocumentObject*,
+                                 std::vector<App::DocumentObject*>>& histories);
     static Role classify(
         const App::DocumentObject* object,
         const Ownership& ownership,
-        bool publishedOutput
+        bool publishedOutput,
+        bool inspectOrigin = true
     );
 
     std::vector<Entry> _entries;
     std::unordered_map<const App::DocumentObject*, std::size_t> _index;
+    std::vector<App::DocumentObject*> _operations;
+    std::unordered_map<const App::DocumentObject*, const App::DocumentObject*> _timelineRoots;
+    std::unordered_set<App::DocumentObject*> _internalTransformations;
+    std::vector<SourceRevision> _sourceRevisions;
+};
+
+/** One GUI-document-owned preparation/cache shared by Tree and History.
+ * Requests are asynchronous and coalesced per receiver. A cached result is
+ * reused only while every captured source revision remains current.
+ */
+class GuiExport ModelTreeBrowserCache
+{
+public:
+    using Result = std::shared_ptr<const ModelTreeBrowserProjection>;
+    using Completion = std::function<void(Result, std::string)>;
+    explicit ModelTreeBrowserCache(App::Document* document);
+    ~ModelTreeBrowserCache();
+    void request(QObject* receiver, Completion completion);
+    /// Coalesced schema and referenced-document changes. Local value changes
+    /// use each consumer's property-specific handlers; destruction disconnects it.
+    void observeInvalidation(QObject* receiver, std::function<void()> invalidated);
+
+private:
+    struct Data;
+    std::unique_ptr<Data> data;
 };
 
 }  // namespace Gui

--- a/src/Gui/ModuleIO.cpp
+++ b/src/Gui/ModuleIO.cpp
@@ -61,10 +61,26 @@ void ModuleIO::openFile(const QString& filename)
     }
 }
 
+void ModuleIO::openFileFromGui(const QString& filename)
+{
+    const auto handlers = SelectModule::importHandler(filename);
+    if (!handlers.isEmpty()) {
+        const auto selected = handlers.cbegin();
+        Application::Instance->openFileFromGui(selected.key().toUtf8(), selected.value().toLatin1());
+    }
+}
+
 void ModuleIO::verifyAndOpenFile(const QString& filename)
 {
     if (verifyFile(filename)) {
         openFile(filename);
+    }
+}
+
+void ModuleIO::verifyAndOpenFileFromGui(const QString& filename)
+{
+    if (verifyFile(filename)) {
+        openFileFromGui(filename);
     }
 }
 

--- a/src/Gui/ModuleIO.h
+++ b/src/Gui/ModuleIO.h
@@ -49,6 +49,8 @@ public:
      * \param filename
      */
     static void openFile(const QString& filename);
+    /// Interactive variant: native documents restore asynchronously.
+    static void openFileFromGui(const QString& filename);
     /*!
      * \brief verifyAndOpenFile
      * Verifies the existence of the file and opens it.
@@ -56,6 +58,7 @@ public:
      * \param filename
      */
     static void verifyAndOpenFile(const QString& filename);
+    static void verifyAndOpenFileFromGui(const QString& filename);
     /*!
      * \brief importFile
      * Imports the files into the given document.

--- a/src/Gui/ProgressBar.cpp
+++ b/src/Gui/ProgressBar.cpp
@@ -21,8 +21,13 @@
  ***************************************************************************/
 
 
+#include <algorithm>
+#include <atomic>
+#include <mutex>
+
 #include <QApplication>
 #include <QElapsedTimer>
+#include <QEventLoop>
 #include <QKeyEvent>
 #include <QMessageBox>
 #include <QMetaObject>
@@ -33,9 +38,11 @@
 
 
 #include "ProgressBar.h"
+#include "FrameBudget.h"
 #include "MainWindow.h"
 #include "ProgressDialog.h"
 #include "WaitCursor.h"
+
 
 
 using namespace Gui;
@@ -49,14 +56,16 @@ struct SequencerBarPrivate
     WaitCursor* waitCursor;
     QElapsedTimer measureTime;
     QElapsedTimer progressTime;
-    QElapsedTimer checkAbortTime;
+    QElapsedTimer eventServiceTime;
     QString text;
-    bool guiThread;
+    std::mutex presentationMutex;
+    std::atomic_bool guiThread {true};
 };
 
 struct ProgressBarPrivate
 {
     QTimer* delayShowTimer;
+    QTimer* statusTimer;
     int minimumDuration;
     int observeEventFilter;
     bool userEnabled {true};
@@ -104,11 +113,12 @@ SequencerBar::SequencerBar()
     d = new SequencerBarPrivate;
     d->bar = nullptr;
     d->waitCursor = nullptr;
-    d->guiThread = true;
+    setProgressPulseHandler(&SequencerBar::progressPulse, this);
 }
 
 SequencerBar::~SequencerBar()
 {
+    setProgressPulseHandler(nullptr, nullptr);
     delete d;
 }
 
@@ -116,8 +126,17 @@ void SequencerBar::pause()
 {
     QThread* currentThread = QThread::currentThread();
     QThread* thr = d->bar->thread();  // this is the main thread
-    d->bar->leaveControlEvents(d->guiThread);
+    const bool guiThread = d->guiThread.load(std::memory_order_acquire);
     if (thr != currentThread) {
+        QMetaObject::invokeMethod(
+            d->bar,
+            [bar = d->bar, guiThread] { bar->leaveControlEvents(guiThread); },
+            Qt::QueuedConnection
+        );
+        return;
+    }
+    d->bar->leaveControlEvents(guiThread);
+    if (!guiThread) {
         return;
     }
 
@@ -130,42 +149,54 @@ void SequencerBar::resume()
 {
     QThread* currentThread = QThread::currentThread();
     QThread* thr = d->bar->thread();  // this is the main thread
-    if (thr == currentThread) {
-        QApplication::restoreOverrideCursor();
-        d->waitCursor->setWaitCursor();
+    const bool guiThread = d->guiThread.load(std::memory_order_acquire);
+    if (thr != currentThread) {
+        QMetaObject::invokeMethod(
+            d->bar,
+            [bar = d->bar, guiThread] { bar->enterControlEvents(guiThread); },
+            Qt::QueuedConnection
+        );
+        return;
+    }
+    if (!guiThread) {
+        d->bar->enterControlEvents(false);
+        return;
     }
 
+    QApplication::restoreOverrideCursor();
+    d->waitCursor->setWaitCursor();
+
     // must be called as last to get control before WaitCursor
-    d->bar->enterControlEvents(d->guiThread);  // grab again
+    d->bar->enterControlEvents(guiThread);  // grab again
 }
 
 void SequencerBar::startStep()
 {
     QThread* currentThread = QThread::currentThread();
     QThread* thr = d->bar->thread();  // this is the main thread
+    d->progressTime.start();
+    d->eventServiceTime.start();
+    {
+        std::lock_guard lock(d->presentationMutex);
+        d->measureTime.start();
+    }
     if (thr != currentThread) {
-        d->guiThread = false;
+        d->guiThread.store(false, std::memory_order_release);
         QMetaObject::invokeMethod(
             d->bar,
-            "setRangeEx",
-            Qt::QueuedConnection,
-            Q_ARG(int, 0),
-            Q_ARG(int, (int)nTotalSteps)
+            [bar = d->bar, totalSteps = nTotalSteps] {
+                bar->setRangeEx(0, static_cast<int>(totalSteps));
+                bar->aboutToShow();
+                bar->enterControlEvents(false);
+            },
+            Qt::QueuedConnection
         );
-        d->progressTime.start();
-        d->checkAbortTime.start();
-        d->measureTime.start();
-        QMetaObject::invokeMethod(d->bar, "aboutToShow", Qt::QueuedConnection);
-        d->bar->enterControlEvents(d->guiThread);
     }
     else {
-        d->guiThread = true;
+        d->guiThread.store(true, std::memory_order_release);
         d->bar->setRangeEx(0, (int)nTotalSteps);
-        d->progressTime.start();
-        d->checkAbortTime.start();
-        d->measureTime.start();
         d->waitCursor = new Gui::WaitCursor;
-        d->bar->enterControlEvents(d->guiThread);
+        d->bar->enterControlEvents(true);
         d->bar->aboutToShow();
     }
 }
@@ -180,12 +211,8 @@ void SequencerBar::checkAbort()
     if (d->bar->thread() != QThread::currentThread()) {
         return;
     }
+    serviceGuiEvents();
     if (!wasCanceled()) {
-        if (d->checkAbortTime.elapsed() < 500) {
-            return;
-        }
-        d->checkAbortTime.restart();
-        qApp->processEvents();
         return;
     }
     // restore cursor
@@ -201,6 +228,35 @@ void SequencerBar::checkAbort()
     else {
         rejectCancel();
     }
+}
+
+void SequencerBar::serviceGuiEvents()
+{
+    if (!d->bar || d->bar->thread() != QThread::currentThread()) {
+        return;
+    }
+    if (!d->eventServiceTime.isValid()) {
+        d->eventServiceTime.start();
+        return;
+    }
+    if (d->eventServiceTime.elapsed() < FrameBudget::Milliseconds) {
+        return;
+    }
+
+    d->eventServiceTime.restart();
+    // The owning operation is still exposing a partial document state. Paint,
+    // timers, and progress may advance, but no user command may re-enter the
+    // document until the operation reaches its stable boundary.
+    qApp->processEvents(
+        QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers,
+        1
+    );
+}
+
+void SequencerBar::progressPulse(void* context)
+{
+    auto* sequencer = static_cast<SequencerBar*>(context);
+    sequencer->serviceGuiEvents();
 }
 
 void SequencerBar::nextStep(bool canAbort)
@@ -265,14 +321,12 @@ void SequencerBar::setValue(int step)
             if (thr != currentThread) {
                 QMetaObject::invokeMethod(
                     d->bar,
-                    "setValueEx",
-                    Qt::/*Blocking*/ QueuedConnection,
-                    Q_ARG(int, d->bar->value() + 1)
+                    [bar = d->bar] { bar->setValueEx(bar->value() + 1); },
+                    Qt::QueuedConnection
                 );
             }
             else {
                 d->bar->setValueEx(d->bar->value() + 1);
-                qApp->processEvents();
             }
         }
     }
@@ -284,13 +338,14 @@ void SequencerBar::setValue(int step)
             if (thr != currentThread) {
                 QMetaObject::invokeMethod(
                     d->bar,
-                    "setValueEx",
-                    Qt::/*Blocking*/ QueuedConnection,
-                    Q_ARG(int, step)
+                    [this, bar = d->bar, step] {
+                        bar->setValueEx(step);
+                        if (bar->isVisible()) {
+                            showRemainingTime();
+                        }
+                    },
+                    Qt::QueuedConnection
                 );
-                if (d->bar->isVisible()) {
-                    showRemainingTime();
-                }
             }
             else {
                 d->bar->setValueEx(step);
@@ -298,7 +353,6 @@ void SequencerBar::setValue(int step)
                     showRemainingTime();
                 }
                 d->bar->resetObserveEventFilter();
-                qApp->processEvents();
             }
         }
     }
@@ -309,34 +363,45 @@ void SequencerBar::showRemainingTime()
     QThread* currentThread = QThread::currentThread();
     QThread* thr = d->bar->thread();  // this is the main thread
 
-    int elapsed = d->measureTime.elapsed();
-    int progress = d->bar->value();
+    qint64 elapsed;
+    QString txt;
+    {
+        std::lock_guard lock(d->presentationMutex);
+        elapsed = d->measureTime.elapsed();
+        txt = d->text;
+    }
+    int progress = std::max(0, d->bar->value());
     int totalSteps = d->bar->maximum() - d->bar->minimum();
+    const auto duration = [](qint64 seconds) {
+        return QStringLiteral("%1:%2:%3")
+            .arg(seconds / 3600, 2, 10, QLatin1Char('0'))
+            .arg((seconds / 60) % 60, 2, 10, QLatin1Char('0'))
+            .arg(seconds % 60, 2, 10, QLatin1Char('0'));
+    };
+    QString status = txt;
+    if (totalSteps > 0) {
+        status += QStringLiteral(" — %1 / %2").arg(progress).arg(totalSteps);
+    }
+    status += QStringLiteral(" — ")
+        + Gui::ProgressBar::tr("Elapsed: %1").arg(duration(elapsed / 1000));
 
-    QString txt = d->text;
     // More than 5 percent complete or more than 5 secs have elapsed.
-    if (progress * 20 > totalSteps || elapsed > 5000) {
-        int rest = (int)((double)totalSteps / progress * elapsed) - elapsed;
+    if (progress > 0 && totalSteps > progress
+        && (progress * 20LL > totalSteps || elapsed > 5000)) {
+        qint64 rest = static_cast<qint64>((double)totalSteps / progress * elapsed) - elapsed;
 
         // more than 1 secs have elapsed and at least 100 ms are remaining
         if (elapsed > 1000 && rest > 100) {
-            QTime time(0, 0, 0);
-            time = time.addSecs(rest / 1000);
-            QString remain = Gui::ProgressBar::tr("Remaining: %1").arg(time.toString());
-            QString status = QStringLiteral("%1\t[%2]").arg(txt, remain);
-
-            if (thr != currentThread) {
-                QMetaObject::invokeMethod(
-                    getMainWindow(),
-                    "showMessage",
-                    Qt::/*Blocking*/ QueuedConnection,
-                    Q_ARG(QString, status)
-                );
-            }
-            else {
-                getMainWindow()->showMessage(status);
-            }
+            status += QStringLiteral(" — ")
+                + Gui::ProgressBar::tr("Estimated remaining: %1").arg(duration(rest / 1000));
         }
+    }
+    if (thr != currentThread) {
+        QMetaObject::invokeMethod(getMainWindow(), "showMessage", Qt::QueuedConnection,
+                                  Q_ARG(QString, status));
+    }
+    else {
+        getMainWindow()->showMessage(status);
     }
 }
 
@@ -345,22 +410,18 @@ void SequencerBar::resetData()
     QThread* currentThread = QThread::currentThread();
     QThread* thr = d->bar->thread();  // this is the main thread
     if (thr != currentThread) {
-        QMetaObject::invokeMethod(d->bar, "resetEx", Qt::QueuedConnection);
-        QMetaObject::invokeMethod(d->bar, "aboutToHide", Qt::QueuedConnection);
+        auto* mainWindow = getMainWindow();
         QMetaObject::invokeMethod(
-            getMainWindow(),
-            "showMessage",
-            Qt::/*Blocking*/ QueuedConnection,
-            Q_ARG(QString, QString())
+            d->bar,
+            [bar = d->bar, mainWindow] {
+                bar->resetEx();
+                bar->aboutToHide();
+                mainWindow->showMessage(QString());
+                mainWindow->setPaneText(1, QString());
+                bar->leaveControlEvents(false);
+            },
+            Qt::QueuedConnection
         );
-        QMetaObject::invokeMethod(
-            getMainWindow(),
-            "setPaneText",
-            Qt::/*Blocking*/ QueuedConnection,
-            Q_ARG(int, 1),
-            Q_ARG(QString, QString())
-        );
-        d->bar->leaveControlEvents(d->guiThread);
     }
     else {
         d->bar->resetEx();
@@ -370,7 +431,7 @@ void SequencerBar::resetData()
         d->bar->aboutToHide();
         delete d->waitCursor;
         d->waitCursor = nullptr;
-        d->bar->leaveControlEvents(d->guiThread);
+        d->bar->leaveControlEvents(d->guiThread.load(std::memory_order_acquire));
         getMainWindow()->setPaneText(1, QString());
         getMainWindow()->showMessage(QString());
     }
@@ -392,23 +453,27 @@ void SequencerBar::setText(const char* pszTxt)
     QThread* thr = d->bar->thread();  // this is the main thread
 
     // print message to the statusbar
-    d->text = pszTxt ? QString::fromUtf8(pszTxt) : QLatin1String("");
+    const QString text = pszTxt ? QString::fromUtf8(pszTxt) : QLatin1String("");
+    {
+        std::lock_guard lock(d->presentationMutex);
+        d->text = text;
+    }
     if (thr != currentThread) {
         QMetaObject::invokeMethod(
             getMainWindow(),
             "showMessage",
             Qt::/*Blocking*/ QueuedConnection,
-            Q_ARG(QString, d->text)
+            Q_ARG(QString, text)
         );
     }
     else {
-        getMainWindow()->showMessage(d->text);
+        getMainWindow()->showMessage(text);
     }
 }
 
 bool SequencerBar::isBlocking() const
 {
-    return d->guiThread;
+    return d->guiThread.load(std::memory_order_acquire);
 }
 
 QProgressBar* SequencerBar::getProgressBar(QWidget* parent)
@@ -436,6 +501,13 @@ ProgressBar::ProgressBar(SequencerBar* s, QWidget* parent)
     d->delayShowTimer = new QTimer(this);
     d->delayShowTimer->setSingleShot(true);
     connect(d->delayShowTimer, &QTimer::timeout, this, &ProgressBar::delayedShow);
+    d->statusTimer = new QTimer(this);
+    d->statusTimer->setInterval(1000);
+    connect(d->statusTimer, &QTimer::timeout, this, [this] {
+        if (sequencer->isRunning()) {
+            sequencer->showRemainingTime();
+        }
+    });
     d->observeEventFilter = 0;
     // Visibility is owned by MainWindow's status-bar registry, which sets
     // userEnabled from the persisted value after registration.
@@ -528,6 +600,7 @@ void ProgressBar::setMinimumDuration(int ms)
 
 void ProgressBar::aboutToShow()
 {
+    d->statusTimer->start();
     // delay showing the bar
     d->delayShowTimer->start(d->minimumDuration);
 #ifdef QT_WINEXTRAS_LIB
@@ -545,6 +618,7 @@ void ProgressBar::delayedShow()
 
 void ProgressBar::aboutToHide()
 {
+    d->statusTimer->stop();
     hide();
 #ifdef QT_WINEXTRAS_LIB
     setupTaskBarProgress();
@@ -627,6 +701,17 @@ void ProgressBar::setupTaskBarProgress()
 bool ProgressBar::eventFilter(QObject* o, QEvent* e)
 {
     if (sequencer->isRunning() && e) {
+        if (!sequencer->isBlocking()) {
+            if (e->type() == QEvent::KeyPress) {
+                auto* keyEvent = static_cast<QKeyEvent*>(e);
+                if (keyEvent->key() == Qt::Key_Escape) {
+                    sequencer->tryToCancel();
+                    return true;
+                }
+            }
+            return QProgressBar::eventFilter(o, e);
+        }
+
         QThread* currentThread = QThread::currentThread();
         QThread* thr = this->thread();  // this is the main thread
         if (thr != currentThread) {

--- a/src/Gui/ProgressBar.h
+++ b/src/Gui/ProgressBar.h
@@ -132,6 +132,8 @@ private:
     /** @name for internal use only */
     //@{
     void setValue(int step);
+    void serviceGuiEvents();
+    static void progressPulse(void* context);
     /** Throws an exception to stop the pending operation. */
     void abort();
     //@}

--- a/src/Gui/ProgressDialog.cpp
+++ b/src/Gui/ProgressDialog.cpp
@@ -23,6 +23,7 @@
 
 #include <QApplication>
 #include <QElapsedTimer>
+#include <QEventLoop>
 #include <QMessageBox>
 #include <QPushButton>
 #include <QThread>
@@ -30,6 +31,7 @@
 
 
 #include "ProgressDialog.h"
+#include "FrameBudget.h"
 #include "MainWindow.h"
 
 
@@ -42,6 +44,7 @@ struct SequencerDialogPrivate
     ProgressDialog* dlg;
     QElapsedTimer measureTime;
     QElapsedTimer progressTime;
+    QElapsedTimer eventServiceTime;
     QString text;
     bool guiThread;
     bool canabort;
@@ -67,10 +70,12 @@ SequencerDialog::SequencerDialog()
     d->dlg->hide();
     d->guiThread = true;
     d->canabort = false;
+    setProgressPulseHandler(&SequencerDialog::progressPulse, this);
 }
 
 SequencerDialog::~SequencerDialog()
 {
+    setProgressPulseHandler(nullptr, nullptr);
     delete d;
 }
 
@@ -82,6 +87,7 @@ void SequencerDialog::resume()
 
 void SequencerDialog::startStep()
 {
+    d->eventServiceTime.start();
     QThread* currentThread = QThread::currentThread();
     QThread* thr = d->dlg->thread();  // this is the main thread
     if (thr != currentThread) {
@@ -114,6 +120,31 @@ void SequencerDialog::startStep()
         d->dlg->setValueEx(0);
         d->dlg->aboutToShow();
     }
+}
+
+void SequencerDialog::serviceGuiEvents()
+{
+    if (d->dlg->thread() != QThread::currentThread()) {
+        return;
+    }
+    if (!d->eventServiceTime.isValid()) {
+        d->eventServiceTime.start();
+        return;
+    }
+    if (d->eventServiceTime.elapsed() < FrameBudget::Milliseconds) {
+        return;
+    }
+
+    d->eventServiceTime.restart();
+    qApp->processEvents(
+        QEventLoop::ExcludeUserInputEvents | QEventLoop::ExcludeSocketNotifiers,
+        1
+    );
+}
+
+void SequencerDialog::progressPulse(void* context)
+{
+    static_cast<SequencerDialog*>(context)->serviceGuiEvents();
 }
 
 void SequencerDialog::nextStep(bool canAbort)
@@ -186,7 +217,6 @@ void SequencerDialog::setValue(int step)
             }
             else {
                 d->dlg->setValueEx(d->dlg->value() + 1);
-                qApp->processEvents();
             }
         }
     }
@@ -207,7 +237,6 @@ void SequencerDialog::setValue(int step)
             if (d->dlg->isVisible()) {
                 showRemainingTime();
             }
-            qApp->processEvents();
         }
     }
 }

--- a/src/Gui/ProgressDialog.h
+++ b/src/Gui/ProgressDialog.h
@@ -67,6 +67,8 @@ private:
     /** @name for internal use only */
     //@{
     void setValue(int step);
+    void serviceGuiEvents();
+    static void progressPulse(void* context);
     /** Throws an exception to stop the pending operation. */
     void abort();
     //@}

--- a/src/Gui/TextDocumentEditorView.cpp
+++ b/src/Gui/TextDocumentEditorView.cpp
@@ -186,7 +186,7 @@ bool TextDocumentEditorView::onMsg(const char* msg)
 
     if (strcmp(msg, "Save") == 0) {
         saveToObject();
-        getGuiDocument()->save();
+        getGuiDocument()->saveAsync();
         return true;
     }
     if (strcmp(msg, "Cut") == 0) {

--- a/src/Gui/Thumbnail.cpp
+++ b/src/Gui/Thumbnail.cpp
@@ -30,6 +30,7 @@
 
 
 #include <App/Application.h>
+#include <Base/Exception.h>
 #include <Base/Reader.h>
 #include <Base/Writer.h>
 #ifdef _MSC_VER
@@ -39,6 +40,7 @@
 
 #include "Thumbnail.h"
 #include "BitmapFactory.h"
+#include "FrameBudget.h"
 #include "View3DInventorViewer.h"
 
 
@@ -88,13 +90,15 @@ void Thumbnail::SaveDocFile(Base::Writer& writer) const
 {
     QImage img;
     bool created = false;
+    const auto onOwner = [](std::function<void()> capture) {
+        if (!dispatchToGuiFrameAndWait(std::move(capture))) {
+            throw Base::RuntimeError("Unable to capture document thumbnail");
+        }
+    };
 
     // 1. Try to create the thumbnail from the viewer
-    if (this->viewer) {
-        if (this->viewer->thread() != QThread::currentThread()) {
-            qWarning("Cannot create a thumbnail from non-GUI thread");
-        }
-        else {
+    onOwner([&] {
+        if (this->viewer) {
             QColor invalid;
             this->viewer->imageFromFramebuffer(
                 this->size,
@@ -106,9 +110,10 @@ void Thumbnail::SaveDocFile(Base::Writer& writer) const
             );
             created = !img.isNull();
         }
-    }
+    });
 
-    // 2. If creation failed (e.g. no viewer or background thread), try to restore from the existing file
+    // 2. If creation failed (e.g. no viewer), restore from the existing file.
+    // Archive access stays on the save caller, never in the owner capture.
     if (!created) {
         QString filename = this->uri.toLocalFile();
         Base::FileInfo fi(filename.toUtf8().constData());
@@ -146,28 +151,34 @@ void Thumbnail::SaveDocFile(Base::Writer& writer) const
 
     // Get app icon and resize to half size to insert in topbottom position over the current view
     // snapshot
-    QPixmap appIcon = Gui::BitmapFactory().pixmap(App::Application::Config()["AppIcon"].c_str());
-    QPixmap px = appIcon;
-    if (!img.isNull()) {
-        // Create a small "Fc" Application icon in the bottom right of the thumbnail
-        if (App::GetApplication()
-                .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
-                ->GetBool("AddThumbnailLogo", false)) {
-            // only scale app icon if an offscreen image could be created
-            appIcon = appIcon.scaled(
-                this->size / 4,
-                this->size / 4,
-                Qt::KeepAspectRatio,
-                Qt::SmoothTransformation
-            );
-            px = BitmapFactory().merge(QPixmap::fromImage(img), appIcon, BitmapFactoryInst::BottomRight);
+    QImage thumbnail;
+    onOwner([&] {
+        QPixmap appIcon = Gui::BitmapFactory().pixmap(App::Application::Config()["AppIcon"].c_str());
+        QPixmap px = appIcon;
+        if (!img.isNull()) {
+            // Create a small "Fc" Application icon in the bottom right of the thumbnail
+            if (App::GetApplication()
+                    .GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document")
+                    ->GetBool("AddThumbnailLogo", false)) {
+                // only scale app icon if an offscreen image could be created
+                appIcon = appIcon.scaled(
+                    this->size / 4,
+                    this->size / 4,
+                    Qt::KeepAspectRatio,
+                    Qt::SmoothTransformation
+                );
+                px = BitmapFactory()
+                         .merge(QPixmap::fromImage(img), appIcon, BitmapFactoryInst::BottomRight);
+            }
+            else {
+                px = QPixmap::fromImage(img);
+            }
         }
-        else {
-            px = QPixmap::fromImage(img);
-        }
-    }
 
-    if (!px.isNull()) {
+        thumbnail = px.toImage();
+    });
+
+    if (!thumbnail.isNull()) {
         // according to specification add some meta-information to the image
         qint64 mt = QDateTime::currentDateTimeUtc().toSecsSinceEpoch();
         QString mtime = QStringLiteral("%1").arg(mt);
@@ -179,7 +190,7 @@ void Thumbnail::SaveDocFile(Base::Writer& writer) const
         QByteArray ba;
         QBuffer buffer(&ba);
         buffer.open(QIODevice::WriteOnly);
-        px.save(&buffer, "PNG");
+        thumbnail.save(&buffer, "PNG");
         writer.Stream().write(ba.constData(), ba.length());
     }
 }

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -29,11 +29,14 @@
 #include <QDir>
 #include <QFileInfo>
 #include <QHeaderView>
+#include <QItemSelectionModel>
 #include <QMenu>
 #include <QMessageBox>
 #include <QPainter>
 #include <QPixmap>
 #include <QProcess>
+#include <QScopedValueRollback>
+#include <QScopeGuard>
 #include <QThread>
 #include <QTimer>
 #include <QToolTip>
@@ -41,6 +44,7 @@
 
 #include <charconv>
 #include <memory>
+#include <span>
 #include <string_view>
 
 #include <Base/Console.h>
@@ -65,6 +69,7 @@
 #include "BitmapFactory.h"
 #include "Command.h"
 #include "Document.h"
+#include "FrameBudget.h"
 #include "ExactTransaction.h"
 #include "ExpressionCompleter.h"
 #include "Macro.h"
@@ -471,7 +476,7 @@ public:
         setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable);
         setText(0, std::move(label));
         setExpanded(false);
-        updateStatus();
+        applyStatus(0, 0, false);
     }
 
     DocumentItem* getOwnerDocument() const
@@ -527,15 +532,11 @@ public:
 
     void updateStatus()
     {
-        std::vector<DocumentObjectItem*> items;
-        collectObjectItems(this, items);
+        owner->updateBrowserFolderStatus();
+    }
 
-        int visibleCount = 0;
-        for (const auto* item : items) {
-            visibleCount += TreeWidget::objectItemVisibility(item) ? 1 : 0;
-        }
-
-        const int total = static_cast<int>(items.size());
+    void applyStatus(int visibleCount, int total, bool hasTreeChild)
+    {
         const bool anyVisible = visibleCount > 0;
         const bool allVisible = total > 0 && visibleCount == total;
 
@@ -597,13 +598,6 @@ public:
                 : TreeWidget::tr("%1 of %2 items visible").arg(visibleCount).arg(total)
         );
 
-        bool hasTreeChild = false;
-        for (int index = 0; index < childCount(); ++index) {
-            if (!child(index)->isHidden()) {
-                hasTreeChild = true;
-                break;
-            }
-        }
         setHidden(!hasTreeChild && !owner->showHidden());
     }
 
@@ -643,6 +637,29 @@ private:
 };
 
 // ---------------------------------------------------------------------------
+
+struct DocumentItem::BrowserFolderStatus
+{
+    struct Visit
+    {
+        QTreeWidgetItem* item;
+        int nextChild {};
+        int visible {};
+        int total {};
+        bool hasTreeChild {};
+    };
+    App::Document* document;
+    std::uint64_t generation;
+    std::vector<Visit> stack;
+
+    BrowserFolderStatus(DocumentItem* owner, std::uint64_t generation)
+        : document(owner->document()->getDocument()), generation(generation)
+    {
+        stack.push_back({owner});
+        document->beginPresentationUpdate();
+    }
+    ~BrowserFolderStatus() { document->endPresentationUpdate(); }
+};
 
 class DocumentItem::ExpandInfo: public std::unordered_map<std::string, DocumentItem::ExpandInfoPtr>
 {
@@ -1039,7 +1056,7 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
     this->preselectTimer->setSingleShot(true);
 
     this->statusTimer = new QTimer(this);
-    this->statusTimer->setSingleShot(false);
+    this->statusTimer->setSingleShot(true);
 
     this->selectTimer = new QTimer(this);
     this->selectTimer->setSingleShot(true);
@@ -1049,6 +1066,27 @@ TreeWidget::TreeWidget(const char* name, QWidget* parent)
     connect(this, &QTreeWidget::itemCollapsed, this, &TreeWidget::onItemCollapsed);
     connect(this, &QTreeWidget::itemExpanded, this, &TreeWidget::onItemExpanded);
     connect(this, &QTreeWidget::itemSelectionChanged, this, &TreeWidget::onItemSelectionChanged);
+    connect(selectionModel(), &QItemSelectionModel::selectionChanged, this,
+        [this](const QItemSelection& selected, const QItemSelection& deselected) {
+            const auto record = [this](const QItemSelection& ranges, bool value) {
+                for (const auto& range : ranges) {
+                    if (range.left() > 0) { continue; }
+                    for (int row = range.top(); row <= range.bottom(); ++row) {
+                        auto* item = itemFromIndex(model()->index(row, 0, range.parent()));
+                        if (item && item->type() == ObjectType) {
+                            auto* object = static_cast<DocumentObjectItem*>(item);
+                            // Removing selected rows emits selectionChanged after
+                            // deletion has detached their document ownership.
+                            if (auto* owner = object->getOwnerDocument()) {
+                                owner->recordBrowserSelection(object, value);
+                            }
+                        }
+                    }
+                }
+            };
+            record(deselected, false);
+            record(selected, true);
+        });
     connect(this, &QTreeWidget::itemChanged, this, &TreeWidget::onItemChanged);
     connect(this->preselectTimer, &QTimer::timeout, this, &TreeWidget::onPreSelectTimer);
     connect(this->selectTimer, &QTimer::timeout, this, &TreeWidget::onSelectTimer);
@@ -1083,6 +1121,13 @@ TreeWidget::~TreeWidget()
     Instances.erase(this);
     if (_LastSelectedTreeWidget == this) {
         _LastSelectedTreeWidget = nullptr;
+    }
+    // QTreeWidget destroys its rows only after our maps have been destroyed.
+    // Retire document rows through the normal path while their owner maps and
+    // cross-document item table are still alive. This also nulls child owners
+    // before Qt emits selection/removal notifications.
+    while (!DocumentMap.empty()) {
+        slotDeleteDocument(*DocumentMap.begin()->first);
     }
 }
 
@@ -1495,10 +1540,23 @@ void TreeWidget::_updateStatus(bool delay)
         return;
     }
 
+    if (statusUpdateExecuting) {
+        onUpdateStatus();
+        return;
+    }
+
     if (!delay) {
-        if (!ChangedObjects.empty() || !NewObjects.empty()) {
+        if (statusUpdatePhase != StatusUpdatePhase::Idle
+            || !ChangedObjects.empty() || !NewObjects.empty()) {
             onUpdateStatus();
         }
+        return;
+    }
+    if (statusUpdatePhase != StatusUpdatePhase::Idle) {
+        onUpdateStatus();
+        return;
+    }
+    if (statusUpdateScheduled || statusTimer->isActive()) {
         return;
     }
     int timeout = TreeParams::getStatusTimeout();
@@ -1506,6 +1564,22 @@ void TreeWidget::_updateStatus(bool delay)
         timeout = 1;
     }
     statusTimer->start(timeout);
+}
+
+void TreeWidget::resetStatusUpdate()
+{
+    statusUpdatePhase = StatusUpdatePhase::Idle;
+    statusUpdateDocuments.clear();
+    statusUpdateObjects.clear();
+    statusUpdateErrors.clear();
+    statusUpdateDocumentIndex = 0;
+    statusUpdateObjectIndex = 0;
+    statusUpdateErrorIndex = 0;
+    statusUpdateFirstErrorItem = nullptr;
+    statusUpdateElapsed.invalidate();
+    statusUpdateProjectedObjectCount = 0;
+    statusUpdateAllObjects = false;
+    statusTimer->stop();
 }
 
 void TreeWidget::contextMenuEvent(QContextMenuEvent* e)
@@ -4247,19 +4321,20 @@ void TreeWidget::slotChangedViewObject(const Gui::ViewProvider& vp, const App::P
 {
     if (!App::GetApplication().isRestoring() && vp.isDerivedFrom<ViewProviderDocumentObject>()) {
         const auto& vpd = static_cast<const ViewProviderDocumentObject&>(vp);
+        if (&prop != &vpd.ShowInTree) {
+            return;
+        }
         auto* document = vpd.getObject() ? vpd.getObject()->getDocument() : nullptr;
         if (Gui::Document::projectionRefreshBlocked(document)) {
             if (auto documentIt = DocumentMap.find(vpd.getDocument());
                 documentIt != DocumentMap.end()) {
-                documentIt->second->modelBrowserDirty = true;
                 documentIt->second->transactionRefreshPending = true;
+                documentIt->second->deferStatusChange(vpd.getObject()->getID());
             }
             return;
         }
-        if (&prop == &vpd.ShowInTree) {
-            ChangedObjects.emplace(vpd.getObject(), 0);
-            _updateStatus();
-        }
+        ChangedObjects.emplace(vpd.getObject(), 0);
+        _updateStatus();
     }
 }
 
@@ -4270,8 +4345,8 @@ void TreeWidget::slotTouchedObject(const App::DocumentObject& obj)
         auto* guiDocument = Application::Instance->getDocument(document);
         if (auto documentIt = DocumentMap.find(guiDocument);
             documentIt != DocumentMap.end()) {
-            documentIt->second->modelBrowserDirty = true;
             documentIt->second->transactionRefreshPending = true;
+            documentIt->second->deferStatusChange(obj.getID());
         }
         return;
     }
@@ -4384,7 +4459,29 @@ struct UpdateDisabler
 
 void TreeWidget::onUpdateStatus()
 {
-    if (this->state() == DraggingState || App::GetApplication().isRestoring()) {
+    statusTimer->stop();
+    if (statusUpdateScheduled) {
+        return;
+    }
+    statusUpdateScheduled = true;
+    if (!dispatchToGuiFrame(this, [this] {
+            statusUpdateScheduled = false;
+            processUpdateStatus();
+        })) {
+        statusUpdateScheduled = false;
+        FC_ERR("Cannot schedule Tree projection update");
+    }
+}
+
+void TreeWidget::processUpdateStatus()
+{
+    if (statusUpdateExecuting) {
+        onUpdateStatus();
+        return;
+    }
+    QScopedValueRollback updateGuard(statusUpdateExecuting, true);
+
+    if (this->state() == DraggingState) {
         _updateStatus();
         return;
     }
@@ -4398,11 +4495,11 @@ void TreeWidget::onUpdateStatus()
         // graph.  Keep collecting object identities, but never poll and rebuild
         // the entire tree while that graph is changing. signalBecameStable()
         // schedules one authoritative refresh from the completed document.
-        v.second->modelBrowserDirty = true;
         v.second->transactionRefreshPending = true;
         projectionBlocked = true;
     }
     if (projectionBlocked) {
+        resetStatusUpdate();
         return;
     }
 
@@ -4410,59 +4507,106 @@ void TreeWidget::onUpdateStatus()
 
     UpdateDisabler disabler(*this, updateBlocked);
 
-    std::vector<App::DocumentObject*> errors;
+    FrameBudget budget;
 
-    // Use a local copy in case of nested calls
-    auto localNewObjects = NewObjects;
-    NewObjects.clear();
+    auto scheduleNextSlice = [this]() {
+        onUpdateStatus();
+    };
 
-    // Checking for new objects
-    for (auto& v : localNewObjects) {
-        auto doc = App::GetApplication().getDocument(v.first.c_str());
-        if (!doc) {
+    auto documentItemForName = [this](const std::string& documentName) -> DocumentItem* {
+        auto* document = App::GetApplication().getDocument(documentName.c_str());
+        auto* guiDocument = document && Application::Instance
+            ? Application::Instance->getDocument(document)
+            : nullptr;
+        return guiDocument ? getDocumentItem(guiDocument) : nullptr;
+    };
+
+    if (statusUpdatePhase == StatusUpdatePhase::Idle) {
+        statusUpdatePhase = StatusUpdatePhase::Objects;
+        statusUpdateElapsed.start();
+        statusUpdateProjectedObjectCount = 0;
+        statusUpdateAllObjects = NewObjects.empty() && ChangedObjects.empty();
+        statusUpdateDocuments.clear();
+        statusUpdateObjects.clear();
+        statusUpdateErrors.clear();
+        statusUpdateDocumentIndex = 0;
+        statusUpdateObjectIndex = 0;
+        statusUpdateErrorIndex = 0;
+        statusUpdateFirstErrorItem = nullptr;
+    }
+
+    // A user callback may enqueue another object change between slices. Fold
+    // it into the same authoritative projection before final document-level
+    // work instead of completing and immediately rebuilding a second time.
+    if (statusUpdatePhase != StatusUpdatePhase::Objects
+        && (!NewObjects.empty() || !ChangedObjects.empty())) {
+        statusUpdatePhase = StatusUpdatePhase::Objects;
+    }
+
+    while (statusUpdatePhase == StatusUpdatePhase::Objects && !NewObjects.empty()) {
+        auto documentEntry = NewObjects.begin();
+        if (documentEntry->second.empty()) {
+            NewObjects.erase(documentEntry);
             continue;
         }
-        auto gdoc = Application::Instance->getDocument(doc);
-        if (!gdoc) {
-            continue;
+
+        const std::string documentName = documentEntry->first;
+        const long objectId = documentEntry->second.back();
+        documentEntry->second.pop_back();
+        if (documentEntry->second.empty()) {
+            NewObjects.erase(documentEntry);
         }
-        auto docItem = getDocumentItem(gdoc);
-        if (!docItem) {
-            continue;
+
+        auto* document = App::GetApplication().getDocument(documentName.c_str());
+        auto* guiDocument = document && Application::Instance
+            ? Application::Instance->getDocument(document)
+            : nullptr;
+        auto* documentItem = guiDocument ? getDocumentItem(guiDocument) : nullptr;
+        auto* object = document ? document->getObjectByID(objectId) : nullptr;
+        if (object && documentItem) {
+            statusUpdateObjects.push_back({documentName, objectId});
+            if (object->isError()) {
+                statusUpdateErrors.push_back({documentName, objectId});
+            }
+            if (!documentItem->ObjectMap.contains(object)) {
+                auto* provider = freecad_cast<ViewProviderDocumentObject*>(
+                    guiDocument->getViewProvider(object)
+                );
+                if (provider) {
+                    documentItem->createNewItem(*provider);
+                }
+            }
         }
-        for (auto id : v.second) {
-            auto obj = doc->getObjectByID(id);
-            if (!obj) {
-                continue;
-            }
-            if (obj->isError()) {
-                errors.push_back(obj);
-            }
-            if (docItem->ObjectMap.contains(obj)) {
-                continue;
-            }
-            auto vpd = freecad_cast<ViewProviderDocumentObject*>(gdoc->getViewProvider(obj));
-            if (vpd) {
-                docItem->createNewItem(*vpd);
-            }
+
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
         }
     }
 
-    // Use a local copy in case of nested calls
-    auto localChangedObjects = ChangedObjects;
-    ChangedObjects.clear();
+    // Update one live object identity at a time. Erasing it before callbacks
+    // means a nested notification is retained as fresh work for the next slice.
+    while (statusUpdatePhase == StatusUpdatePhase::Objects && !ChangedObjects.empty()) {
+        const auto changedEntry = ChangedObjects.begin();
+        auto* obj = changedEntry->first;
+        const auto changedStatus = changedEntry->second;
+        ChangedObjects.erase(changedEntry);
 
-    // Update children of changed objects
-    for (auto& v : localChangedObjects) {
-        auto obj = v.first;
+        if (obj && obj->isAttachedToDocument() && obj->getDocument()) {
+            statusUpdateObjects.push_back(
+                {obj->getDocument()->getName(), obj->getID()}
+            );
+        }
 
         auto iter = ObjectTable.find(obj);
         if (iter == ObjectTable.end()) {
             continue;
         }
 
-        if (v.second.test(CS_Error) && obj->isError()) {
-            errors.push_back(obj);
+        if (changedStatus.test(CS_Error) && obj->isError()) {
+            statusUpdateErrors.push_back(
+                {obj->getDocument()->getName(), obj->getID()}
+            );
         }
 
         if (!iter->second.empty()) {
@@ -4484,29 +4628,150 @@ void TreeWidget::onUpdateStatus()
             }
         }
 
-        updateChildren(iter->first, iter->second, v.second.test(CS_Output), false);
+        updateChildren(iter->first, iter->second, changedStatus.test(CS_Output), false);
+
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
+        }
     }
 
-    for (const auto& documentEntry : DocumentMap) {
-        documentEntry.second->refreshModelBrowser();
+    if (statusUpdatePhase == StatusUpdatePhase::Objects) {
+        statusUpdateDocuments.clear();
+        statusUpdateDocuments.reserve(DocumentMap.size());
+        for (const auto& [guiDocument, documentItem] : DocumentMap) {
+            if (guiDocument && documentItem && guiDocument->getDocument()) {
+                statusUpdateDocuments.emplace_back(guiDocument->getDocument()->getName());
+            }
+        }
+        statusUpdateDocumentIndex = 0;
+        statusUpdatePhase = StatusUpdatePhase::Browsers;
+    }
+
+    while (statusUpdatePhase == StatusUpdatePhase::Browsers
+           && statusUpdateDocumentIndex < statusUpdateDocuments.size()) {
+        if (auto* documentItem = documentItemForName(
+                statusUpdateDocuments[statusUpdateDocumentIndex]
+            )) {
+            if (documentItem->modelBrowserDirty) {
+                documentItem->refreshModelBrowser();
+                if (documentItem->modelBrowserPreparationPending) {
+                    return; // The shared cache completion resumes this phase.
+                }
+                if (documentItem->modelBrowserRefreshPending()) {
+                    scheduleNextSlice();
+                    return;
+                }
+            }
+        }
+        ++statusUpdateDocumentIndex;
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
+        }
+    }
+    if (statusUpdatePhase == StatusUpdatePhase::Browsers) {
+        if (statusUpdateAllObjects) {
+            statusUpdateObjects.clear();
+            for (const auto& documentName : statusUpdateDocuments) {
+                auto* documentItem = documentItemForName(documentName);
+                if (!documentItem) {
+                    continue;
+                }
+                statusUpdateObjects.reserve(
+                    statusUpdateObjects.size() + documentItem->ObjectMap.size()
+                );
+                for (const auto& [object, data] : documentItem->ObjectMap) {
+                    if (object && data && object->isAttachedToDocument()) {
+                        statusUpdateObjects.push_back({documentName, object->getID()});
+                    }
+                }
+            }
+        }
+        statusUpdateProjectedObjectCount = statusUpdateObjects.size();
+        statusUpdateObjectIndex = 0;
+        statusUpdateDocumentIndex = 0;
+        statusUpdatePhase = StatusUpdatePhase::ObjectStatus;
+    }
+
+    while (statusUpdatePhase == StatusUpdatePhase::ObjectStatus
+           && statusUpdateObjectIndex < statusUpdateObjects.size()) {
+        const auto identity = statusUpdateObjects[statusUpdateObjectIndex++];
+        auto* document = App::GetApplication().getDocument(identity.documentName.c_str());
+        auto* object = document ? document->getObjectByID(identity.objectId) : nullptr;
+        auto* documentItem = documentItemForName(identity.documentName);
+        if (object && documentItem) {
+            const auto data = documentItem->ObjectMap.find(object);
+            if (data != documentItem->ObjectMap.end() && data->second) {
+                data->second->testStatus();
+            }
+        }
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
+        }
+    }
+    if (statusUpdatePhase == StatusUpdatePhase::ObjectStatus) {
+        statusUpdateObjects.clear();
+        statusUpdateObjectIndex = 0;
+        statusUpdatePhase = StatusUpdatePhase::DocumentStatus;
     }
 
     FC_LOG("update item status");
-    for (auto pos = DocumentMap.begin(); pos != DocumentMap.end(); ++pos) {
-        pos->second->testStatus();
-        pos->second->updateBrowserFolderStatus();
+    while (statusUpdatePhase == StatusUpdatePhase::DocumentStatus
+           && statusUpdateDocumentIndex < statusUpdateDocuments.size()) {
+        if (auto* documentItem = documentItemForName(
+                statusUpdateDocuments[statusUpdateDocumentIndex]
+            )) {
+            documentItem->setBaseIcon(
+                0,
+                documentItem->document()->getDocument()->testStatus(App::Document::PartialDoc)
+                    ? *documentPartialPixmap
+                    : *documentPixmap
+            );
+            documentItem->updateBrowserFolderStatus();
+        }
+        ++statusUpdateDocumentIndex;
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
+        }
+    }
+    if (statusUpdatePhase == StatusUpdatePhase::DocumentStatus) {
+        statusUpdateDocumentIndex = 0;
+        statusUpdatePhase = StatusUpdatePhase::RestoredObjects;
     }
 
-    // Checking for just restored documents
-    for (auto& v : DocumentMap) {
-        auto docItem = v.second;
-
-        for (auto obj : docItem->PopulateObjects) {
-            docItem->populateObject(obj);
+    // Checking for just restored documents. Child population can recursively
+    // create many tree items, so resume after every bounded unit of work.
+    while (statusUpdatePhase == StatusUpdatePhase::RestoredObjects
+           && statusUpdateDocumentIndex < statusUpdateDocuments.size()) {
+        auto* docItem = documentItemForName(
+            statusUpdateDocuments[statusUpdateDocumentIndex]
+        );
+        if (!docItem) {
+            ++statusUpdateDocumentIndex;
+            continue;
         }
-        docItem->PopulateObjects.clear();
 
-        auto doc = v.first->getDocument();
+        auto* doc = docItem->document()->getDocument();
+        if (!doc) {
+            ++statusUpdateDocumentIndex;
+            continue;
+        }
+
+        if (!docItem->PopulateObjects.empty()) {
+            auto* obj = docItem->PopulateObjects.back();
+            docItem->PopulateObjects.pop_back();
+            if (obj && obj->isAttachedToDocument() && obj->getDocument() == doc) {
+                docItem->populateObject(obj);
+            }
+            if (budget.exhausted()) {
+                scheduleNextSlice();
+                return;
+            }
+            continue;
+        }
 
         if (!docItem->connectChgObject.connected()) {
             // NOLINTBEGIN
@@ -4547,22 +4812,58 @@ void TreeWidget::onUpdateStatus()
             }
         }
         docItem->_ExpandInfo.reset();
+        ++statusUpdateDocumentIndex;
+
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
+        }
+    }
+    if (statusUpdatePhase == StatusUpdatePhase::RestoredObjects) {
+        statusUpdateDocumentIndex = 0;
+        statusUpdatePhase = StatusUpdatePhase::Selection;
     }
 
-    if (Selection().hasSelection() && !selectTimer->isActive() && !this->isSelectionBlocked()) {
+    if (statusUpdatePhase == StatusUpdatePhase::Selection
+        && Selection().hasSelection() && !selectTimer->isActive()
+        && !this->isSelectionBlocked()) {
         this->blockSelection(true);
         currentDocItem = nullptr;
-        for (auto& v : DocumentMap) {
-            v.second->setSelected(false);
-            v.second->selectItems();
+        while (statusUpdateDocumentIndex < statusUpdateDocuments.size()) {
+            if (auto* documentItem = documentItemForName(
+                    statusUpdateDocuments[statusUpdateDocumentIndex]
+                )) {
+                documentItem->setSelected(false);
+                documentItem->selectItems();
+            }
+            ++statusUpdateDocumentIndex;
+            if (budget.exhausted()) {
+                this->blockSelection(false);
+                scheduleNextSlice();
+                return;
+            }
         }
         this->blockSelection(false);
     }
 
-    auto activeDocItem = getDocumentItem(Application::Instance->activeDocument());
+    if (statusUpdatePhase == StatusUpdatePhase::Selection) {
+        statusUpdateDocumentIndex = 0;
+        statusUpdatePhase = StatusUpdatePhase::Errors;
+    }
 
-    QTreeWidgetItem* errItem = nullptr;
-    for (auto obj : errors) {
+    auto* activeDocItem = Application::Instance
+        ? getDocumentItem(Application::Instance->activeDocument())
+        : nullptr;
+
+    while (statusUpdatePhase == StatusUpdatePhase::Errors
+           && statusUpdateErrorIndex < statusUpdateErrors.size()) {
+        const auto identity = statusUpdateErrors[statusUpdateErrorIndex++];
+        auto* document = App::GetApplication().getDocument(identity.documentName.c_str());
+        auto* obj = document ? document->getObjectByID(identity.objectId) : nullptr;
+        if (!obj) {
+            continue;
+        }
+
         DocumentObjectDataPtr data;
         if (activeDocItem) {
             auto it = activeDocItem->ObjectMap.find(obj);
@@ -4571,7 +4872,10 @@ void TreeWidget::onUpdateStatus()
             }
         }
         if (!data) {
-            auto docItem = getDocumentItem(Application::Instance->getDocument(obj->getDocument()));
+            auto* guiDocument = Application::Instance
+                ? Application::Instance->getDocument(obj->getDocument())
+                : nullptr;
+            auto* docItem = guiDocument ? getDocumentItem(guiDocument) : nullptr;
             if (docItem) {
                 auto it = docItem->ObjectMap.find(obj);
                 if (it != docItem->ObjectMap.end()) {
@@ -4594,21 +4898,53 @@ void TreeWidget::onUpdateStatus()
             if (item) {
                 data->docItem->showItem(item, false, true);
             }
-            if (!errItem) {
-                errItem = item;
+            if (!statusUpdateFirstErrorItem) {
+                statusUpdateFirstErrorItem = item;
             }
         }
+
+        if (budget.exhausted()) {
+            scheduleNextSlice();
+            return;
+        }
     }
-    if (errItem) {
-        scrollToItem(errItem);
+    if (statusUpdatePhase == StatusUpdatePhase::Errors) {
+        if (statusUpdateFirstErrorItem) {
+            scrollToItem(statusUpdateFirstErrorItem);
+        }
+        statusUpdatePhase = StatusUpdatePhase::Geometry;
     }
 
-    updateGeometries();
-    statusTimer->stop();
+    if (statusUpdatePhase == StatusUpdatePhase::Geometry) {
+        updateGeometries();
+    }
+
+    const qint64 projectionElapsed = statusUpdateElapsed.isValid()
+        ? statusUpdateElapsed.elapsed()
+        : 0;
+    const std::size_t projectedObjectCount = statusUpdateProjectedObjectCount;
+    const bool projectedAllObjects = statusUpdateAllObjects;
+    resetStatusUpdate();
     if (!ChangedObjects.empty() || !NewObjects.empty()) {
         // Property callbacks can enqueue another tree update while this pass is running.  Do not
         // discard the timer they started: process the newly queued changes in a subsequent pass.
         _updateStatus();
+    }
+    else {
+        for (const auto& [guiDocument, documentItem] : DocumentMap) {
+            if (guiDocument && documentItem) {
+                documentItem->releasePresentationUpdate();
+            }
+        }
+    }
+
+    if (qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE")) {
+        Base::Console().message(
+            "VIBECAD_PROJECTION tree total_ms=%lld objects=%zu full=%d\n",
+            static_cast<long long>(projectionElapsed),
+            projectedObjectCount,
+            projectedAllObjects ? 1 : 0
+        );
     }
 
     FC_LOG("done update status");
@@ -4688,9 +5024,13 @@ void TreeWidget::onPreSelectTimer()
 
 void TreeWidget::onItemCollapsed(QTreeWidgetItem* item)
 {
+    if (item && item->type() == BrowserFolderType) {
+        static_cast<BrowserFolderItem*>(item)->getOwnerDocument()->recordBrowserExpansion(item, false);
+    }
     // object item collapsed
     if (item && item->type() == TreeWidget::ObjectType) {
         auto* objectItem = static_cast<DocumentObjectItem*>(item);
+        objectItem->getOwnerDocument()->recordBrowserExpansion(item, false);
         if (!objectItem->isBrowserProxy()) {
             objectItem->setExpandedStatus(false);
         }
@@ -4699,9 +5039,13 @@ void TreeWidget::onItemCollapsed(QTreeWidgetItem* item)
 
 void TreeWidget::onItemExpanded(QTreeWidgetItem* item)
 {
+    if (item && item->type() == BrowserFolderType) {
+        static_cast<BrowserFolderItem*>(item)->getOwnerDocument()->recordBrowserExpansion(item, true);
+    }
     // object item expanded
     if (item && item->type() == TreeWidget::ObjectType) {
         auto objItem = static_cast<DocumentObjectItem*>(item);
+        objItem->getOwnerDocument()->recordBrowserExpansion(item, true);
         if (!objItem->isBrowserProxy()) {
             objItem->setExpandedStatus(true);
             objItem->getOwnerDocument()->populateItem(objItem, false, false);
@@ -5334,6 +5678,17 @@ DocumentItem::DocumentItem(const Gui::Document* doc, QTreeWidgetItem* parent)
     connectDocumentStable = adoc->signalBecameStable.connect(
         std::bind(&DocumentItem::slotDocumentStable, this, sp::_1)
     );
+    connectFinishRestoreDocument =
+        App::GetApplication().signalFinishRestoreDocument.connect(
+            [this, adoc](const App::Document& restored) {
+                if (&restored == adoc) {
+                    // This signal precedes the outer restore scope's idle
+                    // transition. The idle connections below also wake a pass
+                    // that ran early and still observed the document as busy.
+                    getTree()->_updateStatus();
+                }
+            }
+        );
     connectRecomputeRequestFinished =
         App::GetApplication().signalRecomputeRequestFinished.connect(
             [this, adoc](const std::string& documentName) {
@@ -5342,6 +5697,12 @@ DocumentItem::DocumentItem(const Gui::Document* doc, QTreeWidgetItem* parent)
                 }
             }
         );
+    const auto restoreIdle = [this, adoc] {
+        slotDocumentStable(*adoc);
+        if (modelBrowserDirty) { getTree()->_updateStatus(); }
+    };
+    connectRestoreActivityIdle = App::GetApplication().signalRestoreActivityIdle.connect(restoreIdle);
+    connectFinishOpenDocument = App::GetApplication().signalFinishOpenDocument.connect(restoreIdle);
     // NOLINTEND
 
     setFlags(Qt::ItemIsEnabled | Qt::ItemIsSelectable /*|Qt::ItemIsEditable*/);
@@ -5363,7 +5724,15 @@ DocumentItem::~DocumentItem()
     connectRecomputed.disconnect();
     connectRecomputedObj.disconnect();
     connectDocumentStable.disconnect();
+    connectFinishRestoreDocument.disconnect();
+    connectRestoreActivityIdle.disconnect();
+    connectFinishOpenDocument.disconnect();
     connectRecomputeRequestFinished.disconnect();
+    modelBrowserBuild.reset();
+    modelBrowserDetachedItems.clear();
+    stagedModelBrowserRoot.reset();
+    browserFolderStatus.reset();
+    releasePresentationUpdate();
 }
 
 TreeWidget* DocumentItem::getTree() const
@@ -5451,7 +5820,10 @@ void DocumentItem::slotNewObject(const Gui::ViewProviderDocumentObject& obj)
         FC_ERR("view provider not attached");
         return;
     }
-    modelBrowserDirty = true;
+    markModelBrowserDirty();
+    if (Gui::Document::projectionRefreshBlocked(pDocument->getDocument())) {
+        transactionRefreshPending = true;
+    }
     getTree()->NewObjects[pDocument->getDocument()->getName()].push_back(obj.getObject()->getID());
     getTree()->_updateStatus();
 }
@@ -5518,7 +5890,7 @@ bool DocumentItem::createNewItem(
     if (TreeParams::getOrganizeModelByType()) {
         item->setHidden(true);
     }
-    modelBrowserDirty = true;
+    markModelBrowserDirty();
 
     populateItem(item);
     return true;
@@ -5561,9 +5933,21 @@ DocumentObjectItem* DocumentItem::createBrowserObjectItem(
     item->setHidden(
         !showHidden() && (browserDefaultHidden || !data->viewObject->showInTree())
     );
+    if (modelBrowserBuildExecuting) {
+        modelBrowserStagedStates[item].hidden =
+            !showHidden() && (browserDefaultHidden || !data->viewObject->showInTree());
+    }
     item->populated = true;
     item->setChildIndicatorPolicy(QTreeWidgetItem::DontShowIndicator);
-    item->testStatus(true);
+    // The legacy item already carries the current provider status. Copy its
+    // presentation while this replacement tree is detached; the shared
+    // ObjectStatus phase refreshes every item in bounded slices after the
+    // hierarchy is installed. Recomputing icons here made the unsliced staging
+    // pass scale with the complete document a second time.
+    if (data->rootItem) {
+        item->setIcon(0, data->rootItem->icon(0));
+        item->setFont(0, data->rootItem->font(0));
+    }
     return item;
 }
 
@@ -5592,7 +5976,7 @@ DocumentObjectItem* DocumentItem::findBrowserItem(App::DocumentObject* object) c
     }
     DocumentObjectItem* hidden = nullptr;
     for (auto* item : dataIt->second->items) {
-        if (!item->isBrowserProxy()) {
+        if (!item->isBrowserProxy() || item->treeWidget() != getTree()) {
             continue;
         }
         if (!item->isHidden()) {
@@ -5605,51 +5989,89 @@ DocumentObjectItem* DocumentItem::findBrowserItem(App::DocumentObject* object) c
 
 bool DocumentItem::isPresentationItem(const DocumentObjectItem* item) const
 {
-    return item && item->isBrowserProxy() == modelBrowserActive;
+    return item && item->treeWidget() == getTree()
+        && item->isBrowserProxy() == modelBrowserActive;
 }
 
 void DocumentItem::clearModelBrowser()
 {
+    // Synchronous compatibility entry point. Interactive replacement advances
+    // the same removal cursor once per frame via clearModelBrowserStep().
+    while (!clearModelBrowserStep()) {}
+}
+
+bool DocumentItem::clearModelBrowserStep()
+{
     auto* tree = getTree();
     if (!tree) {
-        return;
+        return true;
     }
-
-    if (tree->editingItem && tree->editingItem->isBrowserProxy()
-        && tree->editingItem->getOwnerDocument() == this) {
-        tree->editingItem = nullptr;
-    }
-
-    const bool selectionLock = tree->blockSelection(true);
-    QSignalBlocker signalBlocker(tree);
-    for (int index = childCount() - 1; index >= 0; --index) {
-        auto* childItem = child(index);
-        const bool isBrowserRoot = childItem->type() == TreeWidget::BrowserFolderType
-            || (childItem->type() == TreeWidget::ObjectType
-                && static_cast<DocumentObjectItem*>(childItem)->isBrowserProxy());
-        if (isBrowserRoot) {
-            delete childItem;
+    if (!modelBrowserClearing) {
+        browserFolderStatus.reset();
+        browserFolderStatusDirty = false;
+        if (tree->editingItem && tree->editingItem->isBrowserProxy()
+            && tree->editingItem->getOwnerDocument() == this) {
+            tree->editingItem = nullptr;
         }
+        modelBrowserRemovalRoot = childCount() - 1;
+        modelBrowserRemovalCursor = QPersistentModelIndex();
+        modelBrowserClearing = true;
     }
-    tree->blockSelection(selectionLock);
-    modelBrowserActive = false;
+    QScopedValueRollback applying(modelBrowserApplyingState, true);
+    const bool selectionLock = tree->blockSelection(true);
+    const auto restoreSelection = qScopeGuard([&] { tree->blockSelection(selectionLock); });
+    QSignalBlocker signalBlocker(tree);
+    FrameBudget budget;
+    do {
+        if (modelBrowserRemovalCursor.isValid()) {
+            auto* item = tree->itemFromIndex(modelBrowserRemovalCursor);
+            if (item->childCount()) {
+                modelBrowserRemovalCursor = tree->indexFromItem(item->child(item->childCount() - 1));
+            }
+            else {
+                auto* parent = item->parent();
+                modelBrowserRemovalCursor = parent == this ? QModelIndex() : tree->indexFromItem(parent);
+                delete item;
+                if (!modelBrowserClearing) { return false; }
+            }
+        }
+        else if (modelBrowserRemovalRoot >= 0) {
+            modelBrowserRemovalRoot = std::min(modelBrowserRemovalRoot, childCount() - 1);
+            if (modelBrowserRemovalRoot < 0) { continue; }
+            auto* item = child(modelBrowserRemovalRoot--);
+            if (item->type() == TreeWidget::BrowserFolderType
+                || (item->type() == TreeWidget::ObjectType
+                    && static_cast<DocumentObjectItem*>(item)->isBrowserProxy())) {
+                modelBrowserRemovalCursor = tree->indexFromItem(item);
+            }
+        }
+        else {
+            modelBrowserClearing = false;
+            modelBrowserActive = false;
+            return true;
+        }
+    } while (!budget.exhausted());
+    return false;
 }
 
 void DocumentItem::setLegacyTreeVisible(bool visible)
 {
     for (const auto& entry : ObjectMap) {
         for (auto* item : entry.second->items) {
-            if (item->isBrowserProxy()) {
-                continue;
-            }
-            item->setHidden(!visible || (!showHidden() && !item->object()->showInTree()));
-            if (!visible) {
-                item->selected = 0;
-                item->mySubs.clear();
-                item->setSelected(false);
-                item->setCheckState(false);
-            }
+            setLegacyItemVisible(item, visible);
         }
+    }
+}
+
+void DocumentItem::setLegacyItemVisible(DocumentObjectItem* item, bool visible)
+{
+    if (item->isBrowserProxy()) { return; }
+    item->setHidden(!visible || (!showHidden() && !item->object()->showInTree()));
+    if (!visible) {
+        item->selected = 0;
+        item->mySubs.clear();
+        item->setSelected(false);
+        item->setCheckState(false);
     }
 }
 
@@ -5659,30 +6081,190 @@ void DocumentItem::updateBrowserFolderStatus()
         return;
     }
 
-    std::vector<BrowserFolderItem*> folders;
-    std::function<void(QTreeWidgetItem*)> collect = [&](QTreeWidgetItem* parent) {
-        for (int index = 0; index < parent->childCount(); ++index) {
-            auto* childItem = parent->child(index);
-            if (childItem->type() == TreeWidget::BrowserFolderType) {
-                auto* folder = static_cast<BrowserFolderItem*>(childItem);
-                if (folder->getOwnerDocument() == this) {
-                    folders.push_back(folder);
-                    collect(folder);
-                }
+    browserFolderStatusDirty = true;
+    scheduleBrowserFolderStatus();
+}
+
+void DocumentItem::scheduleBrowserFolderStatus()
+{
+    auto* tree = getTree();
+    if (!tree || browserFolderStatusScheduled) {
+        return;
+    }
+    browserFolderStatusScheduled = true;
+    auto* guiDocument = document();
+    auto* identity = this;
+    dispatchToGuiFrame(tree, [tree, guiDocument, identity] {
+        const auto found = tree->DocumentMap.find(guiDocument);
+        if (found != tree->DocumentMap.end() && found->second == identity) {
+            try {
+                found->second->processBrowserFolderStatus();
             }
-            else if (
-                childItem->type() == TreeWidget::ObjectType
-                && static_cast<DocumentObjectItem*>(childItem)->isBrowserProxy()
-            ) {
-                collect(childItem);
+            catch (const std::exception& error) {
+                found->second->browserFolderStatus.reset();
+                Base::Console().error("Browser folder status failed: %s\n", error.what());
+            }
+            catch (...) {
+                found->second->browserFolderStatus.reset();
+                Base::Console().error("Browser folder status failed\n");
             }
         }
-    };
-    collect(this);
+    });
+}
 
-    // Inner folders determine whether their parents have visible children.
-    for (auto it = folders.rbegin(); it != folders.rend(); ++it) {
-        (*it)->updateStatus();
+void DocumentItem::processBrowserFolderStatus()
+{
+    browserFolderStatusScheduled = false;
+    if (!modelBrowserActive || modelBrowserDirty
+        || Gui::Document::projectionRefreshBlocked(document()->getDocument())) {
+        browserFolderStatus.reset();
+        return; // Hierarchy adoption / document-stable notifications resume it.
+    }
+    if (!browserFolderStatus || browserFolderStatus->generation != modelBrowserGeneration) {
+        browserFolderStatus = std::make_unique<BrowserFolderStatus>(this, modelBrowserGeneration);
+        browserFolderStatusDirty = false;
+    }
+    FrameBudget budget;
+    QSignalBlocker signalBlocker(getTree());
+    auto& stack = browserFolderStatus->stack;
+    do {
+        auto& visit = stack.back();
+        if (visit.nextChild < visit.item->childCount()) {
+            auto* child = visit.item->child(visit.nextChild++);
+            const bool folder = child->type() == TreeWidget::BrowserFolderType
+                && static_cast<BrowserFolderItem*>(child)->getOwnerDocument() == this;
+            const bool object = child->type() == TreeWidget::ObjectType
+                && static_cast<DocumentObjectItem*>(child)->isBrowserProxy();
+            if (folder || object) {
+                stack.push_back({child});
+            }
+            else {
+                visit.hasTreeChild |= !child->isHidden();
+            }
+        }
+        else {
+            auto completed = visit;
+            stack.pop_back();
+            const bool folder = completed.item->type() == TreeWidget::BrowserFolderType;
+            if (folder) {
+                static_cast<BrowserFolderItem*>(completed.item)->applyStatus(
+                    completed.visible, completed.total, completed.hasTreeChild);
+            }
+            if (!stack.empty() && !completed.item->isHidden()) {
+                auto& parent = stack.back();
+                parent.hasTreeChild = true;
+                if (folder) {
+                    parent.total += completed.total;
+                    parent.visible += completed.visible;
+                }
+                else if (completed.item->type() == TreeWidget::ObjectType) {
+                    auto* item = static_cast<DocumentObjectItem*>(completed.item);
+                    if (item->object() && item->object()->canToggleVisibility()) {
+                        ++parent.total;
+                        parent.visible += TreeWidget::objectItemVisibility(item) ? 1 : 0;
+                    }
+                }
+            }
+        }
+    } while (!stack.empty() && !budget.exhausted());
+    if (!stack.empty()) {
+        scheduleBrowserFolderStatus();
+        return;
+    }
+    // Each Qt item is read once; folder aggregates propagate bottom-up and
+    // stop at object boundaries. There is no per-folder subtree rescan.
+    if (browserFolderStatusDirty) {
+        browserFolderStatusDirty = false;
+        stack.push_back({this});
+        scheduleBrowserFolderStatus();
+    }
+    else {
+        browserFolderStatus.reset();
+    }
+}
+
+void DocumentItem::recordBrowserExpansion(QTreeWidgetItem* item, bool expanded)
+{
+    if (modelBrowserApplyingState || !modelBrowserDirty || !TreeParams::getOrganizeModelByType()) {
+        return;
+    }
+    if (item->type() == TreeWidget::BrowserFolderType) {
+        const auto* folder = static_cast<BrowserFolderItem*>(item);
+        modelBrowserFolderOverrides[folder->key().toStdString()] = expanded;
+    }
+    else if (item->type() == TreeWidget::ObjectType) {
+        auto* object = static_cast<DocumentObjectItem*>(item);
+        if (isPresentationItem(object) && object->object()) {
+            modelBrowserObjectOverrides[object->object()->getObject()->getID()].expanded = expanded;
+        }
+    }
+}
+
+void DocumentItem::recordBrowserSelection(DocumentObjectItem* item, bool selected)
+{
+    if (!modelBrowserApplyingState && modelBrowserDirty && TreeParams::getOrganizeModelByType()
+        && isPresentationItem(item) && item->object()) {
+        modelBrowserObjectOverrides[item->object()->getObject()->getID()].selected = selected;
+    }
+}
+
+void DocumentItem::applyModelBrowserState()
+{
+    auto* tree = getTree();
+    QScopedValueRollback applying(modelBrowserApplyingState, true);
+    QSignalBlocker signals(tree);
+    FrameBudget budget;
+    while (!modelBrowserStagedStates.empty()) {
+        auto entry = modelBrowserStagedStates.extract(modelBrowserStagedStates.begin());
+        auto* item = entry.key();
+        auto state = entry.mapped();
+        if (item->type() == TreeWidget::BrowserFolderType) {
+            const auto key = static_cast<BrowserFolderItem*>(item)->key().toStdString();
+            if (const auto found = modelBrowserFolderOverrides.find(key);
+                found != modelBrowserFolderOverrides.end()) {
+                state.expanded = found->second;
+            }
+        }
+        else if (item->type() == TreeWidget::ObjectType) {
+            auto* objectItem = static_cast<DocumentObjectItem*>(item);
+            const auto id = objectItem->object()->getObject()->getID();
+            if (const auto found = modelBrowserObjectOverrides.find(id);
+                found != modelBrowserObjectOverrides.end()) {
+                state.expanded = found->second.expanded.value_or(state.expanded);
+                state.selected = found->second.selected.value_or(state.selected);
+            }
+            objectItem->selected = state.selected ? 1 : 0;
+            objectItem->setCheckState(state.selected);
+            if (!modelBrowserStatePending) { return; }
+        }
+        item->setExpanded(state.expanded);
+        if (!modelBrowserStatePending) { return; }
+        item->setSelected(state.selected);
+        if (!modelBrowserStatePending) { return; }
+        if (item->parent() != this) { item->setHidden(state.hidden); }
+        if (budget.exhausted()) { return; }
+    }
+    // Roots stay hidden until all descendants have their real Qt view state.
+    // Detached items cannot retain setHidden()/setExpanded() in Qt.
+    while (modelBrowserRevealIndex < modelBrowserRootsToReveal.size()) {
+        const auto [root, hidden] = modelBrowserRootsToReveal[modelBrowserRevealIndex++];
+        root->setHidden(hidden);
+        if (budget.exhausted()) { return; }
+    }
+    modelBrowserRootsToReveal.clear();
+    modelBrowserObjectOverrides.clear();
+    modelBrowserFolderOverrides.clear();
+    modelBrowserStatePending = false;
+    modelBrowserDirty = false;
+    stagedModelBrowserGeneration = 0;
+    updateBrowserFolderStatus();
+    if (Application::Instance->isInEdit(document())) {
+        ViewProviderDocumentObject* parentView = nullptr;
+        std::string subname;
+        auto* editingView = document()->getInEdit(&parentView, &subname);
+        auto* objectView = parentView ? parentView
+            : freecad_cast<ViewProviderDocumentObject*>(editingView);
+        if (objectView) { tree->editingItem = findBrowserItem(objectView->getObject()); }
     }
 }
 
@@ -5694,6 +6276,186 @@ void DocumentItem::rebuildModelBrowser()
         return;
     }
 
+    QElapsedTimer phaseElapsed;
+    std::string traceDocument;
+    const char* phase = modelBrowserStatePending ? "state"
+        : stagedModelBrowserRoot ? (modelBrowserAttaching ? "attach" : "remove")
+        : "prepare";
+    if (qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE")) {
+        traceDocument = appDocument->getName();
+        phaseElapsed.start();
+    }
+    const auto tracePhase = qScopeGuard([&] {
+        if (phaseElapsed.isValid()) {
+            Base::Console().message(
+                "VIBECAD_PROJECTION tree_slice document=%s phase=%s elapsed_us=%lld\n",
+                traceDocument.c_str(), phase,
+                static_cast<long long>(phaseElapsed.nsecsElapsed() / 1000));
+        }
+    });
+
+    if (modelBrowserStatePending) {
+        if (stagedModelBrowserGeneration == modelBrowserGeneration
+            && preparedModelBrowserProjection && preparedModelBrowserProjection->isCurrent()) {
+            applyModelBrowserState();
+            return;
+        }
+        markModelBrowserDirty();
+    }
+
+    if (preparedModelBrowserProjection && !preparedModelBrowserProjection->isCurrent()) {
+        markModelBrowserDirty();
+    }
+    if (!preparedModelBrowserProjection) {
+        if (!modelBrowserPreparationPending) {
+            modelBrowserPreparationPending = true;
+            auto* guiDocument = document();
+            const auto generation = modelBrowserGeneration;
+            auto* identity = this;
+            auto& cache = guiDocument->modelBrowserProjectionCache();
+            cache.observeInvalidation(tree, [tree, guiDocument, identity] {
+                const auto found = tree->DocumentMap.find(guiDocument);
+                if (found != tree->DocumentMap.end() && found->second == identity) {
+                    found->second->markModelBrowserDirty();
+                    tree->_updateStatus();
+                }
+            });
+            cache.request(tree,
+                [tree, guiDocument, generation, identity](auto result, std::string failure) {
+                    const auto found = tree->DocumentMap.find(guiDocument);
+                    if (found == tree->DocumentMap.end() || found->second != identity
+                        || found->second->modelBrowserGeneration != generation) {
+                        return;
+                    }
+                    auto* item = found->second;
+                    item->modelBrowserPreparationPending = false;
+                    if (!result) {
+                        item->modelBrowserDirty = false;
+                        Base::Console().error("Model browser preparation failed: %s\n", failure.c_str());
+                    }
+                    else {
+                        item->preparedModelBrowserProjection = std::move(result);
+                    }
+                    tree->_updateStatus();
+                });
+        }
+        return;
+    }
+
+    if (stagedModelBrowserRoot) {
+        if (stagedModelBrowserGeneration != modelBrowserGeneration) {
+            stagedModelBrowserRoot.reset();
+            modelBrowserDetachedItems.clear();
+            modelBrowserStagedStates.clear();
+            stagedModelBrowserGeneration = 0;
+        }
+        else {
+            QScopedValueRollback applying(modelBrowserApplyingState, true);
+            const bool selectionLock = tree->blockSelection(true);
+            const auto restoreSelection = qScopeGuard([&] { tree->blockSelection(selectionLock); });
+            QSignalBlocker signalBlocker(tree);
+            if (!modelBrowserAttaching) {
+                if (!clearModelBrowserStep()) { return; }
+                if (!stagedModelBrowserRoot
+                    || stagedModelBrowserGeneration != modelBrowserGeneration) { return; }
+                modelBrowserRootsToReveal.clear();
+                modelBrowserRevealIndex = 0;
+                modelBrowserAttaching = true;
+                return;
+            }
+            FrameBudget budget;
+            while (!modelBrowserDetachedItems.empty()) {
+                auto entry = std::move(modelBrowserDetachedItems.back());
+                modelBrowserDetachedItems.pop_back();
+                const bool root = entry.parent == stagedModelBrowserRoot.get();
+                auto* parent = root ? this : entry.parent;
+                auto* item = entry.item.get();
+                // Qt owns the child as soon as it is inserted, including while
+                // model observers run. Never retain a second owning pointer.
+                parent->addChild(entry.item.release());
+                if (!modelBrowserAttaching) { return; }
+                if (root) {
+                    modelBrowserRootsToReveal.emplace_back(item, modelBrowserStagedStates.at(item).hidden);
+                    item->setHidden(true);
+                    if (!modelBrowserAttaching) { return; }
+                }
+                if (budget.exhausted()) { return; }
+            }
+            stagedModelBrowserRoot.reset();
+
+            modelBrowserActive = true;
+            modelBrowserAttaching = false;
+            modelBrowserStatePending = true;
+            return;
+        }
+    }
+
+    if (!modelBrowserBuild) {
+        modelBrowserBuildGeneration = modelBrowserGeneration;
+        modelBrowserBuild.emplace(buildModelBrowser());
+        modelBrowserBuildSteps = 0;
+        modelBrowserBuildMaxStepNs = 0;
+        if (qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE")) {
+            modelBrowserBuildElapsed.start();
+        }
+        else {
+            modelBrowserBuildElapsed.invalidate();
+        }
+    }
+    FrameBudget budget;
+    QScopedValueRollback executing(modelBrowserBuildExecuting, true);
+    try {
+        do {
+            QElapsedTimer step;
+            if (modelBrowserBuildElapsed.isValid()) { step.start(); }
+            const bool pending = modelBrowserBuild->advance();
+            if (step.isValid()) {
+                ++modelBrowserBuildSteps;
+                modelBrowserBuildMaxStepNs = std::max(modelBrowserBuildMaxStepNs, step.nsecsElapsed());
+            }
+            if (modelBrowserBuildGeneration != modelBrowserGeneration
+                || !preparedModelBrowserProjection
+                || !preparedModelBrowserProjection->isCurrent()) {
+                modelBrowserBuild.reset();
+                modelBrowserDetachedItems.clear();
+                modelBrowserStagedStates.clear();
+                return;
+            }
+            if (!pending) {
+                stagedModelBrowserRoot = modelBrowserBuild->takeResult();
+                stagedModelBrowserGeneration = modelBrowserBuildGeneration;
+                modelBrowserBuild.reset();
+                if (modelBrowserBuildElapsed.isValid()) {
+                    Base::Console().message(
+                        "VIBECAD_PROJECTION tree_build document=%s total_ms=%lld steps=%zu max_step_us=%lld\n",
+                        appDocument->getName(),
+                        static_cast<long long>(modelBrowserBuildElapsed.elapsed()),
+                        modelBrowserBuildSteps,
+                        static_cast<long long>(modelBrowserBuildMaxStepNs / 1000));
+                }
+                return;
+            }
+        } while (!budget.exhausted());
+    }
+    catch (const std::exception& error) {
+        modelBrowserBuild.reset();
+        modelBrowserDetachedItems.clear();
+        modelBrowserStagedStates.clear();
+        modelBrowserDirty = false;
+        Base::Console().error("Model browser construction failed: %s\n", error.what());
+    }
+    catch (...) {
+        modelBrowserBuild.reset();
+        modelBrowserDetachedItems.clear();
+        modelBrowserStagedStates.clear();
+        modelBrowserDirty = false;
+        Base::Console().error("Model browser construction failed\n");
+    }
+}
+
+FrameSequence<std::unique_ptr<QTreeWidgetItem>> DocumentItem::buildModelBrowser()
+{
+    auto* appDocument = document()->getDocument();
     using Projection = ModelTreeBrowserProjection;
     using Entry = Projection::Entry;
     using Role = Projection::Role;
@@ -5702,25 +6464,30 @@ void DocumentItem::rebuildModelBrowser()
     std::set<std::string> expandedFolders;
     std::set<const App::DocumentObject*> selectedObjects;
 
-    std::function<void(QTreeWidgetItem*)> captureState = [&](QTreeWidgetItem* parent) {
+    std::function<FrameSequence<>(QTreeWidgetItem*)> captureState = [&](QTreeWidgetItem* parent) -> FrameSequence<> {
+        co_await std::suspend_always {};
         for (int index = 0; index < parent->childCount(); ++index) {
+            co_await std::suspend_always {};
             auto* childItem = parent->child(index);
             if (childItem->type() == TreeWidget::BrowserFolderType) {
                 auto* folder = static_cast<BrowserFolderItem*>(childItem);
+                modelBrowserFolderOverrides.try_emplace(folder->key().toStdString(), folder->isExpanded());
                 if (folder->isExpanded()) {
                     expandedFolders.insert(folder->key().toStdString());
                 }
-                captureState(folder);
+                co_await captureState(folder);
             }
             else if (childItem->type() == TreeWidget::ObjectType) {
                 auto* objectItem = static_cast<DocumentObjectItem*>(childItem);
-                if (!objectItem->isBrowserProxy()) {
+                if (!isPresentationItem(objectItem)) {
                     continue;
                 }
                 const auto* object = objectItem->object()
                     ? objectItem->object()->getObject()
                     : nullptr;
                 if (object) {
+                    modelBrowserObjectOverrides.try_emplace(
+                        object->getID(), BrowserItemOverride {objectItem->isExpanded(), objectItem->isSelected()});
                     if (objectItem->isExpanded()) {
                         expandedObjects.insert(object);
                     }
@@ -5728,19 +6495,23 @@ void DocumentItem::rebuildModelBrowser()
                         selectedObjects.insert(object);
                     }
                 }
-                captureState(objectItem);
+                co_await captureState(objectItem);
             }
         }
     };
-    captureState(this);
+    co_await captureState(this);
     const bool firstBuild = !modelBrowserActive;
 
-    const bool selectionLock = tree->blockSelection(true);
-    QSignalBlocker signalBlocker(tree);
-    clearModelBrowser();
-    setLegacyTreeVisible(false);
+    // Construct off-view, then detach leaves cooperatively before handoff.
+    // Qt receives childless items in parent-first order; transferring populated
+    // roots would recursively install the entire hierarchy in one GUI call.
+    auto stagedRoot = std::make_unique<QTreeWidgetItem>();
+    auto presentationParent = [this, &stagedRoot](QTreeWidgetItem* parent) {
+        return parent == this ? stagedRoot.get() : parent;
+    };
 
-    Projection projection(appDocument);
+    const auto projectionOwner = preparedModelBrowserProjection;
+    const auto& projection = *projectionOwner;
     const auto& entries = projection.entries();
     std::unordered_map<App::DocumentObject*, DocumentObjectItem*> proxies;
     std::set<App::DocumentObject*> rendered;
@@ -5800,13 +6571,13 @@ void DocumentItem::rebuildModelBrowser()
         const QString key = QString::fromStdString(context + "/folder:" + id);
         auto* folder = new BrowserFolderItem(
             this,
-            parent,
+            presentationParent(parent),
             logicalParent,
             key,
             label,
             QByteArray(icon)
         );
-        folder->setExpanded(expandedFolders.contains(key.toStdString()));
+        modelBrowserStagedStates[folder].expanded = expandedFolders.contains(key.toStdString());
         return folder;
     };
 
@@ -5814,22 +6585,23 @@ void DocumentItem::rebuildModelBrowser()
                             const Entry& entry,
                             QTreeWidgetItem* parent,
                             DocumentObjectItem* logicalParent
-                        ) -> DocumentObjectItem* {
+                        ) -> FrameSequence<DocumentObjectItem*> {
+                            co_await std::suspend_always {};
         if (!entryAvailable(entry)) {
-            return nullptr;
+            co_return nullptr;
         }
         if (const auto existing = proxies.find(entry.object); existing != proxies.end()) {
-            return existing->second;
+            co_return existing->second;
         }
 
         auto* item = createBrowserObjectItem(
             entry.object,
-            parent,
+            presentationParent(parent),
             logicalParent,
             entry.publishedImplementation
         );
         if (!item) {
-            return nullptr;
+            co_return nullptr;
         }
         item->setText(0, modelBrowserPresentationLabel(entry));
         try {
@@ -5838,7 +6610,9 @@ void DocumentItem::rebuildModelBrowser()
             const auto details = detailProvider
                 ? detailProvider->getTreeViewDetails()
                 : std::vector<TreeViewDetail> {};
+            co_await std::suspend_always {}; // Revalidate after a provider callback.
             for (const auto& detail : details) {
+                co_await std::suspend_always {};
                 if (detail.key.empty() || detail.label.empty()) {
                     continue;
                 }
@@ -5878,12 +6652,12 @@ void DocumentItem::rebuildModelBrowser()
         const bool wasExpanded = expandedObjects.contains(entry.object);
         const bool persistedExpanded = entry.object->testStatus(App::Expand);
         const bool defaultExpanded = firstBuild && entry.role == Role::Component;
-        item->setExpanded(wasExpanded || persistedExpanded || defaultExpanded);
+        modelBrowserStagedStates[item].expanded = wasExpanded || persistedExpanded || defaultExpanded;
         const bool selected = selectedObjects.contains(entry.object);
         item->selected = selected ? 1 : 0;
-        item->setSelected(selected);
+        modelBrowserStagedStates[item].selected = selected;
         item->setCheckState(selected);
-        return item;
+        co_return item;
     };
 
     // One indexing pass over the projection replaces the former per-category
@@ -5965,6 +6739,7 @@ void DocumentItem::rebuildModelBrowser()
     };
 
     for (const auto& entry : entries) {
+        co_await std::suspend_always {};
         if (entry.role == Role::Origin || entry.role == Role::OriginFeature) {
             entriesByLogicalParentRole[{entry.logicalParent, entry.role}].push_back(&entry);
         }
@@ -5994,6 +6769,7 @@ void DocumentItem::rebuildModelBrowser()
                 continue;
             }
             for (auto* child : viewProvider->claimChildren()) {
+                co_await std::suspend_always {};
                 const Entry* childEntry = projection.find(child);
                 if (childEntry && isDrawingObject(childEntry->object)) {
                     drawingChildren[entry.object].push_back(childEntry);
@@ -6028,6 +6804,7 @@ void DocumentItem::rebuildModelBrowser()
         return static_cast<App::DocumentObject*>(nullptr);
     };
     for (const auto& entry : entries) {
+        co_await std::suspend_always {};
         if (isAnalysis(entry.object)
             || (isFemObject(entry.object) && !analysisOwner(entry))) {
             analyzeEntriesByComponent[entry.component].push_back(&entry);
@@ -6038,7 +6815,10 @@ void DocumentItem::rebuildModelBrowser()
         const auto* group = object
             ? object->getExtensionByType<App::GroupExtension>(true, false)
             : nullptr;
-        return group ? group->getObjects() : std::vector<App::DocumentObject*> {};
+        // The owner checks the source epoch before each resumed step. Borrow
+        // the ordered list instead of copying it every time a category reads it.
+        return group ? std::span<App::DocumentObject* const>(group->Group.getValues())
+                     : std::span<App::DocumentObject* const> {};
     };
 
     // Consume every object that belongs exclusively to a CAM setup before
@@ -6047,22 +6827,26 @@ void DocumentItem::rebuildModelBrowser()
     // selected cutter, not document design geometry. ViewProvider ownership is
     // authoritative for that tool-only subtree.
     std::set<App::DocumentObject*> manufactureOwnedObjects;
-    std::function<void(App::DocumentObject*)> consumeClaimedChildren;
-    consumeClaimedChildren = [&](App::DocumentObject* object) {
+    std::function<FrameSequence<>(App::DocumentObject*)> consumeClaimedChildren;
+    consumeClaimedChildren = [&](App::DocumentObject* object) -> FrameSequence<> {
+        co_await std::suspend_always {};
         if (!object || !manufactureOwnedObjects.insert(object).second) {
-            return;
+            co_return;
         }
         auto* viewProvider = getViewProvider(object);
         if (!viewProvider) {
-            return;
+            co_return;
         }
         for (auto* child : viewProvider->claimChildren()) {
-            consumeClaimedChildren(child);
+            co_await std::suspend_always {};
+            co_await consumeClaimedChildren(child);
         }
     };
     for (const auto& [component, setupEntries] : manufactureSetupsByComponent) {
+        co_await std::suspend_always {};
         (void)component;
         for (const auto* setupEntry : setupEntries) {
+            co_await std::suspend_always {};
             auto* setup = setupEntry->object;
             manufactureOwnedObjects.insert(setup);
             auto* operations = linkedObject(setup, "Operations");
@@ -6071,22 +6855,27 @@ void DocumentItem::rebuildModelBrowser()
             auto* setupSheet = linkedObject(setup, "SetupSheet");
             auto* tools = linkedObject(setup, "Tools");
             for (auto* owned : {operations, model, stock, setupSheet, tools}) {
+                co_await std::suspend_always {};
                 if (owned) {
                     manufactureOwnedObjects.insert(owned);
                 }
             }
             for (auto* operation : groupMembers(operations)) {
+                co_await std::suspend_always {};
                 manufactureOwnedObjects.insert(operation);
             }
             for (auto* modelResource : groupMembers(model)) {
+                co_await std::suspend_always {};
                 manufactureOwnedObjects.insert(modelResource);
             }
             for (auto* controller : groupMembers(tools)) {
-                consumeClaimedChildren(controller);
+                co_await std::suspend_always {};
+                co_await consumeClaimedChildren(controller);
             }
             const auto results = manufactureSimulationResultsBySetup.find(setup);
             if (results != manufactureSimulationResultsBySetup.end()) {
                 for (const auto* result : results->second) {
+                    co_await std::suspend_always {};
                     manufactureOwnedObjects.insert(result->object);
                 }
             }
@@ -6101,39 +6890,44 @@ void DocumentItem::rebuildModelBrowser()
 
     // Residual predicates preserve exactly the conjuncts the former scans
     // applied beyond the bucket key itself.
-    auto filterBucket = [&](const EntryBucket* bucket, auto&& residual) {
+    auto filterBucket = [&](const EntryBucket* bucket, auto&& residual) -> FrameSequence<EntryBucket> {
+        co_await std::suspend_always {};
         EntryBucket result;
         if (!bucket) {
-            return result;
+            co_return result;
         }
         for (const auto* entry : *bucket) {
+            co_await std::suspend_always {};
             if (entryAvailable(*entry) && !rendered.contains(entry->object)
                 && residual(*entry)) {
                 result.push_back(entry);
             }
         }
-        return result;
+        co_return result;
     };
-    auto takeBucket = [&](const EntryBucket* bucket) {
-        return filterBucket(bucket, [](const Entry&) {
+    auto takeBucket = [&](const EntryBucket* bucket) -> FrameSequence<EntryBucket> {
+        co_await std::suspend_always {};
+        co_return co_await filterBucket(bucket, [](const Entry&) {
             return true;
         });
     };
-    auto originEntriesFor = [&](const App::DocumentObject* context) {
-        return takeBucket(
+    auto originEntriesFor = [&](const App::DocumentObject* context) -> FrameSequence<EntryBucket> {
+        co_await std::suspend_always {};
+        co_return co_await takeBucket(
             findBucket(entriesByLogicalParentRole, RoleContextKey {context, Role::Origin})
         );
     };
-    auto componentRoleEntries = [&](const App::DocumentObject* component, Role role) {
-        return takeBucket(findBucket(entriesByComponentRole, RoleContextKey {component, role}));
+    auto componentRoleEntries = [&](const App::DocumentObject* component, Role role) -> FrameSequence<EntryBucket> {
+        co_await std::suspend_always {};
+        co_return co_await takeBucket(findBucket(entriesByComponentRole, RoleContextKey {component, role}));
     };
 
-    std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderOrigin;
-    std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderBody;
-    std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderComponent;
-    std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderGroup;
-    std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderAnalyzeObject;
-    std::function<void(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderDrawingObject;
+    std::function<FrameSequence<>(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderOrigin;
+    std::function<FrameSequence<>(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderBody;
+    std::function<FrameSequence<>(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderComponent;
+    std::function<FrameSequence<>(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderGroup;
+    std::function<FrameSequence<>(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderAnalyzeObject;
+    std::function<FrameSequence<>(const Entry&, QTreeWidgetItem*, DocumentObjectItem*)> renderDrawingObject;
 
     // FreeCAD resolves duplicate default labels by appending a zero-padded
     // numeric suffix of at least three digits ("Origin001", "X-axis002"; see
@@ -6201,10 +6995,11 @@ void DocumentItem::rebuildModelBrowser()
 
     renderOrigin = [&](const Entry& originEntry,
                        QTreeWidgetItem* parent,
-                       DocumentObjectItem* logicalParent) {
-        auto* originItem = renderObject(originEntry, parent, logicalParent);
+                       DocumentObjectItem* logicalParent) -> FrameSequence<> {
+                           co_await std::suspend_always {};
+        auto* originItem = co_await renderObject(originEntry, parent, logicalParent);
         if (!originItem) {
-            return;
+            co_return;
         }
         // Internal Origin names are document-unique (Origin, Origin001, ...),
         // but each is the local Origin of its own component or Body.  Show
@@ -6218,12 +7013,13 @@ void DocumentItem::rebuildModelBrowser()
         if (!originBase.isEmpty()) {
             originItem->setText(0, TreeWidget::tr("Origin"));
         }
-        const auto features = takeBucket(findBucket(
+        const auto features = co_await takeBucket(findBucket(
             entriesByLogicalParentRole,
             RoleContextKey {originEntry.object, Role::OriginFeature}
         ));
         for (const auto* feature : features) {
-            auto* featureItem = renderObject(*feature, originItem, originItem);
+            co_await std::suspend_always {};
+            auto* featureItem = co_await renderObject(*feature, originItem, originItem);
             if (featureItem) {
                 featureItem->setText(
                     0,
@@ -6245,9 +7041,10 @@ void DocumentItem::rebuildModelBrowser()
                               const QString& label,
                               const char* icon,
                               const std::vector<const Entry*>& categoryEntries
-                          ) {
+                          ) -> FrameSequence<BrowserFolderItem*> {
+                              co_await std::suspend_always {};
         if (categoryEntries.empty()) {
-            return static_cast<BrowserFolderItem*>(nullptr);
+            co_return static_cast<BrowserFolderItem*>(nullptr);
         }
         auto* folder = makeFolder(
             parent,
@@ -6258,24 +7055,26 @@ void DocumentItem::rebuildModelBrowser()
             icon
         );
         for (const auto* entry : categoryEntries) {
+            co_await std::suspend_always {};
             // A type category can intentionally present an object outside its
             // plain organizational Group. If that Group has not been rendered
             // yet, retain the component as the selection-path parent rather
             // than incorrectly treating the object as document-root.
             auto* logicalParent = logicalItem(entry->logicalParent, contextItem);
-            renderObject(*entry, folder, logicalParent);
+            co_await renderObject(*entry, folder, logicalParent);
         }
-        return folder;
+        co_return folder;
     };
 
     renderGroup = [&](const Entry& groupEntry,
                       QTreeWidgetItem* parent,
-                      DocumentObjectItem* logicalParent) {
-        auto* groupItem = renderObject(groupEntry, parent, logicalParent);
+                      DocumentObjectItem* logicalParent) -> FrameSequence<> {
+                          co_await std::suspend_always {};
+        auto* groupItem = co_await renderObject(groupEntry, parent, logicalParent);
         if (!groupItem) {
-            return;
+            co_return;
         }
-        const auto children = takeBucket(
+        const auto children = co_await takeBucket(
             findBucket(entriesByGroup, groupEntry.object)
         );
         const bool assemblyStructureGroup = groupEntry.object
@@ -6285,13 +7084,14 @@ void DocumentItem::rebuildModelBrowser()
                         == std::string_view("Assembly::AssemblyObject")));
         const bool meshesGroup = isMeshesGroup(groupEntry.object);
         for (const auto* child : children) {
+            co_await std::suspend_always {};
             if (child->role == Role::Group) {
-                renderGroup(*child, groupItem, groupItem);
+                co_await renderGroup(*child, groupItem, groupItem);
                 continue;
             }
             if (meshesGroup && child->role != Role::Internal
                 && !child->publishedImplementation && !child->bodyRepresentation) {
-                renderObject(*child, groupItem, groupItem);
+                co_await renderObject(*child, groupItem, groupItem);
                 continue;
             }
             // Bodies, Sketches, Parameters, References, and loose Geometry are
@@ -6301,7 +7101,7 @@ void DocumentItem::rebuildModelBrowser()
             if ((child->role == Role::Other
                  || (assemblyStructureGroup && child->role == Role::AssemblyOperation))
                 && !child->publishedImplementation && !child->bodyRepresentation) {
-                renderObject(*child, groupItem, groupItem);
+                co_await renderObject(*child, groupItem, groupItem);
             }
         }
         groupItem->setChildIndicatorPolicy(
@@ -6312,20 +7112,22 @@ void DocumentItem::rebuildModelBrowser()
 
     renderBody = [&](const Entry& bodyEntry,
                      QTreeWidgetItem* parent,
-                     DocumentObjectItem* logicalParent) {
-        auto* bodyItem = renderObject(bodyEntry, parent, logicalParent);
+                     DocumentObjectItem* logicalParent) -> FrameSequence<> {
+                         co_await std::suspend_always {};
+        auto* bodyItem = co_await renderObject(bodyEntry, parent, logicalParent);
         if (!bodyItem) {
-            return;
+            co_return;
         }
 
         // A Body is an independently usable modeling object, so expose its
         // user-facing feature chain here as well as in chronological History.
         // Resource/internal state never enters operationEntriesByBody.
-        const auto operations = takeBucket(
+        const auto operations = co_await takeBucket(
             findBucket(operationEntriesByBody, bodyEntry.object)
         );
         for (const auto* operation : operations) {
-            renderObject(*operation, bodyItem, bodyItem);
+            co_await std::suspend_always {};
+            co_await renderObject(*operation, bodyItem, bodyItem);
         }
         bodyItem->setChildIndicatorPolicy(
             bodyItem->childCount() > 0 ? QTreeWidgetItem::ShowIndicator
@@ -6335,13 +7137,14 @@ void DocumentItem::rebuildModelBrowser()
 
     renderAnalyzeObject = [&](const Entry& entry,
                               QTreeWidgetItem* parent,
-                              DocumentObjectItem* logicalParent) {
+                              DocumentObjectItem* logicalParent) -> FrameSequence<> {
+                                  co_await std::suspend_always {};
         if (entry.publishedImplementation || entry.bodyRepresentation) {
-            return;
+            co_return;
         }
-        auto* item = renderObject(entry, parent, logicalParent);
+        auto* item = co_await renderObject(entry, parent, logicalParent);
         if (!item) {
-            return;
+            co_return;
         }
 
         // FemAnalysis is the document's authoritative study container. Show
@@ -6349,9 +7152,10 @@ void DocumentItem::rebuildModelBrowser()
         // materials, meshes, constraints, and solvers that are deliberately
         // hidden from the generic model categories. Recurse through any plain
         // organizational groups nested inside a study as well.
-        const auto members = takeBucket(findBucket(entriesByGroup, entry.object));
+        const auto members = co_await takeBucket(findBucket(entriesByGroup, entry.object));
         for (const auto* member : members) {
-            renderAnalyzeObject(*member, item, item);
+            co_await std::suspend_always {};
+            co_await renderAnalyzeObject(*member, item, item);
         }
         item->setChildIndicatorPolicy(
             item->childCount() > 0 ? QTreeWidgetItem::ShowIndicator
@@ -6361,13 +7165,14 @@ void DocumentItem::rebuildModelBrowser()
 
     auto renderAnalyze = [&](QTreeWidgetItem* parent,
                              DocumentObjectItem* contextItem,
-                             App::DocumentObject* contextObject) {
-        const auto entries = takeBucket(findBucket(
+                             App::DocumentObject* contextObject) -> FrameSequence<> {
+                                 co_await std::suspend_always {};
+        const auto entries = co_await takeBucket(findBucket(
             analyzeEntriesByComponent,
             static_cast<const App::DocumentObject*>(contextObject)
         ));
         if (entries.empty()) {
-            return;
+            co_return;
         }
         auto* folder = makeFolder(
             parent,
@@ -6378,7 +7183,8 @@ void DocumentItem::rebuildModelBrowser()
             "FemWorkbench"
         );
         for (const auto* entry : entries) {
-            renderAnalyzeObject(
+            co_await std::suspend_always {};
+            co_await renderAnalyzeObject(
                 *entry,
                 folder,
                 logicalItem(entry->logicalParent, contextItem)
@@ -6388,22 +7194,24 @@ void DocumentItem::rebuildModelBrowser()
 
     renderDrawingObject = [&](const Entry& entry,
                               QTreeWidgetItem* parent,
-                              DocumentObjectItem* logicalParent) {
+                              DocumentObjectItem* logicalParent) -> FrameSequence<> {
+                                  co_await std::suspend_always {};
         if (entry.publishedImplementation || entry.bodyRepresentation) {
-            return;
+            co_return;
         }
-        auto* item = renderObject(entry, parent, logicalParent);
+        auto* item = co_await renderObject(entry, parent, logicalParent);
         if (!item) {
-            return;
+            co_return;
         }
 
         // TechDraw's ViewProviders are the authoritative presentation owners:
         // Page claims its template, views, and annotations; a projected view
         // claims its dimensions and dependent drawing objects. Follow that
         // graph recursively instead of flattening timeline operations.
-        const auto children = takeBucket(findBucket(drawingChildren, entry.object));
+        const auto children = co_await takeBucket(findBucket(drawingChildren, entry.object));
         for (const auto* child : children) {
-            renderDrawingObject(*child, item, item);
+            co_await std::suspend_always {};
+            co_await renderDrawingObject(*child, item, item);
         }
         item->setChildIndicatorPolicy(
             item->childCount() > 0 ? QTreeWidgetItem::ShowIndicator
@@ -6413,13 +7221,14 @@ void DocumentItem::rebuildModelBrowser()
 
     auto renderDrawings = [&](QTreeWidgetItem* parent,
                               DocumentObjectItem* contextItem,
-                              App::DocumentObject* contextObject) {
-        const auto pages = takeBucket(findBucket(
+                              App::DocumentObject* contextObject) -> FrameSequence<> {
+                                  co_await std::suspend_always {};
+        const auto pages = co_await takeBucket(findBucket(
             drawingPagesByComponent,
             static_cast<const App::DocumentObject*>(contextObject)
         ));
         if (pages.empty()) {
-            return;
+            co_return;
         }
         auto* folder = makeFolder(
             parent,
@@ -6430,7 +7239,8 @@ void DocumentItem::rebuildModelBrowser()
             "preferences-techdraw"
         );
         for (const auto* page : pages) {
-            renderDrawingObject(
+            co_await std::suspend_always {};
+            co_await renderDrawingObject(
                 *page,
                 folder,
                 logicalItem(page->logicalParent, contextItem)
@@ -6440,24 +7250,27 @@ void DocumentItem::rebuildModelBrowser()
 
     auto renderManufacture = [&](QTreeWidgetItem* parent,
                                  DocumentObjectItem* contextItem,
-                                 App::DocumentObject* contextObject) {
+                                 App::DocumentObject* contextObject) -> FrameSequence<> {
+                                     co_await std::suspend_always {};
         const auto setupBucket = findBucket(
             manufactureSetupsByComponent,
             static_cast<const App::DocumentObject*>(contextObject)
         );
         if (!setupBucket) {
-            return;
+            co_return;
         }
 
         auto renderLinkedObject = [&](App::DocumentObject* object,
                                       QTreeWidgetItem* visualParent,
-                                      DocumentObjectItem* logicalParent) {
+                                      DocumentObjectItem* logicalParent) -> FrameSequence<DocumentObjectItem*> {
+                                          co_await std::suspend_always {};
             const Entry* entry = projection.find(object);
-            return entry ? renderObject(*entry, visualParent, logicalParent) : nullptr;
+            co_return entry ? co_await renderObject(*entry, visualParent, logicalParent) : nullptr;
         };
 
         for (const auto* setupEntry : *setupBucket) {
-            auto* setupItem = renderObject(
+            co_await std::suspend_always {};
+            auto* setupItem = co_await renderObject(
                 *setupEntry,
                 parent,
                 logicalItem(setupEntry->logicalParent, contextItem)
@@ -6467,7 +7280,7 @@ void DocumentItem::rebuildModelBrowser()
             }
 
             auto* setup = setupEntry->object;
-            renderLinkedObject(linkedObject(setup, "Stock"), setupItem, setupItem);
+            co_await renderLinkedObject(linkedObject(setup, "Stock"), setupItem, setupItem);
 
             auto* toolsFolder = makeFolder(
                 setupItem,
@@ -6478,7 +7291,8 @@ void DocumentItem::rebuildModelBrowser()
                 "CAM_ToolController"
             );
             for (auto* controller : groupMembers(linkedObject(setup, "Tools"))) {
-                auto* controllerItem = renderLinkedObject(controller, toolsFolder, setupItem);
+                co_await std::suspend_always {};
+                auto* controllerItem = co_await renderLinkedObject(controller, toolsFolder, setupItem);
                 if (!controllerItem) {
                     continue;
                 }
@@ -6508,7 +7322,8 @@ void DocumentItem::rebuildModelBrowser()
                 "CAM_Toolpath"
             );
             for (auto* operation : groupMembers(linkedObject(setup, "Operations"))) {
-                renderLinkedObject(operation, operationsFolder, setupItem);
+                co_await std::suspend_always {};
+                co_await renderLinkedObject(operation, operationsFolder, setupItem);
             }
 
             const auto resultBucket = findBucket(
@@ -6525,8 +7340,9 @@ void DocumentItem::rebuildModelBrowser()
                     "CAM_Simulator"
                 );
                 for (std::size_t index = 0; index < resultBucket->size(); ++index) {
+                    co_await std::suspend_always {};
                     const auto* result = (*resultBucket)[index];
-                    auto* resultItem = renderObject(
+                    auto* resultItem = co_await renderObject(
                         *result,
                         resultsFolder,
                         logicalItem(result->logicalParent, contextItem)
@@ -6552,7 +7368,7 @@ void DocumentItem::rebuildModelBrowser()
                 }
             }
 
-            renderLinkedObject(
+            co_await renderLinkedObject(
                 linkedObject(setup, "SetupSheet"),
                 setupItem,
                 setupItem
@@ -6570,23 +7386,27 @@ void DocumentItem::rebuildModelBrowser()
                                 App::DocumentObject* contextObject,
                                 const EntryBucket& bodyEntries,
                                 const EntryBucket& referenceEntries
-                            ) {
+                            ) -> FrameSequence<> {
+                                co_await std::suspend_always {};
         struct OriginReference
         {
             const Entry* entry {};
             App::DocumentObject* owner {};
         };
         std::vector<OriginReference> origins;
-        for (const auto* origin : originEntriesFor(contextObject)) {
+        for (const auto* origin : co_await originEntriesFor(contextObject)) {
+            co_await std::suspend_always {};
             origins.push_back({origin, contextObject});
         }
         for (const auto* body : bodyEntries) {
-            for (const auto* origin : originEntriesFor(body->object)) {
+            co_await std::suspend_always {};
+            for (const auto* origin : co_await originEntriesFor(body->object)) {
+                co_await std::suspend_always {};
                 origins.push_back({origin, body->object});
             }
         }
 
-        const auto visibleReferences = filterBucket(
+        const auto visibleReferences = co_await filterBucket(
             &referenceEntries,
             [](const Entry& entry) {
                 return !entry.publishedImplementation
@@ -6594,7 +7414,7 @@ void DocumentItem::rebuildModelBrowser()
             }
         );
         if (origins.empty() && visibleReferences.empty()) {
-            return;
+            co_return;
         }
 
         auto* folder = makeFolder(
@@ -6606,8 +7426,9 @@ void DocumentItem::rebuildModelBrowser()
             "PartDesign_SubShapeBinder"
         );
         for (const auto& origin : origins) {
+            co_await std::suspend_always {};
             auto* logicalParent = logicalItem(origin.entry->logicalParent, contextItem);
-            renderOrigin(*origin.entry, folder, logicalParent);
+            co_await renderOrigin(*origin.entry, folder, logicalParent);
             const auto item = proxies.find(origin.entry->object);
             if (item == proxies.end() || !item->second
                 || origin.owner == contextObject) {
@@ -6629,7 +7450,8 @@ void DocumentItem::rebuildModelBrowser()
             );
         }
         for (const auto* reference : visibleReferences) {
-            renderObject(
+            co_await std::suspend_always {};
+            co_await renderObject(
                 *reference,
                 folder,
                 logicalItem(reference->logicalParent, contextItem)
@@ -6639,22 +7461,24 @@ void DocumentItem::rebuildModelBrowser()
 
     renderComponent = [&](const Entry& componentEntry,
                           QTreeWidgetItem* parent,
-                          DocumentObjectItem* logicalParent) {
-        auto* componentItem = renderObject(componentEntry, parent, logicalParent);
+                          DocumentObjectItem* logicalParent) -> FrameSequence<> {
+                              co_await std::suspend_always {};
+        auto* componentItem = co_await renderObject(componentEntry, parent, logicalParent);
         if (!componentItem) {
-            return;
+            co_return;
         }
         const bool vibeScriptProgram =
             Projection::isVibeScriptProgram(componentEntry.object);
 
-        const auto nestedComponents = componentRoleEntries(componentEntry.object, Role::Component);
+        const auto nestedComponents = co_await componentRoleEntries(componentEntry.object, Role::Component);
         for (const auto* nested : nestedComponents) {
-            renderComponent(*nested, componentItem, componentItem);
+            co_await std::suspend_always {};
+            co_await renderComponent(*nested, componentItem, componentItem);
         }
 
         const auto assemblyOccurrences
-            = componentRoleEntries(componentEntry.object, Role::AssemblyOccurrence);
-        renderCategory(
+            = co_await componentRoleEntries(componentEntry.object, Role::AssemblyOccurrence);
+        co_await renderCategory(
             componentItem,
             componentItem,
             componentEntry.object,
@@ -6664,8 +7488,8 @@ void DocumentItem::rebuildModelBrowser()
             assemblyOccurrences
         );
 
-        const auto assemblyMotions = componentRoleEntries(componentEntry.object, Role::AssemblyMotion);
-        renderCategory(
+        const auto assemblyMotions = co_await componentRoleEntries(componentEntry.object, Role::AssemblyMotion);
+        co_await renderCategory(
             componentItem,
             componentItem,
             componentEntry.object,
@@ -6676,8 +7500,8 @@ void DocumentItem::rebuildModelBrowser()
         );
 
         const auto parameters =
-            componentRoleEntries(componentEntry.object, Role::Parameter);
-        renderCategory(
+            co_await componentRoleEntries(componentEntry.object, Role::Parameter);
+        co_await renderCategory(
             componentItem,
             componentItem,
             componentEntry.object,
@@ -6687,7 +7511,7 @@ void DocumentItem::rebuildModelBrowser()
             parameters
         );
 
-        const auto bodies = componentRoleEntries(componentEntry.object, Role::Body);
+        const auto bodies = co_await componentRoleEntries(componentEntry.object, Role::Body);
         if (!bodies.empty()) {
             auto* folder = makeFolder(
                 componentItem,
@@ -6698,15 +7522,17 @@ void DocumentItem::rebuildModelBrowser()
                 "PartDesign_Body"
             );
             for (const auto* body : bodies) {
-                renderBody(*body, folder, componentItem);
+                co_await std::suspend_always {};
+                co_await renderBody(*body, folder, componentItem);
             }
             if (firstBuild && vibeScriptProgram) {
-                folder->setExpanded(true);
+                modelBrowserStagedStates[folder].expanded = true;
             }
         }
 
-        const auto renderComponentHistory = [&]() {
-            const auto operations = filterBucket(
+        const auto renderComponentHistory = [&]() -> FrameSequence<> {
+            co_await std::suspend_always {};
+            const auto operations = co_await filterBucket(
                 findBucket(
                     entriesByComponentRole,
                     RoleContextKey {componentEntry.object, Role::History}
@@ -6715,7 +7541,7 @@ void DocumentItem::rebuildModelBrowser()
                     return !entry.body && !isMeshesGroup(entry.group);
                 }
             );
-            renderCategory(
+            co_await renderCategory(
                 componentItem,
                 componentItem,
                 componentEntry.object,
@@ -6726,8 +7552,9 @@ void DocumentItem::rebuildModelBrowser()
             );
         };
 
-        const auto renderComponentOutputs = [&]() {
-            const auto vibeCADOutputs = filterBucket(
+        const auto renderComponentOutputs = [&]() -> FrameSequence<> {
+            co_await std::suspend_always {};
+            const auto vibeCADOutputs = co_await filterBucket(
                 findBucket(
                     entriesByComponentRole,
                     RoleContextKey {componentEntry.object, Role::VibeCADOutput}
@@ -6740,7 +7567,7 @@ void DocumentItem::rebuildModelBrowser()
                     return vibeScriptProgram || !entry.bodyRepresentation;
                 }
             );
-            renderCategory(
+            co_await renderCategory(
                 componentItem,
                 componentItem,
                 componentEntry.object,
@@ -6756,12 +7583,12 @@ void DocumentItem::rebuildModelBrowser()
         // their source-level Design History, and stable published interfaces.
         // Generic components retain the established category ordering below.
         if (vibeScriptProgram) {
-            renderComponentHistory();
-            renderComponentOutputs();
+            co_await renderComponentHistory();
+            co_await renderComponentOutputs();
         }
 
-        const auto sketches = componentRoleEntries(componentEntry.object, Role::Sketch);
-        renderCategory(
+        const auto sketches = co_await componentRoleEntries(componentEntry.object, Role::Sketch);
+        co_await renderCategory(
             componentItem,
             componentItem,
             componentEntry.object,
@@ -6771,9 +7598,9 @@ void DocumentItem::rebuildModelBrowser()
             sketches
         );
 
-        renderManufacture(componentItem, componentItem, componentEntry.object);
+        co_await renderManufacture(componentItem, componentItem, componentEntry.object);
 
-        const auto meshGroups = filterBucket(
+        const auto meshGroups = co_await filterBucket(
             findBucket(
                 entriesByComponentRole,
                 RoleContextKey {componentEntry.object, Role::Group}
@@ -6783,19 +7610,20 @@ void DocumentItem::rebuildModelBrowser()
             }
         );
         for (const auto* group : meshGroups) {
-            renderGroup(*group, componentItem, componentItem);
+            co_await std::suspend_always {};
+            co_await renderGroup(*group, componentItem, componentItem);
         }
 
-        renderAnalyze(componentItem, componentItem, componentEntry.object);
-        renderDrawings(componentItem, componentItem, componentEntry.object);
+        co_await renderAnalyze(componentItem, componentItem, componentEntry.object);
+        co_await renderDrawings(componentItem, componentItem, componentEntry.object);
 
         if (!vibeScriptProgram) {
-            renderComponentHistory();
-            renderComponentOutputs();
+            co_await renderComponentHistory();
+            co_await renderComponentOutputs();
         }
 
-        const auto references = componentRoleEntries(componentEntry.object, Role::Reference);
-        renderReferences(
+        const auto references = co_await componentRoleEntries(componentEntry.object, Role::Reference);
+        co_await renderReferences(
             componentItem,
             componentItem,
             componentEntry.object,
@@ -6806,7 +7634,7 @@ void DocumentItem::rebuildModelBrowser()
         // Geometry is a compatibility escape hatch only for genuine loose
         // user/legacy objects. Body history and scripted publication internals
         // are deliberately represented elsewhere and must never appear here.
-        const auto looseGeometry = filterBucket(
+        const auto looseGeometry = co_await filterBucket(
             findBucket(
                 entriesByComponentRole,
                 RoleContextKey {componentEntry.object, Role::Geometry}
@@ -6816,7 +7644,7 @@ void DocumentItem::rebuildModelBrowser()
                     && !entry.bodyRepresentation;
             }
         );
-        renderCategory(
+        co_await renderCategory(
             componentItem,
             componentItem,
             componentEntry.object,
@@ -6826,7 +7654,7 @@ void DocumentItem::rebuildModelBrowser()
             looseGeometry
         );
 
-        const auto groups = filterBucket(
+        const auto groups = co_await filterBucket(
             findBucket(
                 entriesByComponentRole,
                 RoleContextKey {componentEntry.object, Role::Group}
@@ -6848,16 +7676,18 @@ void DocumentItem::rebuildModelBrowser()
                 "folder"
             );
             for (const auto* group : groups) {
-                renderGroup(*group, folder, componentItem);
+                co_await std::suspend_always {};
+                co_await renderGroup(*group, folder, componentItem);
             }
         }
         else if (assemblyComponent) {
             for (const auto* group : groups) {
-                renderGroup(*group, componentItem, componentItem);
+                co_await std::suspend_always {};
+                co_await renderGroup(*group, componentItem, componentItem);
             }
         }
 
-        const auto other = filterBucket(
+        const auto other = co_await filterBucket(
             findBucket(
                 entriesByComponentRole,
                 RoleContextKey {componentEntry.object, Role::Other}
@@ -6868,7 +7698,7 @@ void DocumentItem::rebuildModelBrowser()
                     && !entry.bodyRepresentation;
             }
         );
-        renderCategory(
+        co_await renderCategory(
             componentItem,
             componentItem,
             componentEntry.object,
@@ -6886,16 +7716,17 @@ void DocumentItem::rebuildModelBrowser()
 
     // Components are the primary browser roots, matching component-oriented CAD
     // systems.  Type folders below handle document-level loose objects and Bodies.
-    const auto topComponents = filterBucket(&componentEntries, [](const Entry& entry) {
+    const auto topComponents = co_await filterBucket(&componentEntries, [](const Entry& entry) {
         return !entry.logicalParent
             || !Projection::isComponent(entry.logicalParent);
     });
     for (const auto* component : topComponents) {
-        renderComponent(*component, this, nullptr);
+        co_await std::suspend_always {};
+        co_await renderComponent(*component, this, nullptr);
     }
 
-    const auto rootParameters = componentRoleEntries(nullptr, Role::Parameter);
-    renderCategory(
+    const auto rootParameters = co_await componentRoleEntries(nullptr, Role::Parameter);
+    co_await renderCategory(
         this,
         nullptr,
         nullptr,
@@ -6905,7 +7736,7 @@ void DocumentItem::rebuildModelBrowser()
         rootParameters
     );
 
-    const auto rootBodies = componentRoleEntries(nullptr, Role::Body);
+    const auto rootBodies = co_await componentRoleEntries(nullptr, Role::Body);
     if (!rootBodies.empty()) {
         auto* folder = makeFolder(
             this,
@@ -6916,12 +7747,13 @@ void DocumentItem::rebuildModelBrowser()
             "PartDesign_Body"
         );
         for (const auto* body : rootBodies) {
-            renderBody(*body, folder, nullptr);
+            co_await std::suspend_always {};
+            co_await renderBody(*body, folder, nullptr);
         }
     }
 
-    const auto rootSketches = componentRoleEntries(nullptr, Role::Sketch);
-    renderCategory(
+    const auto rootSketches = co_await componentRoleEntries(nullptr, Role::Sketch);
+    co_await renderCategory(
         this,
         nullptr,
         nullptr,
@@ -6931,28 +7763,29 @@ void DocumentItem::rebuildModelBrowser()
         rootSketches
     );
 
-    renderManufacture(this, nullptr, nullptr);
+    co_await renderManufacture(this, nullptr, nullptr);
 
-    const auto rootMeshGroups = filterBucket(
+    const auto rootMeshGroups = co_await filterBucket(
         findBucket(entriesByComponentRole, RoleContextKey {nullptr, Role::Group}),
         [&](const Entry& entry) {
             return !entry.group && isMeshesGroup(entry.object);
         }
     );
     for (const auto* group : rootMeshGroups) {
-        renderGroup(*group, this, nullptr);
+        co_await std::suspend_always {};
+        co_await renderGroup(*group, this, nullptr);
     }
 
-    renderAnalyze(this, nullptr, nullptr);
-    renderDrawings(this, nullptr, nullptr);
+    co_await renderAnalyze(this, nullptr, nullptr);
+    co_await renderDrawings(this, nullptr, nullptr);
 
-    const auto rootOperations = filterBucket(
+    const auto rootOperations = co_await filterBucket(
         findBucket(entriesByComponentRole, RoleContextKey {nullptr, Role::History}),
         [&](const Entry& entry) {
             return !entry.body && !isMeshesGroup(entry.group);
         }
     );
-    renderCategory(
+    co_await renderCategory(
         this,
         nullptr,
         nullptr,
@@ -6963,8 +7796,8 @@ void DocumentItem::rebuildModelBrowser()
     );
 
     const auto rootOccurrences =
-        componentRoleEntries(nullptr, Role::AssemblyOccurrence);
-    renderCategory(
+        co_await componentRoleEntries(nullptr, Role::AssemblyOccurrence);
+    co_await renderCategory(
         this,
         nullptr,
         nullptr,
@@ -6974,7 +7807,7 @@ void DocumentItem::rebuildModelBrowser()
         rootOccurrences
     );
 
-    const auto rootVibeCADOutputs = filterBucket(
+    const auto rootVibeCADOutputs = co_await filterBucket(
         findBucket(
             entriesByComponentRole,
             RoleContextKey {nullptr, Role::VibeCADOutput}
@@ -6983,7 +7816,7 @@ void DocumentItem::rebuildModelBrowser()
             return !entry.bodyRepresentation;
         }
     );
-    renderCategory(
+    co_await renderCategory(
         this,
         nullptr,
         nullptr,
@@ -6993,8 +7826,8 @@ void DocumentItem::rebuildModelBrowser()
         rootVibeCADOutputs
     );
 
-    const auto rootReferences = componentRoleEntries(nullptr, Role::Reference);
-    renderReferences(
+    const auto rootReferences = co_await componentRoleEntries(nullptr, Role::Reference);
+    co_await renderReferences(
         this,
         nullptr,
         nullptr,
@@ -7002,14 +7835,14 @@ void DocumentItem::rebuildModelBrowser()
         rootReferences
     );
 
-    const auto rootLooseGeometry = filterBucket(
+    const auto rootLooseGeometry = co_await filterBucket(
         findBucket(entriesByComponentRole, RoleContextKey {nullptr, Role::Geometry}),
         [](const Entry& entry) {
             return !entry.body && !entry.publishedImplementation
                 && !entry.bodyRepresentation;
         }
     );
-    renderCategory(
+    co_await renderCategory(
         this,
         nullptr,
         nullptr,
@@ -7019,7 +7852,7 @@ void DocumentItem::rebuildModelBrowser()
         rootLooseGeometry
     );
 
-    const auto rootGroups = filterBucket(
+    const auto rootGroups = co_await filterBucket(
         findBucket(entriesByComponentRole, RoleContextKey {nullptr, Role::Group}),
         [&](const Entry& entry) {
             return !entry.group && !isMeshesGroup(entry.object);
@@ -7035,11 +7868,12 @@ void DocumentItem::rebuildModelBrowser()
             "folder"
         );
         for (const auto* group : rootGroups) {
-            renderGroup(*group, folder, nullptr);
+            co_await std::suspend_always {};
+            co_await renderGroup(*group, folder, nullptr);
         }
     }
 
-    const auto rootOther = filterBucket(
+    const auto rootOther = co_await filterBucket(
         findBucket(entriesByComponentRole, RoleContextKey {nullptr, Role::Other}),
         [](const Entry& entry) {
             return !entry.body && !entry.group
@@ -7047,7 +7881,7 @@ void DocumentItem::rebuildModelBrowser()
                 && !entry.bodyRepresentation;
         }
     );
-    auto* rootOtherFolder = renderCategory(
+    auto* rootOtherFolder = co_await renderCategory(
         this,
         nullptr,
         nullptr,
@@ -7062,6 +7896,7 @@ void DocumentItem::rebuildModelBrowser()
     // publications and implementation objects are omitted here.
     EntryBucket unrendered;
     for (const auto& entry : entries) {
+        co_await std::suspend_always {};
         if (!entryAvailable(entry) || rendered.contains(entry.object)) {
             continue;
         }
@@ -7084,7 +7919,8 @@ void DocumentItem::rebuildModelBrowser()
                   "folder"
               );
         for (const auto* entry : unrendered) {
-            renderObject(
+            co_await std::suspend_always {};
+            co_await renderObject(
                 *entry,
                 folder,
                 logicalItem(entry->logicalParent, nullptr)
@@ -7092,22 +7928,63 @@ void DocumentItem::rebuildModelBrowser()
         }
     }
 
-    modelBrowserActive = true;
-    modelBrowserDirty = false;
-    updateBrowserFolderStatus();
-
-    if (Application::Instance->isInEdit(document())) {
-        ViewProviderDocumentObject* parentView = nullptr;
-        std::string subname;
-        auto* editingView = document()->getInEdit(&parentView, &subname);
-        auto* objectView = parentView ? parentView
-                                      : freecad_cast<ViewProviderDocumentObject*>(editingView);
-        if (objectView) {
-            tree->editingItem = findBrowserItem(objectView->getObject());
+    if (firstBuild) {
+        for (const auto& entry : ObjectMap) {
+            for (auto* item : entry.second->items) {
+                co_await std::suspend_always {};
+                QScopedValueRollback applying(modelBrowserApplyingState, true);
+                QSignalBlocker signals(getTree());
+                const bool selectionLock = getTree()->blockSelection(true);
+                const auto restoreSelection = qScopeGuard([&] { getTree()->blockSelection(selectionLock); });
+                setLegacyItemVisible(item, false);
+            }
         }
     }
+    auto* cursor = stagedRoot.get();
+    while (cursor != stagedRoot.get() || stagedRoot->childCount()) {
+        co_await std::suspend_always {};
+        if (cursor->childCount()) {
+            cursor = cursor->child(cursor->childCount() - 1);
+        }
+        else {
+            auto* parent = cursor->parent();
+            // Allocate the ownership record before detaching so allocation
+            // failure cannot leak an item from the staged hierarchy.
+            modelBrowserDetachedItems.push_back({nullptr, parent});
+            modelBrowserDetachedItems.back().item.reset(parent->takeChild(parent->childCount() - 1));
+            cursor = parent;
+        }
+    }
+    co_return std::move(stagedRoot);
+}
 
-    tree->blockSelection(selectionLock);
+void DocumentItem::markModelBrowserDirty()
+{
+    if (!modelBrowserBuildExecuting) {
+        modelBrowserBuild.reset();
+    }
+    modelBrowserDetachedItems.clear();
+    modelBrowserRemovalCursor = QPersistentModelIndex();
+    modelBrowserClearing = false;
+    modelBrowserAttaching = false;
+    modelBrowserStagedStates.clear();
+    modelBrowserRootsToReveal.clear();
+    modelBrowserRevealIndex = 0;
+    modelBrowserStatePending = false;
+    browserFolderStatus.reset();
+    browserFolderStatusDirty = true;
+    modelBrowserPreparationPending = false;
+    preparedModelBrowserProjection.reset();
+    modelBrowserDirty = true;
+    ++modelBrowserGeneration;
+    stagedModelBrowserGeneration = 0;
+    stagedModelBrowserRoot.reset();
+}
+
+bool DocumentItem::modelBrowserRefreshPending() const
+{
+    return TreeParams::getOrganizeModelByType()
+        && modelBrowserDirty && !modelBrowserPreparationPending;
 }
 
 void DocumentItem::refreshModelBrowser(bool force)
@@ -7117,16 +7994,18 @@ void DocumentItem::refreshModelBrowser(bool force)
             clearModelBrowser();
         }
         setLegacyTreeVisible(true);
-        modelBrowserDirty = true;
+        markModelBrowserDirty();
         return;
     }
 
-    setLegacyTreeVisible(false);
     if (force) {
-        modelBrowserDirty = true;
+        markModelBrowserDirty();
     }
     if (modelBrowserDirty) {
         rebuildModelBrowser();
+        if (modelBrowserRefreshPending()) {
+            getTree()->_updateStatus();
+        }
     }
     else {
         updateBrowserFolderStatus();
@@ -7149,7 +8028,17 @@ void TreeWidget::refreshModelBrowsers()
 
 void TreeWidget::slotDeleteDocument(const Gui::Document& Doc)
 {
+    // A document close can arrive between cooperative projection slices. Drop
+    // every retained presentation identity before any tree item is destroyed;
+    // remaining live documents will enqueue their own authoritative refresh.
+    resetStatusUpdate();
     NewObjects.erase(Doc.getDocument()->getName());
+    // Restore cancellation can close a document before its queued providers
+    // have acquired Tree rows. Those objects are not in ObjectMap yet, but
+    // their changes must be discarded before the document releases them.
+    for (auto* object : Doc.getDocument()->getObjects()) {
+        ChangedObjects.erase(object);
+    }
     auto it = DocumentMap.find(&Doc);
     if (it != DocumentMap.end()) {
         UpdateDisabler disabler(*this, updateBlocked);
@@ -7172,6 +8061,9 @@ void TreeWidget::slotDeleteDocument(const Gui::Document& Doc)
         delete docItem;
         DocumentMap.erase(it);
     }
+    if (!ChangedObjects.empty() || !NewObjects.empty()) {
+        _updateStatus();
+    }
 }
 
 void TreeWidget::slotDeleteObject(const Gui::ViewProviderDocumentObject& view)
@@ -7182,6 +8074,7 @@ void TreeWidget::slotDeleteObject(const Gui::ViewProviderDocumentObject& view)
 void TreeWidget::_slotDeleteObject(const Gui::ViewProviderDocumentObject& view, DocumentItem* deletingDoc)
 {
     auto obj = view.getObject();
+    ChangedObjects.erase(obj);
     auto itEntry = ObjectTable.find(obj);
     if (itEntry == ObjectTable.end()) {
         return;
@@ -7205,7 +8098,7 @@ void TreeWidget::_slotDeleteObject(const Gui::ViewProviderDocumentObject& view, 
         if (docItem == deletingDoc) {
             continue;
         }
-        docItem->modelBrowserDirty = true;
+        docItem->markModelBrowserDirty();
 
         auto doc = docItem->document()->getDocument();
         auto& items = data->items;
@@ -7677,6 +8570,7 @@ void TreeWidget::slotChangeObject(const Gui::ViewProviderDocumentObject& view, c
     if (!obj || !obj->isAttachedToDocument()) {
         return;
     }
+    const char* propertyName = prop.getName();
 
     // Undo, Cancel, and Redo restore linked properties as an atomic document
     // operation. In particular, PropertyLinkList::Paste can remove a newly
@@ -7689,8 +8583,8 @@ void TreeWidget::slotChangeObject(const Gui::ViewProviderDocumentObject& view, c
         Gui::Document::projectionRefreshBlocked(document)) {
         if (auto documentIt = DocumentMap.find(view.getDocument());
             documentIt != DocumentMap.end()) {
-            documentIt->second->modelBrowserDirty = true;
             documentIt->second->transactionRefreshPending = true;
+            documentIt->second->deferPropertyChange(obj->getID(), propertyName);
         }
         return;
     }
@@ -7700,9 +8594,19 @@ void TreeWidget::slotChangeObject(const Gui::ViewProviderDocumentObject& view, c
         return;
     }
 
-    const char* propertyName = prop.getName();
     const std::string_view changedProperty =
         propertyName ? std::string_view(propertyName) : std::string_view();
+    // Transient simulation placements deliberately suppress object touch state.
+    // They still reach the ViewProvider synchronously, but cannot change the
+    // tree hierarchy or status. Avoid scheduling a whole-tree status pass for
+    // every moving component in every playback frame.
+    const bool transientPlacement =
+        &prop == obj->getPlacementProperty()
+        || changedProperty == "Placement"
+        || changedProperty == "LinkPlacement";
+    if (obj->testStatus(App::ObjectStatus::NoTouch) && transientPlacement) {
+        return;
+    }
     const bool changesBrowserProjection =
         changedProperty == "Group" || changedProperty == "Origin"
         || changedProperty.find("LinkedObject") != std::string_view::npos
@@ -7720,7 +8624,7 @@ void TreeWidget::slotChangeObject(const Gui::ViewProviderDocumentObject& view, c
     std::set<App::DocumentObject*> directGroupMembers;
     for (const auto& data : itEntry->second) {
         if (changesBrowserProjection) {
-            data->docItem->modelBrowserDirty = true;
+            data->docItem->markModelBrowserDirty();
         }
         if (!changesDirectChildGroup) {
             continue;
@@ -7748,15 +8652,9 @@ void TreeWidget::slotChangeObject(const Gui::ViewProviderDocumentObject& view, c
     _updateStatus();
 
     if (&prop == &obj->Visibility) {
-        std::set<DocumentItem*> documents;
-        for (const auto& data : itEntry->second) {
-            if (data && data->docItem) {
-                documents.insert(data->docItem);
-            }
-        }
-        for (auto* document : documents) {
-            document->updateBrowserFolderStatus();
-        }
+        // The scheduled document-status phase refreshes folder aggregates once
+        // after the complete notification burst. Traversing every browser
+        // folder for every object makes bulk visibility O(objects * tree).
         return;
     }
 
@@ -8198,6 +9096,18 @@ void DocumentItem::slotRecomputedObject(const App::DocumentObject& obj)
 void DocumentItem::slotRecomputed(const App::Document&, const std::vector<App::DocumentObject*>& objs)
 {
     auto tree = getTree();
+    auto* appDocument = document()->getDocument();
+    if (Gui::Document::projectionRefreshBlocked(appDocument)) {
+        for (auto* obj : objs) {
+            if (obj) {
+                deferStatusChange(obj->getID());
+            }
+        }
+        if (!objs.empty()) {
+            transactionRefreshPending = true;
+        }
+        return;
+    }
     for (auto obj : objs) {
         if (!obj->isValid()) {
             tree->ChangedObjects[obj].set(TreeWidget::CS_Error);
@@ -8219,21 +9129,68 @@ void DocumentItem::slotDocumentStable(const App::Document& stableDocument)
     }
 
     transactionRefreshPending = false;
-    modelBrowserDirty = true;
-
-    // Re-establish the incremental child cache only from identities that are
-    // live after the complete transaction outcome. This gives the legacy tree
-    // and the VibeCAD type projection the same post-transaction model without
-    // carrying pointers across rollback.
     auto* tree = getTree();
-    for (const auto& [object, data] : ObjectMap) {
-        if (object && data && object->isAttachedToDocument()
-            && object->getDocument() == &stableDocument
-            && tree->ObjectTable.contains(object)) {
+    auto deferred = std::move(deferredProjectionChanges);
+    deferredProjectionChanges.clear();
+    for (const auto& [objectId, change] : deferred) {
+        auto* object = stableDocument.getObjectByID(objectId);
+        if (!object || !object->isAttachedToDocument()
+            || object->getDocument() != &stableDocument) {
+            continue;
+        }
+        bool replayedProperty = false;
+        if (auto* provider = getViewProvider(object)) {
+            for (const auto& propertyName : change.properties) {
+                auto* property = object->getPropertyByName(propertyName.c_str());
+                if (!property) {
+                    continue;
+                }
+                tree->slotChangeObject(*provider, *property);
+                replayedProperty = true;
+            }
+        }
+        if (change.status || !replayedProperty) {
             tree->ChangedObjects.emplace(object, 0);
         }
     }
-    tree->_updateStatus();
+    acquirePresentationUpdate(const_cast<App::Document&>(stableDocument));
+    tree->onUpdateStatus();
+}
+
+void DocumentItem::deferPropertyChange(long objectId, const char* propertyName)
+{
+    auto& change = deferredProjectionChanges[objectId];
+    if (propertyName && *propertyName) {
+        change.properties.emplace(propertyName);
+    }
+    else {
+        change.status = true;
+    }
+}
+
+void DocumentItem::deferStatusChange(long objectId)
+{
+    deferredProjectionChanges[objectId].status = true;
+}
+
+void DocumentItem::acquirePresentationUpdate(App::Document& document)
+{
+    if (presentationUpdateDocument == &document) {
+        return;
+    }
+    releasePresentationUpdate();
+    document.beginPresentationUpdate();
+    presentationUpdateDocument = &document;
+}
+
+void DocumentItem::releasePresentationUpdate()
+{
+    if (!presentationUpdateDocument) {
+        return;
+    }
+    auto* document = presentationUpdateDocument;
+    presentationUpdateDocument = nullptr;
+    document->endPresentationUpdate();
 }
 
 Gui::Document* DocumentItem::document() const

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -23,9 +23,18 @@
 
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <memory>
+#include <optional>
+#include <set>
+#include <string>
 #include <unordered_map>
+#include <vector>
 #include <QTimer>
 #include <QElapsedTimer>
+#include <QPersistentModelIndex>
 #include <QStyledItemDelegate>
 #include <QTreeWidget>
 
@@ -34,6 +43,7 @@
 #include <Base/Parameter.h>
 #include <Base/Persistence.h>
 #include <Gui/DockWindow.h>
+#include <Gui/FrameSequence.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/TreeItemMode.h>
 
@@ -43,6 +53,7 @@ namespace Gui
 {
 
 class TreeParams;
+class ModelTreeBrowserProjection;
 class ViewProviderDocumentObject;
 class DocumentObjectItem;
 class DocumentObjectData;
@@ -218,6 +229,8 @@ protected:
 
 private:
     void _updateStatus(bool delay = true);
+    void processUpdateStatus();
+    void resetStatusUpdate();
 
     // Helpers for the two-stage "Select All" feature
     void selectGroupItems(const QTreeWidgetItem* group, bool recursive);
@@ -291,6 +304,25 @@ private:
     void addDependentToSelection(App::Document* doc, App::DocumentObject* docObject);
     static TreeWidget* getTreeForSelection();
 
+    struct PendingObjectIdentity
+    {
+        std::string documentName;
+        long objectId {};
+    };
+
+    enum class StatusUpdatePhase
+    {
+        Idle,
+        Objects,
+        Browsers,
+        ObjectStatus,
+        DocumentStatus,
+        RestoredObjects,
+        Selection,
+        Errors,
+        Geometry,
+    };
+
 private:
     QAction* createGroupAction;
     QAction* relabelObjectAction;
@@ -337,6 +369,20 @@ private:
     std::unordered_map<App::DocumentObject*, std::bitset<32>> ChangedObjects;
 
     std::unordered_map<std::string, std::vector<long>> NewObjects;
+
+    StatusUpdatePhase statusUpdatePhase {StatusUpdatePhase::Idle};
+    std::vector<std::string> statusUpdateDocuments;
+    std::vector<PendingObjectIdentity> statusUpdateObjects;
+    std::vector<PendingObjectIdentity> statusUpdateErrors;
+    std::size_t statusUpdateDocumentIndex {0};
+    std::size_t statusUpdateObjectIndex {0};
+    std::size_t statusUpdateErrorIndex {0};
+    QTreeWidgetItem* statusUpdateFirstErrorItem {};
+    QElapsedTimer statusUpdateElapsed;
+    std::size_t statusUpdateProjectedObjectCount {0};
+    bool statusUpdateAllObjects {false};
+    bool statusUpdateScheduled {false};
+    bool statusUpdateExecuting {false};
 
     static std::set<TreeWidget*> Instances;
 
@@ -445,6 +491,8 @@ protected:
     void slotRecomputed(const App::Document& doc, const std::vector<App::DocumentObject*>& objs);
     void slotRecomputedObject(const App::DocumentObject&);
     void slotDocumentStable(const App::Document& stableDocument);
+    void acquirePresentationUpdate(App::Document& document);
+    void releasePresentationUpdate();
 
     bool updateObject(const Gui::ViewProviderDocumentObject&, const App::Property& prop);
 
@@ -481,9 +529,19 @@ protected:
     void setReadOnlyIconInfo(int column, QIcon& overlayedIcon);
     void refreshModelBrowser(bool force = false);
     void rebuildModelBrowser();
+    FrameSequence<std::unique_ptr<QTreeWidgetItem>> buildModelBrowser();
+    void markModelBrowserDirty();
+    bool modelBrowserRefreshPending() const;
     void clearModelBrowser();
+    bool clearModelBrowserStep();
     void setLegacyTreeVisible(bool visible);
+    void setLegacyItemVisible(DocumentObjectItem* item, bool visible);
     void updateBrowserFolderStatus();
+    void scheduleBrowserFolderStatus();
+    void processBrowserFolderStatus();
+    void recordBrowserExpansion(QTreeWidgetItem* item, bool expanded);
+    void recordBrowserSelection(DocumentObjectItem* item, bool selected);
+    void applyModelBrowserState();
     DocumentObjectItem* createBrowserObjectItem(
         App::DocumentObject* object,
         QTreeWidgetItem* parent,
@@ -505,6 +563,14 @@ protected:
     bool isPresentationItem(const DocumentObjectItem* item) const;
 
 private:
+    struct DeferredProjectionChange
+    {
+        std::set<std::string> properties;
+        bool status {false};
+    };
+
+    void deferPropertyChange(long objectId, const char* propertyName);
+    void deferStatusChange(long objectId);
     const char* treeName;  // for debugging purpose
     Gui::Document* pDocument;
     std::unordered_map<App::DocumentObject*, DocumentObjectDataPtr> ObjectMap;
@@ -513,6 +579,53 @@ private:
     bool modelBrowserDirty {true};
     bool modelBrowserActive {false};
     bool transactionRefreshPending {false};
+    std::map<long, DeferredProjectionChange> deferredProjectionChanges;
+    App::Document* presentationUpdateDocument {};
+    std::uint64_t modelBrowserGeneration {1};
+    std::uint64_t stagedModelBrowserGeneration {0};
+    std::unique_ptr<QTreeWidgetItem> stagedModelBrowserRoot;
+    struct DetachedBrowserItem
+    {
+        std::unique_ptr<QTreeWidgetItem> item;
+        QTreeWidgetItem* parent {};
+    };
+    // Reverse postorder: each item has no children, and its parent is attached
+    // before the item is released to Qt. No subtree-sized Qt insertion occurs.
+    std::vector<DetachedBrowserItem> modelBrowserDetachedItems;
+    QPersistentModelIndex modelBrowserRemovalCursor;
+    int modelBrowserRemovalRoot {-1};
+    bool modelBrowserClearing {false};
+    bool modelBrowserAttaching {false};
+    std::optional<FrameSequence<std::unique_ptr<QTreeWidgetItem>>> modelBrowserBuild;
+    std::uint64_t modelBrowserBuildGeneration {};
+    bool modelBrowserBuildExecuting {false};
+    QElapsedTimer modelBrowserBuildElapsed;
+    std::size_t modelBrowserBuildSteps {};
+    qint64 modelBrowserBuildMaxStepNs {};
+    struct BrowserItemState
+    {
+        bool expanded {};
+        bool selected {};
+        bool hidden {};
+    };
+    struct BrowserItemOverride
+    {
+        std::optional<bool> expanded;
+        std::optional<bool> selected;
+    };
+    std::unordered_map<QTreeWidgetItem*, BrowserItemState> modelBrowserStagedStates;
+    std::unordered_map<long, BrowserItemOverride> modelBrowserObjectOverrides;
+    std::unordered_map<std::string, bool> modelBrowserFolderOverrides;
+    std::vector<std::pair<QTreeWidgetItem*, bool>> modelBrowserRootsToReveal;
+    std::size_t modelBrowserRevealIndex {};
+    bool modelBrowserStatePending {false};
+    bool modelBrowserApplyingState {false};
+    std::shared_ptr<const ModelTreeBrowserProjection> preparedModelBrowserProjection;
+    bool modelBrowserPreparationPending {false};
+    struct BrowserFolderStatus;
+    std::unique_ptr<BrowserFolderStatus> browserFolderStatus;
+    bool browserFolderStatusScheduled {false};
+    bool browserFolderStatusDirty {false};
 
     ExpandInfoPtr _ExpandInfo;
     void restoreItemExpansion(const ExpandInfoPtr&, DocumentObjectItem*);
@@ -530,6 +643,9 @@ private:
     Connection connectRecomputed;
     Connection connectRecomputedObj;
     Connection connectDocumentStable;
+    Connection connectFinishRestoreDocument;
+    Connection connectRestoreActivityIdle;
+    Connection connectFinishOpenDocument;
     Connection connectRecomputeRequestFinished;
 
     friend class TreeWidget;

--- a/src/Gui/View3DInventor.cpp
+++ b/src/Gui/View3DInventor.cpp
@@ -22,6 +22,7 @@
 
 
 #include <string>
+#include "FrameBudget.h"
 #include <QApplication>
 #include <QKeyEvent>
 #include <QEvent>
@@ -154,6 +155,7 @@ View3DInventor::View3DInventor(
 
 View3DInventor::~View3DInventor()
 {
+    PerformanceScope closeTiming("View3DInventor destruction");
     if (_pcDocument) {
         SoCamera* Cam = _viewer->getSoRenderManager()->getCamera();
         if (Cam) {
@@ -441,15 +443,15 @@ bool View3DInventor::onMsg(const char* pMsg)
         return true;
     }
     else if (strcmp("Save", pMsg) == 0) {
-        getGuiDocument()->save();
+        getGuiDocument()->saveAsync();
         return true;
     }
     else if (strcmp("SaveAs", pMsg) == 0) {
-        getGuiDocument()->saveAs();
+        getGuiDocument()->saveAsAsync();
         return true;
     }
     else if (strcmp("SaveCopy", pMsg) == 0) {
-        getGuiDocument()->saveCopy();
+        getGuiDocument()->saveCopyAsync();
         return true;
     }
     else if (strcmp("AlignToSelection", pMsg) == 0) {

--- a/src/Gui/View3DInventorViewer.cpp
+++ b/src/Gui/View3DInventorViewer.cpp
@@ -22,6 +22,7 @@
  ******************************************************************************/
 
 #include <FCConfig.h>
+#include "FrameBudget.h"
 
 #include <algorithm>
 #include <cmath>
@@ -1267,6 +1268,7 @@ void View3DInventorViewer::init()
 
 View3DInventorViewer::~View3DInventorViewer()
 {
+    PerformanceScope closeTiming("View3DInventorViewer destruction");
     // to prevent following OpenGL error message: "Texture is not valid in the current context.
     // Texture has not been destroyed"
     aboutToDestroyGLContext();
@@ -1298,14 +1300,20 @@ View3DInventorViewer::~View3DInventorViewer()
     this->pcBackGround->unref();
     this->pcBackGround = nullptr;
 
-    setSceneGraph(nullptr);
+    {
+        PerformanceScope sceneTiming("View3DInventorViewer detach scene graph");
+        setSceneGraph(nullptr);
+    }
     this->pEventCallback->unref();
     this->pEventCallback = nullptr;
     // Note: It can happen that there is still someone who references
     // the root node but isn't destroyed when closing this viewer so
     // that it prevents all children from being deleted. To reduce this
     // likelihood we explicitly remove all child nodes now.
-    coinRemoveAllChildren(this->pcViewProviderRoot);
+    {
+        PerformanceScope graphTiming("View3DInventorViewer release provider graph");
+        coinRemoveAllChildren(this->pcViewProviderRoot);
+    }
     this->pcViewProviderRoot->unref();
     this->pcViewProviderRoot = nullptr;
     this->objectGroup->unref();
@@ -1349,7 +1357,10 @@ View3DInventorViewer::~View3DInventorViewer()
     // order to free the memory.
     SoGLRenderAction* glAction = this->getSoRenderManager()->getGLRenderAction();
     this->getSoRenderManager()->setGLRenderAction(nullptr);
-    delete glAction;
+    {
+        PerformanceScope actionTiming("View3DInventorViewer release GL render action");
+        delete glAction;
+    }
 }
 
 void View3DInventorViewer::createStandardCursors()
@@ -1365,6 +1376,7 @@ void View3DInventorViewer::createStandardCursors()
 
 void View3DInventorViewer::aboutToDestroyGLContext()
 {
+    PerformanceScope contextTiming("View3DInventorViewer release GL context resources");
     if (naviCube) {
         if (auto gl = qobject_cast<QOpenGLWidget*>(this->viewport())) {
             gl->makeCurrent();

--- a/src/Gui/View3DViewerPy.cpp
+++ b/src/Gui/View3DViewerPy.cpp
@@ -26,7 +26,10 @@
 #include <Base/GeometryPyCXX.h>
 #include <Base/Interpreter.h>
 #include <Base/MatrixPy.h>
+#include <App/Application.h>
 
+#include "Application.h"
+#include "AsyncImageExport.h"
 #include "PythonWrapper.h"
 #include "Navigation/NavigationStyle.h"
 #include "View3DViewerPy.h"
@@ -157,6 +160,12 @@ void View3DInventorViewerPy::init_type()
         &View3DInventorViewerPy::grabFramebuffer,
         "grabFramebuffer() -> QImage: renders and returns a 32-bit RGB image of the framebuffer."
     );
+    add_varargs_method("startFrameExport", &View3DInventorViewerPy::startFrameExport,
+        "startFrameExport(path, width, height) -> int: capture pixels and encode PNG on the native runtime.");
+    add_varargs_method("finishFrameExport", &View3DInventorViewerPy::finishFrameExport,
+        "finishFrameExport(request) -> bool: poll completion without waiting; raise on failure.");
+    add_varargs_method("cancelFrameExport", &View3DInventorViewerPy::cancelFrameExport,
+        "cancelFrameExport(request): cancel only the identified frame export.");
 
     add_varargs_method(
         "setOverrideMode",
@@ -704,6 +713,69 @@ Py::Object View3DInventorViewerPy::grabFramebuffer(const Py::Tuple& args)
 #else
     return wrap.fromQImage(img.flipped(Qt::Vertical));
 #endif
+}
+
+Py::Object View3DInventorViewerPy::startFrameExport(const Py::Tuple& args)
+{
+    Gui::requireMainThread("Viewer.startFrameExport");
+    const char* path = nullptr;
+    int width = 0;
+    int height = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "sii", &path, &width, &height)) {
+        throw Py::Exception();
+    }
+    if (!_viewer || width <= 0 || height <= 0) {
+        throw Py::RuntimeError("Frame export requires a live viewer and positive dimensions");
+    }
+    // One immutable framebuffer at a time, including cancellation in flight.
+    // Callers cannot enqueue an unbounded series of image buffers.
+    if (frameExport && !frameExport->isReady()) {
+        throw Py::RuntimeError("The previous frame export has not completed");
+    }
+    try {
+        // Flush this pose to the framebuffer without pumping unrelated input.
+        // In the non-MSAA path grabFramebuffer reads existing pixels.
+        _viewer->redraw();
+        auto image = _viewer->grabFramebuffer();
+        frameExport = std::make_unique<detail::AsyncImageExport>(
+            App::GetApplication().hostRuntime(), std::move(image), QString::fromUtf8(path),
+            width, height, true);
+    }
+    catch (const std::exception& error) {
+        throw Py::RuntimeError(error.what());
+    }
+    return Py::Object(PyLong_FromUnsignedLongLong(++frameExportRequest), true);
+}
+
+Py::Object View3DInventorViewerPy::finishFrameExport(const Py::Tuple& args)
+{
+    Gui::requireMainThread("Viewer.finishFrameExport");
+    unsigned long long request = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "K", &request)) {
+        throw Py::Exception();
+    }
+    if (!frameExport || request != frameExportRequest) {
+        throw Py::RuntimeError("The frame export request is no longer current");
+    }
+    try {
+        return Py::Boolean(frameExport->finish());
+    }
+    catch (const std::exception& error) {
+        throw Py::RuntimeError(error.what());
+    }
+}
+
+Py::Object View3DInventorViewerPy::cancelFrameExport(const Py::Tuple& args)
+{
+    Gui::requireMainThread("Viewer.cancelFrameExport");
+    unsigned long long request = 0;
+    if (!PyArg_ParseTuple(args.ptr(), "K", &request)) {
+        throw Py::Exception();
+    }
+    if (frameExport && request == frameExportRequest) {
+        frameExport->cancel();
+    }
+    return Py::None();
 }
 
 Py::Object View3DInventorViewerPy::setOverrideMode(const Py::Tuple& args)

--- a/src/Gui/View3DViewerPy.h
+++ b/src/Gui/View3DViewerPy.h
@@ -24,10 +24,13 @@
 
 #include <CXX/Extensions.hxx>
 #include <list>
+#include <cstdint>
+#include <memory>
 
 
 namespace Gui
 {
+namespace detail { class AsyncImageExport; }
 
 class View3DInventorViewer;
 class EditableDatumLabelPy;
@@ -74,6 +77,9 @@ public:
     Py::Object setRedirectToSceneGraph(const Py::Tuple& args);
     Py::Object isRedirectedToSceneGraph(const Py::Tuple& args);
     Py::Object grabFramebuffer(const Py::Tuple& args);
+    Py::Object startFrameExport(const Py::Tuple& args);
+    Py::Object finishFrameExport(const Py::Tuple& args);
+    Py::Object cancelFrameExport(const Py::Tuple& args);
 
     Py::Object setOverrideMode(const Py::Tuple& args);
 
@@ -99,6 +105,8 @@ private:
     friend class EditableDatumLabelPy;
     std::list<PyObject*> callbacks;
     View3DInventorViewer* _viewer;
+    std::unique_ptr<detail::AsyncImageExport> frameExport;
+    std::uint64_t frameExportRequest {0};
     friend class View3DInventorViewer;
 };
 

--- a/src/Gui/ViewProviderDocumentObject.cpp
+++ b/src/Gui/ViewProviderDocumentObject.cpp
@@ -244,7 +244,7 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
     }
 
     if (prop && !prop->testStatus(App::Property::NoModify) && pcDocument
-        && !pcDocument->isModified() && testStatus(Gui::ViewStatus::TouchDocument)) {
+        && testStatus(Gui::ViewStatus::TouchDocument)) {
         if (prop) {
             FC_LOG(prop->getFullName() << " changed");
         }
@@ -257,8 +257,9 @@ void ViewProviderDocumentObject::onChanged(const App::Property* prop)
 void ViewProviderDocumentObject::hide()
 {
     ViewProvider::hide();
-    // use this bit to check whether 'Visibility' must be adjusted
-    if (!Visibility.testStatus(App::Property::User2)) {
+    // Reapply scene state even when unchanged, but do not manufacture a
+    // persistent edit when presentation adoption repeats an existing value.
+    if (Visibility.getValue() && !Visibility.testStatus(App::Property::User2)) {
         Visibility.setStatus(App::Property::User2, true);
         Visibility.setValue(false);
         Visibility.setStatus(App::Property::User2, false);
@@ -378,15 +379,17 @@ void ViewProviderDocumentObject::show()
         ViewProvider::show();
     }
     else {
-        Visibility.setValue(false);
-        if (getObject()) {
+        if (Visibility.getValue()) {
+            Visibility.setValue(false);
+        }
+        if (getObject() && getObject()->Visibility.getValue()) {
             getObject()->Visibility.setValue(false);
         }
         return;
     }
 
     // use this bit to check whether 'Visibility' must be adjusted
-    if (!Visibility.testStatus(App::Property::User2)) {
+    if (!Visibility.getValue() && !Visibility.testStatus(App::Property::User2)) {
         Visibility.setStatus(App::Property::User2, true);
         Visibility.setValue(true);
         Visibility.setStatus(App::Property::User2, false);

--- a/src/Gui/ViewProviderGeometryObject.cpp
+++ b/src/Gui/ViewProviderGeometryObject.cpp
@@ -38,9 +38,12 @@
 
 #include <App/GeoFeature.h>
 #include <App/PropertyGeo.h>
+#include <App/HostRuntime.h>
+#include <Base/CancellationScope.h>
 
 #include "Application.h"
 #include "Document.h"
+#include "FrameBudget.h"
 #include "Inventor/SoFCBoundingBox.h"
 #include "SoFCSelection.h"
 #include "View3DInventorViewer.h"
@@ -55,8 +58,18 @@ PROPERTY_SOURCE(Gui::ViewProviderGeometryObject, Gui::ViewProviderDragger)
 
 const App::PropertyIntegerConstraint::Constraints intPercent = {0, 100, 5};
 
+struct ViewProviderGeometryObject::BoundingBoxRequest
+{
+    ViewProviderGeometryObject* owner;
+    std::uint64_t generation {0};
+    bool queued {false};
+    bool active {false};
+    std::stop_source cancellation;
+};
+
 ViewProviderGeometryObject::ViewProviderGeometryObject()
 {
+    boundingBoxRequest = std::make_shared<BoundingBoxRequest>(this);
     App::Material mat = App::Material::getDefaultAppearance();
 
     long initialTransparency = Base::toPercent(mat.transparency);
@@ -109,6 +122,11 @@ ViewProviderGeometryObject::ViewProviderGeometryObject()
 
 ViewProviderGeometryObject::~ViewProviderGeometryObject()
 {
+    // Workers retain only a property snapshot. Late completions must not use
+    // a destroyed provider, even if another provider reuses its address.
+    boundingBoxRequest->owner = nullptr;
+    boundingBoxRequest->cancellation.request_stop();
+    boundingBoxRequest.reset();
     pcShapeMaterial->unref();
     pcBoundingBox->unref();
     pcBoundColor->unref();
@@ -164,25 +182,136 @@ void ViewProviderGeometryObject::onChanged(const App::Property* prop)
 
 void ViewProviderGeometryObject::attach(App::DocumentObject* pcObj)
 {
+    ++boundingBoxRequest->generation;
+    boundingBoxDirty = true;
+    boundingBoxPropertyName.clear();
     ViewProviderDragger::attach(pcObj);
+}
+
+void ViewProviderGeometryObject::updateBoundingBox(const App::PropertyComplexGeoData* geometry)
+{
+    // These bounds serve only the optional bounding-box overlay. In particular,
+    // shaded display and selection do not consume them. Do not traverse a BREP
+    // on every property notification for an overlay that is not being shown.
+    boundingBoxDirty = true;
+    ++boundingBoxRequest->generation;
+    boundingBoxRequest->cancellation.request_stop();
+    if (geometry) {
+        const char* name = geometry->getName();
+        boundingBoxPropertyName = name ? name : "";
+    }
+    if (!geometry || !pcBoundSwitch || pcBoundSwitch->whichChild.getValue() < 0) {
+        return;
+    }
+    scheduleBoundingBox();
+}
+
+void ViewProviderGeometryObject::scheduleBoundingBox()
+{
+    auto& request = *boundingBoxRequest;
+    if (request.queued || request.active || !boundingBoxDirty
+        || !pcBoundSwitch || pcBoundSwitch->whichChild.getValue() < 0) {
+        return;
+    }
+    request.queued = true;
+    if (!dispatchToGuiFrame([weak = std::weak_ptr(boundingBoxRequest)] {
+            if (auto request = weak.lock(); request && request->owner) {
+                request->queued = false;
+                request->owner->prepareBoundingBox();
+            }
+        })) {
+        request.queued = false;
+    }
+}
+
+void ViewProviderGeometryObject::prepareBoundingBox()
+{
+    if (!boundingBoxDirty || !pcBoundSwitch || pcBoundSwitch->whichChild.getValue() < 0) {
+        return;
+    }
+    const App::PropertyComplexGeoData* geometry = nullptr;
+    if (auto object = getObject(); object && !boundingBoxPropertyName.empty()) {
+        geometry = dynamic_cast<const App::PropertyComplexGeoData*>(
+            object->getPropertyByName(boundingBoxPropertyName.c_str()));
+    }
+    else if (auto object = getObject<App::GeoFeature>()) {
+        geometry = object->getPropertyOfGeometry();
+    }
+    if (!geometry) { return; }
+
+    const auto generation = boundingBoxRequest->generation;
+    const auto weak = std::weak_ptr(boundingBoxRequest);
+    try {
+        // Property copies preserve the geometry's transform and detach the
+        // worker lifetime from document/property deletion. Never give a worker
+        // a live document property or a Coin node.
+        const bool trace = qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE");
+        QElapsedTimer capture;
+        if (trace) { capture.start(); }
+        std::unique_ptr<App::Property> snapshot(geometry->Copy());
+        if (trace) {
+            Base::Console().message("VIBECAD_PROJECTION bounds_capture elapsed_us=%lld\n",
+                                    static_cast<long long>(capture.nsecsElapsed() / 1000));
+        }
+        boundingBoxRequest->cancellation = std::stop_source {};
+        const auto cancelled = boundingBoxRequest->cancellation.get_token();
+        boundingBoxRequest->active = true;
+        App::GetApplication().hostRuntime().submitWithCompletion(
+            App::HostRuntime::Lane::Compute,
+            [snapshot = std::move(snapshot), cancelled](std::stop_token stop) {
+                Base::CancellationScope cancellation(stop);
+                Base::CancellationScope replacement(cancelled);
+                Base::CancellationScope::check();
+                auto box = dynamic_cast<const App::PropertyComplexGeoData&>(*snapshot).getBoundingBox();
+                Base::CancellationScope::check();
+                return box;
+            },
+            [weak, generation](std::future<Base::BoundBox3d> result) {
+                Base::BoundBox3d box;
+                std::exception_ptr failure;
+                try { box = result.get(); }
+                catch (...) { failure = std::current_exception(); }
+                dispatchToGuiFrame([weak, generation, box, failure] {
+                    auto request = weak.lock();
+                    if (!request || !request->owner) { return; }
+                    auto& owner = *request->owner;
+                    request->active = false;
+                    if (request->generation != generation) {
+                        owner.scheduleBoundingBox();
+                        return;
+                    }
+                    if (failure) {
+                        try { std::rethrow_exception(failure); }
+                        catch (const Base::Exception& error) {
+                            Base::Console().error("Bounding-box preparation failed: %s\n", error.what());
+                        }
+                        catch (const std::exception& error) {
+                            Base::Console().error("Bounding-box preparation failed: %s\n", error.what());
+                        }
+                        catch (...) { Base::Console().error("Bounding-box preparation failed\n"); }
+                        return;
+                    }
+                    owner.pcBoundingBox->minBounds.setValue(box.MinX, box.MinY, box.MinZ);
+                    owner.pcBoundingBox->maxBounds.setValue(box.MaxX, box.MaxY, box.MaxZ);
+                    owner.boundingBoxDirty = false;
+                });
+            });
+    }
+    catch (const std::exception& error) {
+        boundingBoxRequest->active = false;
+        Base::Console().error("Cannot prepare bounding box: %s\n", error.what());
+    }
 }
 
 void ViewProviderGeometryObject::updateData(const App::Property* prop)
 {
     if (prop->isDerivedFrom<App::PropertyComplexGeoData>()) {
-        Base::BoundBox3d box = static_cast<const App::PropertyComplexGeoData*>(prop)->getBoundingBox();
-        pcBoundingBox->minBounds.setValue(box.MinX, box.MinY, box.MinZ);
-        pcBoundingBox->maxBounds.setValue(box.MaxX, box.MaxY, box.MaxZ);
+        updateBoundingBox(static_cast<const App::PropertyComplexGeoData*>(prop));
     }
     else if (prop->isDerivedFrom<App::PropertyPlacement>()) {
         auto geometry = getObject<App::GeoFeature>();
         if (geometry && prop == &geometry->Placement) {
-            const App::PropertyComplexGeoData* data = geometry->getPropertyOfGeometry();
-            if (data) {
-                Base::BoundBox3d box = data->getBoundingBox();
-                pcBoundingBox->minBounds.setValue(box.MinX, box.MinY, box.MinZ);
-                pcBoundingBox->maxBounds.setValue(box.MaxX, box.MaxY, box.MaxZ);
-            }
+            updateBoundingBox(geometry->getPropertyOfGeometry());
         }
     }
     else if (std::string(prop->getName()) == "ShapeMaterial") {
@@ -326,6 +455,9 @@ void ViewProviderGeometryObject::showBoundingBox(bool show)
     if (pcBoundSwitch) {
         // Respect object visibility: never show bounding box on a hidden object
         pcBoundSwitch->whichChild = (show && isShow()) ? 0 : -1;
+        // Showing the same overlay does not invalidate an in-flight result.
+        // Resolve its property identity only when the queued capture runs.
+        scheduleBoundingBox();
     }
 }
 

--- a/src/Gui/ViewProviderGeometryObject.h
+++ b/src/Gui/ViewProviderGeometryObject.h
@@ -23,6 +23,9 @@
 
 #pragma once
 
+#include <string>
+#include <memory>
+
 #include "ViewProviderDragger.h"
 #include <Inventor/lists/SoPickedPointList.h>
 
@@ -32,6 +35,11 @@ class SoSwitch;
 class SoSensor;
 class SbVec2s;
 class SoBaseColor;
+
+namespace App
+{
+class PropertyComplexGeoData;
+}
 
 namespace Gui
 {
@@ -117,6 +125,13 @@ protected:
 
 private:
     bool isSelectionEnabled() const;
+    void updateBoundingBox(const App::PropertyComplexGeoData* geometry);
+    void scheduleBoundingBox();
+    void prepareBoundingBox();
+    struct BoundingBoxRequest;
+    std::shared_ptr<BoundingBoxRequest> boundingBoxRequest;
+    bool boundingBoxDirty {true};
+    std::string boundingBoxPropertyName;
 
 protected:
     SoMaterial* pcShapeMaterial {nullptr};

--- a/src/Main/CMakeLists.txt
+++ b/src/Main/CMakeLists.txt
@@ -165,6 +165,14 @@ endif()
 SET_BIN_DIR(FreeCADMainPy FreeCAD)
 SET_PYTHON_PREFIX_SUFFIX(FreeCADMainPy)
 
+if(MSVC)
+    # The executable and Python module share a basename, but must not write
+    # the same linker PDB when the two targets build in parallel.
+    set_target_properties(FreeCADMainPy PROPERTIES
+        PDB_NAME "FreeCADMainPy"
+        PDB_NAME_DEBUG "FreeCADMainPy_d")
+endif()
+
 if(WIN32)
     INSTALL(TARGETS FreeCADMainPy
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/src/Mod/Assembly/AnimationEncoder.py
+++ b/src/Mod/Assembly/AnimationEncoder.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Detached animation encoding. No document, Qt, or scene-graph access.
+
+The caller owns the private output artifact and its atomic publication. Only
+one input frame is decoded at a time, including for GIFs with local palettes.
+This module is also the staged entry point for the existing isolation pool.
+"""
+from pathlib import Path
+import json
+import math
+
+
+def encode_animation(frame_files, output_path, fps, size, *, check=lambda: None):
+    destination = Path(output_path)
+    suffix = destination.suffix.lower()
+    if suffix not in {'.gif', '.mp4', '.avi'}:
+        raise ValueError('Animation export requires GIF, MP4 or AVI')
+    if not frame_files or not math.isfinite(fps) or fps <= 0:
+        raise ValueError('Animation export requires frames and a positive frame rate')
+    size = tuple(size)
+    if len(size) != 2 or any(type(value) is not int or value <= 0 for value in size):
+        raise ValueError('Animation export requires positive integer dimensions')
+    check()
+    if suffix == '.gif':
+        from PIL import Image, GifImagePlugin
+
+        with destination.open('wb') as stream:
+            for index, filename in enumerate(frame_files):
+                check()
+                with Image.open(filename) as source:
+                    if source.size != size:
+                        raise ValueError('Animation frame dimensions changed during export')
+                    # Captures use the opaque viewport background, as the old
+                    # saveImage(..., "Current") path did. Each frame gets its own
+                    # palette so different poses/colours are not quantized using
+                    # only the first frame's colours.
+                    with source.convert('RGB') as rgb:
+                        with rgb.quantize() as frame:
+                            if index == 0:
+                                header, _ = GifImagePlugin.getheader(frame, info={'loop': 0})
+                                stream.writelines(header)
+                            stream.writelines(GifImagePlugin.getdata(
+                                frame, duration=int(1000 / fps),
+                                include_color_table=True, disposal=2,
+                            ))
+            stream.write(b';')
+    else:
+        import cv2
+
+        # Limit OpenCV's own parallel regions inside this admitted worker. The
+        # codec implementation is separate from OpenCV's parallel scheduler.
+        previous_threads = cv2.getNumThreads()
+        cv2.setNumThreads(1)
+        writer = None
+        try:
+            codec = 'mp4v' if suffix == '.mp4' else 'XVID'
+            writer = cv2.VideoWriter(str(destination), cv2.VideoWriter_fourcc(*codec), fps, size)
+            if not writer.isOpened():
+                raise RuntimeError('Could not open the animation video encoder')
+            for filename in frame_files:
+                check()
+                frame = cv2.imread(str(filename))
+                if frame is None:
+                    raise ValueError('Could not read an animation frame')
+                if (frame.shape[1], frame.shape[0]) != size:
+                    raise ValueError('Animation frame dimensions changed during export')
+                writer.write(frame)
+        finally:
+            if writer is not None:
+                writer.release()
+            cv2.setNumThreads(previous_threads)
+    check()
+
+
+if __name__ == '__main__':
+    request = json.loads(Path('animation.json').read_text(encoding='utf-8'))
+    encode_animation(request['frames'], request['output'], request['fps'], request['size'])

--- a/src/Mod/Assembly/AnimationExport.py
+++ b/src/Mod/Assembly/AnimationExport.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Nonblocking frame capture and detached animation-file publication."""
+from pathlib import Path
+import json
+import os
+import queue
+import shutil
+import tempfile
+import threading
+
+from PySide import QtCore
+from VibeCADNativeBackground import NativeBackgroundCancelled
+
+
+class AnimationExportError(RuntimeError):
+    def failure(self):
+        return {'error_code': 'ANIMATION_EXPORT_FAILED', 'message': str(self)}
+
+
+class AnimationExportJob:
+    """Only detached values cross into the existing job supervisor/isolation pool.
+
+    Capture owns the staging directory until finish_capture. The supervisor
+    waits outside Qt, then encodes, atomically publishes and removes staging.
+    Neither file I/O nor final encoding is dispatched back onto the GUI.
+    """
+    def __init__(self, manager, *, document_uid, output, frame_count, fps, size,
+                 execute, isolation):
+        self.manager = manager
+        self.output = Path(output)
+        self.frame_count = frame_count
+        self.size = tuple(size)
+        self.staging_ready = queue.Queue(maxsize=1)
+        self._capture_done = threading.Event()
+        self._capture_error = ''
+        self._temporary = None
+
+        def prepare(cancelled, report):
+            try:
+                # Same volume as the destination: publication is one rename,
+                # never a cross-volume copy or a partially overwritten file.
+                self._temporary = tempfile.TemporaryDirectory(
+                    prefix='.vibecad-animation-', dir=self.output.parent,
+                )
+                staging = Path(self._temporary.name)
+                self.staging_ready.put_nowait(staging)
+                report(1, 'Capturing animation frames')
+                # Cancellation cannot release staging while native PNG writing
+                # still owns it. The controller acknowledges after PNG completion.
+                self._capture_done.wait()
+                if cancelled():
+                    raise NativeBackgroundCancelled()
+                if self._capture_error:
+                    raise AnimationExportError(self._capture_error)
+                report(50, 'Encoding animation on a background worker')
+                candidate = staging / ('animation' + self.output.suffix.lower())
+                request = {
+                    'frames': [str(staging / f'frame_{index:05d}.png')
+                               for index in range(frame_count)],
+                    'output': str(candidate), 'fps': fps, 'size': self.size,
+                }
+                (staging / 'animation.json').write_text(json.dumps(request), encoding='utf-8')
+                shutil.copyfile(Path(__file__).with_name('AnimationEncoder.py'),
+                                staging / 'AnimationEncoder.py')
+                result = execute(staging=staging, script='AnimationEncoder.py',
+                                 cancellation_check=cancelled, **isolation)
+                if result.get('cancelled') or cancelled():
+                    raise NativeBackgroundCancelled()
+                if result.get('returncode') != 0:
+                    raise AnimationExportError(result.get('error') or result.get('stderr')
+                                               or 'Animation encoding failed')
+                if not candidate.is_file() or candidate.stat().st_size == 0:
+                    raise AnimationExportError('The animation encoder produced no file')
+                return candidate
+            except (AnimationExportError, NativeBackgroundCancelled):
+                raise
+            except Exception as error:
+                raise AnimationExportError(str(error)) from error
+
+        def commit(candidate):
+            try:
+                os.replace(candidate, self.output)
+            except OSError as error:
+                raise AnimationExportError(str(error)) from error
+            return {'file': str(self.output), 'frames': frame_count}
+
+        def cleanup(_):
+            if self._temporary is not None:
+                self._temporary.cleanup()
+
+        submitted = manager.submit(
+            document_uid=document_uid, capability_name='assembly.animation_export',
+            resource_scope='animation-export', prepare=prepare,
+            validate_before_commit=lambda: None, commit=commit,
+            # This commit mutates only a detached file, never a document or Qt
+            # object. Keep it on the supervisor, including the atomic rename.
+            dispatch_to_document_thread=lambda callback: callback(),
+            finalize_message='Publishing animation file', cleanup=cleanup,
+        )
+        self.job_id = submitted.job_id
+
+    def finish_capture(self, error=''):
+        self._capture_error = str(error)
+        self._capture_done.set()
+
+
+class AnimationExportController(QtCore.QObject):
+    progress = QtCore.Signal(int, str)
+    finished = QtCore.Signal(object)
+
+    def __init__(self, panel, viewer, job):
+        super().__init__()
+        self.panel, self.job = panel, job
+        # Retain the bound cancellation/completion methods: looking up a new
+        # attribute on a deleted viewer is deliberately rejected by its wrapper.
+        self.start_png = viewer.startFrameExport
+        self.finish_png = viewer.finishFrameExport
+        self.cancel_png = viewer.cancelFrameExport
+        self.original_frame = panel.form.frameSlider.value()
+        self.index = 0
+        self.staging = None
+        self.frame = None
+        self.image = None
+        self.restore = None
+        self.capture_finished = False
+        self.cancelled = False
+        self.error = ''
+        self.timer = QtCore.QTimer(self)
+        self.timer.setInterval(16)  # Completion polling cadence, never a deadline.
+        self.timer.timeout.connect(self.tick)
+        panel.playbackClosed.connect(self.cancel)
+        self.timer.start()
+
+    def cancel(self):
+        if self.cancelled:
+            return
+        self.cancelled = True
+        self.job.manager.cancel(self.job.job_id)
+        if self.frame is not None:
+            self.frame.cancel()
+            self.frame = None
+        if self.image is not None:
+            self.cancel_png(self.image)
+
+    def _finish_capture(self):
+        if self.capture_finished:
+            return
+        self.capture_finished = True
+        self.job.finish_capture(self.error)
+        if self.panel._ownsLiveTaskContext():
+            self.restore = self.panel.requestFrameAsync(self.original_frame)
+
+    def tick(self):
+        try:
+            snapshot = self.job.manager.snapshot(self.job.job_id)
+            if snapshot.cancel_requested:
+                self.cancel()
+            if self.image is not None:
+                try:
+                    if not self.finish_png(self.image):
+                        return
+                except Exception:
+                    self.image = None
+                    raise
+                self.image = None
+                self.index += 1
+            if self.cancelled:
+                self._finish_capture()
+            if not self.capture_finished:
+                if not self.panel._ownsLiveTaskContext():
+                    self.cancel()
+                    self._finish_capture()
+                elif self.staging is None:
+                    try:
+                        self.staging = self.job.staging_ready.get_nowait()
+                    except queue.Empty:
+                        pass
+                if self.staging is not None and not self.capture_finished:
+                    if self.frame is not None:
+                        if not self.frame.done():
+                            return
+                        self.frame.result()
+                        self.frame = None
+                        self.image = self.start_png(
+                            str(self.staging / f'frame_{self.index:05d}.png'), *self.job.size,
+                        )
+                        return
+                    if self.index == self.job.frame_count:
+                        self._finish_capture()
+                    else:
+                        self.progress.emit(self.index, 'Capturing animation frames')
+                        self.frame = self.panel.requestFrameAsync(self.index, include_input=True)
+                        return
+            snapshot = self.job.manager.snapshot(self.job.job_id)
+            if snapshot.terminal and not snapshot.worker_active:
+                self._finish_capture()
+                if self.restore is not None:
+                    if not self.restore.done():
+                        return
+                    restore, self.restore = self.restore, None
+                    restore.result()
+                self.timer.stop()
+                self.panel.playbackClosed.disconnect(self.cancel)
+                self.finished.emit(snapshot)
+            elif self.capture_finished:
+                self.progress.emit(self.job.frame_count, snapshot.progress_message)
+        except Exception as error:
+            self.error = str(error)
+            self.cancel()
+            if self.image is None:
+                self._finish_capture()

--- a/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -23,9 +23,15 @@
 
 #include <boost/core/ignore_unused.hpp>
 #include <algorithm>
+#include <atomic>
+#include <charconv>
 #include <cmath>
+#include <cstring>
+#include <cstdlib>
 #include <vector>
 #include <unordered_map>
+#include <filesystem>
+#include <Build/Version.h>
 
 
 #include <App/Application.h>
@@ -34,7 +40,11 @@
 #include <App/DocumentTimeline.h>
 #include <App/DocumentObjectGroup.h>
 #include <App/FeaturePythonPyImp.h>
+#include <App/GeoFeatureGroupExtension.h>
+#include <App/GroupExtension.h>
+#include <App/HostRuntime.h>
 #include <App/Link.h>
+#include <App/MainThreadSignal.h>
 #include <App/PropertyLinks.h>
 #include <App/PropertyPythonObject.h>
 #include <Base/Console.h>
@@ -82,6 +92,8 @@
 
 #include "AssemblyLink.h"
 #include "AssemblyObject.h"
+#include "SimulationFrameSnapshot.h"
+#include "SimulationPlaybackCache.h"
 #include "AssemblyObjectPy.h"
 #include "AssemblyUtils.h"
 #include "JointGroup.h"
@@ -146,6 +158,42 @@ void setGroundingReadOnly(App::DocumentObject* component, bool readOnly)
 
 // ================================ Assembly Object ============================
 
+struct AssemblyObject::SimulationJob
+{
+    std::string simulationName;
+    long simulationId = 0;
+    struct Binding
+    {
+        std::string name;
+        long id;
+        MbDPartData data;
+    };
+    std::vector<Binding> bindings;
+    using Tracks = std::vector<detail::SimulationFrameTrack>;
+    struct Result
+    {
+        std::shared_ptr<ASMTAssembly> solver;
+        std::shared_ptr<const Tracks> tracks;
+    };
+    std::future<Result> completion;
+    Result result;
+    std::shared_ptr<ASMTAssembly> solverIdentity;
+    std::shared_ptr<std::stop_source> cancellation = std::make_shared<std::stop_source>();
+    std::shared_ptr<std::atomic_bool> invalidated = std::make_shared<std::atomic_bool>(false);
+    std::shared_ptr<std::atomic_bool> applying = std::make_shared<std::atomic_bool>(false);
+    fastsignals::scoped_connection changed;
+    fastsignals::scoped_connection deleted;
+    ~SimulationJob() { cancellation->request_stop(); }
+};
+
+struct AssemblyObject::SimulationFrameJob
+{
+    std::future<std::vector<Base::Placement>> completion;
+    std::shared_ptr<std::stop_source> cancellation = std::make_shared<std::stop_source>();
+    std::shared_ptr<const SimulationJob::Tracks> tracks;
+    ~SimulationFrameJob() { cancellation->request_stop(); }
+};
+
 PROPERTY_SOURCE(Assembly::AssemblyObject, App::Part)
 
 AssemblyObject::AssemblyObject()
@@ -161,7 +209,7 @@ AssemblyObject::AssemblyObject()
     mbdAssembly->externalSystem->freecadAssemblyObject = this;
 
     lastDoF = numberOfComponents() * 6;
-    signalSolverUpdate();
+    emitSolverUpdate();
 }
 
 AssemblyObject::~AssemblyObject() = default;
@@ -237,9 +285,143 @@ void AssemblyObject::captureTimelineState() noexcept
 void AssemblyObject::onChanged(const App::Property* prop)
 {
     if (prop == &Group) {
-        updateSolveStatus();
+        invalidateConnectivityCache();
+        requestSolveStatusUpdate();
     }
     App::Part::onChanged(prop);
+}
+
+void AssemblyObject::onSettingDocument()
+{
+    App::Part::onSettingDocument();
+
+    auto* document = getDocument();
+    if (!document) {
+        return;
+    }
+
+    connectivityNewObjectConnection = document->signalNewObject.connect(
+        [this](const App::DocumentObject&) { invalidateConnectivityCache(); }
+    );
+    connectivityDeletedObjectConnection = document->signalDeletedObject.connect(
+        [this](const App::DocumentObject&) { invalidateConnectivityCache(); }
+    );
+    connectivityChangedObjectConnection = document->signalChangedObject.connect(
+        [this](const App::DocumentObject& object, const App::Property& property) {
+            slotConnectivityPropertyChanged(object, property);
+        }
+    );
+    connectivityTouchedObjectConnection = document->signalTouchedObject.connect(
+        [this](const App::DocumentObject&) { invalidateConnectivityCache(); }
+    );
+    connectivityRecomputedObjectConnection = document->signalRecomputedObject.connect(
+        [this](const App::DocumentObject&) { invalidateConnectivityCache(); }
+    );
+    connectivityPropertyStatusConnection = document->signalChangePropertyEditor.connect(
+        [this](const App::Document&, const App::Property&) { invalidateConnectivityCache(); }
+    );
+    solveStatusStableConnection = document->signalBecameStable.connect(
+        [this](const App::Document&) {
+            if (solveStatusUpdatePending && isAttachedToDocument()) {
+                requestSolveStatusUpdate();
+            }
+        }
+    );
+}
+
+void AssemblyObject::unsetupObject()
+{
+    cancelSimulation();
+    cancelSimulationFrame();
+    simulationPlayback.reset();
+    connectivityNewObjectConnection.disconnect();
+    connectivityDeletedObjectConnection.disconnect();
+    connectivityChangedObjectConnection.disconnect();
+    connectivityTouchedObjectConnection.disconnect();
+    connectivityRecomputedObjectConnection.disconnect();
+    connectivityPropertyStatusConnection.disconnect();
+    solveStatusStableConnection.disconnect();
+    solveStatusUpdatePending = false;
+    invalidateConnectivityCache();
+    App::Part::unsetupObject();
+}
+
+void AssemblyObject::invalidateConnectivityCache() noexcept
+{
+    connectivityCacheValid = false;
+}
+
+void AssemblyObject::slotConnectivityPropertyChanged(
+    const App::DocumentObject&,
+    const App::Property& property
+)
+{
+    const char* name = property.getName();
+    if ((name && (std::strcmp(name, "Visibility") == 0 || std::strcmp(name, "Label") == 0
+                  || std::strcmp(name, "Shape") == 0))
+        || property.isDerivedFrom<App::PropertyPlacement>()) {
+        return;
+    }
+    invalidateConnectivityCache();
+}
+
+std::unordered_set<App::DocumentObject*> AssemblyObject::collectConnectedParts(
+    const std::unordered_set<App::DocumentObject*>& roots,
+    const std::vector<App::DocumentObject*>& joints
+)
+{
+    std::unordered_map<App::DocumentObject*, std::vector<App::DocumentObject*>> adjacency;
+    adjacency.reserve(joints.size() * 2);
+
+    for (auto* joint : joints) {
+        if (!joint || !isJointTypeConnecting(joint)) {
+            continue;
+        }
+
+        auto* part1 = getMovingPartFromRef(joint, "Reference1");
+        auto* part2 = getMovingPartFromRef(joint, "Reference2");
+        if (!part1 || !part2) {
+            continue;
+        }
+
+        adjacency[part1].push_back(part2);
+        adjacency[part2].push_back(part1);
+    }
+
+    std::unordered_set<App::DocumentObject*> connected;
+    connected.reserve(adjacency.size() + roots.size());
+    std::vector<App::DocumentObject*> pending;
+    pending.reserve(adjacency.size() + roots.size());
+    for (auto* root : roots) {
+        if (root && connected.insert(root).second) {
+            pending.push_back(root);
+        }
+    }
+
+    while (!pending.empty()) {
+        auto* current = pending.back();
+        pending.pop_back();
+        const auto found = adjacency.find(current);
+        if (found == adjacency.end()) {
+            continue;
+        }
+        for (auto* next : found->second) {
+            if (next && connected.insert(next).second) {
+                pending.push_back(next);
+            }
+        }
+    }
+
+    return connected;
+}
+
+void AssemblyObject::rebuildConnectivityCache()
+{
+    auto grounded = getGroundedParts();
+    auto connected = collectConnectedParts(grounded, getJoints());
+    groundedPartsCache = std::move(grounded);
+    connectedPartsCache = std::move(connected);
+    connectivityCacheValid = true;
 }
 
 int AssemblyObject::solve(bool enableRedo)
@@ -300,8 +482,34 @@ int AssemblyObject::solve(bool enableRedo)
     return 0;
 }
 
+void AssemblyObject::requestSolveStatusUpdate()
+{
+    const auto* document = getDocument();
+    if (document && (document->isPerformingTransaction()
+                     || document->isCooperativeMutationActive()
+                     || document->testStatus(App::Document::Restoring))) {
+        // Group changes during publication or rollback are intermediate graph
+        // states. Recounting components and inspecting every constraint after
+        // each removal is both quadratic and diagnostically misleading. The
+        // document's stable boundary refreshes the final state once, including
+        // when transaction close occurs inside a still-active mutation lease.
+        solveStatusUpdatePending = true;
+        return;
+    }
+    // Flushing a deferred status projection must not launch a solve against
+    // the newly restored/published graph. Explicit solver calls still retain
+    // the public updateSolveStatus() behavior below.
+    refreshSolveStatus(!solveStatusUpdatePending);
+}
+
 void AssemblyObject::updateSolveStatus()
 {
+    refreshSolveStatus(true);
+}
+
+void AssemblyObject::refreshSolveStatus(bool initializeSolver)
+{
+    solveStatusUpdatePending = false;
     lastRedundantJoints.clear();
     lastConflictingJoints.clear();
     lastPartialRedundantJoints.clear();
@@ -314,11 +522,14 @@ void AssemblyObject::updateSolveStatus()
     //+1 because there's a grounded joint to origin
     lastDoF = (1 + numberOfComponents()) * 6;
 
-    if (!mbdAssembly || !mbdAssembly->mbdSystem) {
+    if (initializeSolver && (!mbdAssembly || !mbdAssembly->mbdSystem)) {
         solve();
     }
 
     if (!mbdAssembly || !mbdAssembly->mbdSystem) {
+        if (!initializeSolver) {
+            emitSolverUpdate();
+        }
         return;
     }
 
@@ -415,10 +626,39 @@ void AssemblyObject::updateSolveStatus()
         lastHasRedundancies = true;
     }
 
-    signalSolverUpdate();
+    emitSolverUpdate();
+}
+
+void AssemblyObject::emitSolverUpdate()
+{
+    if (!App::MainThreadSignalConfig::hasHooks()
+        || App::MainThreadSignalConfig::isMainThread()) {
+        signalSolverUpdate();
+        return;
+    }
+
+    std::unique_ptr<Base::PyGILStateRelease> release;
+    if (Py_IsInitialized() && PyGILState_Check()) {
+        release = std::make_unique<Base::PyGILStateRelease>();
+    }
+    App::MainThreadSignalConfig::invoke([this] { signalSolverUpdate(); }, true);
 }
 
 int AssemblyObject::generateSimulation(App::DocumentObject* sim)
+{
+    const int status = prepareSimulation(sim);
+    if (status != 0) { return status; }
+    try {
+        mbdAssembly->runKINEMATIC();
+    }
+    catch (...) {
+        Base::Console().error("Generation of simulation failed\n");
+        return -1;
+    }
+    return 0;
+}
+
+int AssemblyObject::prepareSimulation(App::DocumentObject* sim)
 {
     mbdAssembly = makeMbdAssembly();
     objectPartMap.clear();
@@ -439,18 +679,463 @@ int AssemblyObject::generateSimulation(App::DocumentObject* sim)
 
     create_mbdSimulationParameters(sim);
 
-    try {
-        mbdAssembly->runKINEMATIC();
-    }
-    catch (...) {
-        Base::Console().error("Generation of simulation failed\n");
-        motions.clear();
-        return -1;
-    }
-
     motions.clear();
 
     return 0;
+}
+
+std::uint64_t AssemblyObject::startSimulation(App::DocumentObject* sim)
+{
+    return startSimulationJob(sim, false);
+}
+
+std::uint64_t AssemblyObject::startSimulationPlayback(App::DocumentObject* sim)
+{
+    return startSimulationJob(sim, true);
+}
+
+std::uint64_t AssemblyObject::startSimulationJob(App::DocumentObject* sim, bool allowPlaybackCache)
+{
+    if (App::MainThreadSignalConfig::hasHooks()
+        && !App::MainThreadSignalConfig::isMainThread()) {
+        throw std::runtime_error("Simulation capture requires the document owner thread");
+    }
+    auto* document = getDocument();
+    if (!document || !sim || sim->getDocument() != document || !hasObject(sim, true)
+        || !isTimelineOperationActive(this) || !isTimelineOperationActive(sim)) {
+        throw std::runtime_error("Simulation capture requires live active objects in one document");
+    }
+    if (document->testStatus(App::Document::Recomputing)
+        || document->testStatus(App::Document::Restoring)
+        || App::GetApplication().hasPendingRecomputeRequest(document->getName())
+        || document->isCooperativeMutationActive()) {
+        throw std::runtime_error("Simulation inputs are being updated");
+    }
+    cancelSimulation();
+    cancelSimulationFrame();
+    if (simulationPlayback && !simulationPlayback->invalidated->load()
+        && simulationPlayback->solverIdentity == mbdAssembly
+        && (allowPlaybackCache || simulationPlayback->result.solver)
+        && simulationPlayback->simulationName == sim->getNameInDocument()
+        && simulationPlayback->simulationId == sim->getID()) {
+        // The subscribed input graph has not changed. Preserve the authenticated
+        // solved channels; a new caller still receives its own request token.
+        simulationReusePending = true;
+        if (++simulationRequest == 0) { ++simulationRequest; }
+        return simulationRequest;
+    }
+    auto job = std::make_unique<SimulationJob>();
+    job->simulationName = sim->getNameInDocument();
+    job->simulationId = sim->getID();
+    // Reuse the authoritative input builder, but restore all live solver state
+    // before returning to the event loop. No worker captures this object.
+    auto previousAssembly = mbdAssembly;
+    auto previousParts = std::move(objectPartMap);
+    auto previousMotions = std::move(motions);
+    std::shared_ptr<ASMTAssembly> detached;
+    try {
+        if (prepareSimulation(sim) != 0) {
+            throw std::runtime_error("Simulation requires a grounded component");
+        }
+        job->bindings.reserve(objectPartMap.size());
+        for (const auto& [object, data] : objectPartMap) {
+            job->bindings.push_back({object->getNameInDocument(), object->getID(), data});
+        }
+        detached = std::move(mbdAssembly);
+        detached->externalSystem->freecadAssemblyObject = nullptr;
+    }
+    catch (...) {
+        mbdAssembly = std::move(previousAssembly);
+        objectPartMap = std::move(previousParts);
+        motions = std::move(previousMotions);
+        throw;
+    }
+    mbdAssembly = std::move(previousAssembly);
+    objectPartMap = std::move(previousParts);
+    motions = std::move(previousMotions);
+    std::sort(job->bindings.begin(), job->bindings.end(), [](const auto& a, const auto& b) {
+        return a.name < b.name;
+    });
+    auto invalidated = job->invalidated;
+    auto cancellation = job->cancellation;
+    auto applying = job->applying;
+    auto components = std::make_shared<std::unordered_set<const App::DocumentObject*>>();
+    for (const auto& binding : job->bindings) {
+        components->insert(document->getObject(binding.name.c_str()));
+    }
+    // Capture dependencies once, while live inputs are owner-thread confined.
+    // Include linked source geometry and placement ancestors, including objects
+    // in other documents. Observers below only read this immutable identity set.
+    auto watchedInputs = std::make_shared<std::unordered_set<const App::DocumentObject*>>();
+    std::vector<App::DocumentObject*> pending;
+    const auto include = [&](App::DocumentObject* object) {
+        if (object && watchedInputs->insert(object).second) { pending.push_back(object); }
+    };
+    include(this);
+    include(sim);
+    for (const auto& binding : job->bindings) {
+        include(document->getObject(binding.name.c_str()));
+    }
+    for (size_t index = 0; index < pending.size(); ++index) {
+        auto* object = pending[index];
+        for (auto* dependency : object->getOutList()) { include(dependency); }
+        include(App::GeoFeatureGroupExtension::getGroupOfObject(object));
+    }
+    auto invalidate = [invalidated, cancellation](const App::DocumentObject& object, const char* reason) {
+        if (!invalidated->exchange(true)) {
+            FC_LOG("VIBECAD_SIMULATION invalidated object=" << object.getNameInDocument()
+                   << " reason=" << (reason ? reason : "unnamed property"));
+        }
+        cancellation->request_stop();
+    };
+    job->changed = App::GetApplication().signalChangedObject.connect(
+        [invalidate, applying, components, watchedInputs, simulation = sim]
+        (const App::DocumentObject& object, const App::Property& property) {
+            if (!watchedInputs->contains(&object)) { return; }
+            const char* name = property.getName();
+            if (name && (std::strcmp(name, "Visibility") == 0 || std::strcmp(name, "Label") == 0)) {
+                return;
+            }
+            // GroupExtension emits this derived notification for child visibility
+            // and group execution. Real child inputs and Group membership are
+            // observed separately; this property is not consumed by the solver.
+            if (name && std::strcmp(name, "_GroupTouched") == 0) {
+                const auto* group = object.getExtensionByType<App::GroupExtension>(true);
+                if (group && &property == &group->_GroupTouched) {
+                    return;
+                }
+            }
+            // Playback cadence is not consumed by create_mbdSimulationParameters.
+            // Keep this exemption scoped to the exact solved simulation.
+            if (name && &object == simulation
+                && std::strcmp(name, "jFramesPerSecond") == 0) {
+                return;
+            }
+            if (name && applying->load() && components->contains(&object)
+                && (std::strcmp(name, "Placement") == 0 || std::strcmp(name, "LinkPlacement") == 0)) {
+                return;
+            }
+            invalidate(object, name);
+        });
+    job->deleted = App::GetApplication().signalDeletedObject.connect(
+        [invalidate, watchedInputs](const App::DocumentObject& object) {
+            if (watchedInputs->contains(&object)) { invalidate(object, "deleted"); }
+        });
+    // New objects cannot affect the captured inputs until a watched Group,
+    // link, or expression changes to reference them; that change invalidates.
+    std::vector<MbDPartData> inputs;
+    std::vector<detail::SimulationPlaybackCache::Binding> cacheBindings;
+    inputs.reserve(job->bindings.size());
+    cacheBindings.reserve(job->bindings.size());
+    for (const auto& binding : job->bindings) {
+        inputs.push_back(binding.data);
+        cacheBindings.emplace_back(binding.name, binding.data.offsetPlc);
+    }
+    const auto cacheDirectory = (std::filesystem::path(App::Application::getUserCachePath())
+                                / "simulation-playback").string();
+    auto& runtime = App::GetApplication().hostRuntime();
+    job->completion = runtime.submit(
+        [detached = std::move(detached), cancellation, inputs = std::move(inputs),
+         cacheBindings = std::move(cacheBindings), cacheDirectory, allowPlaybackCache,
+         &runtime](std::stop_token runtimeStop) {
+            Base::CancellationScope context(cancellation->get_token());
+            std::stop_callback onShutdown(runtimeStop, [cancellation] { cancellation->request_stop(); });
+            detached->setCancellationCheck([] { Base::CancellationScope::check(); });
+            Base::CancellationScope::check();
+            const auto key = detail::SimulationPlaybackCache::inputKey(
+                *detached, cacheBindings, "simulation-playback-1:" FCRepositoryHash);
+            const detail::SimulationPlaybackCache cache(cacheDirectory);
+            if (allowPlaybackCache) {
+                std::vector<Base::Placement> offsets;
+                offsets.reserve(inputs.size());
+                for (const auto& input : inputs) { offsets.push_back(input.offsetPlc); }
+                if (auto saved = cache.load(key, offsets)) {
+                    Base::CancellationScope::check();
+                    FC_LOG("VIBECAD_SIMULATION playback_source=persisted components=" << saved->size()
+                           << " frames=" << saved->front().frameCount());
+                    return SimulationJob::Result {nullptr,
+                        std::make_shared<SimulationJob::Tracks>(std::move(*saved))};
+                }
+            }
+            FC_LOG("VIBECAD_SIMULATION playback_source=generated components=" << inputs.size());
+            detached->runKINEMATIC();
+            Base::CancellationScope::check();
+            if (detached->numberOfFrames() < 2) {
+                throw std::runtime_error("Simulation generated fewer than two frames");
+            }
+            auto tracks = std::make_shared<SimulationJob::Tracks>(inputs.size());
+            runtime.parallelFor(inputs.size(), [&](size_t index) {
+                Base::CancellationScope::check();
+                tracks->at(index) = detail::SimulationFrameTrack::capture(
+                    *inputs[index].part, inputs[index].offsetPlc, detached->numberOfFrames());
+            });
+            try { cache.store(key, *tracks); }
+            catch (const std::ios_base::failure& error) {
+                // Optional disk persistence must not discard a successful solve.
+                // Cancellation, allocation and solver errors still propagate.
+                Base::Console().warning("Simulation playback was not cached: %s\n", error.what());
+            }
+            return SimulationJob::Result {detached, std::move(tracks)};
+        });
+    simulationJob = std::move(job);
+    // Zero denotes the current request for callers which omit the optional token.
+    if (++simulationRequest == 0) { ++simulationRequest; }
+    return simulationRequest;
+}
+
+bool AssemblyObject::finishSimulation(std::uint64_t request)
+{
+    if (App::MainThreadSignalConfig::hasHooks()
+        && !App::MainThreadSignalConfig::isMainThread()) {
+        throw std::runtime_error("Simulation adoption requires the document owner thread");
+    }
+    if (request != 0 && request != simulationRequest) {
+        throw std::runtime_error("Simulation request was superseded");
+    }
+    const auto* document = getDocument();
+    if (!document || document->testStatus(App::Document::Recomputing)
+        || document->testStatus(App::Document::Restoring)
+        || App::GetApplication().hasPendingRecomputeRequest(document->getName())
+        || document->isCooperativeMutationActive()) {
+        return false;
+    }
+    if (simulationReusePending) {
+        simulationReusePending = false;
+        if (!simulationPlayback || simulationPlayback->invalidated->load()
+            || simulationPlayback->solverIdentity != mbdAssembly) {
+            throw std::runtime_error("Simulation inputs changed before reuse");
+        }
+        return true;
+    }
+    if (!simulationJob) { throw std::runtime_error("No pending simulation"); }
+    if (simulationJob->invalidated->load()) {
+        cancelSimulation();
+        throw std::runtime_error("Simulation inputs changed during generation");
+    }
+    if (simulationJob->completion.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+        return false;
+    }
+    auto job = std::move(simulationJob);
+    job->result = job->completion.get();
+    std::unordered_map<App::DocumentObject*, MbDPartData> parts;
+    parts.reserve(job->bindings.size());
+    for (auto& binding : job->bindings) {
+        auto* object = getDocument()->getObject(binding.name.c_str());
+        if (!object || object->getID() != binding.id) {
+            throw std::runtime_error("Simulation component identity changed during generation");
+        }
+        if (job->result.solver) { parts.emplace(object, binding.data); }
+        else { binding.data.part.reset(); }
+    }
+    if (job->result.solver) {
+        job->result.solver->externalSystem->freecadAssemblyObject = this;
+        mbdAssembly = job->result.solver;
+        objectPartMap = std::move(parts);
+    }
+    job->solverIdentity = mbdAssembly;
+    simulationPlayback = std::move(job);
+    return true;
+}
+
+void AssemblyObject::cancelSimulation(std::uint64_t request)
+{
+    if (request != 0 && request != simulationRequest) { return; }
+    // HostRuntime uses packaged_task, not std::async: destroying this future
+    // never joins the worker. Its captured solver and token outlive the owner.
+    simulationJob.reset();
+    simulationReusePending = false;
+}
+
+std::uint64_t AssemblyObject::requestSimulationFrame(size_t index)
+{
+    if (App::MainThreadSignalConfig::hasHooks() && !App::MainThreadSignalConfig::isMainThread()) {
+        throw std::runtime_error("Frame requests require the document owner thread");
+    }
+    if (!simulationPlayback || simulationPlayback->invalidated->load()
+        || simulationPlayback->solverIdentity != mbdAssembly) {
+        throw std::runtime_error("Simulation frames require current asynchronously generated results");
+    }
+    if (index >= numberOfFrames()) { throw std::out_of_range("Simulation frame index"); }
+    cancelSimulationFrame();
+    auto job = std::make_unique<SimulationFrameJob>();
+    job->tracks = simulationPlayback->result.tracks;
+    auto tracks = job->tracks;
+    auto cancellation = job->cancellation;
+    auto& runtime = App::GetApplication().hostRuntime();
+    job->completion = runtime.submit([tracks, cancellation, index, &runtime](std::stop_token stop) {
+        Base::CancellationScope context(cancellation->get_token());
+        std::stop_callback onShutdown(stop, [cancellation] { cancellation->request_stop(); });
+        Base::CancellationScope::check();
+        std::vector<Base::Placement> placements(tracks->size());
+        runtime.parallelFor(tracks->size(), [&](size_t part) {
+            Base::CancellationScope::check();
+            placements[part] = tracks->at(part).placementAt(index);
+        });
+        return placements;
+    });
+    simulationFrameJob = std::move(job);
+    if (++simulationFrameRequest == 0) { ++simulationFrameRequest; }
+    return simulationFrameRequest;
+}
+
+std::vector<std::pair<std::string, Base::Placement>>
+AssemblyObject::getSimulationFrame(size_t index) const
+{
+    if (App::MainThreadSignalConfig::hasHooks()
+        && !App::MainThreadSignalConfig::isMainThread()) {
+        throw std::runtime_error("Frame presentation requires the document owner thread");
+    }
+    if (!simulationPlayback || simulationPlayback->invalidated->load()
+        || simulationPlayback->solverIdentity != mbdAssembly) {
+        throw std::runtime_error("Simulation frames require current asynchronously generated results");
+    }
+    const auto& tracks = *simulationPlayback->result.tracks;
+    if (tracks.empty() || index >= tracks.front().frameCount()) {
+        throw std::out_of_range("Simulation frame index");
+    }
+    auto* document = getDocument();
+    if (!document || document->testStatus(App::Document::Restoring)
+        || document->testStatus(App::Document::Recomputing)
+        || document->isCooperativeMutationActive()
+        || App::GetApplication().hasPendingRecomputeRequest(document->getName())) {
+        throw std::runtime_error("Simulation frame presentation requires a stable document");
+    }
+    if (tracks.size() != simulationPlayback->bindings.size()) {
+        throw std::runtime_error("Simulation frame does not match its captured components");
+    }
+    std::vector<std::pair<std::string, Base::Placement>> frame;
+    frame.reserve(tracks.size());
+    for (size_t part = 0; part < tracks.size(); ++part) {
+        const auto& binding = simulationPlayback->bindings[part];
+        auto* object = document->getObject(binding.name.c_str());
+        if (!object || object->getID() != binding.id || !object->getPlacementProperty()) {
+            throw std::runtime_error("Simulation frame target identity changed");
+        }
+        frame.emplace_back(binding.name, tracks[part].placementAt(index));
+    }
+    return frame;
+}
+
+bool AssemblyObject::finishSimulationFrame(std::uint64_t request)
+{
+    auto frame = takeSimulationFrame(request);
+    if (!frame) { return false; }
+    std::vector<Base::Placement> placements;
+    placements.reserve(frame->size());
+    for (const auto& [name, placement] : *frame) {
+        (void)name;
+        placements.push_back(placement);
+    }
+    return applySimulationFrame(placements);
+}
+
+std::optional<std::vector<std::pair<std::string, Base::Placement>>>
+AssemblyObject::takeSimulationFrame(std::uint64_t request)
+{
+    if (App::MainThreadSignalConfig::hasHooks() && !App::MainThreadSignalConfig::isMainThread()) {
+        throw std::runtime_error("Frame adoption requires the document owner thread");
+    }
+    if (request != simulationFrameRequest) { throw std::runtime_error("Simulation frame was superseded"); }
+    if (!simulationFrameJob) { throw std::runtime_error("No pending simulation frame"); }
+    if (!simulationPlayback || simulationPlayback->invalidated->load()
+        || simulationPlayback->solverIdentity != mbdAssembly
+        || simulationPlayback->result.tracks != simulationFrameJob->tracks) {
+        cancelSimulationFrame();
+        throw std::runtime_error("Simulation inputs changed during frame preparation");
+    }
+    auto* document = getDocument();
+    if (!document || document->testStatus(App::Document::Restoring)
+        || document->testStatus(App::Document::Recomputing)
+        || document->isCooperativeMutationActive()
+        || App::GetApplication().hasPendingRecomputeRequest(document->getName())) {
+        return std::nullopt;
+    }
+    if (simulationFrameJob->completion.wait_for(std::chrono::seconds(0)) != std::future_status::ready) {
+        return std::nullopt;
+    }
+    auto job = std::move(simulationFrameJob);
+    const auto placements = job->completion.get();
+    if (placements.size() != simulationPlayback->bindings.size()) {
+        throw std::runtime_error("Simulation frame does not match its captured components");
+    }
+    std::vector<std::pair<std::string, Base::Placement>> frame;
+    frame.reserve(placements.size());
+    for (size_t index = 0; index < placements.size(); ++index) {
+        const auto& binding = simulationPlayback->bindings[index];
+        auto* object = document->getObject(binding.name.c_str());
+        if (!object || object->getID() != binding.id || !object->getPlacementProperty()) {
+            throw std::runtime_error("Simulation frame target identity changed");
+        }
+        frame.emplace_back(binding.name, placements[index]);
+    }
+    return frame;
+}
+
+bool AssemblyObject::applySimulationFrame(const std::vector<Base::Placement>& placements)
+{
+    if (App::MainThreadSignalConfig::hasHooks() && !App::MainThreadSignalConfig::isMainThread()) {
+        throw std::runtime_error("Frame adoption requires the document owner thread");
+    }
+    if (placements.size() != simulationPlayback->bindings.size()) {
+        throw std::runtime_error("Simulation frame does not match its captured components");
+    }
+    auto* document = getDocument();
+    std::vector<App::DocumentObject*> targets;
+    targets.reserve(simulationPlayback->bindings.size());
+    for (const auto& binding : simulationPlayback->bindings) {
+        auto* object = document->getObject(binding.name.c_str());
+        if (!object || object->getID() != binding.id || !object->getPlacementProperty()) {
+            throw std::runtime_error("Simulation frame target identity changed");
+        }
+        targets.push_back(object);
+    }
+    // No event pumping: the exact target set is checked before any presentation
+    // write, and notifications from other properties still invalidate the solve.
+    auto applying = simulationPlayback->applying;
+    const bool wasApplying = applying->exchange(true);
+    std::vector<bool> previousNoTouch;
+    previousNoTouch.reserve(targets.size());
+    for (auto* target : targets) {
+        previousNoTouch.push_back(target->testStatus(App::ObjectStatus::NoTouch));
+        target->setStatus(App::ObjectStatus::NoTouch, true);
+    }
+    const auto restoreNoTouch = [&] {
+        for (size_t index = 0; index < targets.size(); ++index) {
+            targets[index]->setStatus(App::ObjectStatus::NoTouch, previousNoTouch[index]);
+        }
+    };
+    try {
+        for (size_t index = 0; index < targets.size(); ++index) {
+            auto* property = targets[index]->getPlacementProperty();
+            if (!property->getValue().isSame(placements[index])) {
+                property->setValue(placements[index]);
+                targets[index]->purgeTouched();
+            }
+        }
+        redrawJointPlacements(getJoints());
+    }
+    catch (...) {
+        restoreNoTouch();
+        applying->store(wasApplying);
+        throw;
+    }
+    restoreNoTouch();
+    applying->store(wasApplying);
+    return true;
+}
+
+bool AssemblyObject::setSimulationPresentation(bool active)
+{
+    if (App::MainThreadSignalConfig::hasHooks() && !App::MainThreadSignalConfig::isMainThread()) {
+        throw std::runtime_error("Simulation presentation scopes require the document owner thread");
+    }
+    return simulationPlayback ? simulationPlayback->applying->exchange(active) : false;
+}
+
+void AssemblyObject::cancelSimulationFrame(std::uint64_t request)
+{
+    if (request != 0 && request != simulationFrameRequest) { return; }
+    simulationFrameJob.reset();
 }
 
 std::vector<App::DocumentObject*> AssemblyObject::getMotionsFromSimulation(App::DocumentObject* sim)
@@ -475,6 +1160,18 @@ std::vector<App::DocumentObject*> AssemblyObject::getMotionsFromSimulation(App::
 
 int Assembly::AssemblyObject::updateForFrame(size_t index)
 {
+    if (simulationPlayback && !simulationPlayback->invalidated->load()
+        && simulationPlayback->solverIdentity == mbdAssembly && !simulationPlayback->result.solver) {
+        if (index >= numberOfFrames()) { return -1; }
+        cancelSimulationFrame();
+        std::vector<Base::Placement> placements;
+        placements.reserve(simulationPlayback->result.tracks->size());
+        for (const auto& track : *simulationPlayback->result.tracks) {
+            placements.push_back(track.placementAt(index));
+        }
+        applySimulationFrame(placements);
+        return 0;
+    }
     if (!mbdAssembly) {
         return -1;
     }
@@ -484,15 +1181,27 @@ int Assembly::AssemblyObject::updateForFrame(size_t index)
         return -1;
     }
 
-    mbdAssembly->updateForFrame(index);
-    setNewPlacements();
-    auto jointDocs = getJoints();
-    redrawJointPlacements(jointDocs);
+    cancelSimulationFrame();
+    const auto applying = simulationPlayback && simulationPlayback->result.solver == mbdAssembly
+        ? simulationPlayback->applying : std::shared_ptr<std::atomic_bool>();
+    const bool wasApplying = applying ? applying->exchange(true) : false;
+    try {
+        mbdAssembly->updateForFrame(index);
+        setNewPlacements();
+        redrawJointPlacements(getJoints());
+    }
+    catch (...) { if (applying) { applying->store(wasApplying); } throw; }
+    if (applying) { applying->store(wasApplying); }
     return 0;
 }
 
 size_t Assembly::AssemblyObject::numberOfFrames()
 {
+    if (simulationPlayback && !simulationPlayback->invalidated->load()
+        && simulationPlayback->solverIdentity == mbdAssembly && simulationPlayback->result.tracks
+        && !simulationPlayback->result.tracks->empty()) {
+        return simulationPlayback->result.tracks->front().frameCount();
+    }
     return mbdAssembly->numberOfFrames();
 }
 
@@ -740,6 +1449,35 @@ void AssemblyObject::setNewPlacements()
 
 void AssemblyObject::redrawJointPlacements(std::vector<App::DocumentObject*> joints)
 {
+    if (App::MainThreadSignalConfig::hasHooks()
+        && !App::MainThreadSignalConfig::isMainThread()) {
+        std::vector<std::pair<std::string, std::string>> identities;
+        identities.reserve(joints.size());
+        for (const auto* joint : joints) {
+            if (!joint || !joint->getDocument() || !joint->getNameInDocument()) {
+                continue;
+            }
+            identities.emplace_back(
+                joint->getDocument()->getName(),
+                joint->getNameInDocument()
+            );
+        }
+        App::MainThreadSignalConfig::invoke(
+            [identities = std::move(identities)] {
+                for (const auto& [documentName, objectName] : identities) {
+                    auto* document = App::GetApplication().getDocument(documentName.c_str());
+                    if (document) {
+                        AssemblyObject::redrawJointPlacement(
+                            document->getObject(objectName.c_str())
+                        );
+                    }
+                }
+            },
+            false
+        );
+        return;
+    }
+
     // Notify the joint objects that the transform of the coin object changed.
     for (auto* joint : joints) {
         if (!joint) {
@@ -752,6 +1490,29 @@ void AssemblyObject::redrawJointPlacements(std::vector<App::DocumentObject*> joi
 void AssemblyObject::redrawJointPlacement(App::DocumentObject* joint)
 {
     if (!joint) {
+        return;
+    }
+
+    if (App::MainThreadSignalConfig::hasHooks()
+        && !App::MainThreadSignalConfig::isMainThread()) {
+        auto* document = joint->getDocument();
+        const char* objectName = joint->getNameInDocument();
+        if (!document || !objectName) {
+            return;
+        }
+        const std::string documentName = document->getName();
+        const std::string stableObjectName = objectName;
+        App::MainThreadSignalConfig::invoke(
+            [documentName, stableObjectName] {
+                auto* currentDocument = App::GetApplication().getDocument(documentName.c_str());
+                if (currentDocument) {
+                    AssemblyObject::redrawJointPlacement(
+                        currentDocument->getObject(stableObjectName.c_str())
+                    );
+                }
+            },
+            false
+        );
         return;
     }
 
@@ -790,6 +1551,24 @@ std::shared_ptr<ASMTAssembly> AssemblyObject::makeMbdAssembly()
     );
 
     assembly->setDebug(hPgr->GetBool("LogSolverDebug", false));
+    auto& runtime = App::GetApplication().hostRuntime();
+    std::size_t concurrency = runtime.workerCount();
+    if (const char* configured = std::getenv("VIBECAD_HOST_CPU_SLOTS")) {
+        std::size_t requested = 0;
+        const char* end = configured + std::char_traits<char>::length(configured);
+        const auto parsed = std::from_chars(configured, end, requested);
+        if (parsed.ec == std::errc {} && parsed.ptr == end && requested > 0) {
+            concurrency = std::min(
+                requested,
+                App::HostRuntime::workerBudget(runtime.logicalProcessorCount())
+            );
+        }
+    }
+    assembly->setParallelExecutor(
+        [&runtime, concurrency](std::size_t count, const MbD::ParallelIndexWork& work) {
+            runtime.parallelFor(count, work, concurrency);
+        }
+    );
     return assembly;
 }
 
@@ -1151,17 +1930,7 @@ void AssemblyObject::removeUnconnectedJoints(
     std::unordered_set<App::DocumentObject*> groundedObjs
 )
 {
-    std::vector<ObjRef> connectedParts;
-
-    // Initialize connectedParts with groundedObjs
-    for (auto* groundedObj : groundedObjs) {
-        connectedParts.push_back({groundedObj, nullptr});
-    }
-
-    // Perform a traversal from each grounded object
-    for (auto* groundedObj : groundedObjs) {
-        traverseAndMarkConnectedParts(groundedObj, connectedParts, joints);
-    }
+    const auto connectedParts = collectConnectedParts(groundedObjs, joints);
 
     // Filter out unconnected joints
     joints.erase(
@@ -1171,10 +1940,7 @@ void AssemblyObject::removeUnconnectedJoints(
             [&](App::DocumentObject* joint) {
                 App::DocumentObject* obj1 = getMovingPartFromRef(joint, "Reference1");
                 App::DocumentObject* obj2 = getMovingPartFromRef(joint, "Reference2");
-                return (
-                    !isObjInSetOfObjRefs(obj1, connectedParts)
-                    || !isObjInSetOfObjRefs(obj2, connectedParts)
-                );
+                return !connectedParts.contains(obj1) || !connectedParts.contains(obj2);
             }
         ),
         joints.end()
@@ -1245,15 +2011,10 @@ bool AssemblyObject::isPartGrounded(App::DocumentObject* obj)
         return false;
     }
 
-    auto groundedObjs = getGroundedParts();
-
-    for (auto* groundedObj : groundedObjs) {
-        if (groundedObj->getFullName() == obj->getFullName()) {
-            return true;
-        }
+    if (!connectivityCacheValid) {
+        rebuildConnectivityCache();
     }
-
-    return false;
+    return groundedPartsCache.contains(obj);
 }
 
 bool AssemblyObject::isPartConnected(App::DocumentObject* obj)
@@ -1262,28 +2023,10 @@ bool AssemblyObject::isPartConnected(App::DocumentObject* obj)
         return false;
     }
 
-    auto groundedObjs = getGroundedParts();
-    std::vector<App::DocumentObject*> joints = getJoints();
-
-    std::vector<ObjRef> connectedParts;
-
-    // Initialize connectedParts with groundedObjs
-    for (auto* groundedObj : groundedObjs) {
-        connectedParts.push_back({groundedObj, nullptr});
+    if (!connectivityCacheValid) {
+        rebuildConnectivityCache();
     }
-
-    // Perform a traversal from each grounded object
-    for (auto* groundedObj : groundedObjs) {
-        traverseAndMarkConnectedParts(groundedObj, connectedParts, joints);
-    }
-
-    for (auto& objRef : connectedParts) {
-        if (obj == objRef.obj) {
-            return true;
-        }
-    }
-
-    return false;
+    return connectedPartsCache.contains(obj);
 }
 
 void AssemblyObject::jointParts(std::vector<App::DocumentObject*> joints)
@@ -1814,6 +2557,22 @@ std::string AssemblyObject::handleOneSideOfJoint(
     App::DocumentObject* obj = getObjFromJointRef(joint, propRefName);
 
     if (!part || !obj) {
+        if (std::getenv("VIBECAD_RESTORE_DETAIL_TRACE")) {
+            const auto* property = joint->getPropertyByName<App::PropertyXLinkSub>(propRefName);
+            const auto* target = property ? property->getValue() : nullptr;
+            const auto* document = joint->getDocument();
+            Base::Console().log(
+                "VIBECAD_ASSEMBLY_REFERENCE joint=%s property=%s part_resolved=%d "
+                "object_resolved=%d target=%s sub_count=%zu joint_active=%d "
+                "target_active=%d restoring=%d recomputing=%d owner_thread=%d\n",
+                joint->getFullName(), propRefName, part != nullptr, obj != nullptr,
+                target ? target->getFullName() : "<null>",
+                property ? property->getSubValues().size() : 0,
+                isTimelineOperationActive(joint), isTimelineOperationActive(target),
+                document && document->testStatus(App::Document::Restoring),
+                document && document->testStatus(App::Document::Recomputing),
+                App::MainThreadSignalConfig::isMainThread());
+        }
         Base::Console()
             .warning("The property %s of Joint %s is bad.\n", propRefName, joint->getFullName());
         return "";

--- a/src/Mod/Assembly/App/AssemblyObject.h
+++ b/src/Mod/Assembly/App/AssemblyObject.h
@@ -24,6 +24,11 @@
 
 #pragma once
 
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 #include <boost/signals2.hpp>
 
 #include <Mod/Assembly/AssemblyGlobal.h>
@@ -31,6 +36,7 @@
 #include <App/FeaturePython.h>
 #include <App/Part.h>
 #include <App/PropertyLinks.h>
+#include <Base/Placement.h>
 
 #include <OndselSolver/enum.h>
 
@@ -89,11 +95,33 @@ public:
     App::DocumentObjectExecReturn* execute() override;
     short mustExecute() const override;
     void onChanged(const App::Property* prop) override;
+    void onSettingDocument() override;
+    void unsetupObject() override;
     /* Solve the assembly. It will update first the joints, solve, update placements of the parts
     and redraw the joints Args : enableRedo : This store initial positions to enable undo while
     being in an active transaction (joint creation).*/
     int solve(bool enableRedo = false);
     int generateSimulation(App::DocumentObject* sim);
+    /// Snapshot on the document owner, solve detached data on HostRuntime.
+    std::uint64_t startSimulation(App::DocumentObject* sim);
+    std::uint64_t startSimulationPlayback(App::DocumentObject* sim);
+    /// Nonblocking owner-thread adoption; false means the worker is not ready.
+    bool finishSimulation(std::uint64_t request = 0);
+    /// Invalidate pending work without waiting or retaining the live document.
+    void cancelSimulation(std::uint64_t request = 0);
+    /// Prepare a frame on HostRuntime; newer requests supersede older requests.
+    std::uint64_t requestSimulationFrame(size_t index);
+    /// Read one cached pose without scheduling work or changing the document.
+    std::vector<std::pair<std::string, Base::Placement>>
+    getSimulationFrame(size_t index) const;
+    /// Adopt only a ready, still-current frame; never wait on a worker.
+    bool finishSimulationFrame(std::uint64_t request);
+    /// Consume a ready frame without changing document properties.
+    std::optional<std::vector<std::pair<std::string, Base::Placement>>>
+    takeSimulationFrame(std::uint64_t request);
+    void cancelSimulationFrame(std::uint64_t request = 0);
+    /// Scope exact component placement presentation; returns the previous state.
+    bool setSimulationPresentation(bool active);
     int updateForFrame(size_t index);
     size_t numberOfFrames();
     void preDrag(std::vector<App::DocumentObject*> dragParts);
@@ -282,7 +310,31 @@ public:
     fastsignals::signal<void()> signalSolverUpdate;
 
 private:
+    struct SimulationJob;
+    std::unique_ptr<SimulationJob> simulationJob;
+    std::unique_ptr<SimulationJob> simulationPlayback;
+    bool simulationReusePending = false;
+    struct SimulationFrameJob;
+    std::unique_ptr<SimulationFrameJob> simulationFrameJob;
+    std::uint64_t simulationFrameRequest = 0;
+    std::uint64_t simulationRequest = 0;
+    int prepareSimulation(App::DocumentObject* sim);
+    std::uint64_t startSimulationJob(App::DocumentObject* sim, bool allowPlaybackCache);
+    bool applySimulationFrame(const std::vector<Base::Placement>& placements);
     void captureTimelineState() noexcept;
+    void emitSolverUpdate();
+    void requestSolveStatusUpdate();
+    void refreshSolveStatus(bool initializeSolver);
+    void invalidateConnectivityCache() noexcept;
+    void rebuildConnectivityCache();
+    void slotConnectivityPropertyChanged(
+        const App::DocumentObject& object,
+        const App::Property& property
+    );
+    std::unordered_set<App::DocumentObject*> collectConnectedParts(
+        const std::unordered_set<App::DocumentObject*>& roots,
+        const std::vector<App::DocumentObject*>& joints
+    );
 
     std::shared_ptr<MbD::ASMTAssembly> mbdAssembly;
 
@@ -294,6 +346,18 @@ private:
     std::vector<std::pair<App::DocumentObject*, Base::Placement>> previousPositions;
     long lastTimelinePosition {-1};
     std::vector<App::DocumentObject*> lastTimelineOperations;
+
+    std::unordered_set<App::DocumentObject*> connectedPartsCache;
+    std::unordered_set<App::DocumentObject*> groundedPartsCache;
+    bool connectivityCacheValid {false};
+    fastsignals::scoped_connection connectivityNewObjectConnection;
+    fastsignals::scoped_connection connectivityDeletedObjectConnection;
+    fastsignals::scoped_connection connectivityChangedObjectConnection;
+    fastsignals::scoped_connection connectivityTouchedObjectConnection;
+    fastsignals::scoped_connection connectivityRecomputedObjectConnection;
+    fastsignals::scoped_connection connectivityPropertyStatusConnection;
+    fastsignals::scoped_connection solveStatusStableConnection;
+    bool solveStatusUpdatePending {false};
 
     bool bundleFixed;
 

--- a/src/Mod/Assembly/App/AssemblyObject.pyi
+++ b/src/Mod/Assembly/App/AssemblyObject.pyi
@@ -62,6 +62,95 @@ class AssemblyObject(Part):
         ...
 
     @constmethod
+    def startSimulation(self, simulationObject: DocumentObject, /) -> int:
+        """Capture inputs and submit a detached native simulation to HostRuntime.
+
+        Call on the GUI/document owner. Existing solved frames remain available
+        until finishSimulation adopts a successful, still-current result.
+        Returns a request token. Pass it to finish/cancel to address only this job.
+        """
+        ...
+
+    @constmethod
+    def startSimulationPlayback(self, simulationObject: DocumentObject, /) -> int:
+        """Prepare playback asynchronously, reusing persisted frames for exact inputs.
+
+        Uses finishSimulation and the asynchronous frame methods. Cached poses
+        do not replace the last full native solver or its diagnostics. Request
+        startSimulation instead when complete solver state is required.
+        Missing, corrupt or stale cached data is regenerated on HostRuntime.
+        """
+        ...
+
+    @constmethod
+    def finishSimulation(self, request: int = 0, /) -> bool:
+        """Adopt a ready simulation without waiting; return False while running.
+
+        Raises RuntimeError on cancellation, invalidated inputs or solver failure.
+        Call on the same document owner as startSimulation.
+        A superseded token raises without consuming another caller's job.
+        Omitting the token addresses the current job.
+        """
+        ...
+
+    @constmethod
+    def cancelSimulation(self, request: int = 0, /) -> None:
+        """Cancel without waiting. Superseded tokens leave the current job alone."""
+        ...
+
+    @constmethod
+    def requestSimulationFrame(self, index: int, /) -> int:
+        """Prepare an async-generated simulation frame on the native worker pool.
+
+        Returns a request token. A newer request cancels the previous frame.
+        Inputs must still match the adopted asynchronous simulation.
+        """
+        ...
+
+    @constmethod
+    def getSimulationFrame(self, index: int, /) -> Any:
+        """Return one cached pose without scheduling work or changing the document.
+
+        The result is a list of ``(object_name, placement)`` pairs intended for
+        direct ViewProvider presentation on the GUI owner thread.
+        """
+        ...
+
+    @constmethod
+    def finishSimulationFrame(self, request: int, /) -> bool:
+        """Apply a ready frame on its document owner without waiting.
+
+        False means preparation is still running. Superseded, cancelled or
+        invalidated requests raise without applying their placements.
+        """
+        ...
+
+    @constmethod
+    def takeSimulationFrame(self, request: int, /) -> Any:
+        """Consume a ready frame for graphics-only presentation.
+
+        Returns None while preparation is running. A ready result is a list of
+        ``(object_name, placement)`` pairs and does not change document properties.
+        Superseded, cancelled, or invalidated requests raise.
+        """
+        ...
+
+    @constmethod
+    def cancelSimulationFrame(self, request: int = 0, /) -> None:
+        """Cancel one frame token (or the current frame with zero), without waiting."""
+        ...
+
+    @constmethod
+    def setSimulationPresentation(self, active: bool, /) -> bool:
+        """Scope transient component placements on the owner thread.
+
+        Return the previous state, which must be restored in finally. Do not
+        process GUI events, generate a simulation, or yield inside the scope.
+        Other properties and objects continue to invalidate solved inputs.
+        """
+        ...
+
+    @constmethod
     def updateForFrame(self, index: int, /) -> None:
         """
         Update entire assembly to frame number specified.

--- a/src/Mod/Assembly/App/AssemblyObjectPyImp.cpp
+++ b/src/Mod/Assembly/App/AssemblyObjectPyImp.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 
 #include <App/PropertyLinks.h>
+#include <Base/PlacementPy.h>
 
 using namespace Assembly;
 
@@ -88,6 +89,129 @@ PyObject* AssemblyObjectPy::ensureIdentityPlacements(PyObject* args) const
         return nullptr;
     }
     this->getAssemblyObjectPtr()->ensureIdentityPlacements();
+    Py_Return;
+}
+
+PyObject* AssemblyObjectPy::startSimulation(PyObject* args) const
+{
+    PyObject* object;
+    if (!PyArg_ParseTuple(args, "O!", &App::DocumentObjectPy::Type, &object)) {
+        return nullptr;
+    }
+    PY_TRY {
+        return PyLong_FromUnsignedLongLong(getAssemblyObjectPtr()->startSimulation(
+            static_cast<App::DocumentObjectPy*>(object)->getDocumentObjectPtr()));
+    } PY_CATCH;
+    Py_Return;
+}
+
+PyObject* AssemblyObjectPy::startSimulationPlayback(PyObject* args) const
+{
+    PyObject* object;
+    if (!PyArg_ParseTuple(args, "O!", &App::DocumentObjectPy::Type, &object)) { return nullptr; }
+    PY_TRY {
+        return PyLong_FromUnsignedLongLong(getAssemblyObjectPtr()->startSimulationPlayback(
+            static_cast<App::DocumentObjectPy*>(object)->getDocumentObjectPtr()));
+    } PY_CATCH;
+    return nullptr;
+}
+
+PyObject* AssemblyObjectPy::finishSimulation(PyObject* args) const
+{
+    unsigned long long request = 0;
+    if (!PyArg_ParseTuple(args, "|K", &request)) { return nullptr; }
+    PY_TRY {
+        return PyBool_FromLong(getAssemblyObjectPtr()->finishSimulation(request));
+    } PY_CATCH;
+    return nullptr;
+}
+
+PyObject* AssemblyObjectPy::cancelSimulation(PyObject* args) const
+{
+    unsigned long long request = 0;
+    if (!PyArg_ParseTuple(args, "|K", &request)) { return nullptr; }
+    PY_TRY { getAssemblyObjectPtr()->cancelSimulation(request); } PY_CATCH;
+    Py_Return;
+}
+
+PyObject* AssemblyObjectPy::requestSimulationFrame(PyObject* args) const
+{
+    unsigned long index = 0;
+    if (!PyArg_ParseTuple(args, "k", &index)) { return nullptr; }
+    PY_TRY {
+        return PyLong_FromUnsignedLongLong(getAssemblyObjectPtr()->requestSimulationFrame(index));
+    } PY_CATCH;
+    return nullptr;
+}
+
+PyObject* AssemblyObjectPy::getSimulationFrame(PyObject* args) const
+{
+    unsigned long index = 0;
+    if (!PyArg_ParseTuple(args, "k", &index)) { return nullptr; }
+    PY_TRY {
+        Py::List result;
+        for (const auto& [name, placement] :
+             getAssemblyObjectPtr()->getSimulationFrame(index)) {
+            Py::Tuple item(2);
+            item.setItem(0, Py::String(name));
+            item.setItem(
+                1,
+                Py::asObject(new Base::PlacementPy(new Base::Placement(placement)))
+            );
+            result.append(item);
+        }
+        return Py::new_reference_to(result);
+    } PY_CATCH;
+    return nullptr;
+}
+
+PyObject* AssemblyObjectPy::setSimulationPresentation(PyObject* args) const
+{
+    int active = 0;
+    if (!PyArg_ParseTuple(args, "p", &active)) { return nullptr; }
+    PY_TRY {
+        return PyBool_FromLong(getAssemblyObjectPtr()->setSimulationPresentation(active != 0));
+    } PY_CATCH;
+    return nullptr;
+}
+
+PyObject* AssemblyObjectPy::finishSimulationFrame(PyObject* args) const
+{
+    unsigned long long request = 0;
+    if (!PyArg_ParseTuple(args, "K", &request)) { return nullptr; }
+    PY_TRY {
+        return PyBool_FromLong(getAssemblyObjectPtr()->finishSimulationFrame(request));
+    } PY_CATCH;
+    return nullptr;
+}
+
+PyObject* AssemblyObjectPy::takeSimulationFrame(PyObject* args) const
+{
+    unsigned long long request = 0;
+    if (!PyArg_ParseTuple(args, "K", &request)) { return nullptr; }
+    PY_TRY {
+        auto frame = getAssemblyObjectPtr()->takeSimulationFrame(request);
+        if (!frame) { Py_Return; }
+        Py::List result;
+        for (const auto& [name, placement] : *frame) {
+            Py::Tuple item(2);
+            item.setItem(0, Py::String(name));
+            item.setItem(
+                1,
+                Py::asObject(new Base::PlacementPy(new Base::Placement(placement)))
+            );
+            result.append(item);
+        }
+        return Py::new_reference_to(result);
+    } PY_CATCH;
+    return nullptr;
+}
+
+PyObject* AssemblyObjectPy::cancelSimulationFrame(PyObject* args) const
+{
+    unsigned long long request = 0;
+    if (!PyArg_ParseTuple(args, "|K", &request)) { return nullptr; }
+    PY_TRY { getAssemblyObjectPtr()->cancelSimulationFrame(request); } PY_CATCH;
     Py_Return;
 }
 

--- a/src/Mod/Assembly/App/AssemblyUtils.cpp
+++ b/src/Mod/Assembly/App/AssemblyUtils.cpp
@@ -30,6 +30,7 @@
 #include <gp_Sphere.hxx>
 
 #include <optional>
+#include <cstdlib>
 #include <string>
 #include <unordered_set>
 
@@ -61,6 +62,17 @@ namespace PartApp = Part;
 
 namespace
 {
+bool inactiveAssemblyObject(const App::DocumentObject* object, const char* reason)
+{
+    const auto* document = object ? object->getDocument() : nullptr;
+    if (std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") && document
+        && document->testStatus(App::Document::Recomputing)) {
+        Base::Console().log("VIBECAD_ASSEMBLY_INACTIVE object=%s reason=%s\n",
+                            object->getFullName(), reason);
+    }
+    return false;
+}
+
 struct ManagedAssemblySourceIdentity
 {
     std::string documentUid;
@@ -156,11 +168,11 @@ bool isAssemblyObjectActive(
     std::unordered_set<const App::DocumentObject*>& visiting
 )
 {
-    if (!App::DocumentTimeline::isObjectUsableAtCurrentPosition(
-            object
-        )
-        || !visiting.insert(object).second) {
-        return false;
+    if (!App::DocumentTimeline::isObjectUsableAtCurrentPosition(object)) {
+        return inactiveAssemblyObject(object, "history");
+    }
+    if (!visiting.insert(object).second) {
+        return inactiveAssemblyObject(object, "source_cycle");
     }
 
     bool active = true;
@@ -170,6 +182,9 @@ bool isAssemblyObjectActive(
             resolveManagedAssemblySource(*sourceIdentity);
         active = source
             && isAssemblyObjectActive(source, visiting);
+        if (!source) {
+            inactiveAssemblyObject(object, "managed_source_missing");
+        }
     }
 
     if (active && object->isLink()) {
@@ -180,6 +195,9 @@ bool isAssemblyObjectActive(
                 linkedObject,
                 visiting
             );
+        if (!linkedObject || linkedObject == object) {
+            inactiveAssemblyObject(object, "link_target_unresolved");
+        }
     }
     else if (active) {
         if (const auto* assemblyLink =
@@ -211,8 +229,11 @@ bool isTimelineOperationActive(const App::DocumentObject* object)
         std::unordered_set<const App::DocumentObject*> visiting;
         return isAssemblyObjectActive(object, visiting);
     }
+    catch (const std::exception& error) {
+        return inactiveAssemblyObject(object, error.what());
+    }
     catch (...) {
-        return false;
+        return inactiveAssemblyObject(object, "unknown_exception");
     }
 }
 

--- a/src/Mod/Assembly/App/CMakeLists.txt
+++ b/src/Mod/Assembly/App/CMakeLists.txt
@@ -45,6 +45,9 @@ SOURCE_GROUP("Module" FILES ${Module_SRCS})
 SET(Assembly_SRCS
     AssemblyObject.cpp
     AssemblyObject.h
+    SimulationFrameSnapshot.h
+    SimulationPlaybackCache.cpp
+    SimulationPlaybackCache.h
     AssemblyLink.cpp
     AssemblyLink.h
     AssemblyUtils.cpp
@@ -64,6 +67,7 @@ SET(Assembly_SRCS
 )
 
 add_library(Assembly SHARED ${Assembly_SRCS})
+target_compile_definitions(Assembly PRIVATE _USE_MATH_DEFINES)
 target_include_directories(
     Assembly
     PRIVATE

--- a/src/Mod/Assembly/App/SimulationFrameSnapshot.h
+++ b/src/Mod/Assembly/App/SimulationFrameSnapshot.h
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+
+#include <array>
+#include <cmath>
+#include <stdexcept>
+#include <vector>
+#include <Base/Placement.h>
+#include <OndselSolver/ASMTSpatialItem.h>
+
+namespace Assembly::detail
+{
+// Value-only kinematic channels. Capture while the detached solver is exclusively
+// owned; afterwards the solver can change or disappear without affecting readers.
+// Store the six solved channels, not an eagerly expanded matrix for every frame.
+class SimulationFrameTrack
+{
+public:
+    size_t frameCount() const noexcept { return channels[0].size(); }
+
+    static SimulationFrameTrack capture(
+        const MbD::ASMTSpatialItem& part, const Base::Placement& offset, size_t frames)
+    {
+        SimulationFrameTrack result;
+        result.offset = offset;
+        const std::array<MbD::FRowDsptr, 6> source {
+            part.xs, part.ys, part.zs, part.bryxs, part.bryys, part.bryzs};
+        for (size_t channel = 0; channel < source.size(); ++channel) {
+            if (!source[channel] || source[channel]->size() != frames) {
+                throw std::runtime_error("Simulation component has incomplete frame channels");
+            }
+            result.channels[channel].assign(source[channel]->begin(), source[channel]->end());
+            for (double value : result.channels[channel]) {
+                if (!std::isfinite(value)) {
+                    throw std::runtime_error("Simulation component has a non-finite frame channel");
+                }
+            }
+        }
+        return result;
+    }
+
+    Base::Placement placementAt(size_t frame) const
+    {
+        // Ondsel stores Bryant angles in Rx * Ry * Rz order. Compose the same
+        // rotation directly, without allocating three matrices per component.
+        const double x = channels[3].at(frame) * 0.5;
+        const double y = channels[4].at(frame) * 0.5;
+        const double z = channels[5].at(frame) * 0.5;
+        const auto rotation = Base::Rotation(std::sin(x), 0, 0, std::cos(x))
+            * Base::Rotation(0, std::sin(y), 0, std::cos(y))
+            * Base::Rotation(0, 0, std::sin(z), std::cos(z));
+        return Base::Placement(
+            Base::Vector3d(channels[0].at(frame), channels[1].at(frame), channels[2].at(frame)),
+            rotation) * offset;
+    }
+
+private:
+    friend class SimulationPlaybackCache;
+    std::array<std::vector<double>, 6> channels;
+    Base::Placement offset;
+};
+}

--- a/src/Mod/Assembly/App/SimulationPlaybackCache.cpp
+++ b/src/Mod/Assembly/App/SimulationPlaybackCache.cpp
@@ -1,0 +1,243 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include <FCConfig.h>
+#include "SimulationPlaybackCache.h"
+
+#include <algorithm>
+#include <limits>
+#include <ios>
+#include <fstream>
+#include <iomanip>
+#include <locale>
+#include <streambuf>
+#include <utility>
+#include <QCryptographicHash>
+#include <QDataStream>
+#include <QDir>
+#include <QFile>
+#include <QSaveFile>
+#include <QSysInfo>
+#include <Base/CancellationScope.h>
+#include <OndselSolver/ASMTAssembly.h>
+#include <OndselSolver/ASMTPart.h>
+#include <OndselSolver/ASMTJoint.h>
+#include <OndselSolver/ASMTMotion.h>
+#include <OndselSolver/ASMTLimit.h>
+#include <OndselSolver/ASMTKinematicIJ.h>
+#include <OndselSolver/ASMTForceTorque.h>
+#include <OndselSolver/ASMTRefPoint.h>
+
+namespace Assembly::detail
+{
+namespace
+{
+constexpr char magic[] = "VibeCAD-frames-1";
+constexpr qint64 headerSize = sizeof(magic) - 1 + 1 + 64 + 16 + 32;
+
+// The existing Ondsel serializer takes ofstream, but writes through ostream's
+// stream buffer. Hash directly: no temporary input file or full text allocation.
+class HashBuffer : public std::streambuf
+{
+public:
+    QCryptographicHash hash {QCryptographicHash::Sha256};
+protected:
+    std::streamsize xsputn(const char* data, std::streamsize size) override
+    {
+        hash.addData(QByteArrayView(data, qsizetype(size)));
+        return size;
+    }
+    int_type overflow(int_type value) override
+    {
+        if (!traits_type::eq_int_type(value, traits_type::eof())) {
+            const char byte = traits_type::to_char_type(value);
+            hash.addData(QByteArrayView(&byte, 1));
+        }
+        return traits_type::not_eof(value);
+    }
+};
+
+QByteArray inputDigest(MbD::ASMTItem& item)
+{
+    Base::CancellationScope::check();
+    HashBuffer buffer;
+    std::ofstream stream;
+    static_cast<std::ios&>(stream).rdbuf(&buffer);
+    stream.exceptions(std::ios::badbit | std::ios::failbit);
+    stream.imbue(std::locale::classic());
+    stream << std::setprecision(std::numeric_limits<double>::max_digits10);
+    item.storeOnLevel(stream, 0);
+    stream.flush();
+    return buffer.hash.result();
+}
+
+template<class T>
+auto sortedInputs(const std::shared_ptr<std::vector<std::shared_ptr<T>>>& source)
+{
+    std::vector<std::pair<QByteArray, std::shared_ptr<T>>> entries;
+    entries.reserve(source->size());
+    for (const auto& item : *source) { entries.emplace_back(inputDigest(*item), item); }
+    std::sort(entries.begin(), entries.end(), [](const auto& a, const auto& b) { return a.first < b.first; });
+    auto result = std::make_shared<std::vector<std::shared_ptr<T>>>();
+    result->reserve(entries.size());
+    for (auto& entry : entries) { result->push_back(std::move(entry.second)); }
+    return result;
+}
+
+QString cachePath(const std::string& directory, const std::string& key)
+{
+    if (key.size() != 64 || !std::all_of(key.begin(), key.end(), [](char c) {
+            return (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+        })) {
+        throw std::invalid_argument("Invalid simulation playback input digest");
+    }
+    return QDir(QString::fromStdString(directory)).filePath(QString::fromStdString(key) + ".frames");
+}
+
+QByteArrayView rowBytes(const std::vector<double>& row)
+{
+    if (row.size() > size_t(std::numeric_limits<qsizetype>::max()) / sizeof(double)) {
+        throw std::length_error("Simulation playback channel exceeds addressable memory");
+    }
+    return {reinterpret_cast<const char*>(row.data()), qsizetype(row.size() * sizeof(double))};
+}
+}
+
+std::string SimulationPlaybackCache::inputKey(
+    const MbD::ASMTAssembly& assembly, const std::vector<Binding>& bindings,
+    const std::string& producer)
+{
+    if (!assembly.times->empty() || !assembly.constraintSets->empty()) {
+        throw std::invalid_argument("Playback key requires detached, unserialized-result-free solver inputs");
+    }
+    // Canonicalize copies only. Unordered host capture must not defeat reuse,
+    // and constructing the key must not change the actual solver's input order.
+    auto canonical = assembly;
+    canonical.parts = std::make_shared<std::vector<std::shared_ptr<MbD::ASMTPart>>>();
+    for (const auto& part : *assembly.parts) {
+        auto copy = std::make_shared<MbD::ASMTPart>(*part);
+        copy->refPoints = sortedInputs(part->refPoints);
+        canonical.parts->push_back(std::move(copy));
+    }
+    canonical.parts = sortedInputs(canonical.parts);
+    canonical.refPoints = sortedInputs(assembly.refPoints);
+    canonical.joints = sortedInputs(assembly.joints);
+    canonical.motions = sortedInputs(assembly.motions);
+    canonical.limits = sortedInputs(assembly.limits);
+    canonical.kinematicIJs = sortedInputs(assembly.kinematicIJs);
+    canonical.forcesTorques = sortedInputs(assembly.forcesTorques);
+    QCryptographicHash hash(QCryptographicHash::Sha256);
+    hash.addData(inputDigest(canonical));
+    hash.addData(QByteArray::fromStdString(producer));
+    for (const auto& [name, offset] : bindings) {
+        QByteArray binding;
+        QDataStream stream(&binding, QIODevice::WriteOnly);
+        stream.setVersion(QDataStream::Qt_6_0);
+        stream << QByteArray::fromStdString(name);
+        const auto& position = offset.getPosition();
+        stream << position.x << position.y << position.z;
+        for (size_t index = 0; index < 4; ++index) { stream << offset.getRotation()[index]; }
+        hash.addData(binding);
+    }
+    return hash.result().toHex().toStdString();
+}
+
+SimulationPlaybackCache::SimulationPlaybackCache(std::string directory)
+    : directory(std::move(directory))
+{}
+
+void SimulationPlaybackCache::store(
+    const std::string& key, const std::vector<SimulationFrameTrack>& tracks) const
+{
+    const auto path = cachePath(directory, key);
+    if (tracks.empty() || tracks.front().frameCount() < 2) {
+        throw std::invalid_argument("Cannot cache incomplete simulation playback");
+    }
+    const size_t frames = tracks.front().frameCount();
+    QCryptographicHash hash(QCryptographicHash::Sha256);
+    for (const auto& track : tracks) {
+        Base::CancellationScope::check();
+        for (const auto& row : track.channels) {
+            if (row.size() != frames || !std::all_of(row.begin(), row.end(), [](double value) {
+                    return std::isfinite(value);
+                })) {
+                throw std::invalid_argument("Cannot cache invalid simulation playback channels");
+            }
+            hash.addData(rowBytes(row));
+        }
+    }
+    if (!QDir().mkpath(QString::fromStdString(directory))) {
+        throw std::ios_base::failure("Cannot create simulation playback cache directory");
+    }
+    QSaveFile file(path);
+    if (!file.open(QIODevice::WriteOnly)) {
+        throw std::ios_base::failure("Cannot write simulation playback cache");
+    }
+    QDataStream stream(&file);
+    stream.writeRawData(magic, sizeof(magic) - 1);
+    stream << quint8(QSysInfo::ByteOrder);
+    stream.writeRawData(key.data(), key.size());
+    stream << quint64(frames) << quint64(tracks.size());
+    const auto digest = hash.result();
+    stream.writeRawData(digest.data(), digest.size());
+    for (const auto& track : tracks) {
+        Base::CancellationScope::check();
+        for (const auto& row : track.channels) {
+            const auto bytes = rowBytes(row);
+            if (file.write(bytes.data(), bytes.size()) != bytes.size()) {
+                throw std::ios_base::failure("Incomplete simulation playback cache write");
+            }
+        }
+    }
+    Base::CancellationScope::check();
+    if (stream.status() != QDataStream::Ok || !file.commit()) {
+        throw std::ios_base::failure("Cannot commit simulation playback cache");
+    }
+}
+
+std::optional<std::vector<SimulationFrameTrack>> SimulationPlaybackCache::load(
+    const std::string& key, const std::vector<Base::Placement>& offsets) const
+{
+    QFile file(cachePath(directory, key));
+    if (!file.open(QIODevice::ReadOnly) || file.size() < headerSize) { return {}; }
+    if (file.read(sizeof(magic) - 1) != QByteArray(magic, sizeof(magic) - 1)) { return {}; }
+    QDataStream stream(&file);
+    quint8 byteOrder;
+    stream >> byteOrder;
+    if (byteOrder != QSysInfo::ByteOrder || file.read(64) != QByteArray::fromStdString(key)) {
+        return {};
+    }
+    quint64 frames = 0, count = 0;
+    stream >> frames >> count;
+    const auto digest = file.read(32);
+    const quint64 payloadBytes = file.size() - headerSize;
+    // Validate dimensions against the actual file before allocating. No model-
+    // size cap: these checks prevent overflow and allocation from a forged header.
+    constexpr quint64 bytesPerSample = 6 * sizeof(double);
+    if (stream.status() != QDataStream::Ok || digest.size() != 32 || frames < 2
+        || count == 0 || count != offsets.size() || payloadBytes % bytesPerSample != 0
+        || (payloadBytes / bytesPerSample) % count != 0
+        || (payloadBytes / bytesPerSample) / count != frames
+        || frames > std::vector<double>().max_size()) {
+        return {};
+    }
+    std::vector<SimulationFrameTrack> tracks(offsets.size());
+    QCryptographicHash hash(QCryptographicHash::Sha256);
+    for (size_t index = 0; index < tracks.size(); ++index) {
+        Base::CancellationScope::check();
+        auto& track = tracks[index];
+        track.offset = offsets[index];
+        for (auto& row : track.channels) {
+            row.resize(size_t(frames));
+            const auto bytes = rowBytes(row);
+            if (file.read(reinterpret_cast<char*>(row.data()), bytes.size()) != bytes.size()) {
+                return {};
+            }
+            hash.addData(bytes);
+            if (!std::all_of(row.begin(), row.end(), [](double value) { return std::isfinite(value); })) {
+                return {};
+            }
+        }
+    }
+    if (!file.atEnd() || hash.result() != digest) { return {}; }
+    return tracks;
+}
+}

--- a/src/Mod/Assembly/App/SimulationPlaybackCache.h
+++ b/src/Mod/Assembly/App/SimulationPlaybackCache.h
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+#include <utility>
+#include <Mod/Assembly/AssemblyGlobal.h>
+#include "SimulationFrameSnapshot.h"
+
+namespace MbD { class ASMTAssembly; }
+
+namespace Assembly::detail
+{
+// Private, disposable playback data, never a replacement for a solved engine.
+// Call only on a worker with detached inputs. The key covers solver inputs,
+// binding order/offsets and the producer version; files authenticate their payload.
+class AssemblyExport SimulationPlaybackCache
+{
+public:
+    using Binding = std::pair<std::string, Base::Placement>;
+    static std::string inputKey(
+        const MbD::ASMTAssembly& assembly, const std::vector<Binding>& bindings,
+        const std::string& producer);
+    explicit SimulationPlaybackCache(std::string directory);
+    void store(const std::string& key, const std::vector<SimulationFrameTrack>& tracks) const;
+    std::optional<std::vector<SimulationFrameTrack>> load(
+        const std::string& key, const std::vector<Base::Placement>& offsets) const;
+
+private:
+    std::string directory;
+};
+}

--- a/src/Mod/Assembly/AssemblyTests/TestCore.py
+++ b/src/Mod/Assembly/AssemblyTests/TestCore.py
@@ -24,6 +24,7 @@
 import FreeCAD as App
 import Part
 import tempfile
+import time
 import unittest
 
 import UtilsAssembly
@@ -147,6 +148,38 @@ class TestCore(unittest.TestCase):
         JointObject.Joint(joint, 0)
 
         self.assertTrue(hasattr(joint, "JointType"), "'{}' failed".format(operation))
+
+    def test_joint_worker_recompute_never_enters_view_provider(self):
+        """Keep worker recompute model-only; presentation belongs to Qt."""
+
+        class WorkerJoint:
+            Label = "WorkerJoint"
+            Reference1 = None
+            Reference2 = None
+
+            @property
+            def ViewObject(self):
+                raise AssertionError("worker recompute entered the GUI view provider")
+
+        proxy = object.__new__(JointObject.Joint)
+        calls = []
+        proxy.updateJCSPlacements = lambda joint, **options: calls.append(
+            (joint, options)
+        )
+        original_usable = JointObject._jointInteractionUsable
+        JointObject._jointInteractionUsable = lambda _joint: True
+        self.addCleanup(
+            setattr,
+            JointObject,
+            "_jointInteractionUsable",
+            original_usable,
+        )
+
+        joint = WorkerJoint()
+        proxy.execute(joint)
+
+        self.assertEqual(calls, [(joint, {"redraw": False})])
+        self.assertTrue(proxy.supportsAsyncRecompute(joint))
 
     def test_create_grounded_joint(self):
         """Create a grounded joint in an assembly."""
@@ -300,6 +333,59 @@ class TestCore(unittest.TestCase):
         self.doc.recompute()
         self.assertEqual(UtilsAssembly.number_of_components_in(self.assembly), 2)
         self.assertTrue(self.assembly.isPartConnected(moving_part))
+
+    def test_repeated_connectivity_queries_reuse_unchanged_topology(self):
+        """Joint overlays must not rebuild the assembly graph per tree item."""
+        self._disable_solve_on_recompute()
+
+        parts = [
+            self.assembly.newObject("Part::Box", "ConnectivityPart{:02d}".format(index))
+            for index in range(48)
+        ]
+        self.doc.recompute()
+        ground = self.jointgroup.newObject(
+            "App::FeaturePython", "ConnectivityGroundedJoint"
+        )
+        JointObject.GroundedJoint(ground, parts[0])
+
+        joints = []
+        for index, (part1, part2) in enumerate(zip(parts, parts[1:])):
+            joint = self.jointgroup.newObject(
+                "App::FeaturePython", "ConnectivityJoint{:02d}".format(index)
+            )
+            JointObject.Joint(joint, 0)
+            joint.Proxy.setJointConnectors(
+                joint,
+                [
+                    [part1, ["Face6", "Vertex7"]],
+                    [part2, ["Face6", "Vertex7"]],
+                ],
+            )
+            joints.append(joint)
+        self.doc.recompute()
+
+        started = time.perf_counter()
+        self.assertTrue(self.assembly.isPartConnected(parts[-1]))
+        one_query_seconds = time.perf_counter() - started
+
+        started = time.perf_counter()
+        for part in parts:
+            self.assertTrue(self.assembly.isPartConnected(part))
+        all_queries_seconds = time.perf_counter() - started
+
+        self.assertLess(
+            all_queries_seconds,
+            max(0.05, one_query_seconds * 8.0),
+            "unchanged connectivity was recomputed for every joint overlay: "
+            "one={:.6f}s all={:.6f}s".format(
+                one_query_seconds, all_queries_seconds
+            ),
+        )
+
+        joints[len(joints) // 2].Suppressed = True
+        self.assertFalse(self.assembly.isPartConnected(parts[-1]))
+        joints[len(joints) // 2].Suppressed = False
+        self.assertTrue(self.assembly.isPartConnected(parts[-1]))
 
     def test_timeline_grounding_survives_undo_redo_and_reopen(self):
         """A future GroundedJoint is retained, unlocked, and restored exactly."""

--- a/src/Mod/Assembly/CMakeLists.txt
+++ b/src/Mod/Assembly/CMakeLists.txt
@@ -28,6 +28,8 @@ set(Assembly_Scripts
     CommandEditHistoryOperation.py
     CommandCreateView.py
     CommandCreateSimulation.py
+    AnimationExport.py
+    AnimationEncoder.py
     CommandExportASMT.py
     TestAssemblyWorkbench.py
     JointObject.py

--- a/src/Mod/Assembly/CommandCreateSimulation.py
+++ b/src/Mod/Assembly/CommandCreateSimulation.py
@@ -26,6 +26,8 @@ import re
 import os
 import time
 import tempfile
+import weakref
+from concurrent.futures import Future
 from pathlib import Path
 
 import FreeCAD as App
@@ -957,6 +959,12 @@ SLOPE defines the steepness of the transition between 0 and H1 and H2 to 0 about
 
 ######### Create Simulation Task ###########
 class TaskAssemblyCreateSimulation(QtCore.QObject):
+    generationFinished = QtCore.Signal(bool)
+    frameFinished = QtCore.Signal(int, bool)
+    playbackClosed = QtCore.Signal()
+    rejectPlaybackRequested = QtCore.Signal(object)
+    cancelFrameRequested = QtCore.Signal(object)
+
     def __init__(
         self,
         simFeaturePy=None,
@@ -970,6 +978,12 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         restore_camera=None,
     ):
         super().__init__()
+        self._closing = False
+        self.frame_error = ''
+        self.rejectPlaybackRequested.connect(
+            self._rejectOwnedPlayback, QtCore.Qt.QueuedConnection
+        )
+        self.cancelFrameRequested.connect(self._cancelOwnedFrame)
         self.playback_only = bool(playback_only)
 
         if simFeaturePy is not None:
@@ -1018,6 +1032,7 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
                 self.assembly
             )
         )
+        self.playback_part_ids = frozenset(record[1] for record in self.initialPlcs.parts)
 
         self.doc = self.assembly.Document
         if document_name is not None and self.doc.Name != document_name:
@@ -1169,7 +1184,24 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         self.runKinematicsTimer.setSingleShot(True)
         self.runKinematicsTimer.timeout.connect(self.displayLastFrame)
 
+        self.generation_state = 'idle'
+        self.generation_request = None
+        self.generation_error = ''
+        self.generationTimer = QtCore.QTimer(self)
+        # A UI status cadence, not a solver timeout or compute budget.
+        self.generationTimer.setInterval(50)
+        self.generationTimer.timeout.connect(self._finishKinematicsAsync)
+
+        self.background_frames = False
+        self.frame_request = None
+        self.requested_frame = None
+        self.graphics_frame_active = False
+        self.frameTimer = QtCore.QTimer(self)
+        self.frameTimer.setInterval(16)
+        self.frameTimer.timeout.connect(self._finishFrame)
+
         self.animationTimer = QtCore.QTimer()
+        self.animationTimer.setTimerType(QtCore.Qt.PreciseTimer)
         self.animationTimer.setInterval(50)  # ms
         self.animationTimer.timeout.connect(self.playAnimation)
 
@@ -1207,7 +1239,8 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         self.form.GlobalErrorToleranceSpinBox.valueChanged.connect(
             self.onGlobalErrorToleranceChanged
         )
-        self.form.RunKinematicsButton.clicked.connect(self.runKinematics)
+        self.generate_button_text = self.form.RunKinematicsButton.text()
+        self.form.RunKinematicsButton.clicked.connect(self.runKinematicsAsync)
         self.form.frameSlider.valueChanged.connect(self.onFrameChanged)
         self.form.FramesPerSecondSpinBox.valueChanged.connect(self.onFramesPerSecondChanged)
         self.form.PlayBackwardButton.clicked.connect(self.animationTimerStartBackward)
@@ -1218,7 +1251,8 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         self.form.AddButton.clicked.connect(self.addMotionClicked)
         self.form.RemoveButton.clicked.connect(self.deleteSelectedMotions)
         self.form.groupBox_player.hide()
-        self.form.SaveAnimationButton.clicked.connect(self.saveAnimation)
+        self.animation_export = None
+        self.form.SaveAnimationButton.clicked.connect(self.saveAnimationAsync)
         self.form.SaveAnimationButton.hide()
 
         if self.playback_only:
@@ -1277,6 +1311,8 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
             self._observing_document = True
 
     def _ownsLiveTaskContext(self):
+        if self._closing:
+            return False
         assembly_name, assembly_id, exact_assembly = (
             self.assembly_identity
         )
@@ -1382,6 +1418,7 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         return True
 
     def _restorePlaybackPresentation(self):
+        self._restoreSimulationGraphics()
         if self.presentation is not None:
             self.presentation.Proxy._last_applied_placements = list(
                 self.presentation_applied_placements
@@ -1404,6 +1441,18 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         if self.playback_only and UtilsAssembly._document_is_open(self.doc):
             self.gui_doc.Modified = self.document_was_modified
 
+    def _restoreSimulationGraphics(self):
+        if not self.graphics_frame_active:
+            return
+        if not UtilsAssembly._document_is_open(self.doc):
+            self.graphics_frame_active = False
+            return
+        for name, object_id, component, _baseline in self.initialPlcs.parts:
+            current = self.doc.getObject(name)
+            if current is component and int(current.ID) == object_id:
+                self.gui_doc.setPos(name, current.Placement.toMatrix())
+        self.graphics_frame_active = False
+
     def _restorePlaybackCamera(self):
         try:
             if (
@@ -1424,8 +1473,15 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         for component, _name, _object_id, _visible in self.presentation_visibility:
             component.ViewObject.Visibility = False
         if self.requested_camera_method:
-            getattr(self.view, self.requested_camera_method)()
-            self.view.fitAll()
+            # Setup must have its final camera before generation/capture starts,
+            # without the viewer's nested animation loop excluding user input.
+            animation = self.view.isAnimationEnabled()
+            self.view.setAnimationEnabled(False)
+            try:
+                getattr(self.view, self.requested_camera_method)()
+                self.view.fitAll()
+            finally:
+                self.view.setAnimationEnabled(animation)
 
     def _applyPlaybackPresentation(self):
         if self.presentation is None:
@@ -1439,6 +1495,12 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
                 move.ViewObject.Visibility = True
 
     def autoClosedOnDeletedDocument(self):
+        self._closing = True
+        self.playbackClosed.emit()
+        self.frameTimer.stop()
+        self.frame_request = None
+        self.generationTimer.stop()
+        self.generation_state = 'cancelled'
         self.animationTimer.stop()
         if self.transaction is not None:
             self.transaction.document_deleted()
@@ -1447,6 +1509,9 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
     def closed(self):
         """Restore transient playback state after every task close path."""
 
+        self._closing = True
+        self.playbackClosed.emit()
+        self._cancelPendingFrame()
         try:
             if UtilsAssembly._document_is_open(self.doc):
                 UtilsAssembly._restoreExactAssemblyPartPlacements(
@@ -1469,6 +1534,11 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         self.deactivate()
 
     def deactivate(self):
+        if not self._closing:
+            self._closing = True
+            self.playbackClosed.emit()
+        self._cancelPendingFrame()
+        self.cancelGeneration()
         self.animationTimer.stop()
         self._removeDocumentObserver()
         simulation_name, simulation_id, exact_simulation = (
@@ -1493,6 +1563,20 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         except (AttributeError, RuntimeError):
             pass
 
+    @QtCore.Slot(object)
+    def _rejectOwnedPlayback(self, dialog):
+        # Future cancellation may originate on a provider thread. Qt delivers
+        # this slot on the panel's owner; never close a subsequently opened task.
+        if not self._closing:
+            current = _simulationTaskDialog(self)
+            if current is not None:
+                current.reject()
+
+    @QtCore.Slot(object)
+    def _cancelOwnedFrame(self, request):
+        if request is not None and self.frame_request == request:
+            self._cancelPendingFrame()
+
     def slotStartSaveDocument(self, document, _path):
         """Keep transient playback placements out of the saved FCStd file."""
 
@@ -1509,6 +1593,7 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
             int(self.direction),
         )
         self.animationTimer.stop()
+        self._cancelPendingFrame()
         UtilsAssembly._restoreExactAssemblyPartPlacements(
             self.assembly,
             self.initialPlcs,
@@ -1528,9 +1613,16 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
             return
         self._activatePlaybackPresentation()
         if 0 <= frame < self.assembly.numberOfFrames():
-            self.assembly.updateForFrame(frame)
-            self._applyPlaybackPresentation()
-            self.form.frameSlider.setValue(frame)
+            # Resume through the same transient placement scope as playback.
+            # Apply exactly once, including when the slider already shows this
+            # frame (Qt otherwise emits either zero or one additional callback).
+            slider = self.form.frameSlider
+            was_blocked = slider.blockSignals(True)
+            try:
+                slider.setValue(frame)
+            finally:
+                slider.blockSignals(was_blocked)
+            self.onFrameChanged(frame)
         # Saving establishes a new clean restoration baseline.  A player that
         # opened while the GUI document was dirty must not re-dirty it when the
         # user later closes that same, successfully saved playback task.
@@ -1635,6 +1727,10 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
     def runKinematics(self):
         if not self._ownsLiveTaskContext():
             return
+        # Preserve the synchronous public method for callers which require its
+        # completed-frame postcondition. Interactive Generate uses the async API.
+        self._cancelPendingFrame()
+        self.background_frames = False
         if self.presentation is not None:
             self.presentation.Proxy._prepareApplicationBaseline(self.assembly)
         status = int(self.assembly.generateSimulation(self.simFeaturePy))
@@ -1652,12 +1748,179 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         self.form.groupBox_player.show()
         self.form.SaveAnimationButton.show()
 
+    def _setGenerationState(self, state, error=''):
+        self.generation_state = state
+        self.generation_error = error
+        running = state == 'running'
+        self.form.RunKinematicsButton.setText(
+            translate('Assembly', 'Cancel generation') if running else self.generate_button_text
+        )
+        self.form.groupBox_player.setEnabled(not running)
+        self.form.SaveAnimationButton.setEnabled(not running)
+        self.form.RunKinematicsButton.setToolTip(error)
+        Gui.getMainWindow().statusBar().showMessage(
+            translate('Assembly', 'Generating assembly simulation in background…')
+            if running else error or translate('Assembly', 'Simulation ' + state)
+        )
+
+    def runKinematicsAsync(self):
+        if not self._ownsLiveTaskContext():
+            return
+        if self.generation_state == 'running':
+            self.cancelGeneration()
+            return
+        self.animationTimer.stop()
+        self._cancelPendingFrame()
+        self._setGenerationState('running')
+        try:
+            if self.presentation is not None:
+                self.presentation.Proxy._prepareApplicationBaseline(self.assembly)
+            start = (self.assembly.startSimulationPlayback if self.playback_only
+                     else self.assembly.startSimulation)
+            self.generation_request = start(self.simFeaturePy)
+            self.generationTimer.start()
+        except Exception as error:
+            self._setGenerationState('failed', str(error))
+            self.generationFinished.emit(False)
+
+    def _finishKinematicsAsync(self):
+        if not self._ownsLiveTaskContext():
+            self.cancelGeneration()
+            return
+        try:
+            if not self.assembly.finishSimulation(self.generation_request):
+                return
+            self.generation_request = None
+            self.generationTimer.stop()
+            self.background_frames = True
+            last_frame = self.assembly.numberOfFrames() - 1
+            slider = self.form.frameSlider
+            was_blocked = slider.blockSignals(True)
+            try:
+                slider.setMaximum(last_frame)
+                slider.setValue(last_frame)
+            finally:
+                slider.blockSignals(was_blocked)
+            self.onFrameChanged(last_frame)
+            if self.frame_error:
+                raise RuntimeError(self.frame_error)
+            self.form.groupBox_player.show()
+            self.form.SaveAnimationButton.show()
+            self._setGenerationState('ready')
+            self.generationFinished.emit(True)
+        except Exception as error:
+            self.generationTimer.stop()
+            self._setGenerationState('failed', str(error))
+            self.generationFinished.emit(False)
+
+    def cancelGeneration(self):
+        self.generationTimer.stop()
+        if self.generation_state != 'running':
+            return
+        if UtilsAssembly._document_is_open(self.doc):
+            name, object_id, exact_assembly = self.assembly_identity
+            current = self.doc.getObject(name)
+            if current is exact_assembly and int(current.ID) == object_id:
+                if self.generation_request is not None:
+                    current.cancelSimulation(self.generation_request)
+        self.generation_request = None
+        self.generation_state = 'cancelled'
+        if self.form is not None:
+            self._setGenerationState('cancelled')
+        self.generationFinished.emit(False)
+
     def onFrameChanged(self, val):
         if not self._ownsLiveTaskContext():
             return
-        self.assembly.updateForFrame(val)
-        self._applyPlaybackPresentation()
+        if self.background_frames:
+            try:
+                if self.presentation is None:
+                    self.frame_error = ''
+                    self.requested_frame = int(val)
+                    graphics_frame = self.assembly.getSimulationFrame(int(val))
+                    for object_name, placement in graphics_frame:
+                        self.gui_doc.setPos(object_name, placement.toMatrix())
+                    self.graphics_frame_active = True
+                    self._showFrameStatus(val)
+                    self.frameFinished.emit(int(val), True)
+                    return
+                self._cancelPendingFrame()
+                self.frame_error = ''
+                self.requested_frame = int(val)
+                self.frame_request = self.assembly.requestSimulationFrame(int(val))
+                self.frameTimer.start()
+            except Exception as error:
+                self._frameFailed(error)
+            return
+        with UtilsAssembly.presentationPlacementChanges(
+            self.doc, self.playback_part_ids, self.assembly
+        ):
+            self.assembly.updateForFrame(val)
+            self._applyPlaybackPresentation()
+        self._showFrameStatus(val)
+        self.frameFinished.emit(int(val), True)
+
+    def _finishFrame(self):
+        if self.frame_request is None:
+            self.frameTimer.stop()
+            return
+        if not self._ownsLiveTaskContext():
+            self._cancelPendingFrame()
+            return
+        try:
+            if self.presentation is None:
+                graphics_frame = self.assembly.takeSimulationFrame(
+                    self.frame_request
+                )
+                if graphics_frame is None:
+                    return
+                for object_name, placement in graphics_frame:
+                    self.gui_doc.setPos(object_name, placement.toMatrix())
+                self.graphics_frame_active = True
+            else:
+                with UtilsAssembly.presentationPlacementChanges(
+                    self.doc, self.playback_part_ids, self.assembly
+                ):
+                    if not self.assembly.finishSimulationFrame(
+                        self.frame_request
+                    ):
+                        return
+                    self._applyPlaybackPresentation()
+            frame = self.requested_frame
+            self.frame_request = None
+            self.frameTimer.stop()
+            self._showFrameStatus(frame)
+            self.frameFinished.emit(int(frame), True)
+        except Exception as error:
+            self._frameFailed(error)
+
+    def _cancelPendingFrame(self):
+        self.frameTimer.stop()
+        request, self.frame_request = self.frame_request, None
+        if request is None:
+            return
+        if UtilsAssembly._document_is_open(self.doc):
+            name, object_id, exact_assembly = self.assembly_identity
+            current = self.doc.getObject(name)
+            if current is exact_assembly and int(current.ID) == object_id:
+                current.cancelSimulationFrame(request)
+        self.frameFinished.emit(int(self.requested_frame), False)
+
+    def _frameFailed(self, error):
+        self.frame_error = str(error)
+        had_request = self.frame_request is not None
+        self.animationTimer.stop()
+        self._cancelPendingFrame()
+        if self.form is not None:
+            Gui.getMainWindow().statusBar().showMessage(str(error))
+            self.form.FrameLabel.setText(translate('Assembly', 'Frame update failed'))
+            self.form.FrameLabel.setToolTip(str(error))
+        if not had_request:
+            self.frameFinished.emit(int(self.requested_frame), False)
+
+    def _showFrameStatus(self, val):
         self.form.FrameLabel.setText(translate("Assembly", "Frame" + " " + str(val)))
+        self.form.FrameLabel.setToolTip('')
         time = _simulationFrameTime(self.simFeaturePy, val)
         self.form.FrameTimeLabel.setText(
             translate("Assembly", "Input") if time is None else f"{time:.2f} s"
@@ -1783,6 +2046,7 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         self.fps = self.simFeaturePy.jFramesPerSecond
         self.deltaTime = 1.0 / self.fps
         self.startTime = time.time()
+        self.lastFrameTime = time.perf_counter()
         self.index = self.currentFrm
         self.animationTimer.setInterval(self.deltaTime * 1000)  # ms
         self.animationTimer.start()
@@ -1794,11 +2058,18 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
         if self.form is None or not self._ownsLiveTaskContext():
             self.animationTimer.stop()
             return
-        range_ = self.endFrm - self.startFrm
-        offset = self.currentFrm - self.startFrm
-        count = int((time.time() - self.startTime) / self.deltaTime)
-        self.index = ((self.direction * count + offset) % range_) + self.startFrm
+        now = time.perf_counter()
+        if now - self.lastFrameTime < self.deltaTime * 0.75:
+            return
+        if self.background_frames and self.frame_request is not None:
+            return
+        self.index = self.form.frameSlider.value() + self.direction
+        if self.index > self.endFrm:
+            self.index = self.startFrm
+        elif self.index < self.startFrm:
+            self.index = self.endFrm
         self.setFrameValue(self.index)
+        self.lastFrameTime = time.perf_counter()
 
     def displayLastFrame(self):
         if not self._ownsLiveTaskContext():
@@ -1836,6 +2107,54 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
             val = self.form.frameSlider.maximum()
 
         self.form.frameSlider.setValue(val)
+
+    def requestFrameAsync(self, frame, *, include_input=False):
+        """Select one exact paused frame, completing after native adoption."""
+        if not self._ownsLiveTaskContext() or not self.background_frames:
+            raise RuntimeError('The asynchronous simulation player is not ready')
+        frame = int(frame)
+        if not (0 if include_input else 1) <= frame < self.assembly.numberOfFrames():
+            raise RuntimeError('The requested simulation frame is out of range')
+        self.stopAnimation()
+        self._cancelPendingFrame()
+        result = Future()
+
+        def cleanup():
+            self.frameFinished.disconnect(finished)
+            self.playbackClosed.disconnect(closed)
+
+        def finished(applied_frame, ok):
+            if applied_frame != frame:
+                return
+            cleanup()
+            if result.set_running_or_notify_cancel():
+                if ok:
+                    result.set_result(frame)
+                else:
+                    result.set_exception(RuntimeError(self.frame_error or 'Simulation frame was cancelled'))
+
+        def closed():
+            cleanup()
+            if result.set_running_or_notify_cancel():
+                result.set_exception(RuntimeError('Simulation player closed before the frame applied'))
+
+        self.frameFinished.connect(finished)
+        self.playbackClosed.connect(closed)
+        slider = self.form.frameSlider
+        was_blocked = slider.blockSignals(True)
+        try:
+            # Frame zero is the input snapshot included by animation export,
+            # not a time sample on the interactive player's 1-based slider.
+            if frame > 0:
+                slider.setValue(frame)
+        finally:
+            slider.blockSignals(was_blocked)
+        self.onFrameChanged(frame)
+        request = self.frame_request
+        result.add_done_callback(
+            lambda future: self.cancelFrameRequested.emit(request) if future.cancelled() else None
+        )
+        return result
 
     def stopAnimation(self):
         self.animationTimer.stop()
@@ -1891,9 +2210,115 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
             self.simFeaturePy.Group = group
             self.doc.removeObject(motion.Name)
 
+    def saveAnimationAsync(self):
+        """Interactive export; no frame generation, encoding or file I/O waits on Qt."""
+        if not self._ownsLiveTaskContext() or self.animation_export is not None:
+            return
+        if not self.background_frames or self.assembly.numberOfFrames() <= 1:
+            QMessageBox.warning(self.form, translate('Assembly', 'Animation'),
+                                translate('Assembly', 'Generate simulation frames before exporting.'))
+            return
+        file_path, selected_filter = QFileDialog.getSaveFileName(
+            self.form, translate('Assembly', 'Save Animation'), '',
+            'MP4 Video (*.mp4);;Animated GIF (*.gif);;AVI Video (*.avi)',
+        )
+        if not file_path:
+            return
+        if not Path(file_path).suffix:
+            file_path += '.gif' if '*.gif' in selected_filter else (
+                '.avi' if '*.avi' in selected_filter else '.mp4'
+            )
+        try:
+            if Path(file_path).suffix.lower() not in {'.gif', '.mp4', '.avi'}:
+                raise ValueError('Animation export requires GIF, MP4 or AVI')
+            from AnimationExport import AnimationExportController, AnimationExportJob
+            from VibeCADCore import get_service
+            from VibeCADHostIsolation import execute_staged_script, _freecadcmd
+            import VibeCADHostIsolation
+            from VibeCADPreferences import load_settings
+
+            self.stopAnimation()
+            self._cancelPendingFrame()
+            width, height = self.view.getSize()
+            size = (width - width % 2, height - height % 2)
+            if min(size) <= 0:
+                raise RuntimeError('The animation viewport has no drawable area')
+            # Resolve GUI/application paths before crossing to the supervisor.
+            isolation = {
+                'app': App, 'executable': str(_freecadcmd(App.getHomePath())),
+                'module_root': str(Path(VibeCADHostIsolation.__file__).parent),
+                'memory_limit_bytes': load_settings().scripted_memory_limit_mb * 1024 * 1024,
+                'environment': {},
+            }
+            viewer = self.view.getViewer()
+            # Resolve required native methods before a job owns staging.
+            viewer.startFrameExport
+            viewer.finishFrameExport
+            viewer.cancelFrameExport
+            count = self.assembly.numberOfFrames()
+            progress = QProgressDialog(
+                translate('Assembly', 'Preparing animation export'),
+                translate('Assembly', 'Cancel'), 0, count, self.form,
+            )
+            progress.setWindowModality(Qt.WindowModal)
+            progress.setAutoClose(False)
+            job = AnimationExportJob(
+                get_service().native_background_manager(), document_uid=str(self.doc.Uid),
+                output=file_path, frame_count=count,
+                fps=self.form.FramesPerSecondSpinBox.value(), size=size,
+                execute=execute_staged_script, isolation=isolation,
+            )
+            try:
+                controller = AnimationExportController(self, viewer, job)
+            except Exception:
+                job.manager.cancel(job.job_id)
+                job.finish_capture()
+                raise
+            self.animation_export = controller
+            self.form.SaveAnimationButton.setEnabled(False)
+            progress.canceled.connect(controller.cancel)
+
+            def update(index, message):
+                if self._ownsLiveTaskContext():
+                    label = translate('Assembly', message)
+                    if index < count:
+                        label += f' {index + 1}/{count}'
+                    progress.setLabelText(label)
+                    if index == count:
+                        progress.setRange(0, 0)
+                    else:
+                        progress.setValue(index)
+                    Gui.getMainWindow().statusBar().showMessage(label)
+
+            def finished(snapshot):
+                self.animation_export = None
+                if self._ownsLiveTaskContext():
+                    progress.close()
+                    self.form.SaveAnimationButton.setEnabled(True)
+                error = controller.error or (snapshot.error or {}).get('message', '')
+                if snapshot.phase == 'completed':
+                    App.Console.PrintMessage(f'Animation successfully saved to {file_path}\n')
+                elif snapshot.phase == 'cancelled':
+                    App.Console.PrintMessage('Animation export cancelled.\n')
+                if error and snapshot.phase != 'cancelled':
+                    App.Console.PrintError(f'Animation export: {error}\n')
+                if self._ownsLiveTaskContext():
+                    Gui.getMainWindow().statusBar().showMessage(
+                        error or translate('Assembly', 'Animation export ' + snapshot.phase)
+                    )
+                controller.deleteLater()
+
+            controller.progress.connect(update)
+            controller.finished.connect(finished)
+            progress.show()
+        except Exception as error:
+            QMessageBox.critical(self.form, translate('Assembly', 'Animation export'), str(error))
+
     def saveAnimation(self):
         if not self._ownsLiveTaskContext():
             return
+        self.animationTimer.stop()
+        self._cancelPendingFrame()
         num_frames = self.assembly.numberOfFrames()
         if num_frames <= 1:
             QMessageBox.warning(
@@ -1941,6 +2366,7 @@ class TaskAssemblyCreateSimulation(QtCore.QObject):
 
             try:
                 # Generate and save all frames as temporary images
+                self._restoreSimulationGraphics()
                 frame_files = []
                 for i in range(num_frames):
                     progress.setValue(i)
@@ -2053,6 +2479,172 @@ def _simulationFrameTime(simulation, frame):
     )
 
 
+def _simulationRequestedFrame(simulation, time_seconds, frame_count):
+    start_time = float(simulation.aTimeStart.Value)
+    time_step = float(simulation.cTimeStepOutput.Value)
+    if time_step <= 0:
+        raise RuntimeError("The simulation has no positive output time step")
+    first_time = _simulationFrameTime(simulation, 1)
+    end_time = _simulationFrameTime(simulation, frame_count - 1)
+    requested_time = float(time_seconds)
+    if requested_time < first_time or requested_time > end_time:
+        raise RuntimeError(
+            "Requested playback time "
+            f"{requested_time:g} s is outside the saved simulation range "
+            f"{first_time:g}..{end_time:g} s"
+        )
+    return round((requested_time - start_time) / time_step) + 1
+
+
+_simulationPlayback = None
+
+
+def _simulationTaskDialog(panel):
+    """Native task wrappers are transient; identify the exact hosted Qt form."""
+    dialog = Gui.Control.activeTaskDialog()
+    if dialog is not None and panel.form is not None:
+        for widget in dialog.getDialogContent():
+            if widget is panel.form or widget.isAncestorOf(panel.form):
+                return dialog
+    return None
+
+
+def findSimulationPlayback(simulation, *, presentation=None, hidden_components=(), camera=""):
+    """Return only our exact live saved-player task with the same presentation.
+
+    Keep a weak panel reference; never infer ownership from a task title,
+    transient native wrapper, or object name.
+    """
+    if _simulationPlayback is None:
+        return None
+    panel_ref, shown_presentation, hidden, shown_camera = _simulationPlayback
+    panel = panel_ref()
+    if (panel is None or _simulationTaskDialog(panel) is None
+            or panel.simFeaturePy is not simulation or not panel._ownsLiveTaskContext()
+            or shown_presentation is not presentation or shown_camera != camera
+            or len(hidden) != len(hidden_components)
+            or any(first is not second for first, second in zip(hidden, hidden_components))):
+        return None
+    return panel
+
+
+def controlSimulationPlaybackAsync(panel, *, autoplay=False, time_seconds=None):
+    """Seek the existing player without a second solve; finish after adoption."""
+    frame = (int(panel.form.frameSlider.value()) if time_seconds is None else
+             _simulationRequestedFrame(panel.simFeaturePy, time_seconds,
+                                       int(panel.assembly.numberOfFrames())))
+    pending = panel.requestFrameAsync(frame)
+    result = Future()
+
+    def complete(_done):
+        if not result.set_running_or_notify_cancel():
+            return
+        try:
+            pending.result()
+            if autoplay:
+                panel.animationTimerStartForward()
+            result.set_result(panel)
+        except Exception as error:
+            result.set_exception(error)
+
+    result.add_done_callback(lambda done: pending.cancel() if done.cancelled() else None)
+    pending.add_done_callback(complete)
+    return result
+
+
+def openSimulationAsync(
+    simulation,
+    *,
+    autoplay=False,
+    time_seconds=None,
+    presentation=None,
+    hidden_components=(),
+    camera="",
+):
+    """Start on the GUI owner and resolve only after the requested frame applies.
+
+    Generation and frame computation use the native runtime. No event pumping
+    or wait occurs here. Cancellation is delivered to the exact task via Qt.
+    The synchronous openSimulation contract remains available to external callers.
+    """
+    panel = openSimulation(
+        simulation, presentation=presentation,
+        hidden_components=hidden_components, camera=camera,
+    )
+    dialog = Gui.Control.activeTaskDialog()
+    result = Future()
+    expected_frame = None
+
+    def cleanup():
+        panel.generationFinished.disconnect(generated)
+        panel.frameFinished.disconnect(displayed)
+        panel.playbackClosed.disconnect(closed)
+
+    def fail(error):
+        cleanup()
+        if result.set_running_or_notify_cancel():
+            result.set_exception(error)
+        panel.rejectPlaybackRequested.emit(dialog)
+
+    def closed():
+        cleanup()
+        if result.set_running_or_notify_cancel():
+            result.set_exception(RuntimeError("Simulation player closed before launch completed"))
+
+    def displayed(frame, ok):
+        if expected_frame is None or frame != expected_frame:
+            return
+        if not ok:
+            fail(RuntimeError(panel.frame_error or "Simulation frame was cancelled"))
+            return
+        cleanup()
+        if result.set_running_or_notify_cancel():
+            try:
+                if autoplay:
+                    panel.animationTimerStartForward()
+                result.set_result(panel)
+            except Exception as error:
+                result.set_exception(error)
+                panel.rejectPlaybackRequested.emit(dialog)
+
+    def generated(ok):
+        nonlocal expected_frame
+        if not ok:
+            fail(RuntimeError(panel.generation_error or "Simulation generation was cancelled"))
+            return
+        try:
+            count = int(panel.assembly.numberOfFrames())
+            if count < 2:
+                raise RuntimeError("The simulation generated fewer than two frames")
+            expected_frame = (
+                count - 1 if time_seconds is None
+                else _simulationRequestedFrame(simulation, time_seconds, count)
+            )
+            # Generate already requested its last frame, but it has not applied
+            # yet. A different requested time supersedes that native request.
+            if int(panel.form.frameSlider.value()) != expected_frame:
+                panel.setFrameValue(expected_frame)
+            elif presentation is None and panel.graphics_frame_active:
+                # Graphics-only cached frames complete synchronously. The
+                # generation callback therefore runs after the final frame's
+                # signal rather than before it.
+                displayed(expected_frame, True)
+        except Exception as error:
+            fail(error)
+
+    panel.generationFinished.connect(generated)
+    panel.frameFinished.connect(displayed)
+    panel.playbackClosed.connect(closed)
+    result.add_done_callback(
+        lambda future: panel.rejectPlaybackRequested.emit(dialog) if future.cancelled() else None
+    )
+    try:
+        panel.runKinematicsAsync()
+    except Exception as error:
+        fail(error)
+    return result
+
+
 def openSimulation(
     simulation,
     *,
@@ -2114,22 +2706,9 @@ def openSimulation(
             if assembly.numberOfFrames() < 2:
                 raise RuntimeError("The simulation generated fewer than two frames")
         if time_seconds is not None:
-            start_time = float(simulation.aTimeStart.Value)
-            time_step = float(simulation.cTimeStepOutput.Value)
-            if time_step <= 0:
-                raise RuntimeError("The simulation has no positive output time step")
-            last_frame = assembly.numberOfFrames() - 1
-            first_frame = 1
-            first_time = _simulationFrameTime(simulation, first_frame)
-            end_time = _simulationFrameTime(simulation, last_frame)
-            requested_time = float(time_seconds)
-            if requested_time < first_time or requested_time > end_time:
-                raise RuntimeError(
-                    "Requested playback time "
-                    f"{requested_time:g} s is outside the saved simulation range "
-                    f"{first_time:g}..{end_time:g} s"
-                )
-            requested_frame = round((requested_time - start_time) / time_step) + 1
+            requested_frame = _simulationRequestedFrame(
+                simulation, time_seconds, assembly.numberOfFrames()
+            )
             panel.setFrameValue(requested_frame)
         if autoplay:
             panel.animationTimerStartForward()
@@ -2137,6 +2716,16 @@ def openSimulation(
         if dialog is not None:
             dialog.reject()
         raise
+    global _simulationPlayback
+    binding = (weakref.ref(panel), presentation, tuple(hidden_components), camera)
+    _simulationPlayback = binding
+
+    def releasePlayback():
+        global _simulationPlayback
+        if _simulationPlayback is binding:
+            _simulationPlayback = None
+
+    panel.playbackClosed.connect(releasePlayback)
     return panel
 
 

--- a/src/Mod/Assembly/JointObject.py
+++ b/src/Mod/Assembly/JointObject.py
@@ -640,8 +640,12 @@ class Joint:
             joint.addExtension("App::SuppressibleExtensionPython")
 
         if App.GuiUp:
-            if not joint.ViewObject.hasExtension("Gui::ViewProviderSuppressibleExtensionPython"):
-                joint.ViewObject.addExtension("Gui::ViewProviderSuppressibleExtensionPython")
+            def restore_view_extension():
+                view = joint.ViewObject
+                if not view.hasExtension("Gui::ViewProviderSuppressibleExtensionPython"):
+                    view.addExtension("Gui::ViewProviderSuppressibleExtensionPython")
+
+            Gui.runOnMainThread(restore_view_extension)
 
         if hasattr(joint, "Activated"):
             activated = joint.Activated
@@ -778,7 +782,22 @@ class Joint:
         return None
 
     def getAssembly(self, joint):
-        return UtilsAssembly.findOwningPartOrAssembly(joint)
+        document = joint.Document
+        if not UtilsAssembly._document_is_open(document):
+            return None
+        key = (str(document.Uid), joint.ID, document.getObjectStructureGeneration())
+        cached = getattr(self, "_owner_cache", None)
+        if cached is not None and cached[0] == key:
+            name, identity = cached[1:]
+            if name is None:
+                return None
+            owner = document.getObject(name)
+            if owner is not None and owner.ID == identity:
+                return owner
+        owner = UtilsAssembly.findOwningPartOrAssembly(joint)
+        # Retain identities, not document/owner wrappers that could outlive close.
+        self._owner_cache = (key, owner.Name, owner.ID) if owner is not None else (key, None, None)
+        return owner
 
     def setJointType(self, joint, newType):
         oldType = joint.JointType
@@ -789,8 +808,17 @@ class Joint:
         """Do something when a property has changed"""
         # App.Console.PrintMessage("Change property: " + str(prop) + "\n")
 
-        # during loading the onchanged may be triggered before full init.
-        if App.isRestoring():
+        # Metadata and playback placements have no action in this handler.
+        # Reject them before resolving History state or an owning assembly.
+        if prop not in {"JointType", "Reference1", "Reference2", "Offset1", "Offset2",
+                        "Distance", "Angle"}:
+            return
+
+        # Loading and transaction replay restore the complete saved state.
+        # Reacting to each intermediate joint value can launch a whole assembly
+        # solve during abort/undo/redo, and overwrite values being restored.
+        # Transacting means replay, not an open interactive command transaction.
+        if App.isRestoring() or joint.Document.Transacting:
             return
         if not _jointInteractionUsable(joint):
             return
@@ -810,6 +838,9 @@ class Joint:
 
         if prop == "Reference1" or prop == "Reference2":
             joint.recompute()
+
+        if prop in {"JointType", "Reference1", "Reference2"}:
+            return
 
         if (
             not hasattr(joint, "Reference1")
@@ -864,7 +895,13 @@ class Joint:
         ):
             raise Exception(errStr + "Reference2")
 
-        self.updateJCSPlacements(joint)
+        # Recompute is model work and may execute on a document worker.
+        # ViewObject and Coin remain owned by Qt; placement notifications
+        # update their presentation after this model-only callback completes.
+        self.updateJCSPlacements(joint, redraw=False)
+
+    def supportsAsyncRecompute(self, _joint):
+        return True
 
     def setJointConnectors(self, joint, refs):
         # current selection is a vector of strings like "Assembly.Assembly1.Assembly2.Body.Pad.Edge16" including both what selection return as obj_name and obj_sub
@@ -916,14 +953,15 @@ class Joint:
                 assembly.undoSolve()
             self.undoPreSolve(joint)
 
-    def updateJCSPlacements(self, joint):
+    def updateJCSPlacements(self, joint, *, redraw=True):
         if not joint.Detach1:
             joint.Placement1 = self.findPlacement(joint, joint.Reference1, 0)
 
         if not joint.Detach2:
             joint.Placement2 = self.findPlacement(joint, joint.Reference2, 1)
 
-        self.redrawJointPlacements(joint)
+        if redraw:
+            self.redrawJointPlacements(joint)
 
     def redrawJointPlacements(self, joint):
         if joint.ViewObject:
@@ -1165,6 +1203,11 @@ class ViewProviderJoint:
 
     def updateData(self, joint, prop):
         """If a property of the handled feature has changed we have the chance to handle this here"""
+        if prop not in {"Placement1", "Placement2"}:
+            return
+        view = joint.ViewObject
+        if view is None or not view.Visibility:
+            return
         if prop == "Placement1" and hasattr(joint, "Reference1"):
             self.redrawJointPlacement(self.switch_JCS1, joint.Placement1, joint.Reference1)
 
@@ -1172,6 +1215,8 @@ class ViewProviderJoint:
             self.redrawJointPlacement(self.switch_JCS2, joint.Placement2, joint.Reference2)
 
     def redrawJointPlacements(self, joint):
+        if joint.ViewObject is None or not joint.ViewObject.Visibility:
+            return
         if not hasattr(joint, "Reference1") or not hasattr(joint, "Reference2"):
             return
 
@@ -1220,6 +1265,8 @@ class ViewProviderJoint:
 
     def onChanged(self, vp, prop):
         """Here we can do something when a single property got changed"""
+        if prop == "Visibility" and vp.Visibility:
+            self.redrawJointPlacements(vp.Object)
         # App.Console.PrintMessage("Change property: " + str(prop) + "\n")
         if prop == "color_X_axis" or prop == "color_Y_axis" or prop == "color_Z_axis":
             self.switch_JCS1.onChanged(vp, prop)
@@ -1409,6 +1456,9 @@ class GroundedJoint:
         # App.Console.PrintMessage("Recompute Python Box feature\n")
         pass
 
+    def supportsAsyncRecompute(self, _joint):
+        return True
+
 
 class ViewProviderGroundedJoint:
     def __init__(self, obj):
@@ -1575,6 +1625,10 @@ def _ensureViewProvider(joint, provider_type):
     if not App.GuiUp:
         return None
 
+    return Gui.runOnMainThread(_ensureViewProviderOnGui, joint, provider_type)
+
+
+def _ensureViewProviderOnGui(joint, provider_type):
     view = getattr(joint, "ViewObject", None)
     if view is None:
         return None

--- a/src/Mod/Assembly/SoSwitchMarker.py
+++ b/src/Mod/Assembly/SoSwitchMarker.py
@@ -61,6 +61,10 @@ class SoSwitchMarker(coin.SoSwitch):
         self.gui_doc = Gui.getDocument(app_doc)
 
         self.transform = coin.SoTransform()
+        # Coin fields live as long as this retained transform. Avoid repeated
+        # Python-to-Coin name lookup for every marker in every displayed frame.
+        self._translation = self.transform.translation
+        self._rotation = self.transform.rotation
 
         self.draw_style = coin.SoDrawStyle()
         self.draw_style.style = coin.SoDrawStyle.LINES
@@ -149,10 +153,10 @@ class SoSwitchMarker(coin.SoSwitch):
         placement = global_plc * placement
 
         t = placement.Base
-        self.transform.translation.setValue(t.x, t.y, t.z)
+        self._translation.setValue(t.x, t.y, t.z)
 
         r = placement.Rotation.Q
-        self.transform.rotation.setValue(r[0], r[1], r[2], r[3])
+        self._rotation.setValue(r[0], r[1], r[2], r[3])
 
     def setPickableState(self, state: bool):
         """Set JCS selectable or unselectable in 3D view"""

--- a/src/Mod/Assembly/UtilsAssembly.py
+++ b/src/Mod/Assembly/UtilsAssembly.py
@@ -22,6 +22,8 @@
 # **************************************************************************/
 
 import math
+import threading
+from contextlib import contextmanager
 
 import FreeCAD as App
 import Part
@@ -36,6 +38,35 @@ translate = App.Qt.translate
 __title__ = "Assembly utilitary functions"
 __author__ = "Ondsel"
 __url__ = "https://www.freecad.org"
+
+
+_presentation_changes = threading.local()
+
+
+@contextmanager
+def presentationPlacementChanges(document, object_ids, assembly=None):
+    """Identify exact transient placement notifications within one owner callback.
+
+    This is not a document lease or a session-wide edit exemption. Callers must
+    not pump events or yield inside the scope. Other properties, objects and
+    threads retain their normal mutation semantics.
+    """
+    previous = getattr(_presentation_changes, 'current', None)
+    native_previous = assembly.setSimulationPresentation(True) if assembly is not None else None
+    _presentation_changes.current = (document, object_ids)
+    try:
+        yield
+    finally:
+        _presentation_changes.current = previous
+        if assembly is not None:
+            assembly.setSimulationPresentation(native_previous)
+
+
+def isPresentationPlacementChange(obj, property_name):
+    if property_name not in {'Placement', 'LinkPlacement'}:
+        return False
+    current = getattr(_presentation_changes, 'current', None)
+    return bool(current is not None and obj.Document is current[0] and obj.ID in current[1])
 
 
 def activePartOrAssembly():
@@ -2206,9 +2237,11 @@ def _restoreExactAssemblyPartPlacements(
             )
         return False
 
-    for part, placement in live_parts:
-        part.Placement = App.Placement(placement)
-        part.purgeTouched()
+    with presentationPlacementChanges(document, frozenset(part.ID for part, _ in live_parts), assembly):
+        for part, placement in live_parts:
+            if not part.Placement.isSame(placement):
+                part.Placement = App.Placement(placement)
+                part.purgeTouched()
     return True
 
 

--- a/src/Mod/Inspection/Gui/Command.cpp
+++ b/src/Mod/Inspection/Gui/Command.cpp
@@ -71,7 +71,10 @@ bool CmdVisualInspection::isActive()
     App::Document* document = App::GetApplication().getActiveDocument();
     return document && PartGui::canStartRetainedModelingTask(document)
         && !Gui::Control().activeDialog()
-        && InspectionGui::VisualInspection::candidateObjects(document).size() >= 2;
+        // Enablement only needs two eligible sources. The dialog requests the
+        // complete list when opened; do not resolve every shape on each shared
+        // command refresh after the answer is already known.
+        && InspectionGui::VisualInspection::candidateObjects(document, 2).size() == 2;
 }
 
 //--------------------------------------------------------------------------------------

--- a/src/Mod/Inspection/Gui/VisualInspection.cpp
+++ b/src/Mod/Inspection/Gui/VisualInspection.cpp
@@ -56,8 +56,14 @@ constexpr int ObjectIdRole = Qt::UserRole + 1;
 
 std::vector<App::DocumentObject*> VisualInspection::candidateObjects(App::Document* document)
 {
+    return candidateObjects(document, std::numeric_limits<std::size_t>::max());
+}
+
+std::vector<App::DocumentObject*> VisualInspection::candidateObjects(
+    App::Document* document, std::size_t maximum)
+{
     std::vector<App::DocumentObject*> candidates;
-    if (!document) {
+    if (!document || maximum == 0) {
         return candidates;
     }
 
@@ -83,6 +89,9 @@ std::vector<App::DocumentObject*> VisualInspection::candidateObjects(App::Docume
         Inspection::ResolvedSource source;
         if (Inspection::resolveSource(candidate, document, source)) {
             candidates.push_back(candidate);
+            if (candidates.size() == maximum) {
+                break;
+            }
         }
     }
     return candidates;

--- a/src/Mod/Inspection/Gui/VisualInspection.h
+++ b/src/Mod/Inspection/Gui/VisualInspection.h
@@ -52,6 +52,8 @@ public:
     void accept() override;
 
     static std::vector<App::DocumentObject*> candidateObjects(App::Document* document);
+    static std::vector<App::DocumentObject*> candidateObjects(
+        App::Document* document, std::size_t maximum);
 
 protected Q_SLOTS:
     void onActivateItem(QTreeWidgetItem*);

--- a/src/Mod/Inspection/TestInspectionGui.py
+++ b/src/Mod/Inspection/TestInspectionGui.py
@@ -5,6 +5,7 @@
 import os
 from pathlib import Path
 import tempfile
+import time
 import unittest
 
 import FreeCAD as App
@@ -669,6 +670,44 @@ class InspectionTimelineTest(unittest.TestCase):
         )
         self.assertFalse(replay_actual.Visibility)
         self.assertFalse(replay_nominal.Visibility)
+
+    def test_visual_inspection_enablement_stops_after_two_candidates(self):
+        def wait_for_display():
+            deadline = time.monotonic() + 10
+            while (self.document.PresentationUpdateActive
+                   or self.document.CooperativeMutationActive):
+                self.assertLess(time.monotonic(), deadline, "Display did not settle")
+                self._process_events(10)
+
+        command = Gui.Command.get("Inspection_VisualInspection")
+        self.assertFalse(command.isActive())
+        first = self.document.addObject("Part::Feature", "FirstCandidate")
+        first.Shape = Part.makeBox(2, 2, 2)
+        self.assertFalse(command.isActive())
+        second = self.document.addObject("Part::Feature", "SecondCandidate")
+        second.Shape = first.Shape
+
+        class ObservedSource:
+            calls = 0
+
+            def getLinkedObject(self, obj, recurse, matrix, transform, depth):
+                self.calls += 1
+                return None
+
+        tail = self.document.addObject("App::FeaturePython", "UnneededCandidate")
+        observer = ObservedSource()
+        tail.Proxy = observer
+        self._process_events()
+        wait_for_display()
+        observer.calls = 0
+        self.assertTrue(command.isActive())
+        self.assertEqual(observer.calls, 0,
+                         "Button enablement must not resolve the rest of the document")
+        self.document.removeObject(second.Name)
+        observer.calls = 0
+        self.assertFalse(command.isActive())
+        self.assertGreater(observer.calls, 0,
+                           "Fewer than two candidates must still check remaining sources")
 
     def test_visual_inspection_offers_linked_part_mesh_and_points_occurrences(self):
         if not App.GuiUp:

--- a/src/Mod/Material/App/AppMaterial.cpp
+++ b/src/Mod/Material/App/AppMaterial.cpp
@@ -26,6 +26,7 @@
 #include <Base/PyObjectBase.h>
 
 #include <App/CleanupProcess.h>
+#include <App/HostRuntime.h>
 
 #include "MaterialLoader.h"
 #include "MaterialManagerLocal.h"
@@ -130,6 +131,20 @@ PyMOD_INIT_FUNC(Materials)
 
     Materials::PropertyMaterial         ::init();
     // clang-format on
+
+    // Material discovery parses every configured library. Start that one-time
+    // I/O work as soon as the module is ready so the first Part feature does
+    // not perform the catalog scan on the GUI thread during document restore.
+    // The application-owned runtime outlives this module and owns the task.
+    [[maybe_unused]] auto materialInitialization =
+        App::GetApplication().hostRuntime().submit(
+            App::HostRuntime::Lane::Io,
+            [](std::stop_token stopToken) {
+                if (!stopToken.stop_requested()) {
+                    (void)Materials::MaterialManager::getManager();
+                }
+            }
+        );
 
     PyMOD_Return(module);
 }

--- a/src/Mod/Material/App/MaterialManager.cpp
+++ b/src/Mod/Material/App/MaterialManager.cpp
@@ -42,6 +42,9 @@
 #include "ModelManager.h"
 #include "ModelUuids.h"
 
+#include <chrono>
+#include <cstdlib>
+
 #include <Base/Tools.h>
 
 
@@ -80,15 +83,21 @@ MaterialManager::~MaterialManager()
 
 MaterialManager& MaterialManager::getManager()
 {
-    if (!_manager) {
-        initManagers();
-    }
+    // Always enter the initialization lock. The old unlocked fast-path raced
+    // with process-lifetime workers performing eager catalog discovery.
+    initManagers();
     return *_manager;
 }
 
 void MaterialManager::initManagers()
 {
     QMutexLocker locker(&_mutex);
+
+    if (_manager && _localManager) {
+        return;
+    }
+
+    const auto started = std::chrono::steady_clock::now();
 
     if (!_manager) {
         // Can't use smart pointers for this since the constructor is private
@@ -103,6 +112,16 @@ void MaterialManager::initManagers()
         _externalManager = std::make_unique<MaterialManagerExternal>();
     }
 #endif
+
+    if (std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr) {
+        const auto elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - started
+        ).count();
+        Base::Console().message(
+            "VIBECAD_RESTORE_DETAIL material_catalog_init elapsed_ms=%lld\n",
+            static_cast<long long>(elapsed)
+        );
+    }
 }
 
 void MaterialManager::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp::MessageType Reason)
@@ -117,6 +136,8 @@ void MaterialManager::OnChange(ParameterGrp::SubjectType& rCaller, ParameterGrp:
 
 void MaterialManager::cleanup()
 {
+    QMutexLocker locker(&_mutex);
+
     if (_localManager) {
         _localManager->cleanup();
     }
@@ -129,6 +150,8 @@ void MaterialManager::cleanup()
 
 void MaterialManager::refresh()
 {
+    initManagers();
+    QMutexLocker locker(&_mutex);
     _localManager->refresh();
 }
 

--- a/src/Mod/Mesh/App/Core/MeshKernel.cpp
+++ b/src/Mod/Mesh/App/Core/MeshKernel.cpp
@@ -58,7 +58,7 @@ MeshKernel::MeshKernel(const MeshKernel& rclMesh)
 
 MeshKernel::MeshKernel(MeshKernel&& rclMesh)
 {
-    *this = rclMesh;
+    *this = std::move(rclMesh);
 }
 
 MeshKernel& MeshKernel::operator=(const MeshKernel& rclMesh)

--- a/src/Mod/Mesh/App/Mesh.cpp
+++ b/src/Mod/Mesh/App/Mesh.cpp
@@ -85,11 +85,8 @@ MeshObject::MeshObject(const MeshObject& mesh)
 }
 
 MeshObject::MeshObject(MeshObject&& mesh)
-    : _Mtrx(mesh._Mtrx)
-    , _kernel(mesh._kernel)
 {
-    // copy the mesh structure
-    copySegments(mesh);
+    *this = std::move(mesh);
 }
 
 MeshObject::~MeshObject() = default;
@@ -246,10 +243,13 @@ MeshObject& MeshObject::operator=(const MeshObject& mesh)
 MeshObject& MeshObject::operator=(MeshObject&& mesh)
 {
     if (this != &mesh) {
-        // copy the mesh structure
         setTransform(mesh._Mtrx);
-        this->_kernel = mesh._kernel;
-        copySegments(mesh);
+        this->_kernel = std::move(mesh._kernel);
+        this->_segments = std::move(mesh._segments);
+        // Segment iterators resolve geometry through their owning MeshObject.
+        for (auto& segment : this->_segments) {
+            segment._mesh = this;
+        }
     }
 
     return *this;

--- a/src/Mod/Mesh/App/MeshProperties.cpp
+++ b/src/Mod/Mesh/App/MeshProperties.cpp
@@ -986,10 +986,10 @@ void PropertyMeshKernel::RestoreDocFile(Base::Reader& reader)
 App::Property* PropertyMeshKernel::Copy() const
 {
     // Note: Copy the content, do NOT reference the same mesh object
-    PropertyMeshKernel* prop = new PropertyMeshKernel();
-    const auto snapshot = _meshObject->snapshot();
-    *(prop->_meshObject) = *snapshot;
-    return prop;
+    auto prop = std::make_unique<PropertyMeshKernel>();
+    auto snapshot = _meshObject->snapshot();
+    prop->_meshObject = snapshot.release();
+    return prop.release();
 }
 
 void PropertyMeshKernel::Paste(const App::Property& from)
@@ -999,7 +999,9 @@ void PropertyMeshKernel::Paste(const App::Property& from)
     const PropertyMeshKernel& prop = dynamic_cast<const PropertyMeshKernel&>(from);
     const auto snapshot = prop._meshObject->snapshot();
     auto lock = _meshObject->acquireMutationLock();
-    *(this->_meshObject) = *snapshot;
+    // Preserve the mesh object's identity for existing Python wrappers, but
+    // transfer the detached snapshot's buffers instead of copying them again.
+    *(this->_meshObject) = std::move(*snapshot);
     bumpGeometryRevision();
     lock.unlock();
     hasSetValue();

--- a/src/Mod/Part/App/AppPartPy.cpp
+++ b/src/Mod/Part/App/AppPartPy.cpp
@@ -72,6 +72,10 @@
 #include <BRepFill_Generator.hxx>
 
 #include <App/Application.h>
+#include <App/HostRuntime.h>
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
 #include <App/Document.h>
 #include <App/DocumentObjectPy.h>
 #include <App/ElementNamingUtils.h>
@@ -468,6 +472,12 @@ public:
             "export(list,string) -- Export a list of objects into a single file."
         );
         add_varargs_method("read", &Module::read, "read(string) -- Load the file and return the shape.");
+        add_varargs_method(
+            "readBrepShapes", &Module::readBrepShapes,
+            "readBrepShapes(paths) -- Import and validate independent BREP files on the shared "
+            "compute pool. Returns detached shapes in input order; raises ValueError if any "
+            "artifact is invalid. Does not create or mutate document objects."
+        );
         add_varargs_method(
             "show",
             &Module::show,
@@ -968,6 +978,83 @@ private:
         TopoShape* shape = new TopoShape();
         shape->read(EncodedName.c_str());
         return Py::asObject(new TopoShapePy(shape));
+    }
+    Py::Object readBrepShapes(const Py::Tuple& args)
+    {
+        PyObject* input = nullptr;
+        if (!PyArg_ParseTuple(args.ptr(), "O", &input)) {
+            throw Py::Exception();
+        }
+        if (PyUnicode_Check(input) || !PySequence_Check(input)) {
+            throw Py::TypeError("paths must be a sequence of strings");
+        }
+        Py::Sequence sequence(input);
+        std::vector<std::string> paths;
+        paths.reserve(sequence.size());
+        for (Py_ssize_t index = 0; index < sequence.size(); ++index) {
+            Py::Object item = sequence[index];
+            if (!PyUnicode_Check(item.ptr())) {
+                throw Py::TypeError("Every BREP path must be a string");
+            }
+            paths.push_back(Py::String(item).as_std_string());
+            if (paths.back().find('\0') != std::string::npos) {
+                throw Py::ValueError("BREP paths cannot contain NUL");
+            }
+        }
+        std::vector<std::unique_ptr<TopoShape>> shapes(paths.size());
+        std::vector<std::string> errors(paths.size());
+        std::atomic_size_t active {0};
+        std::atomic_size_t peak {0};
+        const char* traceValue = std::getenv("VIBECAD_TRACE_NATIVE_EVENTS");
+        const bool trace = traceValue && *traceValue && *traceValue != '0';
+        const auto started = std::chrono::steady_clock::now();
+        try {
+            Base::PyGILStateRelease release;
+            App::GetApplication().hostRuntime().parallelFor(paths.size(), [&](std::size_t index) {
+                if (trace) {
+                    const auto count = active.fetch_add(1) + 1;
+                    auto observed = peak.load();
+                    while (observed < count && !peak.compare_exchange_weak(observed, count)) {}
+                }
+                try {
+                    auto shape = std::make_unique<TopoShape>();
+                    shape->importBrep(paths[index].c_str());
+                    if (shape->isNull() || !shape->isValid()) {
+                        errors[index] = "Null or invalid BREP";
+                    }
+                    else {
+                        shapes[index] = std::move(shape);
+                    }
+                }
+                catch (const Standard_Failure& error) {
+                    const char* message = error.GetMessageString();
+                    errors[index] = message ? message : "BREP import or validation failed";
+                }
+                catch (const std::exception& error) {
+                    errors[index] = error.what();
+                }
+                if (trace) {
+                    active.fetch_sub(1);
+                }
+            });
+        }
+        catch (const std::exception& error) {
+            throw Py::RuntimeError(error.what());
+        }
+        if (trace) {
+            const auto milliseconds = std::chrono::duration<double, std::milli>(
+                std::chrono::steady_clock::now() - started).count();
+            Base::Console().message("VIBECAD_ARTIFACT brep count=%zu peak_workers=%zu elapsed_ms=%.3f\n",
+                                paths.size(), peak.load(), milliseconds);
+        }
+        Py::List result;
+        for (std::size_t index = 0; index < shapes.size(); ++index) {
+            if (!shapes[index]) {
+                throw Py::ValueError("BREP artifact " + std::to_string(index) + ": " + errors[index]);
+            }
+            result.append(Py::asObject(new TopoShapePy(shapes[index].release())));
+        }
+        return result;
     }
     Py::Object show(const Py::Tuple& args)
     {

--- a/src/Mod/Part/App/CMakeLists.txt
+++ b/src/Mod/Part/App/CMakeLists.txt
@@ -548,6 +548,8 @@ SET(Part_SRCS
     AppPartPy.cpp
     BRepMesh.cpp
     BRepMesh.h
+    RenderMesh.cpp
+    RenderMesh.h
     BRepOffsetAPI_MakeOffsetFix.cpp
     BRepOffsetAPI_MakeOffsetFix.h
     BSplineCurveBiArcs.cpp

--- a/src/Mod/Part/App/PartFeature.cpp
+++ b/src/Mod/Part/App/PartFeature.cpp
@@ -23,6 +23,8 @@
  ***************************************************************************/
 
 
+#include <chrono>
+#include <cstdlib>
 #include <sstream>
 #include <Bnd_Box.hxx>
 #include <BRep_Builder.hxx>
@@ -95,9 +97,30 @@ PROPERTY_SOURCE(Part::Feature, App::GeoFeature)
 
 Feature::Feature()
 {
+    const bool traceConstruction = std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
+    const auto traceStart = std::chrono::steady_clock::now();
     ADD_PROPERTY(Shape, (TopoDS_Shape()));
+    const auto shapeReady = std::chrono::steady_clock::now();
     auto mat = Materials::MaterialManager::defaultMaterial();
+    const auto materialReady = std::chrono::steady_clock::now();
     ADD_PROPERTY(ShapeMaterial, (*mat));
+    const auto propertyReady = std::chrono::steady_clock::now();
+    if (traceConstruction) {
+        const auto elapsed = [](auto begin, auto end) {
+            return std::chrono::duration_cast<std::chrono::milliseconds>(end - begin).count();
+        };
+        const auto total = elapsed(traceStart, propertyReady);
+        if (total >= 20) {
+            Base::Console().message(
+                "VIBECAD_RESTORE_DETAIL part_feature_ctor shape_ms=%lld "
+                "default_material_ms=%lld material_property_ms=%lld total_ms=%lld\n",
+                static_cast<long long>(elapsed(traceStart, shapeReady)),
+                static_cast<long long>(elapsed(shapeReady, materialReady)),
+                static_cast<long long>(elapsed(materialReady, propertyReady)),
+                static_cast<long long>(total)
+            );
+        }
+    }
 }
 
 Feature::~Feature() = default;

--- a/src/Mod/Part/App/ProgressIndicator.cpp
+++ b/src/Mod/Part/App/ProgressIndicator.cpp
@@ -47,14 +47,23 @@ ProgressIndicator::ProgressIndicator()
     progress = std::make_unique<Base::SequencerLauncher>("Processing...", 100);
 }
 
+ProgressIndicator::ProgressIndicator(std::stop_token cancellation)
+    : cancellation(cancellation)
+{}
+
 ProgressIndicator::~ProgressIndicator()
 {
-    progress->stop();
+    if (progress) {
+        progress->stop();
+    }
 }
 
 void ProgressIndicator::Show(const Message_ProgressScope& theScope, const Standard_Boolean isForce)
 {
     (void)isForce;
+    if (!progress) {
+        return;
+    }
     const char* name = theScope.Name();
     progress->setText(name ? name : "Processing...");
     std::size_t current = static_cast<std::size_t>(100. * theScope.Value() / theScope.MaxValue());
@@ -66,7 +75,7 @@ void ProgressIndicator::Show(const Message_ProgressScope& theScope, const Standa
 
 Standard_Boolean ProgressIndicator::UserBreak()
 {
-    return progress->wasCanceled();
+    return cancellation.stop_requested() || (progress && progress->wasCanceled());
 }
 
 void ProgressIndicator::Reset()

--- a/src/Mod/Part/App/ProgressIndicator.h
+++ b/src/Mod/Part/App/ProgressIndicator.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <memory>
+#include <stop_token>
 
 #include <Message_ProgressIndicator.hxx>
 #include <Standard_Version.hxx>
@@ -40,6 +41,9 @@ class PartExport ProgressIndicator: public Message_ProgressIndicator
 {
 public:
     ProgressIndicator();
+    /// Kernel cancellation for a worker whose owner already reports progress.
+    /// Does not create another global sequencer or access GUI state.
+    explicit ProgressIndicator(std::stop_token cancellation);
     ~ProgressIndicator() override;
 
     void Show(const Message_ProgressScope& theScope, const Standard_Boolean isForce) override;
@@ -49,6 +53,7 @@ public:
 private:
     std::size_t currentStep {0};
     std::unique_ptr<Base::SequencerLauncher> progress;
+    std::stop_token cancellation;
 };
 
 }  // namespace Part

--- a/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -395,7 +395,11 @@ void PropertyPartShape::Save(Base::Writer& writer) const
     }
     else if (binary) {
         writer.Stream() << " binary=\"1\">\n";
-        _Shape.exportBinary(writer.beginCharStream(Base::CharStreamFormat::Base64Encoded));
+        // OCCT binary persistence queries stream positions. A base64 filter is
+        // not seekable; serialize before encoding instead of passing it to OCCT.
+        std::ostringstream binaryStream;
+        _Shape.exportBinary(binaryStream);
+        writer.beginCharStream(Base::CharStreamFormat::Base64Encoded) << binaryStream.str();
         writer.endCharStream() << writer.ind() << "</Part>\n";
     }
     else {
@@ -456,9 +460,10 @@ void PropertyPartShape::Restore(Base::XMLReader& reader)
         }
     }
     else if (reader.hasAttribute(("binary")) && reader.getAttribute<long>("binary")) {
-        TopoShape shape;
-        shape.importBinary(reader.beginCharStream());
-        shape = shape.getShape();
+        auto& decoded = reader.beginCharStream(Base::CharStreamFormat::Base64Encoded);
+        std::istringstream binaryStream(
+            std::string {std::istreambuf_iterator<char>(decoded), {}});
+        shape.importBinary(binaryStream);
     }
     else if (reader.hasAttribute("brep") && reader.getAttribute<long>("brep")) {
         shape.importBrep(reader.beginCharStream(Base::CharStreamFormat::Raw));

--- a/src/Mod/Part/App/RenderMesh.cpp
+++ b/src/Mod/Part/App/RenderMesh.cpp
@@ -1,0 +1,420 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "RenderMesh.h"
+
+#include <memory>
+#include <stdexcept>
+
+#include <BRepBuilderAPI_Copy.hxx>
+#include <BRepMesh_IncrementalMesh.hxx>
+#include <BRepTools.hxx>
+#include <BRep_Tool.hxx>
+#include <IMeshTools_Parameters.hxx>
+#include <Poly_Array1OfTriangle.hxx>
+#include <Poly_Polygon3D.hxx>
+#include <Poly_PolygonOnTriangulation.hxx>
+#include <Poly_Triangulation.hxx>
+#include <Precision.hxx>
+#include <Standard_Version.hxx>
+#include <TColStd_Array1OfInteger.hxx>
+#include <TColgp_Array1OfDir.hxx>
+#include <TColgp_Array1OfPnt.hxx>
+#include <TopExp.hxx>
+#include <TopExp_Explorer.hxx>
+#include <TopTools_IndexedMapOfShape.hxx>
+#include <TopTools_MapOfShape.hxx>
+#include <TopoDS.hxx>
+#include <TopoDS_Edge.hxx>
+#include <TopoDS_Face.hxx>
+#include <TopoDS_Shape.hxx>
+#include <TopoDS_Vertex.hxx>
+#include <gp_Trsf.hxx>
+
+#include <Base/Converter.h>
+#include <Base/Tools.h>
+#include <App/Application.h>
+#include <App/HostRuntime.h>
+
+#include "Tools.h"
+#include "ProgressIndicator.h"
+
+namespace
+{
+
+constexpr std::int32_t endPrimitive = -1;
+
+void checkCancellation(const std::stop_token& stopToken)
+{
+    if (stopToken.stop_requested()) {
+        throw std::runtime_error("Render mesh preparation cancelled");
+    }
+}
+
+void setVector(std::vector<float>& values, int index, const Base::Vector3f& value)
+{
+    const std::size_t offset = static_cast<std::size_t>(index) * 3;
+    values[offset] = value.x;
+    values[offset + 1] = value.y;
+    values[offset + 2] = value.z;
+}
+
+void addVector(std::vector<float>& values, int index, const Base::Vector3f& value)
+{
+    const std::size_t offset = static_cast<std::size_t>(index) * 3;
+    values[offset] += value.x;
+    values[offset + 1] += value.y;
+    values[offset + 2] += value.z;
+}
+
+}  // namespace
+
+Part::RenderMesh Part::prepareRenderMesh(
+    const TopoDS_Shape& sourceShape,
+    double deviation,
+    double angularDeflection,
+    bool normalsFromUV,
+    std::stop_token stopToken
+)
+{
+    RenderMesh result;
+    checkCancellation(stopToken);
+    if (Tools::isShapeEmpty(sourceShape)) {
+        return result;
+    }
+
+    checkCancellation(stopToken);
+    TopoDS_Shape shape = BRepBuilderAPI_Copy(
+                             sourceShape,
+                             Standard_True,
+                             Standard_False
+    ).Shape();
+    if (Tools::isShapeEmpty(shape)) {
+        return result;
+    }
+
+    // The view provider applies the object's Placement in the scene graph.
+    // Mesh in that object's local coordinates, retaining child locations in
+    // compounds. Otherwise both vertices and normals receive the root transform
+    // twice. Only the private copy changes; live/source geometry is untouched.
+    shape.Location(TopLoc_Location());
+
+    Standard_Real deflection = Tools::getDeflection(shape, deviation);
+    if (deflection < gp::Resolution()) {
+        deflection = Precision::Confusion();
+    }
+
+    IMeshTools_Parameters meshParameters;
+    meshParameters.Deflection = deflection;
+    meshParameters.Relative = Standard_False;
+    meshParameters.Angle = Base::toRadians(angularDeflection);
+    // VibeCAD fans independent shapes across its bounded persistent pool. An
+    // inner OCCT pool here would oversubscribe that application-wide budget.
+    meshParameters.InParallel = Standard_False;
+    meshParameters.AllowQualityDecrease = Standard_True;
+
+#if OCC_VERSION_HEX < 0x070600
+    BRepTools::Clean(shape);
+#else
+    BRepTools::Clean(shape, Standard_True);
+#endif
+    checkCancellation(stopToken);
+    // The owner already reports this render operation. Give OCCT the same
+    // cancellation token so an obsolete mesh can stop inside tessellation,
+    // rather than occupying its worker until the entire kernel call returns.
+    Handle(Part::ProgressIndicator) progress = new Part::ProgressIndicator(stopToken);
+    BRepMesh_IncrementalMesh(shape, meshParameters, progress->Start());
+    checkCancellation(stopToken);
+
+    int triangleCount = 0;
+    int nodeCount = 0;
+    int normalCount = 0;
+    TopTools_MapOfShape faceEdges;
+    TopTools_IndexedMapOfShape faceMap;
+    TopExp::MapShapes(shape, TopAbs_FACE, faceMap);
+    TopTools_IndexedMapOfShape edgeMap;
+    TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
+    struct FaceInput
+    {
+        Handle(Poly_Triangulation) mesh;
+        TopLoc_Location location;
+        int nodeOffset {};
+        int triangleOffset {};
+        std::unique_ptr<TColgp_Array1OfDir> uvNormals;
+        std::vector<std::pair<int, Handle(Poly_PolygonOnTriangulation)>> edges;
+    };
+    std::vector<FaceInput> faces(faceMap.Extent());
+    std::vector<bool> edgeAssigned(edgeMap.Extent() + 1, false);
+    for (int faceIndex = 1; faceIndex <= faceMap.Extent(); ++faceIndex) {
+        checkCancellation(stopToken);
+        auto& input = faces[faceIndex - 1];
+        input.nodeOffset = nodeCount;
+        input.triangleOffset = triangleCount;
+        const TopoDS_Face& face = TopoDS::Face(faceMap(faceIndex));
+        auto& mesh = input.mesh;
+        mesh = BRep_Tool::Triangulation(face, input.location);
+        if (mesh.IsNull()) {
+            mesh = Tools::triangulationOfFace(face);
+        }
+        if (!mesh.IsNull()) {
+            triangleCount += mesh->NbTriangles();
+            nodeCount += mesh->NbNodes();
+            normalCount += mesh->NbNodes();
+            if (normalsFromUV) {
+                // This helper populates the triangulation's normal cache.
+                // Finish those mutations before parallel readers use meshes
+                // shared by located instances of the same face.
+                input.uvNormals = std::make_unique<TColgp_Array1OfDir>(1, mesh->NbNodes());
+                Tools::getPointNormals(face, mesh, *input.uvNormals);
+            }
+        }
+        for (TopExp_Explorer explorer(face, TopAbs_EDGE); explorer.More(); explorer.Next()) {
+            const auto& edge = TopoDS::Edge(explorer.Current());
+            faceEdges.Add(edge);
+            const int edgeIndex = edgeMap.FindIndex(edge);
+            if (!mesh.IsNull() && !edgeAssigned[edgeIndex]) {
+                auto polygon = BRep_Tool::PolygonOnTriangulation(edge, mesh, input.location);
+                if (!polygon.IsNull()) {
+                    input.edges.emplace_back(edgeIndex, std::move(polygon));
+                    edgeAssigned[edgeIndex] = true;
+                }
+            }
+        }
+    }
+
+    // Each indexed edge has one writer, selected above. Pre-size the outer
+    // storage so independent face workers never mutate a shared container.
+    std::vector<std::vector<std::int32_t>> lineIndicesByEdge(edgeMap.Extent() + 1);
+    for (int edgeIndex = 1; edgeIndex <= edgeMap.Extent(); ++edgeIndex) {
+        checkCancellation(stopToken);
+        const TopoDS_Edge& edge = TopoDS::Edge(edgeMap(edgeIndex));
+        TopLoc_Location edgeLocation;
+        if (!faceEdges.Contains(edge)) {
+            const Handle(Poly_Polygon3D) polygon = Tools::polygonOfEdge(edge, edgeLocation);
+            if (!polygon.IsNull()) {
+                nodeCount += polygon->NbNodes();
+            }
+        }
+    }
+
+    TopTools_IndexedMapOfShape vertexMap;
+    TopExp::MapShapes(shape, TopAbs_VERTEX, vertexMap);
+    nodeCount += vertexMap.Extent();
+
+    result.vertices.resize(static_cast<std::size_t>(nodeCount) * 3);
+    result.normals.resize(static_cast<std::size_t>(normalCount) * 3);
+    result.triangleIndices.resize(static_cast<std::size_t>(triangleCount) * 4);
+    result.faceTriangleCounts.resize(faceMap.Extent());
+
+    App::GetApplication().hostRuntime().parallelFor(faces.size(), [&](std::size_t index) {
+        checkCancellation(stopToken);
+        const int faceIndex = static_cast<int>(index) + 1;
+        const auto& input = faces[index];
+        const auto& faceLocation = input.location;
+        const auto& mesh = input.mesh;
+        const int faceNodeOffset = input.nodeOffset;
+        const int faceTriangleOffset = input.triangleOffset;
+        const TopoDS_Face& face = TopoDS::Face(faceMap(faceIndex));
+        if (mesh.IsNull()) {
+            result.faceTriangleCounts[faceIndex - 1] = 0;
+            return;
+        }
+
+        const int nodesInFace = mesh->NbNodes();
+        const int trianglesInFace = mesh->NbTriangles();
+        const TopAbs_Orientation orientation = face.Orientation();
+        const bool identity = faceLocation.IsIdentity();
+        const gp_Trsf transformation = faceLocation.Transformation();
+#if OCC_VERSION_HEX < 0x070600
+        const Poly_Array1OfTriangle& triangles = mesh->Triangles();
+        const TColgp_Array1OfPnt& nodes = mesh->Nodes();
+#endif
+
+        for (int triangleIndex = 1; triangleIndex <= trianglesInFace; ++triangleIndex) {
+            if ((triangleIndex & 255) == 0) {
+                checkCancellation(stopToken);
+            }
+            Standard_Integer first;
+            Standard_Integer second;
+            Standard_Integer third;
+#if OCC_VERSION_HEX < 0x070600
+            triangles(triangleIndex).Get(first, second, third);
+            gp_Pnt firstPoint(nodes(first));
+            gp_Pnt secondPoint(nodes(second));
+            gp_Pnt thirdPoint(nodes(third));
+#else
+            mesh->Triangle(triangleIndex).Get(first, second, third);
+            gp_Pnt firstPoint(mesh->Node(first));
+            gp_Pnt secondPoint(mesh->Node(second));
+            gp_Pnt thirdPoint(mesh->Node(third));
+#endif
+            if (orientation != TopAbs_FORWARD) {
+                std::swap(first, second);
+                std::swap(firstPoint, secondPoint);
+            }
+
+            gp_Vec firstNormal;
+            gp_Vec secondNormal;
+            gp_Vec thirdNormal;
+            if (normalsFromUV) {
+                const auto& faceNormals = *input.uvNormals;
+                firstNormal.SetXYZ(faceNormals(first).XYZ());
+                secondNormal.SetXYZ(faceNormals(second).XYZ());
+                thirdNormal.SetXYZ(faceNormals(third).XYZ());
+            }
+            else {
+                const gp_Vec edgeOne(firstPoint, secondPoint);
+                const gp_Vec edgeTwo(firstPoint, thirdPoint);
+                const gp_Vec normal = edgeOne ^ edgeTwo;
+                firstNormal = normal;
+                secondNormal = normal;
+                thirdNormal = normal;
+            }
+
+            if (!identity) {
+                firstPoint.Transform(transformation);
+                secondPoint.Transform(transformation);
+                thirdPoint.Transform(transformation);
+                firstNormal.Transform(transformation);
+                secondNormal.Transform(transformation);
+                thirdNormal.Transform(transformation);
+            }
+
+            addVector(
+                result.normals,
+                faceNodeOffset + first - 1,
+                Base::convertTo<Base::Vector3f>(firstNormal)
+            );
+            addVector(
+                result.normals,
+                faceNodeOffset + second - 1,
+                Base::convertTo<Base::Vector3f>(secondNormal)
+            );
+            addVector(
+                result.normals,
+                faceNodeOffset + third - 1,
+                Base::convertTo<Base::Vector3f>(thirdNormal)
+            );
+            setVector(
+                result.vertices,
+                faceNodeOffset + first - 1,
+                Base::convertTo<Base::Vector3f>(firstPoint)
+            );
+            setVector(
+                result.vertices,
+                faceNodeOffset + second - 1,
+                Base::convertTo<Base::Vector3f>(secondPoint)
+            );
+            setVector(
+                result.vertices,
+                faceNodeOffset + third - 1,
+                Base::convertTo<Base::Vector3f>(thirdPoint)
+            );
+
+            const int outputOffset = (faceTriangleOffset + triangleIndex - 1) * 4;
+            result.triangleIndices[outputOffset] = faceNodeOffset + first - 1;
+            result.triangleIndices[outputOffset + 1] = faceNodeOffset + second - 1;
+            result.triangleIndices[outputOffset + 2] = faceNodeOffset + third - 1;
+            result.triangleIndices[outputOffset + 3] = endPrimitive;
+        }
+
+        result.faceTriangleCounts[faceIndex - 1] = trianglesInFace;
+        for (const auto& [edgeIndex, polygon] : input.edges) {
+            const TColStd_Array1OfInteger& indices = polygon->Nodes();
+            lineIndicesByEdge[edgeIndex].reserve(indices.Length());
+            for (Standard_Integer index = indices.Lower(); index <= indices.Upper(); ++index) {
+                if ((index & 255) == 0) {
+                    checkCancellation(stopToken);
+                }
+                const int nodeIndex = indices(index);
+                const int outputIndex = faceNodeOffset + nodeIndex - 1;
+                lineIndicesByEdge[edgeIndex].push_back(outputIndex);
+#if OCC_VERSION_HEX < 0x070600
+                gp_Pnt point(nodes(nodeIndex));
+#else
+                gp_Pnt point(mesh->Node(nodeIndex));
+#endif
+                if (!identity) {
+                    point.Transform(transformation);
+                }
+                setVector(
+                    result.vertices,
+                    outputIndex,
+                    Base::convertTo<Base::Vector3f>(point)
+                );
+            }
+        }
+
+        for (int node = 0; node < nodesInFace; ++node) {
+            if ((node & 255) == 0) {
+                checkCancellation(stopToken);
+            }
+            const auto offset = static_cast<std::size_t>(faceNodeOffset + node) * 3;
+            Base::Vector3f normal(result.normals[offset], result.normals[offset + 1],
+                                  result.normals[offset + 2]);
+            normal.Normalize();
+            result.normals[offset] = normal.x;
+            result.normals[offset + 1] = normal.y;
+            result.normals[offset + 2] = normal.z;
+        }
+    });
+
+    int faceNodeOffset = normalCount;
+    for (int edgeIndex = 1; edgeIndex <= edgeMap.Extent(); ++edgeIndex) {
+        checkCancellation(stopToken);
+        const TopoDS_Edge& edge = TopoDS::Edge(edgeMap(edgeIndex));
+        if (faceEdges.Contains(edge)) {
+            continue;
+        }
+        TopLoc_Location edgeLocation;
+        const Handle(Poly_Polygon3D) polygon = Tools::polygonOfEdge(edge, edgeLocation);
+        if (polygon.IsNull()) {
+            continue;
+        }
+        const bool identity = edgeLocation.IsIdentity();
+        const gp_Trsf transformation = edgeLocation.Transformation();
+        const TColgp_Array1OfPnt& nodes = polygon->Nodes();
+        for (Standard_Integer index = 1; index <= polygon->NbNodes(); ++index) {
+            if ((index & 255) == 0) {
+                checkCancellation(stopToken);
+            }
+            gp_Pnt point = nodes(index);
+            if (!identity) {
+                point.Transform(transformation);
+            }
+            setVector(
+                result.vertices,
+                faceNodeOffset,
+                Base::convertTo<Base::Vector3f>(point)
+            );
+            lineIndicesByEdge[edgeIndex].push_back(faceNodeOffset);
+            ++faceNodeOffset;
+        }
+    }
+
+    result.vertexStart = faceNodeOffset;
+    for (int vertexIndex = 1; vertexIndex <= vertexMap.Extent(); ++vertexIndex) {
+        if ((vertexIndex & 255) == 0) {
+            checkCancellation(stopToken);
+        }
+        const gp_Pnt point = BRep_Tool::Pnt(TopoDS::Vertex(vertexMap(vertexIndex)));
+        setVector(
+            result.vertices,
+            faceNodeOffset + vertexIndex - 1,
+            Base::convertTo<Base::Vector3f>(point)
+        );
+    }
+
+    std::size_t renderedEdges = 0;
+    for (const auto& indices : lineIndicesByEdge) {
+        checkCancellation(stopToken);
+        if (indices.empty()) {
+            continue;
+        }
+        result.lineIndices.insert(result.lineIndices.end(), indices.begin(), indices.end());
+        result.lineIndices.push_back(endPrimitive);
+        ++renderedEdges;
+    }
+    result.lineMaterialIndices.assign(renderedEdges + 1, 0);
+    checkCancellation(stopToken);
+    return result;
+}

--- a/src/Mod/Part/App/RenderMesh.h
+++ b/src/Mod/Part/App/RenderMesh.h
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <cstdint>
+#include <stop_token>
+#include <vector>
+
+#include <Mod/Part/PartGlobal.h>
+
+class TopoDS_Shape;
+
+namespace Part
+{
+
+/**
+ * Renderer-neutral tessellation prepared without touching a GUI scene graph.
+ *
+ * Face and line index streams use -1 as the primitive delimiter expected by
+ * Inventor-style indexed geometry. faceTriangleCounts retains one entry for
+ * every topological face, including faces without a triangulation.
+ */
+struct PartExport RenderMesh
+{
+    // XYZ values are intentionally stored as tightly packed floats. Besides
+    // keeping this artifact renderer-neutral, a GUI owner can lend these
+    // immutable buffers directly to an Inventor multi-field without copying
+    // every value during adoption.
+    std::vector<float> vertices;
+    std::vector<float> normals;
+    std::vector<std::int32_t> triangleIndices;
+    std::vector<std::int32_t> faceTriangleCounts;
+    std::vector<std::int32_t> lineIndices;
+    // Preview rendering uses one material index per edge primitive, plus the
+    // historical trailing entry. Preparing it here avoids a GUI-thread scan
+    // and thousands of individual Coin field updates during adoption.
+    std::vector<std::int32_t> lineMaterialIndices {0};
+    std::int32_t vertexStart {0};
+
+    [[nodiscard]] std::size_t vertexCount() const
+    {
+        return vertices.size() / 3;
+    }
+
+    [[nodiscard]] std::size_t normalCount() const
+    {
+        return normals.size() / 3;
+    }
+};
+
+/**
+ * Deep-copy and tessellate a shape into renderer-neutral arrays.
+ *
+ * The source shape is only read. All triangulation changes are made on the
+ * private copy, allowing callers to run independent requests concurrently.
+ * Arrays are in root-local coordinates: the renderer applies the root Placement,
+ * while nested child locations remain part of the prepared geometry.
+ * Face-buffer extraction uses the application's shared compute runtime, with
+ * disjoint output ranges and one owner per edge. The call joins that work
+ * before returning; interactive callers use RenderMeshController, not this
+ * synchronous preparation API on the GUI owner.
+ */
+PartExport RenderMesh prepareRenderMesh(
+    const TopoDS_Shape& shape,
+    double deviation,
+    double angularDeflection,
+    bool normalsFromUV = false,
+    std::stop_token stopToken = {}
+);
+
+}  // namespace Part

--- a/src/Mod/Part/Gui/CMakeLists.txt
+++ b/src/Mod/Part/Gui/CMakeLists.txt
@@ -147,6 +147,8 @@ SET(PartGui_SRCS
     PreCompiled.h
     PreviewUpdateScheduler.cpp
     PreviewUpdateScheduler.h
+    RenderMeshController.cpp
+    RenderMeshController.h
     PropertyEnumAttacherItem.cpp
     PropertyEnumAttacherItem.h
     SoFCShapeObject.cpp

--- a/src/Mod/Part/Gui/PreviewUpdateScheduler.cpp
+++ b/src/Mod/Part/Gui/PreviewUpdateScheduler.cpp
@@ -49,6 +49,7 @@ inline void QtPreviewUpdateScheduler::schedulePreviewRecompute(App::DocumentObje
         return;
     }
 
+    scheduled = true;
     QMetaObject::invokeMethod(this, &QtPreviewUpdateScheduler::flush, Qt::QueuedConnection);
 }
 

--- a/src/Mod/Part/Gui/RenderMeshController.cpp
+++ b/src/Mod/Part/Gui/RenderMeshController.cpp
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include "RenderMeshController.h"
+
+#include <chrono>
+#include <cstdint>
+#include <optional>
+#include <stdexcept>
+#include <stop_token>
+#include <unordered_map>
+#include <utility>
+
+#include <QApplication>
+#include <QThread>
+
+#include <Standard_Failure.hxx>
+
+#include <App/Application.h>
+#include <App/HostRuntime.h>
+#include <Base/Console.h>
+#include <Base/Exception.h>
+#include <Gui/FrameBudget.h>
+
+using namespace PartGui;
+
+namespace
+{
+
+void requireGuiOwner()
+{
+    if (!qApp || QThread::currentThread() != qApp->thread()) {
+        throw std::logic_error("Render mesh requests must originate on the GUI owner thread");
+    }
+}
+
+}  // namespace
+
+struct RenderMeshController::State: std::enable_shared_from_this<State>
+{
+    struct Request
+    {
+        std::uint64_t generation {};
+        TopoDS_Shape shape;
+        double deviation {};
+        double angularDeflection {};
+        bool normalsFromUV {};
+        Completion completion;
+        std::shared_ptr<std::stop_source> cancellation;
+    };
+
+    struct Channel
+    {
+        std::uint64_t generation {};
+        std::uint64_t activeGeneration {};
+        bool active {false};
+        Completion activeCompletion;
+        std::shared_ptr<std::stop_source> activeCancellation;
+        std::optional<Request> pending;
+    };
+
+    void request(
+        const void* target,
+        TopoDS_Shape shape,
+        double deviation,
+        double angularDeflection,
+        bool normalsFromUV,
+        Completion completion
+    )
+    {
+        if (!target) {
+            throw std::invalid_argument("Render mesh request requires a target identity");
+        }
+        if (!completion) {
+            throw std::invalid_argument("Render mesh request requires a completion callback");
+        }
+
+        auto& channel = channels[target];
+        Request next {
+            ++lastGeneration,
+            std::move(shape),
+            deviation,
+            angularDeflection,
+            normalsFromUV,
+            std::move(completion),
+            std::make_shared<std::stop_source>()
+        };
+        channel.generation = next.generation;
+        if (channel.active) {
+            // Callback destruction can release presentation leases and enter
+            // this controller again. Commit the replacement before releasing
+            // the old capture, and never retain a map reference across it.
+            auto replaced = std::exchange(channel.pending, std::move(next));
+            auto cancellation = channel.activeCancellation;
+            cancellation->request_stop();
+            return;
+        }
+        start(target, std::move(next));
+    }
+
+    void cancel(const void* target)
+    {
+        const auto found = channels.find(target);
+        if (found == channels.end()) {
+            return;
+        }
+        auto& channel = found->second;
+        channel.generation = ++lastGeneration;
+        auto pending = std::move(channel.pending);
+        channel.pending.reset();
+        auto completion = std::move(channel.activeCompletion);
+        auto cancellation = channel.activeCancellation;
+        if (!channel.active) {
+            channels.erase(found);
+        }
+        // A running worker retains only its shape and cancellation token, not
+        // the provider/document. Cancelled owner captures can be released now;
+        // leave the active channel until its worker completes to keep requests
+        // for this target serialized. Release captures after all map access.
+        if (cancellation) { cancellation->request_stop(); }
+    }
+
+    void cancelAll()
+    {
+        // Completion destruction can release a document presentation lease
+        // and notify observers. Detach first so reentrant requests never modify
+        // the map whose callbacks are being destroyed.
+        decltype(channels) cancelled;
+        cancelled.swap(channels);
+        for (auto& [target, channel] : cancelled) {
+            (void)target;
+            if (channel.activeCancellation) {
+                channel.activeCancellation->request_stop();
+            }
+        }
+    }
+
+private:
+    void start(const void* target, Request request)
+    {
+        auto& channel = channels[target];
+        channel.active = true;
+        channel.activeGeneration = request.generation;
+        channel.activeCompletion = std::move(request.completion);
+        channel.activeCancellation = request.cancellation;
+
+        const std::uint64_t generation = request.generation;
+        const double deviation = request.deviation;
+        const double angularDeflection = request.angularDeflection;
+        const bool normalsFromUV = request.normalsFromUV;
+        auto cancellation = std::move(request.cancellation);
+        auto weakState = weak_from_this();
+        const bool trace = qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE");
+        using Clock = std::chrono::steady_clock;
+        const auto submitted = trace ? Clock::now() : Clock::time_point {};
+        struct Prepared
+        {
+            RenderMeshResult result;
+            Clock::time_point started;
+            Clock::time_point prepared;
+        };
+        try {
+            App::GetApplication().hostRuntime().submitWithCompletion(
+                App::HostRuntime::Lane::Compute,
+                [shape = std::move(request.shape),
+                 deviation,
+                 angularDeflection,
+                 normalsFromUV,
+                 trace,
+                 cancellation](std::stop_token runtimeStop) mutable {
+                    const auto started = trace ? Clock::now() : Clock::time_point {};
+                    std::stop_callback stopWithRuntime(runtimeStop, [cancellation] {
+                        cancellation->request_stop();
+                    });
+                    RenderMeshResult result;
+                    try {
+                        result.mesh = std::make_shared<const Part::RenderMesh>(
+                            Part::prepareRenderMesh(
+                                shape,
+                                deviation,
+                                angularDeflection,
+                                normalsFromUV,
+                                cancellation->get_token()
+                            )
+                        );
+                    }
+                    catch (const Standard_Failure& failure) {
+                        const char* message = failure.GetMessageString();
+                        result.error = message
+                            ? message
+                            : "OpenCASCADE render mesh preparation failed";
+                    }
+                    catch (const Base::Exception& failure) {
+                        result.error = failure.what();
+                    }
+                    catch (const std::exception& failure) {
+                        result.error = failure.what();
+                    }
+                    catch (...) {
+                        result.error = "Unknown render mesh preparation failure";
+                    }
+
+                    if (cancellation->stop_requested()) {
+                        result.mesh.reset();
+                        result.error = "Render mesh preparation was cancelled";
+                    }
+                    return Prepared {std::move(result), started,
+                                     trace ? Clock::now() : Clock::time_point {}};
+                },
+                [weakState, target, generation, trace, submitted](std::future<Prepared> future) {
+                    Prepared output {{}, submitted, submitted};
+                    try { output = future.get(); }
+                    catch (const std::exception& failure) {
+                        output.result.error = failure.what();
+                        output.started = output.prepared = trace ? Clock::now() : Clock::time_point {};
+                    }
+                    catch (...) {
+                        output.result.error = "Render mesh request cancelled or failed";
+                        output.started = output.prepared = trace ? Clock::now() : Clock::time_point {};
+                    }
+                    Gui::dispatchToGuiFrame(
+                        [weakState, target, generation, trace, submitted,
+                         started = output.started, prepared = output.prepared,
+                         result = std::move(output.result)]() mutable {
+                            if (auto state = weakState.lock()) {
+                                const auto adopting = trace ? Clock::now() : Clock::time_point {};
+                                const auto vertices = result.mesh ? result.mesh->vertexCount() : 0;
+                                const auto faces = result.mesh ? result.mesh->faceTriangleCounts.size() : 0;
+                                state->finish(target, generation, std::move(result));
+                                if (trace) {
+                                    const auto milliseconds = [](auto begin, auto end) {
+                                        return std::chrono::duration<double, std::milli>(end - begin).count();
+                                    };
+                                    Base::Console().message(
+                                        "VIBECAD_RENDER request=%llu target=%p queue_ms=%.3f "
+                                        "prepare_ms=%.3f dispatch_ms=%.3f adopt_ms=%.3f "
+                                        "vertices=%zu faces=%zu\n",
+                                        static_cast<unsigned long long>(generation), target,
+                                        milliseconds(submitted, started),
+                                        milliseconds(started, prepared),
+                                        milliseconds(prepared, adopting),
+                                        milliseconds(adopting, Clock::now()), vertices, faces
+                                    );
+                                }
+                            }
+                        }
+                    );
+                }
+            );
+        }
+        catch (const std::exception& failure) {
+            finish(target, generation, RenderMeshResult {{}, failure.what()});
+        }
+    }
+
+    void finish(const void* target, std::uint64_t generation, RenderMeshResult result)
+    {
+        const auto found = channels.find(target);
+        if (found == channels.end()) {
+            return;
+        }
+        auto& channel = found->second;
+        if (!channel.active || channel.activeGeneration != generation) {
+            return;
+        }
+
+        channel.active = false;
+        channel.activeCancellation.reset();
+        Completion completion = std::move(channel.activeCompletion);
+        const bool current = channel.generation == generation;
+        if (current) {
+            channels.erase(found);
+            completion(std::move(result));
+            return;
+        }
+
+        if (!channel.pending) {
+            channels.erase(found);
+            return;
+        }
+        Request pending = std::move(*channel.pending);
+        channel.pending.reset();
+        start(target, std::move(pending));
+    }
+
+    std::unordered_map<const void*, Channel> channels;
+    // Target addresses can be reused after cancellation or destruction. Never
+    // reuse a generation while an old completion may still be in the GUI queue.
+    std::uint64_t lastGeneration {};
+};
+
+RenderMeshController::RenderMeshController()
+    : state(std::make_shared<State>())
+{}
+
+RenderMeshController::~RenderMeshController()
+{
+    if (state) {
+        state->cancelAll();
+    }
+}
+
+void RenderMeshController::request(
+    const void* target,
+    TopoDS_Shape shape,
+    double deviation,
+    double angularDeflection,
+    bool normalsFromUV,
+    Completion completion
+)
+{
+    requireGuiOwner();
+    const auto owner = state;
+    owner->request(
+        target,
+        std::move(shape),
+        deviation,
+        angularDeflection,
+        normalsFromUV,
+        std::move(completion)
+    );
+}
+
+void RenderMeshController::cancel(const void* target)
+{
+    requireGuiOwner();
+    const auto owner = state;
+    owner->cancel(target);
+}
+
+void RenderMeshController::cancelAll()
+{
+    requireGuiOwner();
+    const auto owner = state;
+    owner->cancelAll();
+}

--- a/src/Mod/Part/Gui/RenderMeshController.h
+++ b/src/Mod/Part/Gui/RenderMeshController.h
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <string>
+
+#include <TopoDS_Shape.hxx>
+
+#include <Mod/Part/App/RenderMesh.h>
+#include <Mod/Part/PartGlobal.h>
+
+namespace PartGui
+{
+
+struct PartGuiExport RenderMeshResult
+{
+    std::shared_ptr<const Part::RenderMesh> mesh;
+    std::string error;
+};
+
+/**
+ * Latest-result-wins preparation of renderer-neutral Part meshes.
+ *
+ * Requests run on the process-lifetime compute pool. Completion always runs
+ * on the GUI owner through the shared frame dispatcher. A target may have one
+ * active request and one replaceable pending request, preventing rapid sketch
+ * or task-panel changes from flooding the runtime with obsolete tessellations.
+ */
+class PartGuiExport RenderMeshController final
+{
+public:
+    using Completion = std::function<void(RenderMeshResult)>;
+
+    RenderMeshController();
+    ~RenderMeshController();
+
+    RenderMeshController(const RenderMeshController&) = delete;
+    RenderMeshController& operator=(const RenderMeshController&) = delete;
+    RenderMeshController(RenderMeshController&&) = delete;
+    RenderMeshController& operator=(RenderMeshController&&) = delete;
+
+    void request(
+        const void* target,
+        TopoDS_Shape shape,
+        double deviation,
+        double angularDeflection,
+        bool normalsFromUV,
+        Completion completion
+    );
+    void cancel(const void* target);
+    void cancelAll();
+
+private:
+    struct State;
+    std::shared_ptr<State> state;
+};
+
+}  // namespace PartGui

--- a/src/Mod/Part/Gui/SoFCShapeObject.cpp
+++ b/src/Mod/Part/Gui/SoFCShapeObject.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <Inventor/actions/SoGLRenderAction.h>
 #include <Inventor/bundles/SoMaterialBundle.h>
 #include <Inventor/elements/SoCoordinateElement.h>
@@ -35,6 +36,9 @@
 #include <Inventor/misc/SoState.h>
 
 #include "SoFCShapeObject.h"
+
+#include <Base/Exception.h>
+#include <Mod/Part/App/RenderMesh.h>
 
 
 using namespace PartGui;
@@ -54,6 +58,71 @@ SoFCShape::SoFCShape()
 void SoFCShape::initClass()
 {
     SO_NODE_INIT_CLASS(SoFCShape, SoSeparator, "Separator");
+}
+
+void PartGui::bindPreparedRenderMesh(
+    std::shared_ptr<const Part::RenderMesh> mesh,
+    std::shared_ptr<const Part::RenderMesh>& installedMesh,
+    SoCoordinate3* coords,
+    SoBrepFaceSet* faceset,
+    SoNormal* norm,
+    SoBrepEdgeSet* lineset,
+    SoBrepPointSet* nodeset,
+    bool bindLineMaterialIndices
+)
+{
+    if (!mesh) {
+        throw Base::ValueError("Cannot bind an empty render mesh artifact");
+    }
+    const auto coinSize = [](std::size_t size) {
+        if (size > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+            throw Base::MemoryException("Render mesh exceeds Coin field capacity");
+        }
+        return static_cast<int>(size);
+    };
+
+    const int vertexCount = coinSize(mesh->vertexCount());
+    const int normalCount = coinSize(mesh->normalCount());
+    const int triangleIndexCount = coinSize(mesh->triangleIndices.size());
+    const int faceCount = coinSize(mesh->faceTriangleCounts.size());
+    const int lineIndexCount = coinSize(mesh->lineIndices.size());
+    const int lineMaterialCount = bindLineMaterialIndices
+        ? coinSize(mesh->lineMaterialIndices.size())
+        : 0;
+
+    // Coin borrows these buffers. Keep the prior generation alive until every
+    // field has been rebound, then retain the new generation with this node.
+    auto previous = std::move(installedMesh);
+    installedMesh = mesh;
+    coords->point.setValuesPointer(vertexCount, mesh->vertices.data());
+    norm->vector.setValuesPointer(normalCount, mesh->normals.data());
+    faceset->coordIndex.setValuesPointer(
+        triangleIndexCount,
+        mesh->triangleIndices.data()
+    );
+    faceset->partIndex.setValuesPointer(faceCount, mesh->faceTriangleCounts.data());
+    lineset->coordIndex.setValuesPointer(lineIndexCount, mesh->lineIndices.data());
+    if (bindLineMaterialIndices) {
+        lineset->materialIndex.setValuesPointer(
+            lineMaterialCount,
+            mesh->lineMaterialIndices.data()
+        );
+    }
+    nodeset->startIndex.setValue(mesh->vertexStart);
+}
+
+void SoFCShape::bindRenderMesh(std::shared_ptr<const Part::RenderMesh> mesh)
+{
+    bindPreparedRenderMesh(
+        std::move(mesh),
+        installedRenderMesh,
+        coords,
+        faceset,
+        norm,
+        lineset,
+        nodeset,
+        true
+    );
 }
 
 SO_NODE_SOURCE(SoFCControlPoints)

--- a/src/Mod/Part/Gui/SoFCShapeObject.h
+++ b/src/Mod/Part/Gui/SoFCShapeObject.h
@@ -23,6 +23,7 @@
 
 #pragma once
 
+#include <memory>
 #include <vector>
 
 #include "SoBrepEdgeSet.h"
@@ -40,8 +41,28 @@
 
 #include <Mod/Part/PartGlobal.h>
 
+namespace Part
+{
+struct RenderMesh;
+}
+
 namespace PartGui
 {
+
+/**
+ * Atomically lend immutable prepared arrays to Coin fields while retaining
+ * both the old and new owners for the duration of the rebind.
+ */
+PartGuiExport void bindPreparedRenderMesh(
+    std::shared_ptr<const Part::RenderMesh> mesh,
+    std::shared_ptr<const Part::RenderMesh>& installedMesh,
+    SoCoordinate3* coords,
+    SoBrepFaceSet* faceset,
+    SoNormal* norm,
+    SoBrepEdgeSet* lineset,
+    SoBrepPointSet* nodeset,
+    bool bindLineMaterialIndices = false
+);
 
 class PartGuiExport SoFCShape: public SoSeparator
 {
@@ -52,11 +73,17 @@ public:
     SoFCShape();
     static void initClass();
 
+    /** Install immutable worker-prepared buffers without copying them. */
+    void bindRenderMesh(std::shared_ptr<const Part::RenderMesh> mesh);
+
     SoCoordinate3* coords;
     SoNormal* norm;
     SoBrepFaceSet* faceset;
     SoBrepEdgeSet* lineset;
     SoBrepPointSet* nodeset;
+
+private:
+    std::shared_ptr<const Part::RenderMesh> installedRenderMesh;
 };
 
 class PartGuiExport SoFCControlPoints: public SoShape

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -54,8 +54,10 @@
 #include <QCoreApplication>
 #include <QEventLoop>
 #include <QMenu>
-#include <QTimer>
+#include <QMetaObject>
+#include <atomic>
 #include <deque>
+#include <map>
 #include <memory>
 #include <sstream>
 
@@ -87,6 +89,7 @@
 #include <Gui/Application.h>
 #include <Gui/BitmapFactory.h>
 #include <Gui/Control.h>
+#include <Gui/FrameBudget.h>
 #include <Gui/ProgressBar.h>
 #include <Gui/Selection/SoFCSelectionAction.h>
 #include <Gui/Selection/SoFCUnifiedSelection.h>
@@ -94,6 +97,7 @@
 #include <Gui/Utilities.h>
 
 #include <Mod/Part/App/ShapeMapHasher.h>
+#include <Mod/Part/App/RenderMesh.h>
 #include <Mod/Part/App/Tools.h>
 
 #include "ViewProviderExt.h"
@@ -121,18 +125,150 @@ App::PropertyQuantityConstraint::Constraints ViewProviderPartExt::angDeflectionR
 const char* ViewProviderPartExt::LightingEnums[] = {"One side", "Two side", nullptr};
 const char* ViewProviderPartExt::DrawStyleEnums[] = {"Solid", "Dashed", "Dotted", "Dashdot", nullptr};
 
-namespace
+namespace PartGui
 {
+// Names locate documents; UIDs and provider instances authorize adoption.
+// A queued request never owns a document or a view provider.
 struct DeferredVisual
 {
     std::string documentName;
-    std::string objectName;
+    std::string documentUid;
+    long objectId;
+    std::uint64_t instanceId;
+
+    explicit DeferredVisual(const ViewProviderPartExt& view)
+        : documentName(view.getObject()->getDocument()->getName()),
+          documentUid(view.getObject()->getDocument()->Uid.getValueStr()),
+          objectId(view.getObject()->getID()), instanceId(view.visualInstanceId)
+    {}
+
+    bool matches(const ViewProviderPartExt* view) const
+    {
+        return view && view->visualInstanceId == instanceId;
+    }
+};
+}
+
+namespace
+{
+std::atomic_uint64_t nextVisualInstanceId {1};
+
+std::pair<std::uint64_t, std::uint64_t> appearanceStamp(
+    const SoMaterial* material, const SoMaterialBinding* binding)
+{
+    return {material->getNodeId(), binding->getNodeId()};
+}
+
+void copyRenderMesh(
+    const Part::RenderMesh& mesh,
+    SoCoordinate3* coords,
+    SoBrepFaceSet* faceset,
+    SoNormal* norm,
+    SoBrepEdgeSet* lineset,
+    SoBrepPointSet* nodeset
+)
+{
+    const auto coinSize = [](std::size_t size) {
+        if (size > static_cast<std::size_t>(std::numeric_limits<int>::max())) {
+            throw Base::MemoryException("Render mesh exceeds Coin field capacity");
+        }
+        return static_cast<int>(size);
+    };
+
+    coords->point.setNum(coinSize(mesh.vertexCount()));
+    norm->vector.setNum(coinSize(mesh.normalCount()));
+    faceset->coordIndex.setNum(coinSize(mesh.triangleIndices.size()));
+    faceset->partIndex.setNum(coinSize(mesh.faceTriangleCounts.size()));
+    lineset->coordIndex.setNum(coinSize(mesh.lineIndices.size()));
+
+    auto* vertices = coords->point.startEditing();
+    for (std::size_t index = 0; index < mesh.vertexCount(); ++index) {
+        const std::size_t offset = index * 3;
+        vertices[index].setValue(
+            mesh.vertices[offset],
+            mesh.vertices[offset + 1],
+            mesh.vertices[offset + 2]
+        );
+    }
+    auto* normals = norm->vector.startEditing();
+    for (std::size_t index = 0; index < mesh.normalCount(); ++index) {
+        const std::size_t offset = index * 3;
+        normals[index].setValue(
+            mesh.normals[offset],
+            mesh.normals[offset + 1],
+            mesh.normals[offset + 2]
+        );
+    }
+    std::copy(
+        mesh.triangleIndices.begin(),
+        mesh.triangleIndices.end(),
+        faceset->coordIndex.startEditing()
+    );
+    std::copy(
+        mesh.faceTriangleCounts.begin(),
+        mesh.faceTriangleCounts.end(),
+        faceset->partIndex.startEditing()
+    );
+    std::copy(
+        mesh.lineIndices.begin(),
+        mesh.lineIndices.end(),
+        lineset->coordIndex.startEditing()
+    );
+    nodeset->startIndex.setValue(mesh.vertexStart);
+
+    coords->point.finishEditing();
+    norm->vector.finishEditing();
+    faceset->coordIndex.finishEditing();
+    faceset->partIndex.finishEditing();
+    lineset->coordIndex.finishEditing();
+}
+
+class PresentationUpdateEnd
+{
+public:
+    explicit PresentationUpdateEnd(App::Document* document)
+        : documentName(document ? document->getName() : ""),
+          documentUid(document ? document->Uid.getValueStr() : "")
+    {}
+
+    ~PresentationUpdateEnd()
+    {
+        auto* document = App::GetApplication().getDocument(documentName.c_str());
+        if (document && document->Uid.getValueStr() == documentUid) {
+            try {
+                document->endPresentationUpdate();
+            }
+            catch (const Base::Exception& failure) {
+                failure.reportException();
+            }
+            catch (const std::exception& failure) {
+                Base::Console().error("Render presentation release failed: %s\n", failure.what());
+            }
+            catch (...) {
+                Base::Console().error("Render presentation release failed\n");
+            }
+        }
+    }
+
+    PresentationUpdateEnd(const PresentationUpdateEnd&) = delete;
+    PresentationUpdateEnd& operator=(const PresentationUpdateEnd&) = delete;
+
+private:
+    const std::string documentName;
+    const std::string documentUid;
 };
 
 std::deque<DeferredVisual> deferredVisuals;
+// false = queued, true = started. Cancelling a queued request must not consume
+// another provider's outstanding completion.
+std::map<std::uint64_t, bool> deferredVisualIdentities;
+std::size_t deferredVisualOutstanding = 0;
 bool deferredVisualRefreshScheduled = false;
+bool deferredVisualDispatchPending = false;
 bool deferredVisualShutdown = false;
 bool deferredVisualShutdownConnected = false;
+fastsignals::scoped_connection deferredRestoreIdleConnection;
+fastsignals::scoped_connection deferredOpenFinishedConnection;
 std::unique_ptr<Base::SequencerLauncher> deferredVisualProgress;
 Gui::ProgressBar* deferredVisualProgressBar = nullptr;
 int deferredVisualProgressMinimumDuration = -1;
@@ -155,8 +291,6 @@ void startDeferredVisualProgress()
     deferredVisualProgress =
         std::make_unique<Base::SequencerLauncher>(text.constData(), deferredVisuals.size());
 
-    // Paint the native progress indicator and wait cursor before tessellating the next shape.
-    qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 }
 
 void advanceDeferredVisualProgress()
@@ -180,9 +314,16 @@ void shutdownDeferredVisualRestore()
 {
     deferredVisualShutdown = true;
     deferredVisuals.clear();
+    deferredVisualIdentities.clear();
+    deferredVisualOutstanding = 0;
     deferredVisualRefreshScheduled = false;
+    deferredVisualDispatchPending = false;
+    deferredRestoreIdleConnection.disconnect();
+    deferredOpenFinishedConnection.disconnect();
     finishDeferredVisualProgress();
 }
+
+void scheduleNextDeferredVisual();
 
 void connectDeferredVisualShutdown()
 {
@@ -196,16 +337,49 @@ void connectDeferredVisualShutdown()
                      qApp,
                      shutdownDeferredVisualRestore,
                      Qt::DirectConnection);
+    const auto restoreIdle = [] {
+        Gui::dispatchToGuiFrame(qApp, [] {
+            if (!deferredVisuals.empty()) { scheduleNextDeferredVisual(); }
+        });
+    };
+    deferredRestoreIdleConnection = App::GetApplication().signalRestoreActivityIdle.connect(restoreIdle);
+    deferredOpenFinishedConnection = App::GetApplication().signalFinishOpenDocument.connect(restoreIdle);
 }
 
 void refreshNextDeferredVisual();
 
-void scheduleNextDeferredVisual(int delay = 0)
+void completeDeferredVisualRestore(std::uint64_t instanceId)
 {
-    if (deferredVisualShutdown || !qApp) {
+    const auto found = deferredVisualIdentities.find(instanceId);
+    if (deferredVisualShutdown || found == deferredVisualIdentities.end()) {
         return;
     }
-    QTimer::singleShot(delay, qApp, refreshNextDeferredVisual);
+    const bool started = found->second;
+    deferredVisualIdentities.erase(found);
+    if (started) {
+        --deferredVisualOutstanding;
+    }
+    advanceDeferredVisualProgress();
+    if (deferredVisuals.empty() && deferredVisualOutstanding == 0) {
+        finishDeferredVisualProgress();
+        deferredVisualRefreshScheduled = false;
+    }
+}
+
+void scheduleNextDeferredVisual()
+{
+    if (deferredVisualShutdown || !qApp || deferredVisualDispatchPending) {
+        return;
+    }
+    deferredVisualDispatchPending = true;
+    if (!Gui::dispatchToGuiFrame(qApp, [] {
+        deferredVisualDispatchPending = false;
+        refreshNextDeferredVisual();
+    })) {
+        deferredVisualDispatchPending = false;
+        deferredVisualRefreshScheduled = false;
+        Base::Console().error("Cannot schedule restored model display: GUI dispatcher unavailable\n");
+    }
 }
 
 void refreshNextDeferredVisual()
@@ -214,31 +388,60 @@ void refreshNextDeferredVisual()
         return;
     }
     if (App::Document::isAnyRestoring()) {
-        scheduleNextDeferredVisual(25);
-        return;
+        return; // The actual restore-idle transition schedules the next frame.
     }
 
     startDeferredVisualProgress();
 
+    Gui::FrameBudget budget;
     while (!deferredVisuals.empty()) {
-        DeferredVisual identity = std::move(deferredVisuals.front());
-        deferredVisuals.pop_front();
-        auto* document = App::GetApplication().getDocument(identity.documentName.c_str());
-        auto* object = document ? document->getObject(identity.objectName.c_str()) : nullptr;
-        auto* viewProvider = object && Gui::Application::Instance
-            ? Gui::Application::Instance->getViewProvider<ViewProviderPartExt>(object)
-            : nullptr;
-        if (viewProvider) {
-            viewProvider->finishDeferredVisualRestore();
-            advanceDeferredVisualProgress();
+        if (budget.exhausted()) {
             scheduleNextDeferredVisual();
             return;
         }
-        advanceDeferredVisualProgress();
+        DeferredVisual identity = std::move(deferredVisuals.front());
+        deferredVisuals.pop_front();
+        if (!deferredVisualIdentities.contains(identity.instanceId)) {
+            continue;
+        }
+        auto* document = App::GetApplication().getDocument(identity.documentName.c_str());
+        if (document && document->Uid.getValueStr() != identity.documentUid) {
+            document = nullptr;
+        }
+        if (document && document->testStatus(App::Document::Restoring)) {
+            // A document can remain Restoring between worker phases even when
+            // no archive scope is active. Do not consume its display request.
+            deferredVisuals.push_front(std::move(identity));
+            return;
+        }
+        auto* object = document ? document->getObjectByID(identity.objectId) : nullptr;
+        auto* viewProvider = object && Gui::Application::Instance
+            ? Gui::Application::Instance->getViewProvider<ViewProviderPartExt>(object)
+            : nullptr;
+        if (identity.matches(viewProvider)) {
+            deferredVisualIdentities.at(identity.instanceId) = true;
+            ++deferredVisualOutstanding;
+            try {
+                viewProvider->finishDeferredVisualRestore();
+            }
+            catch (const std::exception& error) {
+                completeDeferredVisualRestore(identity.instanceId);
+                Base::Console().error("Restored model display failed: %s\n", error.what());
+            }
+            catch (...) {
+                completeDeferredVisualRestore(identity.instanceId);
+                Base::Console().error("Restored model display failed\n");
+            }
+            scheduleNextDeferredVisual();
+            return;
+        }
+        completeDeferredVisualRestore(identity.instanceId);
     }
 
-    finishDeferredVisualProgress();
-    deferredVisualRefreshScheduled = false;
+    if (deferredVisualOutstanding == 0) {
+        finishDeferredVisualProgress();
+        deferredVisualRefreshScheduled = false;
+    }
 }
 
 void deferVisualRestore(const ViewProviderPartExt& viewProvider)
@@ -252,7 +455,13 @@ void deferVisualRestore(const ViewProviderPartExt& viewProvider)
         return;
     }
     connectDeferredVisualShutdown();
-    deferredVisuals.push_back({document->getName(), object->getNameInDocument()});
+    DeferredVisual identity(viewProvider);
+    if (!deferredVisualIdentities
+             .emplace(identity.instanceId, false)
+             .second) {
+        return;
+    }
+    deferredVisuals.push_back(std::move(identity));
     if (!deferredVisualRefreshScheduled) {
         deferredVisualRefreshScheduled = true;
         scheduleNextDeferredVisual();
@@ -262,6 +471,7 @@ void deferVisualRestore(const ViewProviderPartExt& viewProvider)
 
 ViewProviderPartExt::ViewProviderPartExt()
 {
+    visualInstanceId = nextVisualInstanceId.fetch_add(1, std::memory_order_relaxed);
     texture.initExtension(this);
 
     VisualTouched = true;
@@ -429,6 +639,9 @@ ViewProviderPartExt::ViewProviderPartExt()
 
 ViewProviderPartExt::~ViewProviderPartExt()
 {
+    visualMeshController.cancelAll();
+    // The provider can disappear before its queued request even starts.
+    completeDeferredVisualRestore(visualInstanceId);
     pcFaceBind->unref();
     pcLineBind->unref();
     pcPointBind->unref();
@@ -532,10 +745,12 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
         pcPointMaterial->transparency.setValue(Mat.transparency);
     }
     else if (prop == &PointColorArray) {
-        setHighlightedPoints(PointColorArray.getValues());
+        pointAppearanceStamp = {};
+        applyPointAppearance();
     }
     else if (prop == &LineColorArray) {
-        setHighlightedEdges(LineColorArray.getValues());
+        edgeAppearanceStamp = {};
+        applyEdgeAppearance();
     }
     else if (prop == &_diffuseColor) {
         // Used to load the old DiffuseColor values asynchronously
@@ -550,7 +765,8 @@ void ViewProviderPartExt::onChanged(const App::Property* prop)
         ShapeAppearance.setTransparencies(transparencies);
     }
     else if (prop == &ShapeAppearance) {
-        setHighlightedFaces(ShapeAppearance);
+        shapeAppearanceStamp = {};
+        applyShapeAppearance();
         ViewProviderGeometryObject::onChanged(prop);
     }
     else if (prop == &Transparency) {
@@ -842,13 +1058,21 @@ void ViewProviderPartExt::setHighlightedFaces(const std::vector<App::Material>& 
     action.apply(this->faceset);
 
     int size = static_cast<int>(materials.size());
+    if (size == 1) {
+        // Uniform appearance is independent of topology. In particular, do
+        // not traverse a restored BREP before its worker mesh is installed.
+        pcFaceBind->value = SoMaterialBinding::OVERALL;
+        setCoinAppearance(materials[0]);
+        return;
+    }
+    if (size == 0) { return; }
     int faceCount = this->faceset->partIndex.getNum();
     if (faceCount == 0) {
         if (const auto* feature = getObject<Part::Feature>()) {
             faceCount = static_cast<int>(feature->Shape.getShape().countSubShapes(TopAbs_FACE));
         }
     }
-    if (size > 1 && size == faceCount) {
+    if (size == faceCount) {
         pcFaceBind->value = SoMaterialBinding::PER_PART;
         texture.activateMaterial();
 
@@ -898,15 +1122,44 @@ void ViewProviderPartExt::setHighlightedFaces(const std::vector<App::Material>& 
         pcShapeMaterial->shininess.finishEditing();
         pcShapeMaterial->transparency.finishEditing();
     }
-    else if (size == 1) {
-        pcFaceBind->value = SoMaterialBinding::OVERALL;
-        setCoinAppearance(materials[0]);
-    }
 }
 
 void ViewProviderPartExt::setHighlightedFaces(const App::PropertyMaterialList& appearance)
 {
     setHighlightedFaces(appearance.getValues());
+}
+
+void ViewProviderPartExt::applyShapeAppearance()
+{
+    const int faceCount = faceset->partIndex.getNum();
+    if (appearanceFaceCount == faceCount
+        && shapeAppearanceStamp == appearanceStamp(pcShapeMaterial, pcFaceBind)) {
+        return;
+    }
+    // Multi-face appearance needs the worker's topology result, not a second
+    // BREP traversal during restore. finishVisualBuild applies the latest
+    // property values after installing that result. Uniform colour is immediate.
+    if (ShapeAppearance.getSize() <= 1 || faceCount > 0) {
+        setHighlightedFaces(ShapeAppearance);
+        shapeAppearanceStamp = appearanceStamp(pcShapeMaterial, pcFaceBind);
+        appearanceFaceCount = faceCount;
+    }
+}
+
+void ViewProviderPartExt::applyEdgeAppearance()
+{
+    if (edgeAppearanceStamp != appearanceStamp(pcLineMaterial, pcLineBind)) {
+        setHighlightedEdges(LineColorArray.getValues());
+        edgeAppearanceStamp = appearanceStamp(pcLineMaterial, pcLineBind);
+    }
+}
+
+void ViewProviderPartExt::applyPointAppearance()
+{
+    if (pointAppearanceStamp != appearanceStamp(pcPointMaterial, pcPointBind)) {
+        setHighlightedPoints(PointColorArray.getValues());
+        pointAppearanceStamp = appearanceStamp(pcPointMaterial, pcPointBind);
+    }
 }
 
 std::map<std::string, Base::Color> ViewProviderPartExt::getElementColors(const char* element) const
@@ -1032,20 +1285,12 @@ void ViewProviderPartExt::setHighlightedEdges(const std::vector<Base::Color>& co
     if (size > 1) {
         // Although indexed lineset is used the material binding must be PER_FACE!
         pcLineBind->value = SoMaterialBinding::PER_FACE;
-        const int32_t* cindices = this->lineset->coordIndex.getValues(0);
-        int numindices = this->lineset->coordIndex.getNum();
         pcLineMaterial->diffuseColor.setNum(size);
         SbColor* ca = pcLineMaterial->diffuseColor.startEditing();
-        int linecount = 0;
-
-        for (int i = 0; i < numindices; ++i) {
-            if (cindices[i] < 0) {
-                ca[linecount].setValue(colors[linecount].r, colors[linecount].g, colors[linecount].b);
-                linecount++;
-                if (linecount >= size) {
-                    break;
-                }
-            }
+        // Colours already have one entry per edge, not per tessellation
+        // vertex. Install the complete table even before geometry arrives.
+        for (int i = 0; i < size; ++i) {
+            ca[i].setValue(colors[i].r, colors[i].g, colors[i].b);
         }
 
         pcLineMaterial->diffuseColor.finishEditing();
@@ -1159,8 +1404,20 @@ void ViewProviderPartExt::finishRestoring()
 
 void ViewProviderPartExt::finishDeferredVisualRestore()
 {
-    if (VisualTouched && (isUpdateForced() || Visibility.getValue())) {
-        updateVisual();
+    deferredVisualRestorePending = true;
+    try {
+        if (VisualTouched && (isUpdateForced() || Visibility.getValue())) {
+            updateVisual();
+        }
+    }
+    catch (...) {
+        deferredVisualRestorePending = false;
+        completeDeferredVisualRestore(visualInstanceId);
+        throw;
+    }
+    if (!visualBuildInFlight) {
+        deferredVisualRestorePending = false;
+        completeDeferredVisualRestore(visualInstanceId);
     }
 }
 
@@ -1220,395 +1477,22 @@ void ViewProviderPartExt::setupCoinGeometry(
     bool normalsFromUV
 )
 {
-    if (Part::Tools::isShapeEmpty(shape)) {
-        coords->point.setNum(0);
-        norm->vector.setNum(0);
-        faceset->coordIndex.setNum(0);
-        faceset->partIndex.setNum(0);
-        lineset->coordIndex.setNum(0);
-        nodeset->startIndex.setValue(0);
-        return;
-    }
+    const Part::RenderMesh mesh =
+        Part::prepareRenderMesh(shape, deviation, angularDeflection, normalsFromUV);
+    copyRenderMesh(mesh, coords, faceset, norm, lineset, nodeset);
+}
 
-    // time measurement and book keeping
-    Base::TimeElapsed startTime;
-
-    [[maybe_unused]]
-    int numTriangles = 0,
-        numNodes = 0, numNorms = 0, numFaces = 0, numEdges = 0, numLines = 0;
-
-    std::set<int> faceEdges;
-
-    // calculating the deflection value
-    Standard_Real deflection = Part::Tools::getDeflection(shape, deviation);
-
-    // Since OCCT 7.6 a value of equal 0 is not allowed any more, this can happen if a single
-    // vertex should be displayed.
-    if (deflection < gp::Resolution()) {
-        deflection = Precision::Confusion();
-    }
-
-    // For very big objects the computed deflection can become very high and thus leads to a
-    // useless tessellation. To avoid this the upper limit is set to 20.0 See also forum:
-    // https://forum.freecad.org/viewtopic.php?t=77521
-    // deflection = std::min(deflection, 20.0);
-
-    // create or use the mesh on the data structure
-    Standard_Real AngDeflectionRads = Base::toRadians(angularDeflection);
-
-    IMeshTools_Parameters meshParams;
-    meshParams.Deflection = deflection;
-    meshParams.Relative = Standard_False;
-    meshParams.Angle = AngDeflectionRads;
-    meshParams.InParallel = Standard_True;
-    meshParams.AllowQualityDecrease = Standard_True;
-
-    // Clear triangulation and PCurves from geometry which can slow down the process
-#if OCC_VERSION_HEX < 0x070600
-    BRepTools::Clean(shape);
-#else
-    BRepTools::Clean(shape, Standard_True);
-#endif
-
-    BRepMesh_IncrementalMesh(shape, meshParams);
-
-    // We must reset the location here because the transformation data
-    // are set in the placement property
-    TopLoc_Location aLoc;
-    shape.Location(aLoc);
-
-    // count triangles and nodes in the mesh
-    TopTools_IndexedMapOfShape faceMap;
-    TopExp::MapShapes(shape, TopAbs_FACE, faceMap);
-    for (int i = 1; i <= faceMap.Extent(); i++) {
-        Handle(Poly_Triangulation) mesh = BRep_Tool::Triangulation(TopoDS::Face(faceMap(i)), aLoc);
-
-        if (mesh.IsNull()) {
-            mesh = Part::Tools::triangulationOfFace(TopoDS::Face(faceMap(i)));
-        }
-
-        // Note: we must also count empty faces
-        if (!mesh.IsNull()) {
-            numTriangles += mesh->NbTriangles();
-            numNodes += mesh->NbNodes();
-            numNorms += mesh->NbNodes();
-        }
-
-        TopExp_Explorer xp;
-        for (xp.Init(faceMap(i), TopAbs_EDGE); xp.More(); xp.Next()) {
-            faceEdges.insert(Part::ShapeMapHasher {}(xp.Current()));
-        }
-        numFaces++;
-    }
-
-    // get an indexed map of edges
-    TopTools_IndexedMapOfShape edgeMap;
-    TopExp::MapShapes(shape, TopAbs_EDGE, edgeMap);
-
-    // key is the edge number, value the coord indexes. This is needed to keep the same order as
-    // the edges.
-    std::map<int, std::vector<int32_t>> lineSetMap;
-    std::set<int> edgeIdxSet;
-    std::vector<int32_t> edgeVector;
-
-    // count and index the edges
-    for (int i = 1; i <= edgeMap.Extent(); i++) {
-        edgeIdxSet.insert(i);
-        numEdges++;
-
-        const TopoDS_Edge& aEdge = TopoDS::Edge(edgeMap(i));
-        TopLoc_Location aLoc;
-
-        // handling of the free edge that are not associated to a face
-        // Note: The assumption that if for an edge BRep_Tool::Polygon3D
-        // returns a valid object is wrong. This e.g. happens for ruled
-        // surfaces which gets created by two edges or wires.
-        // So, we have to store the hashes of the edges associated to a face.
-        // If the hash of a given edge is not in this list we know it's really
-        // a free edge.
-        int hash = Part::ShapeMapHasher {}(aEdge);
-        if (faceEdges.find(hash) == faceEdges.end()) {
-            Handle(Poly_Polygon3D) aPoly = Part::Tools::polygonOfEdge(aEdge, aLoc);
-            if (!aPoly.IsNull()) {
-                int nbNodesInEdge = aPoly->NbNodes();
-                numNodes += nbNodesInEdge;
-            }
-        }
-    }
-
-    // handling of the vertices
-    TopTools_IndexedMapOfShape vertexMap;
-    TopExp::MapShapes(shape, TopAbs_VERTEX, vertexMap);
-    numNodes += vertexMap.Extent();
-
-    // create memory for the nodes and indexes
-    coords->point.setNum(numNodes);
-    norm->vector.setNum(numNorms);
-    faceset->coordIndex.setNum(numTriangles * 4);
-    faceset->partIndex.setNum(numFaces);
-
-    // get the raw memory for fast fill up
-    SbVec3f* verts = coords->point.startEditing();
-    SbVec3f* norms = norm->vector.startEditing();
-    int32_t* index = faceset->coordIndex.startEditing();
-    int32_t* parts = faceset->partIndex.startEditing();
-
-    // preset the normal vector with null vector
-    for (int i = 0; i < numNorms; i++) {
-        norms[i] = SbVec3f(0.0, 0.0, 0.0);
-    }
-
-    int ii = 0, faceNodeOffset = 0, faceTriaOffset = 0;
-    for (int i = 1; i <= faceMap.Extent(); i++, ii++) {
-        TopLoc_Location aLoc;
-        const TopoDS_Face& actFace = TopoDS::Face(faceMap(i));
-        // get the mesh of the shape
-        Handle(Poly_Triangulation) mesh = BRep_Tool::Triangulation(actFace, aLoc);
-        if (mesh.IsNull()) {
-            mesh = Part::Tools::triangulationOfFace(actFace);
-        }
-        if (mesh.IsNull()) {
-            parts[ii] = 0;
-            continue;
-        }
-
-        // getting the transformation of the shape/face
-        gp_Trsf myTransf;
-        Standard_Boolean identity = true;
-        if (!aLoc.IsIdentity()) {
-            identity = false;
-            myTransf = aLoc.Transformation();
-        }
-
-        // getting size of node and triangle array of this face
-        int nbNodesInFace = mesh->NbNodes();
-        int nbTriInFace = mesh->NbTriangles();
-        // check orientation
-        TopAbs_Orientation orient = actFace.Orientation();
-
-        // cycling through the poly mesh
-#if OCC_VERSION_HEX < 0x070600
-        const Poly_Array1OfTriangle& Triangles = mesh->Triangles();
-        const TColgp_Array1OfPnt& Nodes = mesh->Nodes();
-        TColgp_Array1OfDir Normals(Nodes.Lower(), Nodes.Upper());
-#else
-        int numNodes = mesh->NbNodes();
-        TColgp_Array1OfDir Normals(1, numNodes);
-#endif
-        if (normalsFromUV) {
-            Part::Tools::getPointNormals(actFace, mesh, Normals);
-        }
-
-        for (int g = 1; g <= nbTriInFace; g++) {
-            // Get the triangle
-            Standard_Integer N1, N2, N3;
-#if OCC_VERSION_HEX < 0x070600
-            Triangles(g).Get(N1, N2, N3);
-#else
-            mesh->Triangle(g).Get(N1, N2, N3);
-#endif
-
-            // change orientation of the triangle if the face is reversed
-            if (orient != TopAbs_FORWARD) {
-                Standard_Integer tmp = N1;
-                N1 = N2;
-                N2 = tmp;
-            }
-
-            // get the 3 points of this triangle
-#if OCC_VERSION_HEX < 0x070600
-            gp_Pnt V1(Nodes(N1)), V2(Nodes(N2)), V3(Nodes(N3));
-#else
-            gp_Pnt V1(mesh->Node(N1)), V2(mesh->Node(N2)), V3(mesh->Node(N3));
-#endif
-
-            // get the 3 normals of this triangle
-            gp_Vec NV1, NV2, NV3;
-            if (normalsFromUV) {
-                NV1.SetXYZ(Normals(N1).XYZ());
-                NV2.SetXYZ(Normals(N2).XYZ());
-                NV3.SetXYZ(Normals(N3).XYZ());
-            }
-            else {
-                gp_Vec v1 = Base::convertTo<gp_Vec>(V1);
-                gp_Vec v2 = Base::convertTo<gp_Vec>(V2);
-                gp_Vec v3 = Base::convertTo<gp_Vec>(V3);
-
-                gp_Vec normal = (v2 - v1) ^ (v3 - v1);
-                NV1 = normal;
-                NV2 = normal;
-                NV3 = normal;
-            }
-
-            // transform the vertices and normals to the place of the face
-            if (!identity) {
-                V1.Transform(myTransf);
-                V2.Transform(myTransf);
-                V3.Transform(myTransf);
-                if (normalsFromUV) {
-                    NV1.Transform(myTransf);
-                    NV2.Transform(myTransf);
-                    NV3.Transform(myTransf);
-                }
-            }
-
-            // add the normals for all points of this triangle
-            norms[faceNodeOffset + N1 - 1] += Base::convertTo<SbVec3f>(NV1);
-            norms[faceNodeOffset + N2 - 1] += Base::convertTo<SbVec3f>(NV2);
-            norms[faceNodeOffset + N3 - 1] += Base::convertTo<SbVec3f>(NV3);
-
-            // set the vertices
-            verts[faceNodeOffset + N1 - 1] = Base::convertTo<SbVec3f>(V1);
-            verts[faceNodeOffset + N2 - 1] = Base::convertTo<SbVec3f>(V2);
-            verts[faceNodeOffset + N3 - 1] = Base::convertTo<SbVec3f>(V3);
-
-            // set the index vector with the 3 point indexes and the end delimiter
-            index[faceTriaOffset * 4 + 4 * (g - 1)] = faceNodeOffset + N1 - 1;
-            index[faceTriaOffset * 4 + 4 * (g - 1) + 1] = faceNodeOffset + N2 - 1;
-            index[faceTriaOffset * 4 + 4 * (g - 1) + 2] = faceNodeOffset + N3 - 1;
-            index[faceTriaOffset * 4 + 4 * (g - 1) + 3] = SO_END_FACE_INDEX;
-        }
-
-        parts[ii] = nbTriInFace;  // new part
-
-        // handling the edges lying on this face
-        TopExp_Explorer Exp;
-        for (Exp.Init(actFace, TopAbs_EDGE); Exp.More(); Exp.Next()) {
-            const TopoDS_Edge& curEdge = TopoDS::Edge(Exp.Current());
-            // get the overall index of this edge
-            int edgeIndex = edgeMap.FindIndex(curEdge);
-            edgeVector.push_back((int32_t)edgeIndex - 1);
-            // already processed this index ?
-            if (edgeIdxSet.find(edgeIndex) != edgeIdxSet.end()) {
-
-                // this holds the indices of the edge's triangulation to the current polygon
-                Handle(Poly_PolygonOnTriangulation)
-                    aPoly = BRep_Tool::PolygonOnTriangulation(curEdge, mesh, aLoc);
-                if (aPoly.IsNull()) {
-                    continue;  // polygon does not exist
-                }
-
-                // getting the indexes of the edge polygon
-                const TColStd_Array1OfInteger& indices = aPoly->Nodes();
-                for (Standard_Integer i = indices.Lower(); i <= indices.Upper(); i++) {
-                    int nodeIndex = indices(i);
-                    int index = faceNodeOffset + nodeIndex - 1;
-                    lineSetMap[edgeIndex].push_back(index);
-
-                    // usually the coordinates for this edge are already set by the
-                    // triangles of the face this edge belongs to. However, there are
-                    // rare cases where some points are only referenced by the polygon
-                    // but not by any triangle. Thus, we must apply the coordinates to
-                    // make sure that everything is properly set.
-#if OCC_VERSION_HEX < 0x070600
-                    gp_Pnt p(Nodes(nodeIndex));
-#else
-                    gp_Pnt p(mesh->Node(nodeIndex));
-#endif
-                    if (!identity) {
-                        p.Transform(myTransf);
-                    }
-                    verts[index] = Base::convertTo<SbVec3f>(p);
-                }
-
-                // remove the handled edge index from the set
-                edgeIdxSet.erase(edgeIndex);
-            }
-        }
-
-        edgeVector.push_back(-1);
-
-        // counting up the per Face offsets
-        faceNodeOffset += nbNodesInFace;
-        faceTriaOffset += nbTriInFace;
-    }
-
-    // handling of the free edges
-    for (int i = 1; i <= edgeMap.Extent(); i++) {
-        const TopoDS_Edge& aEdge = TopoDS::Edge(edgeMap(i));
-        Standard_Boolean identity = true;
-        gp_Trsf myTransf;
-        TopLoc_Location aLoc;
-
-        // handling of the free edge that are not associated to a face
-        int hash = Part::ShapeMapHasher {}(aEdge);
-        if (faceEdges.find(hash) == faceEdges.end()) {
-            Handle(Poly_Polygon3D) aPoly = Part::Tools::polygonOfEdge(aEdge, aLoc);
-            if (!aPoly.IsNull()) {
-                if (!aLoc.IsIdentity()) {
-                    identity = false;
-                    myTransf = aLoc.Transformation();
-                }
-
-                const TColgp_Array1OfPnt& aNodes = aPoly->Nodes();
-                int nbNodesInEdge = aPoly->NbNodes();
-
-                gp_Pnt pnt;
-                for (Standard_Integer j = 1; j <= nbNodesInEdge; j++) {
-                    pnt = aNodes(j);
-                    if (!identity) {
-                        pnt.Transform(myTransf);
-                    }
-                    int index = faceNodeOffset + j - 1;
-                    verts[index] = Base::convertTo<SbVec3f>(pnt);
-                    lineSetMap[i].push_back(index);
-                }
-
-                faceNodeOffset += nbNodesInEdge;
-            }
-        }
-    }
-
-    nodeset->startIndex.setValue(faceNodeOffset);
-    for (int i = 0; i < vertexMap.Extent(); i++) {
-        const TopoDS_Vertex& aVertex = TopoDS::Vertex(vertexMap(i + 1));
-        gp_Pnt pnt = BRep_Tool::Pnt(aVertex);
-
-        verts[faceNodeOffset + i] = Base::convertTo<SbVec3f>(pnt);
-    }
-
-    // normalize all normals
-    for (int i = 0; i < numNorms; i++) {
-        norms[i].normalize();
-    }
-
-    std::vector<int32_t> lineSetCoords;
-    for (const auto& it : lineSetMap) {
-        lineSetCoords.insert(lineSetCoords.end(), it.second.begin(), it.second.end());
-        lineSetCoords.push_back(-1);
-    }
-
-    // preset the index vector size
-    numLines = lineSetCoords.size();
-    lineset->coordIndex.setNum(numLines);
-    int32_t* lines = lineset->coordIndex.startEditing();
-
-    int l = 0;
-    for (auto it = lineSetCoords.begin(); it != lineSetCoords.end(); ++it, l++) {
-        lines[l] = *it;
-    }
-
-    // end the editing of the nodes
-    coords->point.finishEditing();
-    norm->vector.finishEditing();
-    faceset->coordIndex.finishEditing();
-    faceset->partIndex.finishEditing();
-    lineset->coordIndex.finishEditing();
-
-#ifdef FC_DEBUG
-    Base::Console().log(
-        "ViewProvider update time: %f s\n",
-        Base::TimeElapsed::diffTimeF(startTime, Base::TimeElapsed())
+void ViewProviderPartExt::bindRenderMesh(std::shared_ptr<const Part::RenderMesh> mesh)
+{
+    bindPreparedRenderMesh(
+        std::move(mesh),
+        installedRenderMesh,
+        coords,
+        faceset,
+        norm,
+        lineset,
+        nodeset
     );
-    Base::Console().log(
-        "Shape mesh info: Faces:%d Edges:%d Nodes:%d Triangles:%d IdxVec:%d\n",
-        numFaces,
-        numEdges,
-        numNodes,
-        numTriangles,
-        numLines
-    );
-#endif
 }
 
 void ViewProviderPartExt::setupCoinGeometry(
@@ -1632,6 +1516,141 @@ void ViewProviderPartExt::setupCoinGeometry(
     );
 }
 
+void ViewProviderPartExt::startVisualBuild(
+    TopoDS_Shape shape,
+    std::uint64_t generation
+)
+{
+    auto* object = getObject();
+    auto* document = object ? object->getDocument() : nullptr;
+    if (!object || !document || !qApp) {
+        return;
+    }
+
+    const std::string documentName = document->getName();
+    const std::string documentUid = document->Uid.getValueStr();
+    const long objectId = object->getID();
+    const std::uint64_t instanceId = visualInstanceId;
+    visualBuildInFlight = true;
+    // The controller owns callbacks on the GUI thread. Completion, cancellation
+    // and provider destruction all release this lease there; workers never
+    // retain or dereference a document or view provider.
+    auto presentationFinished = std::make_shared<PresentationUpdateEnd>(document);
+    document->beginPresentationUpdate();
+
+    try {
+        visualMeshController.request(
+            this,
+            shape,
+            Deviation.getValue(),
+            AngularDeflection.getValue(),
+            NormalsFromUV,
+            [documentName, documentUid, objectId, instanceId, generation,
+             shape,
+             presentationFinished](RenderMeshResult result) mutable {
+                auto* document = App::GetApplication().getDocument(documentName.c_str());
+                if (document && document->Uid.getValueStr() != documentUid) {
+                    document = nullptr;
+                }
+                auto* object = document ? document->getObjectByID(objectId) : nullptr;
+                auto* viewProvider = object && Gui::Application::Instance
+                    ? Gui::Application::Instance->getViewProvider<ViewProviderPartExt>(object)
+                    : nullptr;
+                if (viewProvider) {
+                    viewProvider->finishVisualBuild(
+                        instanceId, generation, std::move(shape),
+                        std::move(result.mesh), std::move(result.error)
+                    );
+                }
+                else {
+                    completeDeferredVisualRestore(instanceId);
+                }
+            }
+        );
+    }
+    catch (const std::exception& failure) {
+        visualBuildInFlight = false;
+        FC_ERR(
+            "Cannot schedule render mesh preparation for "
+            << object->getFullName() << ": " << failure.what()
+        );
+        if (deferredVisualRestorePending) {
+            deferredVisualRestorePending = false;
+            completeDeferredVisualRestore(instanceId);
+        }
+    }
+}
+
+void ViewProviderPartExt::finishVisualBuild(
+    std::uint64_t instanceId,
+    std::uint64_t generation,
+    TopoDS_Shape shape,
+    std::shared_ptr<const Part::RenderMesh> mesh,
+    std::string error
+)
+{
+    if (instanceId != visualInstanceId) {
+        return;
+    }
+
+    visualBuildInFlight = false;
+    const bool currentRequest = generation == visualRequestGeneration;
+    bool applied = false;
+    if (currentRequest && !error.empty()) {
+        const auto* object = getObject();
+        FC_ERR(
+            "Cannot compute Inventor representation for the shape of "
+            << (object ? object->getFullName() : "<detached object>")
+            << ": " << error
+        );
+    }
+    else if (currentRequest && mesh) {
+        Gui::SoUpdateVBOAction action;
+        action.apply(this->faceset);
+
+        Gui::SoSelectionElementAction selectionAction(
+            Gui::SoSelectionElementAction::None
+        );
+        selectionAction.apply(this->faceset);
+        selectionAction.apply(this->lineset);
+        selectionAction.apply(this->nodeset);
+
+        Gui::SoHighlightElementAction highlightAction;
+        highlightAction.apply(this->faceset);
+        highlightAction.apply(this->lineset);
+        highlightAction.apply(this->nodeset);
+
+        try {
+            bindRenderMesh(std::move(mesh));
+            lastRenderedShape = shape;
+            VisualTouched = false;
+            applied = true;
+        }
+        catch (const Base::Exception& failure) {
+            failure.reportException();
+        }
+        catch (const std::exception& failure) {
+            const auto* object = getObject();
+            FC_ERR(
+                "Cannot install Inventor representation for the shape of "
+                << (object ? object->getFullName() : "<detached object>")
+                << ": " << failure.what()
+            );
+        }
+    }
+
+    if (applied) {
+        applyShapeAppearance();
+        applyEdgeAppearance();
+        applyPointAppearance();
+    }
+
+    if (!visualBuildInFlight && deferredVisualRestorePending) {
+        deferredVisualRestorePending = false;
+        completeDeferredVisualRestore(visualInstanceId);
+    }
+}
+
 void ViewProviderPartExt::updateVisual()
 {
     auto* object = getObject();
@@ -1643,66 +1662,20 @@ void ViewProviderPartExt::updateVisual()
     }
 
     TopoDS_Shape shape = getRenderedShape().getShape();
-
     if (!VisualTouched && lastRenderedShape.IsPartner(shape)) {
-        // shape unchanged so do not rebuild geometry
-        // but still re-apply materials in case colors changed
-        Gui::SoHighlightElementAction haction;
-        haction.apply(this->faceset);
-        haction.apply(this->lineset);
-        haction.apply(this->nodeset);
-        setHighlightedFaces(ShapeAppearance.getValues());
-        setHighlightedEdges(LineColorArray.getValues());
-        setHighlightedPoints(PointColorArray.getValue());
+        Gui::SoHighlightElementAction highlightAction;
+        highlightAction.apply(this->faceset);
+        highlightAction.apply(this->lineset);
+        highlightAction.apply(this->nodeset);
+        applyShapeAppearance();
+        applyEdgeAppearance();
+        applyPointAppearance();
         return;
     }
 
-    Gui::SoUpdateVBOAction action;
-    action.apply(this->faceset);
-
-    // Clear selection
-    Gui::SoSelectionElementAction saction(Gui::SoSelectionElementAction::None);
-    saction.apply(this->faceset);
-    saction.apply(this->lineset);
-    saction.apply(this->nodeset);
-
-    // Clear highlighting
-    Gui::SoHighlightElementAction haction;
-    haction.apply(this->faceset);
-    haction.apply(this->lineset);
-    haction.apply(this->nodeset);
-
-    try {
-        setupCoinGeometry(
-            shape,
-            coords,
-            faceset,
-            norm,
-            lineset,
-            nodeset,
-            Deviation.getValue(),
-            AngularDeflection.getValue(),
-            NormalsFromUV
-        );
-
-        lastRenderedShape = shape;
-
-        VisualTouched = false;
-    }
-    catch (const Standard_Failure& e) {
-        FC_ERR(
-            "Cannot compute Inventor representation for the shape of "
-            << pcObject->getFullName() << ": " << e.GetMessageString()
-        );
-    }
-    catch (...) {
-        FC_ERR("Cannot compute Inventor representation for the shape of " << pcObject->getFullName());
-    }
-
-    // The material has to be checked again
-    setHighlightedFaces(ShapeAppearance.getValues());
-    setHighlightedEdges(LineColorArray.getValues());
-    setHighlightedPoints(PointColorArray.getValue());
+    VisualTouched = true;
+    const std::uint64_t generation = ++visualRequestGeneration;
+    startVisualBuild(std::move(shape), generation);
 }
 
 void ViewProviderPartExt::forceUpdate(bool enable)

--- a/src/Mod/Part/Gui/ViewProviderExt.h
+++ b/src/Mod/Part/Gui/ViewProviderExt.h
@@ -25,9 +25,14 @@
 #pragma once
 
 #include "SoFCShapeObject.h"
+#include "RenderMeshController.h"
 
 
+#include <cstdint>
 #include <map>
+#include <memory>
+#include <string>
+#include <utility>
 
 #include <App/PropertyUnits.h>
 #include <Gui/ViewProviderGeometryObject.h>
@@ -57,6 +62,11 @@ class SoNormal;
 class SoNormalBinding;
 class SoMaterialBinding;
 class SoIndexedLineSet;
+
+namespace Part
+{
+struct RenderMesh;
+}
 
 namespace PartGui
 {
@@ -240,6 +250,24 @@ protected:
     bool faceHighlightActive = false;
 
 private:
+    friend struct DeferredVisual;
+    void applyShapeAppearance();
+    void applyEdgeAppearance();
+    void applyPointAppearance();
+    using AppearanceStamp = std::pair<std::uint64_t, std::uint64_t>;
+    AppearanceStamp shapeAppearanceStamp {};
+    AppearanceStamp edgeAppearanceStamp {};
+    AppearanceStamp pointAppearanceStamp {};
+    int appearanceFaceCount {-1};
+    void startVisualBuild(TopoDS_Shape shape, std::uint64_t generation);
+    void finishVisualBuild(
+        std::uint64_t instanceId,
+        std::uint64_t generation,
+        TopoDS_Shape shape,
+        std::shared_ptr<const Part::RenderMesh> mesh,
+        std::string error
+    );
+    void bindRenderMesh(std::shared_ptr<const Part::RenderMesh> mesh);
     Gui::ViewProviderFaceTexture texture;
     // settings stuff
     int forceUpdateCount;
@@ -255,6 +283,15 @@ private:
 
     // shape that was last rendered so if it does not change we don't re-render it without need
     TopoDS_Shape lastRenderedShape;
+    std::uint64_t visualInstanceId {0};
+    std::uint64_t visualRequestGeneration {0};
+    bool visualBuildInFlight {false};
+    RenderMeshController visualMeshController;
+    bool deferredVisualRestorePending {false};
+    // Coin borrows the prepared arrays through setValuesPointer(). Keep the
+    // exact immutable artifact alive until every field is rebound or this
+    // provider is destroyed.
+    std::shared_ptr<const Part::RenderMesh> installedRenderMesh;
 };
 
 }  // namespace PartGui

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.cpp
@@ -30,6 +30,7 @@
 
 #include "ViewProviderPreviewExtension.h"
 #include "ViewProviderExt.h"
+#include "RenderMeshController.h"
 
 #include <App/Document.h>
 #include <Gui/Utilities.h>
@@ -124,6 +125,7 @@ void SoPreviewShape::initClass()
 EXTENSION_PROPERTY_SOURCE(PartGui::ViewProviderPreviewExtension, Gui::ViewProviderExtension)
 
 ViewProviderPreviewExtension::ViewProviderPreviewExtension()
+    : renderMeshController(std::make_unique<RenderMeshController>())
 {
     const Base::Color magenta(1.0F, 0.0F, 1.0F);
 
@@ -137,6 +139,8 @@ ViewProviderPreviewExtension::ViewProviderPreviewExtension()
 
     initExtensionType(ViewProviderPreviewExtension::getExtensionClassTypeId());
 }
+
+ViewProviderPreviewExtension::~ViewProviderPreviewExtension() = default;
 
 void ViewProviderPreviewExtension::extensionAttach(App::DocumentObject* documentObject)
 {
@@ -155,6 +159,7 @@ void ViewProviderPreviewExtension::extensionAttach(App::DocumentObject* document
 
 void ViewProviderPreviewExtension::extensionBeforeDelete()
 {
+    cancelPreviewRendering();
     ViewProviderExtension::extensionBeforeDelete();
 
     showPreview(false);
@@ -206,9 +211,14 @@ void ViewProviderPreviewExtension::updatePreview()
     updatePreviewShape(getPreviewShape(), pcPreviewShape);
 }
 
+void ViewProviderPreviewExtension::cancelPreviewRendering()
+{
+    renderMeshController->cancelAll();
+}
+
 void ViewProviderPreviewExtension::updatePreviewShape(Part::TopoShape shape, SoPreviewShape* preview)
 {
-    if (shape.isNull() || preview == nullptr) {
+    if (preview == nullptr) {
         return;
     }
 
@@ -218,46 +228,31 @@ void ViewProviderPreviewExtension::updatePreviewShape(Part::TopoShape shape, SoP
         return;
     }
 
-    const auto updatePreviewShape = [vp](SoPreviewShape* preview, Part::TopoShape shape) {
-        ViewProviderPartExt::setupCoinGeometry(
-            shape.getShape(),
-            preview,
-            vp->Deviation.getValue(),
-            vp->AngularDeflection.getValue()
-        );
-    };
+    const SbMatrix transform = Base::convertTo<SbMatrix>(shape.getTransform());
+    Gui::CoinPtr<SoPreviewShape> target(preview);
+    renderMeshController->request(
+        preview,
+        shape.getShape(),
+        vp->Deviation.getValue(),
+        vp->AngularDeflection.getValue(),
+        false,
+        [target = std::move(target), transform](RenderMeshResult result) mutable {
+            if (!result.error.empty()) {
+                Base::Console().userTranslatedNotification(
+                    tr("Failure while rendering preview: %1. That usually indicates an error with model.")
+                        .arg(QString::fromUtf8(result.error.c_str()))
+                        .toUtf8()
+                );
+                result.mesh = std::make_shared<const Part::RenderMesh>();
+            }
+            if (!result.mesh) {
+                return;
+            }
 
-    try {
-        updatePreviewShape(preview, shape);
-        preview->transform.setValue(Base::convertTo<SbMatrix>(shape.getTransform()));
-    }
-    catch (Standard_Failure& e) {
-        Base::Console().userTranslatedNotification(
-            tr("Failure while rendering preview: %1. That usually indicates an error with model.")
-                .arg(QString::fromUtf8(e.GetMessageString()))
-                .toUtf8()
-        );
-
-        updatePreviewShape(preview, {});
-    }
-
-    // For some reason line patterns are not rendered correctly if material binding is set to
-    // anything other than PER_FACE. PER_FACE material binding seems to require materialIndex per
-    // each distinct edge. Until that is fixed, this code forces each edge to use the first
-    // material.
-    unsigned lineCoordsCount = preview->lineset->coordIndex.getNum();
-    unsigned lineCount = 1;
-
-    for (unsigned i = 0; i < lineCoordsCount; ++i) {
-        if (preview->lineset->coordIndex[i] < 0) {
-            lineCount++;
+            target->bindRenderMesh(result.mesh);
+            target->transform.setValue(transform);
         }
-    }
-
-    preview->lineset->materialIndex.setNum(lineCount);
-    for (unsigned i = 0; i < lineCount; ++i) {
-        preview->lineset->materialIndex.set1Value(i, 0);
-    }
+    );
 }
 
 namespace Gui

--- a/src/Mod/Part/Gui/ViewProviderPreviewExtension.h
+++ b/src/Mod/Part/Gui/ViewProviderPreviewExtension.h
@@ -28,6 +28,8 @@
 #include "SoBrepPointSet.h"
 #include "SoFCShapeObject.h"
 
+#include <memory>
+
 #include <QtCore>
 
 #include <Inventor/nodes/SoSubNode.h>
@@ -46,6 +48,8 @@
 
 namespace PartGui
 {
+
+class RenderMeshController;
 
 class PartGuiExport SoPreviewShape: public SoFCShape
 {
@@ -78,6 +82,7 @@ public:
     App::PropertyColor PreviewColor;
 
     ViewProviderPreviewExtension();
+    ~ViewProviderPreviewExtension() override;
 
     /// Returns shape that should be used as the preview
     virtual Part::TopoShape getPreviewShape() const
@@ -105,12 +110,15 @@ protected:
     virtual void updatePreview();
     /// updates geometry of the preview shape
     void updatePreviewShape(Part::TopoShape shape, SoPreviewShape* preview);
+    /// cancels pending rendering before transient preview nodes are replaced
+    void cancelPreviewRendering();
 
     Gui::CoinPtr<SoSeparator> pcPreviewRoot;
     Gui::CoinPtr<SoPreviewShape> pcPreviewShape;
 
 private:
     bool _isPreviewEnabled {false};
+    std::unique_ptr<RenderMeshController> renderMeshController;
 };
 
 using ViewProviderPreviewExtensionPython

--- a/src/Mod/Part/parttests/BRep_tests.py
+++ b/src/Mod/Part/parttests/BRep_tests.py
@@ -4,9 +4,32 @@ import FreeCAD as App
 import Part
 
 import unittest
+import tempfile
+from pathlib import Path
 
 
 class BRepTests(unittest.TestCase):
+
+    def testReadBrepShapesBatch(self):
+        with tempfile.TemporaryDirectory() as directory:
+            paths = []
+            for index in range(50):
+                path = Path(directory) / f"shape-{index}.brep"
+                Part.makeBox(index + 1, 2, 3).exportBrep(str(path))
+                paths.append(str(path))
+            before = set(App.listDocuments())
+            shapes = Part.readBrepShapes(paths)
+            self.assertEqual(len(shapes), 50)
+            for index, shape in enumerate(shapes):
+                self.assertTrue(shape.isValid())
+                self.assertAlmostEqual(shape.Volume, (index + 1) * 6)
+                self.assertEqual(len(shape.Solids), 1)
+            self.assertEqual(set(App.listDocuments()), before)
+            self.assertEqual(Part.readBrepShapes([]), [])
+            bad = Path(directory) / "bad.brep"
+            bad.write_text("not a BREP", encoding="utf-8")
+            with self.assertRaises(ValueError):
+                Part.readBrepShapes([paths[0], str(bad), paths[1]])
 
     def testProject(self):
         """

--- a/src/Mod/PartDesign/App/AppPartDesignPy.cpp
+++ b/src/Mod/PartDesign/App/AppPartDesignPy.cpp
@@ -182,6 +182,11 @@ public:
             "Validate and atomically publish one Design operation edit."
         );
         add_varargs_method(
+            "adoptDesignScriptOperationEdit",
+            &Module::adoptDesignScriptOperationEdit,
+            "Adopt accepted VibeScript output states without evaluating dependency branches."
+        );
+        add_varargs_method(
             "finalizeDesignScriptOperationEdit",
             &Module::finalizeDesignScriptOperationEdit,
             "Publish one worker-validated VibeScript edit and defer unrelated downstream "
@@ -715,7 +720,13 @@ private:
         return finalizeDesignOperationEditImpl(args, true);
     }
 
-    Py::Object finalizeDesignOperationEditImpl(const Py::Tuple& args, bool scriptOperation)
+    Py::Object adoptDesignScriptOperationEdit(const Py::Tuple& args)
+    {
+        return finalizeDesignOperationEditImpl(args, true, true);
+    }
+
+    Py::Object finalizeDesignOperationEditImpl(
+        const Py::Tuple& args, bool scriptOperation, bool adoptAcceptedState = false)
     {
         PyObject* editObject = nullptr;
         int affectedBodiesOnly = scriptOperation ? 1 : 0;
@@ -731,7 +742,9 @@ private:
         auto* edit = designEditFromCapsule(editObject);
         std::vector<Body*> bodies;
         try {
-            bodies = scriptOperation
+            bodies = adoptAcceptedState
+                ? DesignModel::adoptScriptOperation(*edit)
+                : scriptOperation
                 ? DesignModel::finalizeScriptOperation(*edit)
                 : DesignModel::finalizeOperation(*edit, affectedBodiesOnly != 0);
         }

--- a/src/Mod/PartDesign/App/DesignModel.cpp
+++ b/src/Mod/PartDesign/App/DesignModel.cpp
@@ -2004,7 +2004,8 @@ std::vector<Body*> DesignModel::finalizeScriptOperation(DesignOperationEdit& edi
 
 std::vector<Body*> DesignModel::finalizeOperationImpl(
     DesignOperationEdit& edit,
-    bool affectedBodiesOnly
+    bool affectedBodiesOnly,
+    bool adoptAcceptedState
 )
 {
     auto* operation = edit.operation;
@@ -2030,7 +2031,7 @@ std::vector<Body*> DesignModel::finalizeOperationImpl(
     // the persistent state graph. A full document recompute here would also
     // execute old state resources whose output slots are intentionally being
     // added or removed by this edit, producing transient false errors.
-    document->recomputeFeature(operation, true);
+    document->recomputeFeature(operation, !adoptAcceptedState);
     if (!operation->isValid()) {
         throw Base::RuntimeError(operation->getStatusString());
     }
@@ -2057,7 +2058,7 @@ std::vector<Body*> DesignModel::finalizeOperationImpl(
         finalizeNewOperation(edit, targets);
     }
     else {
-        finalizeExistingOperation(edit, targets);
+        finalizeExistingOperation(edit, targets, adoptAcceptedState);
     }
     if (const auto* script = freecad_cast<const DesignScriptOperation*>(operation)) {
         const auto labels = script->ScriptOutputLabels.getValues();
@@ -2077,7 +2078,25 @@ std::vector<Body*> DesignModel::finalizeOperationImpl(
         }
         targets.front()->Label.setValue(generated->OutputLabel.getValue());
     }
-    if (affectedBodiesOnly) {
+    if (adoptAcceptedState) {
+        // AcceptedShapes already contains the detached worker result. These
+        // three nodes only expose that state; traversing the dependency graph
+        // here both duplicates compute and conflicts with publication's lease.
+        // Later consumers remain touched for the asynchronous recompute phase.
+        for (auto* state : designBodyStatesForOperation(operation)) {
+            if (!document->recomputeFeature(state, false)) {
+                throw Base::RuntimeError("Could not adopt an accepted VibeScript Body state");
+            }
+        }
+        for (auto* body : targets) {
+            auto* publication = ensurePublication(*document, *body);
+            if (!document->recomputeFeature(publication, false)
+                || !document->recomputeFeature(body, false)) {
+                throw Base::RuntimeError("Could not expose an accepted VibeScript Body state");
+            }
+        }
+    }
+    else if (affectedBodiesOnly) {
         std::vector<App::DocumentObject*> affectedBodies;
         affectedBodies.reserve(targets.size());
         for (auto* body : targets) {
@@ -2099,6 +2118,14 @@ std::vector<Body*> DesignModel::finalizeOperationImpl(
     }
     validateDesign(*document);
     return targets;
+}
+
+std::vector<Body*> DesignModel::adoptScriptOperation(DesignOperationEdit& edit)
+{
+    if (!freecad_cast<DesignScriptOperation*>(edit.operation)) {
+        throw Base::TypeError("Only a DesignScriptOperation has accepted outputs to adopt");
+    }
+    return finalizeOperationImpl(edit, true, true);
 }
 
 std::vector<std::string> DesignModel::removeOperationResources(App::DocumentObject& operation)
@@ -2654,7 +2681,8 @@ void DesignModel::finalizeNewOperation(DesignOperationEdit& edit, std::vector<Bo
     edit.resourcesStaged = false;
 }
 
-void DesignModel::finalizeExistingOperation(DesignOperationEdit& edit, std::vector<Body*>& targets)
+void DesignModel::finalizeExistingOperation(
+    DesignOperationEdit& edit, std::vector<Body*>& targets, bool adoptAcceptedState)
 {
     auto* operation = edit.operation;
     auto* document = operation->getDocument();
@@ -2885,8 +2913,10 @@ void DesignModel::finalizeExistingOperation(DesignOperationEdit& edit, std::vect
         // operation port so timeline filtering cannot clear an otherwise
         // anonymous force-recompute request.
         state->Operation.touch();
-        document->recomputeFeature(state, true);
-        if (!state->isValid()) {
+        if (!adoptAcceptedState) {
+            document->recomputeFeature(state, true);
+        }
+        if (!adoptAcceptedState && !state->isValid()) {
             throw Base::RuntimeError(
                 state->getStatusString() && *state->getStatusString()
                     ? state->getStatusString()

--- a/src/Mod/PartDesign/App/DesignModel.h
+++ b/src/Mod/PartDesign/App/DesignModel.h
@@ -355,6 +355,14 @@ public:
     static std::vector<Body*> finalizeScriptOperation(DesignOperationEdit& edit);
 
     /**
+     * Adopt an already computed script result into its state/publication graph.
+     * Copies the accepted output state without evaluating dependency branches.
+     * The caller owns the transaction and schedules downstream recompute after
+     * publication. Existing finalization APIs retain their recompute behavior.
+     */
+    static std::vector<Body*> adoptScriptOperation(DesignOperationEdit& edit);
+
+    /**
      * Remove one complete Design operation and reconcile every Body output.
      *
      * Operation-created Bodies are removed only when nothing outside the
@@ -413,11 +421,13 @@ public:
 private:
     static std::vector<Body*> finalizeOperationImpl(
         DesignOperationEdit& edit,
-        bool affectedBodiesOnly
+        bool affectedBodiesOnly,
+        bool adoptAcceptedState = false
     );
 
     static void finalizeNewOperation(DesignOperationEdit& edit, std::vector<Body*>& targets);
-    static void finalizeExistingOperation(DesignOperationEdit& edit, std::vector<Body*>& targets);
+    static void finalizeExistingOperation(
+        DesignOperationEdit& edit, std::vector<Body*>& targets, bool adoptAcceptedState = false);
 };
 
 }  // namespace PartDesign

--- a/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProviderBoolean.cpp
@@ -214,6 +214,7 @@ void ViewProviderBoolean::updatePreview()
             return;
         }
 
+        cancelPreviewRendering();
         Gui::coinRemoveAllChildren(pcToolsPreview);
         Gui::coinRemoveAllChildren(pcBasePreviewToggle);
 

--- a/src/Mod/PartDesign/PartDesignTests/TestDesignModeling.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestDesignModeling.py
@@ -4099,6 +4099,46 @@ class TestDesignModeling(unittest.TestCase):
         PartDesign.validateDesign(operation)
         self._assert_dependency_graph_acyclic(self.document)
 
+    def test_vibescript_adoption_under_publication_lease_preserves_body_identity(self):
+        program = self.document.addObject("App::Part", "ScriptProgram")
+        unrelated = self.document.addObject("PartDesign::Body", "Unrelated")
+        unrelated.touch()
+        identities = None
+        operation = None
+        self.document.beginCooperativeMutation()
+        try:
+            for count, height in ((50, 3), (50, 4), (49, 5), (51, 6)):
+                keys = [f"Part{index}" for index in range(count)]
+                self.document.openTransaction("Adopt validated outputs")
+                if operation is None:
+                    operation = self.document.addObject(
+                        "PartDesign::DesignScriptOperation", "ScriptOperation"
+                    )
+                edit = PartDesign.beginDesignOperationEdit(operation)
+                PartDesign.setDesignScriptOutputs(
+                    edit, program.Name, "program-batch", f"revision-{height}",
+                    keys, keys, [Part.makeBox(i + 1, 2, height) for i in range(count)],
+                    [None] * count,
+                )
+                bodies = PartDesign.adoptDesignScriptOperationEdit(edit)
+                self.assertEqual(len(bodies), count)
+                current = [body.Name for body in bodies]
+                if identities is not None:
+                    retained = min(len(current), len(identities))
+                    self.assertEqual(current[:retained], identities[:retained])
+                identities = current
+                for index, body in enumerate(bodies):
+                    self.assertTrue(body.isValid())
+                    self.assertAlmostEqual(body.Shape.Volume, (index + 1) * 2 * height)
+                    self.assertIs(body.Tip.CurrentState.Operation, operation)
+                self.assertIn("Touched", unrelated.State)
+                PartDesign.validateDesign(operation)
+                self.document.commitTransaction()
+        finally:
+            self.document.abortTransaction()
+            self.document.endCooperativeMutation()
+        self._assert_dependency_graph_acyclic(self.document)
+
     def test_vibescript_program_is_one_global_multi_body_operation(self):
         program = self.document.addObject("App::Part", "ScriptProgram")
         program.Label = "Parametric enclosure"

--- a/src/Mod/PartDesign/__init__.py
+++ b/src/Mod/PartDesign/__init__.py
@@ -25,5 +25,6 @@ assignDesignSplitRegions = _PartDesign.assignDesignSplitRegions
 setDesignSeparateDefinition = _PartDesign.setDesignSeparateDefinition
 finalizeDesignOperationEdit = _PartDesign.finalizeDesignOperationEdit
 finalizeDesignScriptOperationEdit = _PartDesign.finalizeDesignScriptOperationEdit
+adoptDesignScriptOperationEdit = _PartDesign.adoptDesignScriptOperationEdit
 removeDesignOperation = _PartDesign.removeDesignOperation
 validateDesign = _PartDesign.validateDesign

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -104,6 +104,7 @@
 #include <TopTools_ListOfListOfShape.hxx>
 
 #include <Mod/Part/Gui/SoFCShapeObject.h>
+#include <Mod/Part/Gui/RenderMeshController.h>
 
 
 // clang-format off
@@ -574,6 +575,7 @@ ViewProviderSketch::ViewProviderSketch()
     , Mode(STATUS_NONE)
     , pcSketchFaces(new SoSketchFaces)
     , pcSketchFacesToggle(new SoToggleSwitch)
+    , sketchFaceRenderController(std::make_unique<PartGui::RenderMeshController>())
     , listener(nullptr)
     , editCoinManager(nullptr)
     , snapManager(nullptr)
@@ -3678,10 +3680,26 @@ void ViewProviderSketch::updateData(const App::Property* prop) {
 
     if (prop == &getSketchObject()->InternalShape) {
         const auto& shape = getSketchObject()->InternalShape.getValue();
-        setupCoinGeometry(shape,
-                pcSketchFaces,
-                Deviation.getValue(),
-                AngularDeflection.getValue());
+        Gui::CoinPtr<SoSketchFaces> target(pcSketchFaces);
+        sketchFaceRenderController->request(
+            pcSketchFaces,
+            shape,
+            Deviation.getValue(),
+            AngularDeflection.getValue(),
+            false,
+            [target = std::move(target)](PartGui::RenderMeshResult result) mutable {
+                if (!result.error.empty()) {
+                    Base::Console().error(
+                        "Cannot prepare Sketch face rendering: %s\n",
+                        result.error.c_str()
+                    );
+                    return;
+                }
+                if (result.mesh) {
+                    target->bindRenderMesh(std::move(result.mesh));
+                }
+            }
+        );
     }
 
     if (prop != &getSketchObject()->Constraints) {

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.h
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.h
@@ -88,6 +88,11 @@ namespace Part
 class Geometry;
 }
 
+namespace PartGui
+{
+class RenderMeshController;
+}
+
 namespace Gui
 {
 class View3DInventorViewer;
@@ -1063,6 +1068,7 @@ private:
 
     Gui::CoinPtr<SoSketchFaces> pcSketchFaces;
     Gui::CoinPtr<SoToggleSwitch> pcSketchFacesToggle;
+    std::unique_ptr<PartGui::RenderMeshController> sketchFaceRenderController;
 
     std::unique_ptr<ShortcutListener> listener;
 

--- a/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
+++ b/src/Mod/Spreadsheet/Gui/SpreadsheetView.cpp
@@ -165,11 +165,11 @@ bool SheetView::onMsg(const char* pMsg)
         return true;
     }
     else if (strcmp("Save", pMsg) == 0) {
-        getGuiDocument()->save();
+        getGuiDocument()->saveAsync();
         return true;
     }
     else if (strcmp("SaveAs", pMsg) == 0) {
-        getGuiDocument()->saveAs();
+        getGuiDocument()->saveAsAsync();
         return true;
     }
     else if (strcmp("Std_Delete", pMsg) == 0) {

--- a/src/Mod/Start/Gui/StartView.cpp
+++ b/src/Mod/Start/Gui/StartView.cpp
@@ -46,6 +46,7 @@
 #include "FlowLayout.h"
 #include "NewFileButton.h"
 #include <App/DocumentObject.h>
+#include <App/Document.h>
 #include <App/Application.h>
 #include <Base/Interpreter.h>
 #include <Base/Tools.h>
@@ -399,13 +400,22 @@ void StartView::newPartDesignFile()
 
 void StartView::openExistingFile()
 {
-    auto originalDocument = Gui::Application::Instance->activeDocument();
+    const auto* original = App::GetApplication().getActiveDocument();
+    const std::string originalName = original ? original->getName() : "";
     Gui::Application::Instance->commandManager().runCommandByName("Std_Open");
-    Gui::Application::checkForRecomputes();
-    if (Gui::Application::Instance->activeDocument() != originalDocument) {
-        // Only run this if the user chose a new document to open (that is, they didn't cancel the
-        // open file dialog)
-        postStart(PostStartBehavior::switchWorkbench);
+    const auto finish = [this, originalName] {
+        openCompletion.disconnect();
+        const auto* current = App::GetApplication().getActiveDocument();
+        if (current && originalName != current->getName()) {
+            postStart(PostStartBehavior::switchWorkbench);
+        }
+    };
+    if (App::GetApplication().hasPendingDocumentOpens()) {
+        openCompletion = App::GetApplication().signalDocumentOpenQueueIdle.connect(finish);
+    }
+    else {
+        Gui::Application::checkForRecomputes();
+        finish();
     }
 }
 
@@ -467,7 +477,7 @@ void StartView::fileCardSelected(const QModelIndex& index)
 {
     try {
         auto filename = index.data(static_cast<int>(Start::DisplayedFilesModelRoles::path)).toString();
-        Gui::ModuleIO::verifyAndOpenFile(filename);
+        Gui::ModuleIO::verifyAndOpenFileFromGui(filename);
     }
     catch (Base::PyException& e) {
         Base::Console().error(e.getMessage().c_str());

--- a/src/Mod/Start/Gui/StartView.h
+++ b/src/Mod/Start/Gui/StartView.h
@@ -29,6 +29,7 @@
 
 #include "../App/DisplayedFilesModel.h"
 #include "../App/RecentFilesModel.h"
+#include <fastsignals/signal.h>
 #include "../App/ExamplesModel.h"
 #include "../App/CustomFolderModel.h"
 
@@ -124,6 +125,7 @@ private:
     QCheckBox* _showOnStartupCheckBox;
 
     bool isInitialized = false;
+    fastsignals::scoped_connection openCompletion;
 
 };  // namespace StartGui
 

--- a/src/Mod/TechDraw/App/DrawPage.h
+++ b/src/Mod/TechDraw/App/DrawPage.h
@@ -22,10 +22,10 @@
 
 #pragma once
 
-#include <fastsignals/signal.h>
 #include <fastsignals/connection.h>
 
 #include <App/DocumentObject.h>
+#include <App/MainThreadSignal.h>
 #include <App/PropertyStandard.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
@@ -71,7 +71,7 @@ public:
     int removeView(App::DocumentObject* docObj);
     bool isTimelineStructuralChild(const App::DocumentObject* object) const override;
     short mustExecute() const override;
-    fastsignals::signal<void(const DrawPage*)> signalGuiPaint;
+    App::MainThreadSignal<void(const DrawPage*)> signalGuiPaint;
 
     /// returns the type name of the ViewProvider
     const char* getViewProviderName() const override

--- a/src/Mod/TechDraw/App/DrawView.h
+++ b/src/Mod/TechDraw/App/DrawView.h
@@ -24,12 +24,12 @@
 
 #include <unordered_set>
 
-#include <fastsignals/signal.h>
 #include <QCoreApplication>
 #include <QRectF>
 
 #include <App/DocumentObject.h>
 #include <App/FeaturePython.h>
+#include <App/MainThreadSignal.h>
 #include <App/PropertyUnits.h>
 #include <Mod/TechDraw/TechDrawGlobal.h>
 
@@ -69,7 +69,7 @@ public:
     App::DocumentObjectExecReturn* recompute() override;
     /// recalculate the Feature
     App::DocumentObjectExecReturn *execute() override;
-    bool canRecomputeOnWorker() const override { return false; }
+    bool canRecomputeOnWorker() const override { return true; }
     void onDocumentRestored() override;
     short mustExecute() const override;
     //@}
@@ -105,8 +105,8 @@ public:
     /// True when this view is on the active side of the document timeline.
     virtual bool isActiveInDocumentTimeline() const;
 
-    fastsignals::signal<void (const DrawView*)> signalGuiPaint;
-    fastsignals::signal<void (const DrawView*, std::string, std::string)> signalProgressMessage;
+    App::MainThreadSignal<void (const DrawView*)> signalGuiPaint;
+    App::MainThreadSignal<void (const DrawView*, std::string, std::string)> signalProgressMessage;
     void requestPaint(void);
     void showProgressMessage(std::string featureName, std::string text);
 

--- a/src/Mod/TechDraw/Gui/MDIViewPage.cpp
+++ b/src/Mod/TechDraw/Gui/MDIViewPage.cpp
@@ -230,15 +230,15 @@ bool MDIViewPage::onMsg(const char* pMsg)
         return true;
     }
     else if (strcmp("Save", pMsg) == 0) {
-        doc->save();
+        doc->saveAsync();
         return true;
     }
     else if (strcmp("SaveAs", pMsg) == 0) {
-        doc->saveAs();
+        doc->saveAsAsync();
         return true;
     }
     else if (strcmp("SaveCopy", pMsg) == 0) {
-        doc->saveCopy();
+        doc->saveCopyAsync();
         return true;
     }
     else if (strcmp("Undo", pMsg) == 0) {

--- a/src/Mod/Test/Document.py
+++ b/src/Mod/Test/Document.py
@@ -320,6 +320,25 @@ class DocumentBasicCases(unittest.TestCase):
     def testMem(self):
         self.Doc.MemSize
 
+    def testFindObjectsByProperty(self):
+        first = self.Doc.addObject("App::FeaturePython", "First")
+        second = self.Doc.addObject("App::FeaturePython", "Second")
+        group = self.Doc.addObject("App::DocumentObjectGroup", "Group")
+        for obj in (first, group):
+            obj.addProperty("App::PropertyString", "CandidateMetadata")
+        second.Label = "Selected label"
+        self.assertEqual(self.Doc.findObjects(Property="CandidateMetadata"), [first, group])
+        self.assertEqual(self.Doc.findObjects(Type="App::FeaturePython",
+                                             Property="CandidateMetadata"), [first])
+        self.assertEqual(self.Doc.findObjects(Name="Group", Property="CandidateMetadata"), [group])
+        self.assertEqual(self.Doc.findObjects(Label="Selected", Property="CandidateMetadata"), [])
+        first.removeProperty("CandidateMetadata")
+        second.addProperty("App::PropertyString", "CandidateMetadata")
+        self.assertEqual(self.Doc.findObjects(Property="CandidateMetadata"), [second, group])
+        self.assertEqual(self.Doc.findObjects(Property="Label"), self.Doc.Objects)
+        self.assertEqual(self.Doc.findObjects(), self.Doc.Objects)
+        self.assertEqual(self.Doc.findObjects(Property="MissingProperty"), [])
+
     def testDuplicateLinks(self):
         obj = self.Doc.addObject("App::FeatureTest", "obj")
         grp = self.Doc.addObject("App::DocumentObjectGroup", "group")

--- a/src/Mod/VibeCAD/CMakeLists.txt
+++ b/src/Mod/VibeCAD/CMakeLists.txt
@@ -31,6 +31,9 @@ set(VibeCAD_Scripts
     VibeCADFastenerAttachment.py
     VibeCADFastenerAssembly.py
     VibeCADGrid.py
+    VibeCADHostIsolation.py
+    VibeCADIsolationWorker.py
+    VibeCADNumericalRuntime.py
     VibeCADSectionView.py
     VibeCADSectionViewGui.py
     VibeCADGrokAuth.py

--- a/src/Mod/VibeCAD/InitGui.py
+++ b/src/Mod/VibeCAD/InitGui.py
@@ -352,6 +352,21 @@ try:
             except Exception:
                 pass
 
+    def _setup_host_isolation() -> None:
+        try:
+            import VibeCADHostIsolation
+
+            VibeCADHostIsolation.ensure_started()
+        except Exception as exc:
+            try:
+                import FreeCAD as _App
+
+                _App.Console.PrintError(
+                    f"VibeCAD native worker pool failed to start: {exc}\n"
+                )
+            except Exception:
+                pass
+
     def _setup_agent_control() -> None:
         try:
             import os
@@ -395,6 +410,7 @@ try:
                 pass
 
     QtCore.QTimer.singleShot(0, _setup_development_identity)
+    QtCore.QTimer.singleShot(0, _setup_host_isolation)
     QtCore.QTimer.singleShot(0, _setup_always_on_grid)
     QtCore.QTimer.singleShot(0, _setup_agent_control)
     QtCore.QTimer.singleShot(0, _setup_aero_ribbon)

--- a/src/Mod/VibeCAD/VibeCADAssemblyBOM.py
+++ b/src/Mod/VibeCAD/VibeCADAssemblyBOM.py
@@ -20,11 +20,12 @@ from typing import Any
 
 ASSEMBLY_BOM_SCHEMA = "vibecad-assembly-bom-v1"
 MAX_BOM_COLUMNS = 32
-MAX_BOM_ROWS = 4096
-MAX_BOM_OCCURRENCE_PATHS = 8192
+# Zero denotes no fixed model-capacity ceiling in publication metadata.
+MAX_BOM_ROWS = 0
+MAX_BOM_OCCURRENCE_PATHS = 0
 MAX_BOM_PATH_SEGMENTS = 16
 MAX_BOM_ERROR_PATHS = 256
-MAX_BOM_CONTRACT_BYTES = 400_000
+MAX_BOM_CONTRACT_BYTES = 0
 
 _IDENTIFIER = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 _PROPERTY_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
@@ -502,15 +503,12 @@ def _column_label(number: int) -> str:
 
 
 def _stable_digest(value: Mapping[str, Any]) -> str:
-    return hashlib.sha256(
-        json.dumps(
-            value,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-    ).hexdigest()
+    digest = hashlib.sha256()
+    encoder = json.JSONEncoder(ensure_ascii=True, sort_keys=True,
+                               separators=(",", ":"), allow_nan=False)
+    for chunk in encoder.iterencode(value):
+        digest.update(chunk.encode("utf-8"))
+    return digest.hexdigest()
 
 
 def plan_assembly_bom(
@@ -590,7 +588,6 @@ def plan_assembly_bom(
         )
 
     rows: list[dict[str, Any]] = []
-    total_paths = 0
 
     def child_instances(parent: Mapping[str, Any]) -> list[dict[str, Any]]:
         node = parent["node"]
@@ -666,7 +663,6 @@ def plan_assembly_bom(
         index_prefix: str,
         active: tuple[tuple[str, str], ...],
     ) -> None:
-        nonlocal total_paths
         eligible: list[dict[str, Any]] = []
         for instance in instances:
             if only_parts and instance["node"]["kind"] == "shape":
@@ -697,20 +693,6 @@ def plan_assembly_bom(
             paths = list(
                 dict.fromkeys(path for member in members for path in member["paths"])
             )
-            total_paths += len(paths)
-            if len(rows) >= MAX_BOM_ROWS or total_paths > MAX_BOM_OCCURRENCE_PATHS:
-                raise _error(
-                    "The detailed Assembly BOM exceeds its bounded row/path budget.",
-                    stage="bom_budget",
-                    correction=(
-                        "Set detail_subassemblies=False or detail_parts=False, or split "
-                        "the design into smaller module BOMs."
-                    ),
-                    maximum_rows=MAX_BOM_ROWS,
-                    maximum_occurrence_paths=MAX_BOM_OCCURRENCE_PATHS,
-                    observed_rows=len(rows) + 1,
-                    observed_occurrence_paths=total_paths,
-                )
             quantity = sum(int(member["units"]) for member in members)
             cells = {
                 str(column["heading"]): _column_text(
@@ -905,28 +887,6 @@ def plan_assembly_bom(
         },
     }
     contract["table_sha256"] = _stable_digest(contract)
-    encoded_bytes = len(
-        json.dumps(
-            contract,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-    )
-    if encoded_bytes > MAX_BOM_CONTRACT_BYTES:
-        raise _error(
-            "The Assembly BOM exceeds its bounded publication contract size.",
-            stage="bom_budget",
-            correction=(
-                "Reduce columns or hierarchy detail, omit long custom values, or split "
-                "the design into smaller named module BOMs."
-            ),
-            observed_contract_bytes=encoded_bytes,
-            maximum_contract_bytes=MAX_BOM_CONTRACT_BYTES,
-            observed_rows=len(rows),
-            observed_occurrence_paths=contract["occurrence_path_count"],
-        )
     return contract
 
 

--- a/src/Mod/VibeCAD/VibeCADAssemblyHierarchy.py
+++ b/src/Mod/VibeCAD/VibeCADAssemblyHierarchy.py
@@ -25,10 +25,11 @@ from typing import Any
 
 ASSEMBLY_HIERARCHY_SCHEMA = "vibecad-assembly-source-hierarchy-v1"
 MAX_HIERARCHY_DEPTH = 16
-MAX_HIERARCHY_NODES = 512
-MAX_HIERARCHY_OCCURRENCES = 2048
-MAX_HIERARCHY_JOINTS = 1024
-MAX_HIERARCHY_SHAPES = 256
+# Zero means no fixed count ceiling; these keys remain in saved contracts.
+MAX_HIERARCHY_NODES = 0
+MAX_HIERARCHY_OCCURRENCES = 0
+MAX_HIERARCHY_JOINTS = 0
+MAX_HIERARCHY_SHAPES = 0
 MAX_BOM_PROPERTIES_PER_NODE = 64
 MAX_BOM_PROPERTY_TEXT = 4096
 MAX_CONTEXT_OCCURRENCES = 256
@@ -498,11 +499,6 @@ def capture_assembly_hierarchy(
                 f"Assembly hierarchy exceeds depth {MAX_HIERARCHY_DEPTH} at "
                 f"{identity[1]!r}. Split the source into shallower modules."
             )
-        if len(nodes) >= MAX_HIERARCHY_NODES:
-            raise AssemblyHierarchyError(
-                f"Assembly hierarchy exceeds {MAX_HIERARCHY_NODES} unique source nodes. "
-                "Split the source into reusable module programs."
-            )
         node_id = f"n{len(nodes):04d}"
         kind = _node_kind(obj)
         node: dict[str, Any] = {
@@ -531,11 +527,6 @@ def capture_assembly_hierarchy(
                 detached = _shape_copy(obj, node_name=identity[1])
                 if detached is not None:
                     shape_count += 1
-                    if shape_count > MAX_HIERARCHY_SHAPES:
-                        raise AssemblyHierarchyError(
-                            f"Assembly hierarchy exceeds {MAX_HIERARCHY_SHAPES} unique "
-                            "shape artifacts. Reuse linked source objects or split the module."
-                        )
                     detached_shapes[node_id] = detached
                     node["has_shape_artifact"] = True
             if kind in {"assembly", "part"}:
@@ -545,11 +536,6 @@ def capture_assembly_hierarchy(
                         continue
                     occurrence_index = occurrence_count
                     occurrence_count += 1
-                    if occurrence_count > MAX_HIERARCHY_OCCURRENCES:
-                        raise AssemblyHierarchyError(
-                            f"Assembly hierarchy exceeds {MAX_HIERARCHY_OCCURRENCES} "
-                            "occurrences. Split the source into reusable module programs."
-                        )
                     name = str(getattr(child, "Name", "") or "")
                     if not name or "/" in name or name in seen_names:
                         raise AssemblyHierarchyError(
@@ -770,11 +756,6 @@ def capture_assembly_hierarchy(
         joints = []
         for joint in _joint_objects(assembly):
             total_joints += 1
-            if total_joints > MAX_HIERARCHY_JOINTS:
-                raise AssemblyHierarchyError(
-                    f"Assembly hierarchy exceeds {MAX_HIERARCHY_JOINTS} native joints. "
-                    "Split the source into reusable modules."
-                )
             record = _joint_record(joint)
             for index in (1, 2):
                 target, subelements = _reference_value(joint, f"Reference{index}")
@@ -817,13 +798,6 @@ def capture_assembly_hierarchy(
                     "depth": depth + 1,
                 }
             )
-            if len(flattened) > MAX_HIERARCHY_OCCURRENCES:
-                raise AssemblyHierarchyError(
-                    "Assembly source reuse expands to more than "
-                    f"{MAX_HIERARCHY_OCCURRENCES} stable occurrence paths. Split the "
-                    "design into smaller modules before using detailed BOMs or internal "
-                    "connector paths."
-                )
             if str(source["kind"]) in {"assembly", "part"}:
                 flatten(str(source["node_id"]), path, depth + 1)
             visiting.remove(key)
@@ -858,17 +832,15 @@ def capture_assembly_hierarchy(
 def hierarchy_context(hierarchy: Mapping[str, Any]) -> dict[str, Any]:
     """Return a bounded provider view with exact copy-ready occurrence paths."""
 
-    paths = [dict(item) for item in list(hierarchy.get("occurrence_paths") or [])]
-    nodes = [dict(item) for item in list(hierarchy.get("nodes") or [])]
+    paths = list(hierarchy.get("occurrence_paths") or [])
+    nodes = list(hierarchy.get("nodes") or [])
+    first_paths: dict[str, str] = {}
+    for item in paths:
+        first_paths.setdefault(str(item.get("source_node_id") or ""), str(item["path"]))
     joints = []
     grounded = []
     for node in nodes:
-        assembly_prefixes = [
-            str(item["path"])
-            for item in paths
-            if str(item.get("source_node_id") or "") == str(node.get("node_id") or "")
-        ]
-        prefix = assembly_prefixes[0] if assembly_prefixes else ""
+        prefix = first_paths.get(str(node.get("node_id") or ""), "")
         for path in list(node.get("grounded_occurrence_paths") or []):
             grounded.append("/".join(item for item in (prefix, str(path)) if item))
         for item in list(node.get("joints") or []):
@@ -901,7 +873,7 @@ def hierarchy_context(hierarchy: Mapping[str, Any]) -> dict[str, Any]:
         "available": True,
         "counts": dict(hierarchy.get("counts") or {}),
         "limits": dict(hierarchy.get("limits") or {}),
-        "occurrence_paths": paths[:MAX_CONTEXT_OCCURRENCES],
+        "occurrence_paths": [dict(item) for item in paths[:MAX_CONTEXT_OCCURRENCES]],
         "occurrence_paths_truncated": len(paths) > MAX_CONTEXT_OCCURRENCES,
         "occurrence_paths_omitted": max(0, len(paths) - MAX_CONTEXT_OCCURRENCES),
         "joints": joints[:MAX_CONTEXT_JOINTS],

--- a/src/Mod/VibeCAD/VibeCADCodex.py
+++ b/src/Mod/VibeCAD/VibeCADCodex.py
@@ -24,7 +24,7 @@ import time
 from typing import Any, Callable, Mapping
 
 
-CODEX_APP_SERVER_VERSION = "0.144.5"
+CODEX_APP_SERVER_VERSION = "0.153.4"
 CODEX_APP_SERVER_ENV = "VIBECAD_CODEX_APP_SERVER"
 CODEX_HOME_ENV = "VIBECAD_CODEX_HOME"
 CODEX_RUNTIME_DIRECTORY = "codex_runtime"
@@ -228,6 +228,14 @@ def resolve_runtime_command() -> CodexRuntimeCommand:
 
     root = bundled_runtime_root()
     executable = root / _runtime_binary_name()
+    if (root / "codex-package.json").is_file():
+        executable = root / "bin" / _runtime_binary_name()
+        companion = executable.with_name("codex-code-mode-host" + executable.suffix)
+        if not companion.is_file():
+            raise CodexAppServerError(
+                "The bundled Codex code-mode companion is missing. Reinstall VibeCAD "
+                "with the complete OpenAI Codex runtime."
+            )
     if not executable.is_file():
         raise CodexAppServerError(
             "The bundled Codex app-server runtime is missing. Reinstall VibeCAD "

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -381,10 +381,12 @@ class VibeCADService:
     def invalidate_vibescript_reference_snapshots_many(
         self,
         objects: Any,
+        *,
+        identities: Any = (),
     ) -> None:
-        """Invalidate snapshots for many changed sources under one cache lock."""
+        """Invalidate changed sources, including identities captured before deletion."""
 
-        identities = {
+        identities = set(identities) | {
             identity
             for identity in (
                 self._vibescript_object_identity(obj)

--- a/src/Mod/VibeCAD/VibeCADDocumentChangeBatch.py
+++ b/src/Mod/VibeCAD/VibeCADDocumentChangeBatch.py
@@ -11,7 +11,8 @@ until the outermost atomic document change has finished.
 from __future__ import annotations
 
 import threading
-from typing import Callable
+from contextlib import contextmanager
+from typing import Callable, Iterator
 
 _lock = threading.RLock()
 _depth_by_document: dict[str, int] = {}
@@ -20,6 +21,31 @@ _origins_by_document: dict[str, set[tuple[str, str]]] = {}
 _completed_listeners: list[Callable[[str], None]] = []
 _finished_listeners: list[Callable[[str, bool], None]] = []
 _flush_listeners: list[Callable[[str], None]] = []
+_rollback_scope = threading.local()
+
+
+@contextmanager
+def rolling_back_document_change_batch(document_uid: str) -> Iterator[None]:
+    """Scope advisory notification discard to an already failed atomic batch.
+
+    Native rollback and other observers still run normally. Ordinary undo/redo,
+    changes to other documents and notifications on other threads are unaffected.
+    The caller remains responsible for ending the batch with commit=False.
+    """
+    uid = str(document_uid or "").strip()
+    if not document_change_batch_active(uid):
+        yield
+        return
+    previous = getattr(_rollback_scope, "documents", frozenset())
+    _rollback_scope.documents = previous | {uid}
+    try:
+        yield
+    finally:
+        _rollback_scope.documents = previous
+
+
+def document_change_batch_rolling_back(document_uid: str) -> bool:
+    return document_uid in getattr(_rollback_scope, "documents", ())
 
 
 def begin_document_change_batch(

--- a/src/Mod/VibeCAD/VibeCADFasteners.py
+++ b/src/Mod/VibeCAD/VibeCADFasteners.py
@@ -30,7 +30,8 @@ MAX_OPTIONS = 16
 MAX_MODEL_THREAD_DIAMETER_MM = 64.0
 MAX_MODEL_THREAD_AXIAL_LENGTH_MM = 250.0
 MAX_MODEL_THREAD_TURNS = 512.0
-MAX_MODEL_THREAD_OBJECTS_PER_DOCUMENT = 32
+# Zero denotes no fixed object-count ceiling; retained for capability consumers.
+MAX_MODEL_THREAD_OBJECTS_PER_DOCUMENT = 0
 
 PROP_SCHEMA = "VibeCADFastenerSchema"
 PROP_CATALOG = "VibeCADFastenerCatalog"
@@ -274,7 +275,7 @@ def provenance() -> dict[str, str]:
 
 
 def model_thread_limits() -> dict[str, float | int]:
-    """Return the declared release limits for real thread geometry."""
+    """Return geometry limits; a zero document count means unlimited objects."""
 
     return {
         "maximum_nominal_diameter_mm": MAX_MODEL_THREAD_DIAMETER_MM,
@@ -2610,20 +2611,6 @@ def create_fastener_feature(
         raise FastenerCatalogError(
             "container must be a FreeCAD document or Part Design Body."
         )
-    if bool(identity["model_thread"]):
-        model_thread_count = sum(
-            1
-            for candidate in list(getattr(document, "Objects", []) or [])
-            if bool(getattr(candidate, "Thread", False))
-        )
-        if model_thread_count >= MAX_MODEL_THREAD_OBJECTS_PER_DOCUMENT:
-            raise FastenerCatalogError(
-                "The document already contains "
-                f"{MAX_MODEL_THREAD_OBJECTS_PER_DOCUMENT} real-thread "
-                "standard components, which is the release object-count limit; "
-                "use model_thread=False."
-            )
-
     obj = None
     try:
         if is_body:

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -15,6 +15,7 @@ import html
 import json
 import queue
 import re
+import sys
 import tempfile
 import threading
 import uuid
@@ -28,6 +29,7 @@ from VibeCADCore import get_service
 from VibeCADDebug import list_provider_request_captures
 from VibeCADDocumentChangeBatch import (
     document_change_batch_active,
+    document_change_batch_rolling_back,
     document_change_batch_origins,
     register_document_change_batch_completed,
     register_document_change_batch_finished,
@@ -2367,6 +2369,8 @@ def _format_progress_event(event: dict[str, Any]) -> str:
         phase = str(event.get("phase") or "publishing")
         if phase == "completed":
             return f"Published {total} CAD objects."
+        if phase == "finalizing":
+            return "Finalizing CAD display and document history..."
         if phase == "failed":
             return f"VibeScript publication stopped after {completed} of {total} objects."
         current = str(event.get("current_output") or "").strip()
@@ -3897,6 +3901,13 @@ def _document_render_refresh_blocked(document: Any) -> bool:
     if _document_restore_active(document) or _document_recompute_active(document):
         return True
     try:
+        if any(
+            bool(getattr(document, state, False))
+            for state in (
+                "RecomputePending", "CooperativeMutationActive", "PresentationUpdateActive",
+            )
+        ):
+            return True
         document_uid = str(getattr(document, "Uid", "") or "").strip()
     except (ReferenceError, RuntimeError):
         return False
@@ -4071,9 +4082,8 @@ def _redraw_document_view(document: Any) -> None:
         gui_document = Gui.getDocument(str(document.Name))
         view = gui_document.activeView() if gui_document is not None else None
         if view is not None:
-            update_gui = getattr(Gui, "updateGui", None)
-            if callable(update_gui):
-                update_gui()
+            # A redraw schedules paint; draining the GUI here recursively runs
+            # unrelated restore/assistant callbacks inside this presentation step.
             redraw = getattr(view, "redraw", None)
             if callable(redraw):
                 redraw()
@@ -4135,12 +4145,29 @@ def _recompute_pending_document_geometry(document: Any) -> bool:
 
 def _recompute_pending_document_geometry_slice(
     document: Any,
+    attempted: set[str] | None = None,
 ) -> tuple[bool, bool]:
-    """Recompute one restored object and report whether more work remains."""
+    """Queue restored geometry together, or advance a legacy direct caller."""
 
-    if _document_recompute_active(document):
+    if _document_render_refresh_blocked(document):
         return False, True
     pending = _pending_document_objects(document)
+    if attempted is not None and callable(getattr(document, "recomputeAsync", None)):
+        targets = [obj for obj in pending if str(obj.Name) not in attempted]
+        if targets:
+            # A list produces one recursive request per object in the native
+            # API, repeating dependency walks and resetting progress. One
+            # document request evaluates dirty dependency waves together.
+            document.recomputeAsync()
+            attempted.update(str(obj.Name) for obj in targets)
+            return False, True
+        unresolved = _document_geometry_problems(document, pending)
+        if unresolved:
+            _warn(
+                "VibeCAD restored-document recompute left invalid geometry: "
+                + ", ".join(unresolved)
+            )
+        return bool(attempted) and not unresolved, False
     if not pending:
         unresolved = _document_geometry_problems(document, [])
         if unresolved:
@@ -4388,6 +4415,7 @@ def _schedule_document_render_after_restore(document: Any) -> None:
         modified_state_captured = False
         geometry_recomputed_any = False
         restored_projection_names: set[str] = set()
+        recompute_attempted: set[str] = set()
         was_modified = None
 
         def finish_refresh() -> None:
@@ -4498,7 +4526,9 @@ def _schedule_document_render_after_restore(document: Any) -> None:
                 return
 
             geometry_recomputed, geometry_remaining = (
-                _recompute_pending_document_geometry_slice(live_document)
+                _recompute_pending_document_geometry_slice(
+                    live_document, recompute_attempted
+                )
             )
             geometry_recomputed_any = geometry_recomputed_any or geometry_recomputed
             if _document_recompute_active(live_document):
@@ -4680,10 +4710,14 @@ def _defer_vibescript_dependency_change(
         return
     state = _deferred_vibescript_dependency_changes.setdefault(
         uid,
-        {"changes": {}, "excluded_programs": set()},
+        {"changes": {}, "identities": set(), "excluded_programs": set()},
     )
     name = str(getattr(obj, "Name", "") or "")
-    identity = name or f"@{id(obj)}"
+    # Retain the cache identity before a later slice can delete the object.
+    # Python wrapper identity also distinguishes replacements with the same name.
+    if name:
+        state["identities"].add((uid, name))
+    identity = id(obj)
     state["changes"][(identity, str(property_name or ""))] = (
         obj,
         str(property_name or ""),
@@ -4704,13 +4738,18 @@ def _finish_vibescript_dependency_batch(
     state = _deferred_vibescript_dependency_changes.pop(uid, None)
     if not state or not committed:
         return
-    changes = tuple(state["changes"].values())
-    if not changes:
+    if not state["changes"]:
         return
     unique_objects = {}
-    for obj, _property_name in changes:
-        name = str(getattr(obj, "Name", "") or "")
-        unique_objects[name or f"@{id(obj)}"] = obj
+    changes = []
+    for obj, property_name in state["changes"].values():
+        try:
+            # Do not pass a deleted wrapper into the live dependency traversal.
+            getattr(obj, "Name", "")
+        except ReferenceError:
+            continue
+        unique_objects[id(obj)] = obj
+        changes.append((obj, property_name))
     service = get_service()
     invalidate_many = getattr(
         service,
@@ -4718,7 +4757,7 @@ def _finish_vibescript_dependency_batch(
         None,
     )
     if callable(invalidate_many):
-        invalidate_many(tuple(unique_objects.values()))
+        invalidate_many(tuple(unique_objects.values()), identities=state["identities"])
     else:
         for obj in unique_objects.values():
             service.invalidate_vibescript_reference_snapshots(obj)
@@ -4728,7 +4767,7 @@ def _finish_vibescript_dependency_batch(
         )
 
         marked = mark_programs_stale_from_sources(
-            changes,
+            tuple(changes),
             excluded_programs=frozenset(state["excluded_programs"]),
         )
     except Exception as exc:
@@ -4739,6 +4778,19 @@ def _finish_vibescript_dependency_batch(
 
 
 class _VibeCADDocumentObserver:
+    def slotCooperativeMutationChanged(self, doc, active: bool) -> None:
+        """Use the same batch for native mutations and nested Python publication."""
+
+        uid = str(doc.Uid)
+        service = get_service()
+        if active:
+            service.begin_document_change_batch(uid)
+        else:
+            # The native lease describes ownership, not transaction outcome.
+            # Nested publishers supply rollback via commit=False; native-only
+            # edits invalidate once against their final, stable document state.
+            service.end_document_change_batch(uid)
+
     @staticmethod
     def _refresh_native_authority_selector(document_uid: str = "") -> None:
         _schedule_native_authority_selector_refresh(document_uid)
@@ -4762,20 +4814,29 @@ class _VibeCADDocumentObserver:
         _schedule_assistant_document_refresh()
 
     def slotChangedObject(self, obj, property_name) -> None:
+        # Playback applies temporary poses, not source edits. Test the exact
+        # synchronous application scope before authority/dependency observers;
+        # an open player alone must never exempt a user's normal CAD edits.
+        assembly_utils = sys.modules.get("UtilsAssembly")
+        if assembly_utils is not None and assembly_utils.isPresentationPlacementChange(
+            obj, property_name
+        ):
+            return
         is_restoring = getattr(App, "isRestoring", None)
         if callable(is_restoring) and bool(is_restoring()):
             return
         document = getattr(obj, "Document", None)
         if document is not None and bool(getattr(document, "Restoring", False)):
             return
-        if str(getattr(document, "Uid", "") or "").strip():
+        document_uid = str(getattr(document, "Uid", "") or "").strip()
+        if document_change_batch_rolling_back(document_uid):
+            return
+        if document_uid:
             get_service().note_native_object_property_change(
                 obj,
                 str(property_name or ""),
             )
-            self._refresh_native_authority_selector(
-                str(getattr(document, "Uid", "") or "")
-            )
+            self._refresh_native_authority_selector(document_uid)
         try:
             from VibeCADVibeScriptDomainPublication import (
                 source_property_affects_vibescript_snapshot,
@@ -4786,7 +4847,6 @@ class _VibeCADDocumentObserver:
         except Exception as exc:
             _warn(f"VibeCAD VibeScript dependency filter failed: {exc}")
             return
-        document_uid = str(getattr(document, "Uid", "") or "").strip()
         if document_uid and document_change_batch_active(document_uid):
             _defer_vibescript_dependency_change(
                 document_uid,
@@ -4816,10 +4876,11 @@ class _VibeCADDocumentObserver:
         document = getattr(obj, "Document", None)
         if document is not None and bool(getattr(document, "Restoring", False)):
             return
+        document_uid = str(getattr(document, "Uid", "") or "").strip()
+        if document_change_batch_rolling_back(document_uid):
+            return
         get_service().note_native_object_created(obj)
-        self._refresh_native_authority_selector(
-            str(getattr(document, "Uid", "") or "")
-        )
+        self._refresh_native_authority_selector(document_uid)
 
     def slotDeletedObject(self, obj) -> None:
         is_restoring = getattr(App, "isRestoring", None)
@@ -4828,10 +4889,11 @@ class _VibeCADDocumentObserver:
         document = getattr(obj, "Document", None)
         if document is not None and bool(getattr(document, "Restoring", False)):
             return
+        document_uid = str(getattr(document, "Uid", "") or "").strip()
+        if document_change_batch_rolling_back(document_uid):
+            return
         get_service().note_native_object_deleted(obj)
-        self._refresh_native_authority_selector(
-            str(getattr(document, "Uid", "") or "")
-        )
+        self._refresh_native_authority_selector(document_uid)
 
     def slotStartSaveDocument(self, doc, filepath) -> None:
         try:

--- a/src/Mod/VibeCAD/VibeCADHostIsolation.py
+++ b/src/Mod/VibeCAD/VibeCADHostIsolation.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Bridge scripted CAD jobs to the application-owned persistent worker pool."""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Callable, Mapping
+import json
+import os
+from pathlib import Path
+import time
+from typing import Any
+
+REQUEST_SCHEMA = "vibecad-host-isolation-request-v1"
+RESPONSE_SCHEMA = "vibecad-host-isolation-response-v1"
+
+
+def _encode(value: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        dict(value),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii")
+
+
+def _decode(value: str) -> dict[str, Any]:
+    try:
+        payload = base64.b64decode(
+            str(value).encode("ascii"),
+            altchars=b"-_",
+            validate=True,
+        )
+        decoded = json.loads(payload.decode("utf-8"))
+    except (UnicodeError, ValueError, json.JSONDecodeError) as exc:
+        raise RuntimeError(
+            "The native isolation worker returned invalid data."
+        ) from exc
+    if not isinstance(decoded, dict) or decoded.get("schema") != RESPONSE_SCHEMA:
+        raise RuntimeError("The native isolation worker response schema is invalid.")
+    return decoded
+
+
+def _freecadcmd(freecad_home: str | Path) -> Path:
+    home = Path(freecad_home).resolve()
+    names = (
+        ("FreeCADCmd.exe", "freecadcmd.exe")
+        if os.name == "nt"
+        else ("FreeCADCmd", "freecadcmd")
+    )
+    for directory in (home / "bin", home):
+        for name in names:
+            candidate = directory / name
+            if candidate.is_file():
+                return candidate.resolve()
+    raise FileNotFoundError(
+        f"No windowless FreeCADCmd executable exists under {str(home)!r}."
+    )
+
+
+def ensure_started(
+    *,
+    app: Any | None = None,
+    executable: str | Path | None = None,
+    module_root: str | Path | None = None,
+    workers: int = 0,
+) -> dict[str, Any]:
+    """Start (or confirm) the one process-lifetime isolation pool."""
+
+    if str(os.environ.get("VIBECAD_ISOLATION_CHILD") or "").strip() == "1":
+        return {"workers": 0, "ready": 0, "isolation_child": True}
+    if app is None:
+        import FreeCAD as app
+
+    root = Path(module_root or Path(__file__).resolve().parent).resolve()
+    worker = root / "VibeCADIsolationWorker.py"
+    if not worker.is_file():
+        raise FileNotFoundError(f"The native isolation worker is missing: {worker}")
+    command = (
+        Path(executable).resolve()
+        if executable is not None
+        else _freecadcmd(app.getHomePath())
+    )
+    if not command.is_file():
+        raise FileNotFoundError(
+            f"The native isolation executable is missing: {command}"
+        )
+    return dict(
+        app.configureHostIsolationRuntime(
+            str(command),
+            str(root),
+            max(0, int(workers)),
+        )
+    )
+
+
+def execute_staged_script(
+    *,
+    staging: str | Path,
+    script: str,
+    environment: Mapping[str, str],
+    cancellation_check: Callable[[], bool] | None,
+    memory_limit_bytes: int,
+    app: Any | None = None,
+    executable: str | Path | None = None,
+    module_root: str | Path | None = None,
+    workers: int = 0,
+    cpu_slots: int = 1,
+) -> dict[str, Any]:
+    """Execute one staged script on the persistent native isolation pool."""
+
+    if app is None:
+        import FreeCAD as app
+
+    root = Path(module_root or Path(__file__).resolve().parent).resolve()
+    working_directory = Path(staging).resolve()
+    if not working_directory.is_dir():
+        raise FileNotFoundError(
+            f"The staged isolation directory is missing: {working_directory}"
+        )
+    relative_script = Path(str(script))
+    if relative_script.is_absolute() or ".." in relative_script.parts:
+        raise ValueError(
+            "The isolation script must be relative to its staging directory."
+        )
+    script_path = (working_directory / relative_script).resolve()
+    if script_path.parent != working_directory or not script_path.is_file():
+        raise FileNotFoundError(
+            f"The staged isolation script is missing: {script_path}"
+        )
+    clean_environment = {str(key): str(value) for key, value in environment.items()}
+    if any("\0" in key or "\0" in value for key, value in clean_environment.items()):
+        raise ValueError(
+            "Isolation environment names and values cannot contain NUL bytes."
+        )
+
+    ensure_started(
+        app=app,
+        executable=executable,
+        module_root=root,
+        workers=workers,
+    )
+    request = _encode(
+        {
+            "schema": REQUEST_SCHEMA,
+            "working_directory": str(working_directory),
+            "script": relative_script.as_posix(),
+            "environment": clean_environment,
+            "memory_limit_bytes": max(0, int(memory_limit_bytes)),
+        }
+    )
+    started_at = time.monotonic()
+    native = dict(
+        app.executeHostIsolationRequest(
+            request,
+            cancellation_check,
+            max(0, int(memory_limit_bytes)),
+            max(1, int(cpu_slots)),
+        )
+    )
+    elapsed = time.monotonic() - started_at
+    status = str(native.get("status") or "failed")
+    cancelled = status == "cancelled"
+    memory_exceeded = bool(native.get("memory_exceeded"))
+    output_tail = str(native.get("output_tail") or "")
+    diagnostic = str(native.get("diagnostic") or "")
+
+    if status == "completed":
+        response = _decode(str(native.get("response") or ""))
+        returncode = int(response.get("returncode") or 0)
+        stdout = str(response.get("stdout") or "")[-16_000:]
+        started = True
+        error = str(response.get("error") or "")
+    else:
+        returncode = -1
+        stdout = ""
+        started = cancelled or memory_exceeded
+        error = diagnostic or "The native isolation worker failed."
+
+    termination_reason = (
+        "host_cancellation_request"
+        if cancelled
+        else (
+            "memory_limit"
+            if memory_exceeded
+            else "process_exit" if status == "completed" else "worker_failure"
+        )
+    )
+    result = {
+        "started": started,
+        "returncode": returncode,
+        "stdout": stdout,
+        "stderr": output_tail[-16_000:],
+        "cancelled": cancelled,
+        "timed_out": False,
+        "memory_exceeded": memory_exceeded,
+        "cpu_exceeded": False,
+        "cancelled_by": "host" if cancelled else None,
+        "limit_reached": "memory_bytes" if memory_exceeded else None,
+        "termination_reason": termination_reason,
+        "timeout_mode": "none",
+        "activity_observations": 0,
+        "memory_limit_bytes": max(0, int(memory_limit_bytes)),
+        "observed_memory_bytes": int(native.get("observed_memory_bytes") or 0),
+        "job_id": int(native.get("job_id") or 0),
+        "elapsed_seconds": elapsed,
+    }
+    if error:
+        result["error"] = error
+    if status == "completed":
+        result["worker_pid"] = int(response.get("worker_pid") or 0)
+        result["worker_sequence"] = int(response.get("worker_sequence") or 0)
+    return result

--- a/src/Mod/VibeCAD/VibeCADIsolationWorker.py
+++ b/src/Mod/VibeCAD/VibeCADIsolationWorker.py
@@ -1,0 +1,203 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Long-lived FreeCADCmd worker for application-owned isolated CAD jobs."""
+
+from __future__ import annotations
+
+import base64
+from contextlib import nullcontext, redirect_stderr, redirect_stdout
+import gc
+from io import StringIO
+import json
+import os
+from pathlib import Path
+import runpy
+import sys
+import traceback
+from typing import Any, Mapping
+
+import FreeCAD as App
+
+PROTOCOL = "VIBECAD-ISOLATION/1"
+REQUEST_SCHEMA = "vibecad-host-isolation-request-v1"
+RESPONSE_SCHEMA = "vibecad-host-isolation-response-v1"
+_OUTPUT_LIMIT = 16_000
+
+
+def _encode(value: Mapping[str, Any]) -> str:
+    payload = json.dumps(
+        dict(value),
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii")
+
+
+def _decode(value: str) -> dict[str, Any]:
+    payload = base64.b64decode(
+        value.encode("ascii"),
+        altchars=b"-_",
+        validate=True,
+    )
+    decoded = json.loads(payload.decode("utf-8"))
+    if not isinstance(decoded, dict) or decoded.get("schema") != REQUEST_SCHEMA:
+        raise ValueError("Unsupported native isolation request schema.")
+    return decoded
+
+
+def _write(line: str) -> None:
+    stream = getattr(sys, "__stdout__", None) or sys.stdout
+    # Native progress writes carriage-return updates without a final newline.
+    # Terminate that diagnostic fragment before emitting a complete protocol
+    # record; otherwise the host treats RESULT as diagnostic text and waits
+    # indefinitely even though the job has finished.
+    stream.write(f"\n{line}\n")
+    stream.flush()
+
+
+def _module_is_below(module: Any, root: Path) -> bool:
+    filename = getattr(module, "__file__", None)
+    if not filename:
+        return False
+    try:
+        return Path(filename).resolve().is_relative_to(root)
+    except (OSError, ValueError):
+        return False
+
+
+def _staged_module_names(root: Path) -> set[str]:
+    return {
+        path.stem
+        for path in root.glob("*.py")
+        if path.name != "worker.py" and path.stem.isidentifier()
+    }
+
+
+def _close_job_documents(existing: set[str]) -> None:
+    for name in tuple(App.listDocuments()):
+        if name not in existing:
+            try:
+                App.closeDocument(name)
+            except Exception:
+                pass
+
+
+def _run(payload: Mapping[str, Any], cpu_slots: int = 1) -> dict[str, Any]:
+    working_directory = Path(str(payload.get("working_directory") or "")).resolve()
+    if not working_directory.is_dir():
+        raise FileNotFoundError(
+            f"The native isolation working directory is missing: {working_directory}"
+        )
+    relative_script = Path(str(payload.get("script") or ""))
+    if relative_script.is_absolute() or ".." in relative_script.parts:
+        raise ValueError("The native isolation script path is invalid.")
+    script = (working_directory / relative_script).resolve()
+    if script.parent != working_directory or not script.is_file():
+        raise FileNotFoundError(f"The native isolation script is missing: {script}")
+    raw_environment = payload.get("environment")
+    if not isinstance(raw_environment, dict):
+        raise TypeError("The native isolation environment must be an object.")
+    environment = {str(key): str(value) for key, value in raw_environment.items()}
+    environment["VIBECAD_HOST_CPU_SLOTS"] = str(max(1, int(cpu_slots)))
+    if sys.platform == "win32":
+        environment["OPENBLAS_NUM_THREADS"] = "1"
+    if any("\0" in key or "\0" in value for key, value in environment.items()):
+        raise ValueError("The native isolation environment contains a NUL byte.")
+
+    original_directory = Path.cwd()
+    original_environment = dict(os.environ)
+    original_path = list(sys.path)
+    existing_documents = set(App.listDocuments())
+    staged_names = _staged_module_names(working_directory)
+    for name in staged_names:
+        sys.modules.pop(name, None)
+
+    stdout = StringIO()
+    returncode = 0
+    try:
+        os.environ.clear()
+        os.environ.update(environment)
+        os.chdir(working_directory)
+        job_pythonpath = [
+            item
+            for item in str(environment.get("PYTHONPATH") or "").split(os.pathsep)
+            if item
+        ]
+        sys.path[:] = [str(working_directory), *job_pythonpath, *original_path]
+        try:
+            with redirect_stdout(stdout), redirect_stderr(stdout):
+                numerical_scope = nullcontext()
+                if sys.platform == "win32":
+                    from VibeCADNumericalRuntime import numerical_thread_limits
+
+                    numerical_scope = numerical_thread_limits(
+                        cpu_slots, int(payload.get("memory_limit_bytes") or 0)
+                    )
+                with numerical_scope:
+                    runpy.run_path(str(script), run_name="__main__")
+        except SystemExit as exc:
+            if exc.code is None:
+                returncode = 0
+            elif isinstance(exc.code, int):
+                returncode = int(exc.code)
+            else:
+                returncode = 1
+                print(str(exc.code), file=stdout)
+    finally:
+        _close_job_documents(existing_documents)
+        for name, module in tuple(sys.modules.items()):
+            if name in staged_names or _module_is_below(module, working_directory):
+                sys.modules.pop(name, None)
+        sys.path[:] = original_path
+        os.chdir(original_directory)
+        os.environ.clear()
+        os.environ.update(original_environment)
+        gc.collect()
+
+    return {
+        "schema": RESPONSE_SCHEMA,
+        "returncode": returncode,
+        "stdout": stdout.getvalue()[-_OUTPUT_LIMIT:],
+    }
+
+
+def main() -> int:
+    _write(f"{PROTOCOL} READY")
+    jobs_completed = 0
+    for raw_line in sys.stdin:
+        line = raw_line.rstrip("\r\n")
+        if line == f"{PROTOCOL} SHUTDOWN":
+            return 0
+        prefix = f"{PROTOCOL} JOB "
+        if not line.startswith(prefix):
+            continue
+        fields = line[len(prefix) :].split(" ", 2)
+        if len(fields) == 3 and fields[0].isdigit() and fields[1].isdigit():
+            job_id, raw_cpu_slots, encoded_request = fields
+            cpu_slots = max(1, int(raw_cpu_slots))
+        elif len(fields) == 2 and fields[0].isdigit():
+            job_id, encoded_request = fields
+            cpu_slots = 1
+        else:
+            continue
+        try:
+            response = _run(_decode(encoded_request), cpu_slots)
+        except BaseException as exc:
+            response = {
+                "schema": RESPONSE_SCHEMA,
+                "returncode": 70,
+                "stdout": "",
+                "error": str(exc),
+                "traceback": traceback.format_exc(limit=40),
+            }
+        jobs_completed += 1
+        response["worker_pid"] = os.getpid()
+        response["worker_sequence"] = jobs_completed
+        response["cpu_slots"] = cpu_slots
+        _write(f"{PROTOCOL} RESULT {job_id} {_encode(response)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/Mod/VibeCAD/VibeCADMechanismEngine.py
+++ b/src/Mod/VibeCAD/VibeCADMechanismEngine.py
@@ -63,10 +63,6 @@ _CONTACT_POLICIES = frozenset(
 )
 _MAX_CONTRACT_BYTES = 64 * 1024 * 1024
 _MAX_CONTRACT_DEPTH = 20
-_MAX_COMPONENTS = 4096
-_MAX_JOINTS = 4096
-_MAX_MOTIONS = 4096
-_MAX_OCCURRENCES = 4096
 
 
 class MechanismContractError(ValueError):
@@ -184,6 +180,29 @@ def _vector(value: Any, *, path: str, size: int) -> list[float]:
         _number(item, path=f"{path}[{index}]")
         for index, item in enumerate(value)
     ]
+
+
+def quaternion_rotation_distance_degrees(first: Any, second: Any) -> float:
+    """Shortest rotation angle, using quaternion chords instead of unstable acos(dot).
+
+    Near identical rotations, rounding a unit dot product loses the entire
+    angle. The chord formula preserves small angles and handles q == -q.
+    """
+    normalized = []
+    for name, value in (("first", first), ("second", second)):
+        values = _vector(value, path=f"quaternion.{name}", size=4)
+        scale = max(abs(item) for item in values)
+        if scale == 0:
+            raise _error(f"quaternion.{name}", "must be non-zero")
+        values = [item / scale for item in values]
+        norm = math.hypot(*values)
+        normalized.append([item / norm for item in values])
+    left, right = normalized
+    if sum(a * b for a, b in zip(left, right)) < 0:
+        right = [-item for item in right]
+    difference = math.hypot(*(a - b for a, b in zip(left, right)))
+    total = math.hypot(*(a + b for a, b in zip(left, right)))
+    return math.degrees(4.0 * math.atan2(difference, total))
 
 
 def _placement(value: Any, *, path: str) -> dict[str, list[float]]:
@@ -560,11 +579,11 @@ def normalize_mechanism_scenario(value: Any) -> dict[str, Any]:
     if (
         not isinstance(raw["components"], Sequence)
         or isinstance(raw["components"], (str, bytes))
-        or not 1 <= len(raw["components"]) <= _MAX_COMPONENTS
+        or not raw["components"]
     ):
         raise _error(
             "scenario.components",
-            f"must contain 1-{_MAX_COMPONENTS} components",
+            "must contain at least one component",
         )
     components: list[dict[str, Any]] = []
     component_ids: set[str] = set()
@@ -615,11 +634,10 @@ def normalize_mechanism_scenario(value: Any) -> dict[str, Any]:
     if (
         not isinstance(raw["joints"], Sequence)
         or isinstance(raw["joints"], (str, bytes))
-        or len(raw["joints"]) > _MAX_JOINTS
     ):
         raise _error(
             "scenario.joints",
-            f"must contain at most {_MAX_JOINTS} joints",
+            "must be a sequence of joints",
         )
     joints: list[dict[str, Any]] = []
     joint_ids: set[str] = set()
@@ -751,11 +769,10 @@ def normalize_mechanism_scenario(value: Any) -> dict[str, Any]:
     if (
         not isinstance(raw["motions"], Sequence)
         or isinstance(raw["motions"], (str, bytes))
-        or len(raw["motions"]) > _MAX_MOTIONS
     ):
         raise _error(
             "scenario.motions",
-            f"must contain at most {_MAX_MOTIONS} motions",
+            "must be a sequence of motions",
         )
     motions: list[dict[str, Any]] = []
     motion_ids: set[str] = set()
@@ -892,15 +909,6 @@ def normalize_mechanism_scenario(value: Any) -> dict[str, Any]:
             raise _error(
                 "scenario.simulation.collision_mode",
                 "must be full or off",
-            )
-        estimated_frames = math.ceil((end - start) / step) + 2
-        if (
-            estimated_frames > 10_000
-            or estimated_frames * len(components) > 100_000
-        ):
-            raise _error(
-                "scenario.simulation",
-                "exceeds the bounded native frame or component-pose limit",
             )
         simulation = {
             "id": _identifier(
@@ -1104,7 +1112,6 @@ def normalize_mechanism_solve_report(
                 "solve_report.component_occurrences",
                 "must contain every scenario component exactly once",
             )
-        occurrence_count = 0
         for component_id, occurrences in component_occurrences.items():
             component_path = (
                 f"solve_report.component_occurrences.{component_id}"
@@ -1113,12 +1120,6 @@ def normalize_mechanism_solve_report(
                 raise _error(component_path, "must be an array")
             seen_paths: set[str] = set()
             for index, occurrence in enumerate(occurrences):
-                occurrence_count += 1
-                if occurrence_count > _MAX_OCCURRENCES:
-                    raise _error(
-                        "solve_report.component_occurrences",
-                        f"must contain at most {_MAX_OCCURRENCES} occurrences",
-                    )
                 path = f"{component_path}[{index}]"
                 occurrence_raw = _mapping(
                     occurrence,
@@ -1156,7 +1157,7 @@ def normalize_mechanism_solve_report(
                     occurrence_raw["source_node_id"],
                     path=f"{path}.source_node_id",
                 )
-                if not re.fullmatch(r"n[0-9]{4}", source_node_id):
+                if not re.fullmatch(r"n[0-9]{4,}", source_node_id):
                     raise _error(
                         f"{path}.source_node_id",
                         "must identify one captured hierarchy node",

--- a/src/Mod/VibeCAD/VibeCADMechanismGeometry.py
+++ b/src/Mod/VibeCAD/VibeCADMechanismGeometry.py
@@ -21,8 +21,6 @@ _COMPONENT_ID = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
 _DECLARATION_ID = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,127}$")
 _INTERFACE_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
 _SUBELEMENT = re.compile(r"^(Face|Edge|Vertex)([1-9][0-9]*)$")
-_MAX_COMPONENTS = 256
-_MAX_PAIRS = (_MAX_COMPONENTS * (_MAX_COMPONENTS - 1)) // 2
 _MAX_WITNESSES_PER_PAIR = 8
 _MAX_CONTACT_WITNESSES = 4096
 _COLLISION_MESH_LINEAR_DEFLECTION_MM = 0.05
@@ -141,11 +139,11 @@ class DynamicCollisionEvaluator:
     ) -> None:
         if (
             not isinstance(components, Mapping)
-            or not 1 <= len(components) <= _MAX_COMPONENTS
+            or not components
         ):
             raise _error(
                 "components",
-                f"must contain 1-{_MAX_COMPONENTS} named solid shapes",
+                "must contain at least one named solid shape",
             )
         if definition_keys is not None and (
             not isinstance(definition_keys, Mapping)
@@ -248,11 +246,9 @@ class DynamicCollisionEvaluator:
             for _source, _shape, triangle_count in mesh_definitions
         )
         self._component_names = list(self._shapes)
-        self._pairs = [
-            (first, second)
-            for index, first in enumerate(self._component_names)
-            for second in self._component_names[index + 1 :]
-        ]
+        self._component_order = {
+            name: index for index, name in enumerate(self._component_names)
+        }
 
     @property
     def component_names(self) -> list[str]:
@@ -260,7 +256,8 @@ class DynamicCollisionEvaluator:
 
     @property
     def pair_count(self) -> int:
-        return len(self._pairs)
+        count = len(self._component_names)
+        return count * (count - 1) // 2
 
     @property
     def collision_mesh_statistics(self) -> dict[str, int | float]:
@@ -298,7 +295,7 @@ class DynamicCollisionEvaluator:
         duplicate._unique_mesh_definition_count = self._unique_mesh_definition_count
         duplicate._unique_mesh_triangle_count = self._unique_mesh_triangle_count
         duplicate._component_names = list(self._component_names)
-        duplicate._pairs = list(self._pairs)
+        duplicate._component_order = dict(self._component_order)
         return duplicate
 
     def precompute_strict_containment(
@@ -356,22 +353,18 @@ class DynamicCollisionEvaluator:
             frame_placements.append(exact_placements)
             frame_bounds.append(exact_bounds)
 
-        jobs: list[tuple[str, str, list[int]]] = []
-        for first_name, second_name in self._pairs:
-            if (first_name, second_name) in excluded_pairs:
-                continue
-            candidate_frames = [
-                frame_offset
-                for frame_offset, bounds in enumerate(frame_bounds, start=1)
-                if bool(
-                    _aabb_evidence(
-                        bounds[first_name],
-                        bounds[second_name],
-                    )["overlaps_or_touches"]
-                )
-            ]
-            if candidate_frames:
-                jobs.append((first_name, second_name, candidate_frames))
+        frames_by_pair: dict[tuple[str, str], list[int]] = {}
+        for frame_offset, bounds in enumerate(frame_bounds, start=1):
+            for pair in _overlapping_component_pairs(bounds):
+                if pair not in excluded_pairs:
+                    frames_by_pair.setdefault(pair, []).append(frame_offset)
+        jobs = [
+            (first, second, frames_by_pair[(first, second)])
+            for first, second in sorted(
+                frames_by_pair,
+                key=lambda pair: tuple(self._component_order[name] for name in pair),
+            )
+        ]
 
         contained: set[tuple[int, tuple[str, str]]] = set()
         for pair_index, (first_name, second_name, candidate_frames) in enumerate(
@@ -511,20 +504,21 @@ class DynamicCollisionEvaluator:
             bounds[name] = _bounds(shape, path=f"placements.{name}.bounds")
 
         collision_results: dict[tuple[str, str], dict[str, Any]] = {}
-        candidates: list[tuple[str, str]] = []
-        for first_name, second_name in self._pairs:
-            pair = (first_name, second_name)
-            if pair in excluded_pairs:
-                continue
-            if pair in known_pair_results:
-                known = known_pair_results[pair]
-                if known is not None:
-                    collision_results[pair] = dict(known)
-                continue
-            broad_phase = _aabb_evidence(bounds[first_name], bounds[second_name])
-            if not bool(broad_phase["overlaps_or_touches"]):
-                continue
-            candidates.append(pair)
+        for pair, known in known_pair_results.items():
+            first_name, second_name = pair
+            if (
+                known is not None
+                and pair not in excluded_pairs
+                and first_name in self._component_order
+                and second_name in self._component_order
+                and self._component_order[first_name] < self._component_order[second_name]
+            ):
+                collision_results[pair] = dict(known)
+        candidates = sorted(
+            (pair for pair in _overlapping_component_pairs(bounds)
+             if pair not in excluded_pairs and pair not in known_pair_results),
+            key=lambda pair: tuple(self._component_order[name] for name in pair),
+        )
 
         candidate_count = len(candidates)
         exact_common_count = 0
@@ -633,11 +627,13 @@ class DynamicCollisionEvaluator:
             }
         collisions = [
             collision_results[pair]
-            for pair in self._pairs
-            if pair in collision_results
+            for pair in sorted(
+                collision_results,
+                key=lambda pair: tuple(self._component_order[name] for name in pair),
+            )
         ]
         return {
-            "possible_pair_count": len(self._pairs),
+            "possible_pair_count": self.pair_count,
             "excluded_pair_count": len(excluded_pairs),
             "broad_phase_candidate_count": candidate_count,
             "exact_common_count": exact_common_count,
@@ -1013,21 +1009,23 @@ def summarize_dynamic_collision_frames(
     if (
         not isinstance(component_names, Sequence)
         or isinstance(component_names, (str, bytes))
-        or not 1 <= len(component_names) <= _MAX_COMPONENTS
+        or not component_names
     ):
         raise _error(
             "component_names",
-            f"must contain 1-{_MAX_COMPONENTS} stable identifiers",
+            "must contain at least one stable identifier",
         )
     names: list[str] = []
+    seen_names: set[str] = set()
     for index, name in enumerate(component_names):
         if not isinstance(name, str) or not _COMPONENT_ID.fullmatch(name):
             raise _error(
                 f"component_names[{index}]",
                 "must be a stable identifier",
             )
-        if name in names:
+        if name in seen_names:
             raise _error("component_names", f"contains duplicate {name!r}")
+        seen_names.add(name)
         names.append(name)
     if (
         not isinstance(frames, Sequence)
@@ -1515,6 +1513,33 @@ def _transformed_bounds(
     }
 
 
+def _overlapping_component_pairs(
+    bounds: Mapping[str, Mapping[str, Sequence[float]]],
+):
+    """Yield all touching/overlapping boxes without allocating all possible pairs.
+
+    Sweep along the widest scene axis; retain original component ordering in
+    each pair. Exact containment and surface tests still decide collisions.
+    Dense scenes can genuinely contain quadratic candidate counts, but sparse
+    assemblies need only their active sweep interval and actual candidates.
+    """
+    if len(bounds) < 2:
+        return
+    order = {name: index for index, name in enumerate(bounds)}
+    axis = max(range(3), key=lambda index:
+        max(box['maximum_mm'][index] for box in bounds.values())
+        - min(box['minimum_mm'][index] for box in bounds.values()))
+    active: list[str] = []
+    for name in sorted(bounds, key=lambda name: bounds[name]['minimum_mm'][axis]):
+        minimum = bounds[name]['minimum_mm'][axis]
+        active = [other for other in active
+                  if bounds[other]['maximum_mm'][axis] >= minimum]
+        for other in active:
+            if _aabb_evidence(bounds[other], bounds[name])['overlaps_or_touches']:
+                yield (other, name) if order[other] < order[name] else (name, other)
+        active.append(name)
+
+
 def _aabb_evidence(
     first: Mapping[str, Sequence[float]],
     second: Mapping[str, Sequence[float]],
@@ -1574,11 +1599,11 @@ def _prepared_components(
 ) -> tuple[dict[str, Any], dict[str, dict[str, list[float]]]]:
     if (
         not isinstance(components, Mapping)
-        or not 1 <= len(components) <= _MAX_COMPONENTS
+        or not components
     ):
         raise _error(
             "components",
-            f"must contain 1-{_MAX_COMPONENTS} named solid shapes",
+            "must contain at least one named solid shape",
         )
     placed: dict[str, Any] = {}
     bounds: dict[str, dict[str, list[float]]] = {}
@@ -1605,11 +1630,11 @@ def _component_pairs(
     if (
         not isinstance(pairs, Sequence)
         or isinstance(pairs, (str, bytes))
-        or not 1 <= len(pairs) <= _MAX_PAIRS
+        or not pairs
     ):
         raise _error(
             "pairs",
-            f"must contain 1-{_MAX_PAIRS} explicit component pairs",
+            "must contain at least one explicit component pair",
         )
     clean_pairs: list[tuple[str, str]] = []
     seen_pairs: set[tuple[str, str]] = set()

--- a/src/Mod/VibeCAD/VibeCADNativeAssemblyBomState.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAssemblyBomState.py
@@ -15,14 +15,16 @@ from VibeCADNativeAssemblyComponents import assembly_components
 from VibeCADNativeTargets import object_reference
 
 
-MAX_BOM_SOURCE_NODES = 4_096
-MAX_BOM_SOURCE_EDGES = 8_192
+# Retained public names: count metadata uses zero for no fixed ceiling;
+# the optional read budget uses None, just like read_bom_table().
+MAX_BOM_SOURCE_NODES = 0
+MAX_BOM_SOURCE_EDGES = 0
 MAX_BOM_PROPERTIES_PER_NODE = 256
-MAX_BOM_PROPERTIES = 32_768
+MAX_BOM_PROPERTIES = 0
 MAX_BOM_OPERATIONS = 1_024
 MAX_BOM_COLUMNS = 32
-MAX_BOM_ROWS = 4_096
-MAX_BOM_CELLS = 262_144
+MAX_BOM_ROWS = 0
+MAX_BOM_CELLS = None
 MAX_BOM_VALUE_CHARACTERS = 4_096
 MAX_BOM_PREVIEW_VALUE_CHARACTERS = 160
 MAX_BOM_OPERATION_PREVIEW = 16
@@ -316,11 +318,8 @@ def _source_graph(assembly: Any) -> tuple[dict[str, Any], ...]:
     records: list[dict[str, Any]] = []
     by_identity: dict[tuple[str, str, int], str] = {}
     active: set[tuple[str, str, int]] = set()
-    edge_count = 0
-    property_count = 0
 
     def visit(obj: Any) -> str:
-        nonlocal edge_count, property_count
         identity = _identity_record(obj)
         key = (
             str(identity["document_uid"]),
@@ -334,17 +333,8 @@ def _source_graph(assembly: Any) -> tuple[dict[str, Any], ...]:
                     "The Assembly BOM source hierarchy contains a cycle."
                 )
             return existing
-        if len(records) >= MAX_BOM_SOURCE_NODES:
-            raise NativeAssemblyBomStateError(
-                f"The Assembly exceeds the {MAX_BOM_SOURCE_NODES}-source-node Native BOM bound."
-            )
         node_id = f"n{len(records):04d}"
         properties = _bom_properties(obj)
-        property_count += len(properties)
-        if property_count > MAX_BOM_PROPERTIES:
-            raise NativeAssemblyBomStateError(
-                f"The Assembly exceeds the {MAX_BOM_PROPERTIES}-property Native BOM bound."
-            )
         record: dict[str, Any] = {
             "node_id": node_id,
             "object": identity,
@@ -373,11 +363,6 @@ def _source_graph(assembly: Any) -> tuple[dict[str, Any], ...]:
                     or not _component_candidate(target)
                 ):
                     continue
-                edge_count += 1
-                if edge_count > MAX_BOM_SOURCE_EDGES:
-                    raise NativeAssemblyBomStateError(
-                        f"The Assembly exceeds the {MAX_BOM_SOURCE_EDGES}-occurrence Native BOM bound."
-                    )
                 scale_value = _occurrence_scale(occurrence)
                 record["occurrences"].append(
                     {
@@ -440,11 +425,11 @@ def _preview_text(value: str) -> tuple[str, bool]:
 def read_bom_table(
     bom: Any,
     *,
-    maximum_cells: int = MAX_BOM_CELLS,
+    maximum_cells: int | None = MAX_BOM_CELLS,
 ) -> dict[str, Any]:
-    """Read and hash one bounded native BOM spreadsheet."""
+    """Hash the complete table; bound only its preview unless a caller sets a budget."""
 
-    if type(maximum_cells) is not int or not 1 <= maximum_cells <= MAX_BOM_CELLS:
+    if maximum_cells is not None and (type(maximum_cells) is not int or maximum_cells < 1):
         raise NativeAssemblyBomStateError(
             "The Assembly BOM table cell budget is invalid."
         )
@@ -481,8 +466,7 @@ def read_bom_table(
         first_column != 1
         or first_row != 1
         or not 1 <= column_count <= MAX_BOM_COLUMNS
-        or row_count > MAX_BOM_ROWS
-        or cell_count > maximum_cells
+        or (maximum_cells is not None and cell_count > maximum_cells)
     ):
         raise NativeAssemblyBomStateError(
             "An Assembly BOM exceeds its bounded A1-origin table or cell budget."
@@ -573,12 +557,7 @@ def _bom_graph(
             )
         resources_by_bom[owner].append(resource)
     records = []
-    remaining_cells = MAX_BOM_CELLS
     for bom in boms:
-        if remaining_cells <= 0:
-            raise NativeAssemblyBomStateError(
-                f"The Assembly exceeds the {MAX_BOM_CELLS}-cell Native BOM bound."
-            )
         if (
             not _live_object(bom)
             or str(getattr(bom, "TypeId", "") or "") != "Assembly::BomObject"
@@ -596,8 +575,7 @@ def _bom_graph(
             raise NativeAssemblyBomStateError(
                 "An existing Assembly BOM has invalid columns."
             )
-        table = read_bom_table(bom, maximum_cells=remaining_cells)
-        remaining_cells -= int(table["cell_count"])
+        table = read_bom_table(bom)
         records.append(
             {
                 "bom": _identity_record(bom),

--- a/src/Mod/VibeCAD/VibeCADNativeAssemblyPlayback.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAssemblyPlayback.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from concurrent.futures import Future
 import math
 import re
 import secrets
@@ -133,6 +134,41 @@ def _open_player(simulation: Any, time_seconds: float) -> Any:
         autoplay=False,
         time_seconds=time_seconds,
     )
+
+
+def _open_player_async(simulation: Any, time_seconds: float) -> Future:
+    from CommandCreateSimulation import openSimulationAsync
+
+    return openSimulationAsync(simulation, autoplay=False, time_seconds=time_seconds)
+
+
+def _playback_completion(context, pending, transform, *, cancel_completed=None):
+    """Map a ready player result on its owner, including dispatcher failure."""
+    result = Future()
+
+    def complete():
+        if not result.set_running_or_notify_cancel():
+            return
+        try:
+            result.set_result(transform(pending.result()))
+        except Exception as error:
+            result.set_exception(error)
+
+    def ready(_done):
+        try:
+            context.document_thread_dispatch(complete)
+        except Exception as error:
+            if not result.done() and result.set_running_or_notify_cancel():
+                result.set_exception(error)
+
+    def cancelled(done):
+        if done.cancelled():
+            if not pending.cancel() and cancel_completed is not None:
+                context.document_thread_dispatch(cancel_completed)
+
+    result.add_done_callback(cancelled)
+    pending.add_done_callback(ready)
+    return result
 
 
 def _task_widgets(dialog: Any) -> tuple[Any, ...]:
@@ -459,6 +495,23 @@ def open_native_assembly_playback(
 ) -> dict[str, Any]:
     """Generate frames and open one exact read-only native player."""
 
+    return _open_native_assembly_playback(context, spec, opener=opener, event_pump=event_pump)
+
+
+def open_native_assembly_playback_async(
+    context: NativeRuntimeContext,
+    spec: AssemblyPlaybackOpenSpec,
+    *,
+    opener: Callable[[Any, float], Future] = _open_player_async,
+) -> Future:
+    """Preserve exact launch checks after nonblocking generation and display."""
+    if not callable(context.document_thread_dispatch):
+        raise NativeAssemblyPlaybackError("Asynchronous playback requires the document dispatcher.")
+    return _open_native_assembly_playback(context, spec, opener=opener, event_pump=lambda: None)
+
+
+def _open_native_assembly_playback(context, spec, *, opener, event_pump):
+
     if not isinstance(context, NativeRuntimeContext):
         raise TypeError("context must be a NativeRuntimeContext")
     state, assembly, simulation, expected_frame, exact_time = _validate_open(
@@ -472,17 +525,28 @@ def open_native_assembly_playback(
     camera_before = _active_camera(document)
     modified_before = _gui_modified(document)
     selection_before = read_current_selection(document)
-    panel = None
     dialog = None
+    launch_content = ()
     playback_id = ""
-    try:
-        panel = opener(simulation, exact_time)
+
+    def owned_dialog():
+        current = _active_task_dialog()
+        content = tuple(current.getDialogContent()) if current is not None else ()
+        if (launch_content and len(content) == len(launch_content)
+                and all(first is second for first, second in zip(content, launch_content))):
+            return current
+        return None
+
+    def finish(panel):
+        nonlocal playback_id
         event_pump()
-        dialog = _active_task_dialog()
+        current_dialog = owned_dialog()
         frame_count = int(assembly.numberOfFrames())
         if (
             panel is None
             or dialog is None
+            or current_dialog is None
+            or not any(widget is panel.form for widget in _task_widgets(current_dialog))
             or not bool(getattr(panel, "playback_only", False))
             or getattr(panel, "assembly", None) is not assembly
             or getattr(panel, "simFeaturePy", None) is not simulation
@@ -539,21 +603,43 @@ def open_native_assembly_playback(
             panel.animationTimerStartBackward()
         event_pump()
         return _status(session, "show")
-    except Exception as exc:
-        if dialog is None:
-            dialog = _active_task_dialog()
-        if dialog is not None:
+
+    def fail(exc):
+        current = owned_dialog()
+        if current is not None:
             try:
-                dialog.reject()
+                current.reject()
                 event_pump()
             except (AttributeError, ReferenceError, RuntimeError):
                 pass
         _forget_session(context.document_uid, playback_id)
         if isinstance(exc, NativeAssemblyPlaybackError):
-            raise
+            raise exc
         raise NativeAssemblyPlaybackError(
             "The exact Assembly simulation could not be opened."
         ) from exc
+
+    try:
+        pending = opener(simulation, exact_time)
+        dialog = _active_task_dialog()
+        launch_content = tuple(dialog.getDialogContent()) if dialog is not None else ()
+        if not isinstance(pending, Future):
+            return finish(pending)
+    except Exception as exc:
+        return fail(exc)
+
+    def complete(panel):
+        try:
+            return finish(panel)
+        except Exception as exc:
+            return fail(exc)
+
+    def cancel_completed():
+        current = owned_dialog()
+        if current is not None:
+            current.reject()
+
+    return _playback_completion(context, pending, complete, cancel_completed=cancel_completed)
 
 
 def _require_session(
@@ -645,6 +731,35 @@ def control_native_assembly_playback(
             "The exact Native Assembly player closed during playback control."
         )
     return _status(session, clean_operation)
+
+
+def control_native_assembly_playback_async(context, operation, spec):
+    """Wait for exact paused frames without waiting on the document owner."""
+    if operation not in {'seek', 'step', 'pause'}:
+        return control_native_assembly_playback(context, operation, spec)
+    if not callable(context.document_thread_dispatch):
+        raise NativeAssemblyPlaybackError('Asynchronous playback requires the document dispatcher.')
+    session = _require_session(context, spec)
+    panel = session.panel
+    count = int(session.assembly.numberOfFrames())
+    frame = int(panel.form.frameSlider.value())
+    if operation == 'seek':
+        frame, _ = _grid_frame(session.simulation, spec.time_seconds, frame_count=count)
+    elif operation == 'step':
+        if spec.direction not in _PLAYBACK_DIRECTIONS:
+            raise NativeAssemblyPlaybackError('direction must be forward or backward.')
+        frame += 1 if spec.direction == 'forward' else -1
+        frame = 1 if frame >= count else count - 1 if frame < 1 else frame
+    pending = panel.requestFrameAsync(frame)
+
+    def complete(applied):
+        if applied != frame or _require_session(context, spec) is not session:
+            raise NativeAssemblyPlaybackError('The requested playback frame changed before completion.')
+        if int(panel.form.frameSlider.value()) != frame:
+            raise NativeAssemblyPlaybackError('The requested playback frame was superseded.')
+        return _status(session, operation)
+
+    return _playback_completion(context, pending, complete)
 
 
 def _close_playback(

--- a/src/Mod/VibeCAD/VibeCADNativeAssemblyPlaybackBindings.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAssemblyPlaybackBindings.py
@@ -17,13 +17,22 @@ ASSEMBLY_PLAYBACK_CAPABILITY_NAME = "assembly.playback"
 
 
 def _playback(call: Any) -> Mapping[str, Any]:
+    return _invoke_playback(call, asynchronous=False)
+
+
+def _playback_async(call: Any):
+    return _invoke_playback(call, asynchronous=True)
+
+
+def _invoke_playback(call: Any, *, asynchronous):
     runtime = getattr(call, "runtime", None)
     arguments = getattr(call, "arguments", None)
     if not isinstance(runtime, NativeAssemblyPlaybackRuntime):
         raise TypeError("An Assembly playback call requires its exact runtime.")
     if not isinstance(arguments, Mapping):
         raise TypeError("An Assembly playback call requires argument data.")
-    return runtime.control(arguments, ticket=getattr(call, "ticket", None))
+    handler = runtime.control_async if asynchronous else runtime.control
+    return handler(arguments, ticket=getattr(call, "ticket", None))
 
 
 def register_assembly_playback_capability_implementation(
@@ -35,6 +44,7 @@ def register_assembly_playback_capability_implementation(
         NativeCapabilityImplementation(
             ASSEMBLY_PLAYBACK_CAPABILITY_NAME,
             _playback,
+            async_handler=_playback_async,
         )
     )
 

--- a/src/Mod/VibeCAD/VibeCADNativeAssemblyPlaybackRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNativeAssemblyPlaybackRuntime.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from typing import Any, Mapping
+from concurrent.futures import Future
 
 from VibeCADNativeArguments import strict_variant_arguments
 from VibeCADNativeAssemblyPlayback import (
@@ -12,7 +13,9 @@ from VibeCADNativeAssemblyPlayback import (
     AssemblyPlaybackOpenSpec,
     NativeAssemblyPlaybackError,
     control_native_assembly_playback,
+    control_native_assembly_playback_async,
     open_native_assembly_playback,
+    open_native_assembly_playback_async,
 )
 from VibeCADNativeRuntimeContext import NativeRuntimeContext
 from VibeCADNativeState import NativeCallTicket
@@ -44,6 +47,13 @@ class NativeAssemblyPlaybackRuntime:
         *,
         ticket: NativeCallTicket,
     ) -> dict[str, Any]:
+        return self._control(arguments, ticket=ticket, asynchronous=False)
+
+    def control_async(self, arguments: Mapping[str, Any], *, ticket: NativeCallTicket):
+        """Return a completion handle for long-running presentation operations."""
+        return self._control(arguments, ticket=ticket, asynchronous=True)
+
+    def _control(self, arguments, *, ticket, asynchronous):
         normalized = dict(arguments)
         if normalized.get("operation") == "show":
             normalized.setdefault("time_seconds", None)
@@ -69,9 +79,14 @@ class NativeAssemblyPlaybackRuntime:
         if authorization.duplicate:
             return dict(authorization.prior_verified_result or {})
         self._context.state.begin_mutation_observation(ticket)
+        deferred = False
         try:
             if operation == "show":
-                result = open_native_assembly_playback(
+                open_player = (
+                    open_native_assembly_playback_async if asynchronous
+                    else open_native_assembly_playback
+                )
+                result = open_player(
                     self._context,
                     AssemblyPlaybackOpenSpec(
                         simulation_ref=_object_ref(
@@ -84,7 +99,11 @@ class NativeAssemblyPlaybackRuntime:
                     ),
                 )
             else:
-                result = control_native_assembly_playback(
+                control_player = (
+                    control_native_assembly_playback_async if asynchronous
+                    else control_native_assembly_playback
+                )
+                result = control_player(
                     self._context,
                     operation,
                     AssemblyPlaybackControlSpec(
@@ -97,6 +116,14 @@ class NativeAssemblyPlaybackRuntime:
                         ),
                     ),
                 )
+            if isinstance(result, Future):
+                result.add_done_callback(
+                    lambda _done: self._context.document_thread_dispatch(
+                        lambda: self._context.state.cancel_mutation(ticket)
+                    )
+                )
+                deferred = True
             return result
         finally:
-            self._context.state.cancel_mutation(ticket)
+            if not deferred:
+                self._context.state.cancel_mutation(ticket)

--- a/src/Mod/VibeCAD/VibeCADNativeCapabilityRegistry.py
+++ b/src/Mod/VibeCAD/VibeCADNativeCapabilityRegistry.py
@@ -793,12 +793,17 @@ class NativeCapabilityImplementation:
         repr=False,
         compare=False,
     )
+    # Optional host-only asynchronous entry point. Provider schemas and the
+    # existing synchronous handler contract are unchanged.
+    async_handler: Callable[[Any], Any] | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         if not _CAPABILITY_NAME.fullmatch(self.name) or not callable(self.handler):
             raise NativeCapabilityRegistryError(
                 "A Native implementation needs a valid name and callable handler."
             )
+        if self.async_handler is not None and not callable(self.async_handler):
+            raise NativeCapabilityRegistryError("A Native asynchronous handler must be callable.")
 
 
 class NativeCapabilityRegistry:

--- a/src/Mod/VibeCAD/VibeCADNativeDispatch.py
+++ b/src/Mod/VibeCAD/VibeCADNativeDispatch.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from concurrent.futures import Future
 from dataclasses import dataclass
 import json
 import threading
@@ -594,6 +595,28 @@ class NativeTurnDispatcher:
         arguments_json: str,
         provider_call_id: str,
     ) -> dict[str, Any]:
+        return self._call(tool_name, arguments_json, provider_call_id)
+
+    def call_async(
+        self,
+        tool_name: str,
+        arguments_json: str,
+        provider_call_id: str,
+        *,
+        document_dispatch: Callable[[Callable[[], Any]], Any],
+    ) -> dict[str, Any] | Future:
+        """Launch on the owner and defer final validation until work completes.
+
+        A returned Future must only be waited on outside the GUI thread. Its
+        result is the same validated/cached JSON response as call().
+        """
+        if not callable(document_dispatch):
+            raise TypeError('Asynchronous dispatch requires an owner dispatcher')
+        return self._call(tool_name, arguments_json, provider_call_id, document_dispatch)
+
+    def _call(
+        self, tool_name, arguments_json, provider_call_id, document_dispatch=None
+    ):
         name = str(tool_name or "").strip()
         try:
             call_id = self._call_id(provider_call_id)
@@ -661,53 +684,30 @@ class NativeTurnDispatcher:
                         "NATIVE_IMPLEMENTATION_MISSING",
                         "The frozen Native capability has no implementation.",
                     )
-                payload = implementation.handler(
+                handler = (
+                    implementation.async_handler
+                    if document_dispatch is not None and implementation.async_handler is not None
+                    else implementation.handler
+                )
+                payload = handler(
                     NativeCapabilityCall(
                         normalized_arguments,
                         ticket,
                         self._runtimes[name],
                     )
                 )
-                if not isinstance(payload, Mapping) or "ok" in payload:
-                    raise NativeDispatchError(
-                        "NATIVE_RESULT_INVALID",
-                        "A Native capability returned an invalid result contract.",
+                if document_dispatch is not None and isinstance(payload, Future):
+                    return self._defer_payload(
+                        payload, document_dispatch, name, variant, normalized_arguments, ticket, record
                     )
-                self._guard_after_call(variant, payload)
-                definition = self._registry.definition(name)
-                if (
-                    definition is not None
-                    and definition.primary_classification in {"read", "view"}
-                ):
-                    revision_after = self._state.current_revision(self._document_uid)
-                    if revision_after != ticket.expected_revision:
-                        raise NativeDispatchError(
-                            "NATIVE_READ_SIDE_EFFECT",
-                            "A read-only Native capability changed the document; "
-                            "its result was rejected.",
-                            details={
-                                "current_revision": revision_after,
-                                "repair": {
-                                    "operation": normalized_arguments.get("operation"),
-                                    "revision_before": ticket.expected_revision,
-                                    "revision_after": revision_after,
-                                },
-                            },
-                        )
-                response = {"ok": True, **dict(payload)}
-                record.result_json = _canonical_json(
-                    response,
-                    label="result",
-                    byte_limit=MAX_NATIVE_RESULT_JSON_BYTES,
-                )
-                if name != "native.job":
-                    self._expected_revision = self._state.current_revision(
-                        self._document_uid
-                    )
-                return json.loads(record.result_json)
+                return self._finish_payload(name, variant, normalized_arguments, ticket, record, payload)
             except Exception as exc:
                 self._debug(name, exc)
                 response = _failure_payload(exc)
+                if isinstance(exc, NativeDispatchError) and exc.code in {
+                    'NATIVE_CALL_IN_PROGRESS', 'NATIVE_CALL_ID_REUSED'
+                }:
+                    return response
                 encoded = _canonical_json(
                     response,
                     label="failure",
@@ -724,6 +724,67 @@ class NativeTurnDispatcher:
                 if record is not None:
                     record.result_json = encoded
                 return json.loads(encoded)
+
+    def _finish_payload(self, name, variant, arguments, ticket, record, payload):
+        if not isinstance(payload, Mapping) or 'ok' in payload:
+            raise NativeDispatchError(
+                'NATIVE_RESULT_INVALID', 'A Native capability returned an invalid result contract.'
+            )
+        self._guard_after_call(variant, payload)
+        definition = self._registry.definition(name)
+        if definition is not None and definition.primary_classification in {'read', 'view'}:
+            revision_after = self._state.current_revision(self._document_uid)
+            if revision_after != ticket.expected_revision:
+                raise NativeDispatchError(
+                    'NATIVE_READ_SIDE_EFFECT',
+                    'A read-only Native capability changed the document; its result was rejected.',
+                    details={'current_revision': revision_after, 'repair': {
+                        'operation': arguments.get('operation'),
+                        'revision_before': ticket.expected_revision,
+                        'revision_after': revision_after,
+                    }},
+                )
+        record.result_json = _canonical_json(
+            {'ok': True, **dict(payload)}, label='result', byte_limit=MAX_NATIVE_RESULT_JSON_BYTES
+        )
+        if name != 'native.job':
+            self._expected_revision = self._state.current_revision(self._document_uid)
+        return json.loads(record.result_json)
+
+    def _defer_payload(self, pending, document_dispatch, name, variant, arguments, ticket, record):
+        response = Future()
+
+        def finalize():
+            with self._lock:
+                try:
+                    return self._finish_payload(name, variant, arguments, ticket, record, pending.result())
+                except Exception as error:
+                    self._debug(name, error)
+                    record.result_json = _canonical_json(
+                        _failure_payload(error), label='failure', byte_limit=MAX_NATIVE_RESULT_JSON_BYTES
+                    )
+                    return json.loads(record.result_json)
+
+        def completed(_future):
+            deliver = response.set_running_or_notify_cancel()
+            try:
+                result = document_dispatch(finalize)
+            except Exception as error:
+                result = _failure_payload(error)
+                with self._lock:
+                    record.result_json = _canonical_json(
+                        result, label='failure', byte_limit=MAX_NATIVE_RESULT_JSON_BYTES
+                    )
+            if deliver:
+                response.set_result(result)
+
+        def cancelled(future):
+            if future.cancelled():
+                document_dispatch(pending.cancel)
+
+        response.add_done_callback(cancelled)
+        pending.add_done_callback(completed)
+        return response
 
     @property
     def call_count(self) -> int:

--- a/src/Mod/VibeCAD/VibeCADNativeProviderRunner.py
+++ b/src/Mod/VibeCAD/VibeCADNativeProviderRunner.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import Future, TimeoutError as FutureTimeout
 import time
 from typing import Any, Callable, Mapping
 
@@ -276,12 +277,29 @@ class NativeProviderToolRunner:
         result = self._wait_for_active_background_job(name)
         if result is None:
             result = self._document_dispatch(
-                lambda: self._execution.dispatcher.call(
+                lambda: self._execution.dispatcher.call_async(
                     name,
                     arguments_json,
                     provider_call_id,
+                    document_dispatch=self._document_dispatch,
                 )
             )
+            if isinstance(result, Future):
+                pending = result
+                while True:
+                    if self._cancelled is not None and self._cancelled():
+                        pending.cancel()
+                        result = {'ok': False, 'error_code': 'NATIVE_RUN_CANCELLED',
+                                  'error': 'VibeCAD stopped the pending Native call.'}
+                        break
+                    try:
+                        # This is a provider-thread wait, not a solver deadline
+                        # or a model-visible polling loop. Qt remains free to
+                        # finish the native job and validate its result.
+                        result = pending.result(timeout=0.1)
+                        break
+                    except FutureTimeout:
+                        continue
         if self._debug_events is not None and self._debug_capture_directory:
             events = [dict(event) for event in self._debug_events]
             self._debug_events.clear()

--- a/src/Mod/VibeCAD/VibeCADNumericalRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADNumericalRuntime.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Numerical scratch admission for single-job Windows isolation processes.
+
+Never change process-global BLAS settings around concurrent in-process jobs.
+The host process uses its outer compute pool; only an exclusive isolation job
+may enlarge its numerical team, within the CPU slots granted by that host.
+"""
+
+from contextlib import contextmanager
+from functools import cache
+import os
+
+# OpenBLAS 0.3.30 common_x86_64.h BUFFER_SIZE; pinned Windows package below.
+# This is a scratch allocation estimate, not a limit on matrices or CAD models.
+_SCRATCH_BYTES_PER_THREAD = 128 * 1024 * 1024
+
+
+@cache
+def _controller():
+    from threadpoolctl import OpenBLASController, ThreadpoolController, register
+
+    # conda-forge Windows calls the DLL openblas.dll, not libopenblas.dll.
+    # Reuse the library controller, extending only its filename recognition.
+    class BundledOpenBLASController(OpenBLASController):
+        filename_prefixes = ("openblas",)
+
+    register(BundledOpenBLASController)
+    return ThreadpoolController()
+
+
+def numerical_thread_count(cpu_slots, available_bytes, memory_limit_bytes, used_bytes):
+    headroom = max(0, int(available_bytes))
+    if memory_limit_bytes > 0:
+        headroom = min(headroom, max(0, int(memory_limit_bytes) - int(used_bytes)))
+    # Leave at least half the current headroom for matrix operands and geometry.
+    memory_threads = headroom // (2 * _SCRATCH_BYTES_PER_THREAD)
+    return max(1, min(max(1, int(cpu_slots)), memory_threads))
+
+
+@contextmanager
+def numerical_thread_limits(cpu_slots, memory_limit_bytes=0):
+    import psutil
+
+    # Discover the numerical backend before setting its team size. Importing
+    # once per persistent worker avoids repeating initialization per operation.
+    import numpy  # noqa: F401
+
+    threads = numerical_thread_count(
+        cpu_slots,
+        psutil.virtual_memory().available,
+        memory_limit_bytes,
+        psutil.Process().memory_info().private,
+    )
+    previous = os.environ.get("OPENBLAS_NUM_THREADS")
+    os.environ["OPENBLAS_NUM_THREADS"] = str(threads)
+    try:
+        with _controller().limit(limits=threads, user_api="blas"):
+            yield threads
+    finally:
+        if previous is None:
+            os.environ.pop("OPENBLAS_NUM_THREADS", None)
+        else:
+            os.environ["OPENBLAS_NUM_THREADS"] = previous

--- a/src/Mod/VibeCAD/VibeCADPublicationProgress.py
+++ b/src/Mod/VibeCAD/VibeCADPublicationProgress.py
@@ -90,6 +90,14 @@ class PublicationProgress:
         self._emit(completed=self._total, phase="completed")
         self._yield_if_due(now)
 
+    def finalizing(self) -> None:
+        """Report post-mutation rendering and projection work."""
+
+        now = self._clock()
+        self._last_completed = self._total
+        self._emit(completed=self._total, phase="finalizing")
+        self._yield_if_due(now)
+
     def fail(self) -> None:
         now = self._clock()
         self._emit(completed=self._last_completed, phase="failed")

--- a/src/Mod/VibeCAD/VibeCADSession.py
+++ b/src/Mod/VibeCAD/VibeCADSession.py
@@ -10,6 +10,7 @@ in the live state packet. There is no workflow phase machine or prose parser.
 from __future__ import annotations
 
 from collections.abc import Mapping
+from concurrent.futures import Future, TimeoutError as FutureTimeout
 from copy import deepcopy
 from dataclasses import dataclass
 import json
@@ -372,6 +373,16 @@ def _document_recompute_state(service: VibeCADService) -> dict[str, Any]:
         if document is not None
         else False,
     }
+
+
+def _start_service_tool(service, tool_name, arguments, *, asynchronous):
+    """Owner-thread entry; preserve schema validation for deferred handlers."""
+    if asynchronous and tool_name == 'assembly.play_simulation':
+        from tool_impl.service.assembly_play_simulation import run_async
+
+        service.registry.get(tool_name).spec.validate_arguments(arguments)
+        return run_async(service, **arguments)
+    return service.registry.call(tool_name, **arguments)
 
 
 def _wait_for_document_idle(
@@ -1831,36 +1842,22 @@ _PROVIDER_REDUNDANT_SOURCE_FIELDS = frozenset(
 
 
 def _provider_editable_sources_payload(value: Mapping[str, Any]) -> dict[str, Any]:
-    """Remove tool-schema duplication from the model-visible source index."""
+    """Orient the model without copying the full program/output inventories."""
 
-    if int(value.get("source_count") or 0) == 0:
+    page = _paged_source_index_payload(value)
+    if page["program_count"] == 0:
         return {
             key: value[key]
             for key in ("schema", "domain", "source_count")
             if key in value
         }
     result = {
-        key: item
-        for key, item in value.items()
-        if key != "tools"
-        and not (
-            key in {"sources_truncated", "sources_omitted"}
-            and item in (False, 0)
-        )
+        key: value[key]
+        for key in ("schema", "domain", "workbench", "source_count",
+                    "authoring_domains", "domain_source_counts", "api_groups", "core_api")
+        if key in value
     }
-    for collection_name in ("sources", "all_sources", "component_sources"):
-        collection = result.get(collection_name)
-        if not isinstance(collection, list):
-            continue
-        result[collection_name] = [
-            {
-                key: item
-                for key, item in source.items()
-                if key not in _PROVIDER_REDUNDANT_SOURCE_FIELDS
-            }
-            for source in collection
-            if isinstance(source, Mapping)
-        ]
+    result["program_index"] = page
     return result
 
 
@@ -2376,6 +2373,14 @@ def _trace_result(payload: dict[str, Any]) -> dict[str, Any]:
     return result
 
 
+def _validate_domain_candidate(adapter, prepared, execution, cancellation_check):
+    """Pass cancellation to capable validators without changing legacy adapters."""
+    validate = getattr(adapter, "validate_result_with_cancellation", None)
+    if callable(validate):
+        return validate(prepared, execution, cancellation_check=cancellation_check)
+    return adapter.validate_result(prepared, execution)
+
+
 def _run_domain_vibescript_tool(
     service: VibeCADService,
     tool_name: str,
@@ -2670,7 +2675,8 @@ def _run_domain_vibescript_tool(
         try:
             validated = run_phase(
                 "validate",
-                lambda: adapter.validate_result(prepared, execution),
+                lambda: _validate_domain_candidate(
+                    adapter, prepared, execution, cancellation_check),
             )
         except DomainRuntimeFailure as exc:
             return retain_failed_candidate(
@@ -3076,6 +3082,75 @@ def _read_source_payload(
         if compact_state:
             result["model_state"] = compact_state
     return result
+
+
+def _paged_source_index_payload(
+    editable_sources: Mapping[str, Any] | None,
+    *,
+    offset: int = 0,
+    limit: int = 20,
+    query: str = "",
+) -> dict[str, Any]:
+    """Page program identities, not their potentially enormous generated outputs.
+
+    The page size bounds model-facing responses, never document capacity. The
+    full internal index remains available for exact tool resolution and reads.
+    """
+    if offset < 0 or not 1 <= limit <= 100:
+        raise ValueError("Source index offset must be nonnegative; limit must be 1-100.")
+    data = editable_sources or {}
+    sources: dict[str, Mapping[str, Any]] = {}
+    for collection in ("all_sources", "sources", "component_sources"):
+        for source in data.get(collection) or []:
+            if isinstance(source, Mapping) and source.get("program"):
+                sources.setdefault(str(source["program"]), source)
+    needle = query.strip().casefold()
+    matches = [
+        name for name, source in sorted(sources.items())
+        if not needle or any(needle in str(source.get(field) or "").casefold()
+                             for field in ("program", "label", "domain"))
+        or any(needle in str(output.get(field) or "").casefold()
+               for output in source.get("affected_outputs") or []
+               if isinstance(output, Mapping)
+               for field in ("name", "label", "object_name"))
+    ]
+    programs = []
+    for name in matches[offset:offset + limit]:
+        source = sources[name]
+        entry = {key: source[key] for key in
+                 ("program", "label", "domain", "status", "current_revision", "accepted_revision")
+                 if source.get(key) not in (None, "")}
+        outputs = source.get("affected_outputs") or []
+        entry["output_count"] = len(outputs)
+        candidate = source.get("latest_candidate")
+        if isinstance(candidate, Mapping):
+            entry["latest_candidate"] = {
+                key: candidate[key] for key in ("status", "revision", "failure")
+                if candidate.get(key) not in (None, "", {})
+            }
+        if source.get("error"):
+            entry["error"] = source["error"]
+        programs.append(entry)
+    next_offset = offset + len(programs)
+    return {
+        "ok": True,
+        "program_count": len(sources),
+        "matched_count": len(matches),
+        "offset": offset,
+        "programs": programs,
+        "next_read": (
+            {"tool": "vibescript.read_source",
+             "arguments": {"offset": next_offset, "limit": limit, "query": query}}
+            if next_offset < len(matches) else None
+        ),
+        "usage": (
+            "This is a program index, not source code or a geometry listing. "
+            "Search with vibescript.read_source(query=part or program name), with program omitted; "
+            "follow next_read to page. Read one exact program with program=<listed identity>; "
+            "line_start/line_end select source lines. Read its current revision before editing. "
+            "Use vibescript.read_api for callable details."
+        ),
+    }
 
 
 def _read_source_index_payload(
@@ -4276,7 +4351,12 @@ def _run_universal_vibescript_tool(
         )
 
         if target is None:
-            return _read_source_index_payload(editable_sources)
+            return _paged_source_index_payload(
+                editable_sources,
+                offset=args.get("offset", 0),
+                limit=args.get("limit", 20),
+                query=args.get("query", ""),
+            )
         source_id = target.source_id
         try:
             captured = _on_document_thread(
@@ -4735,7 +4815,8 @@ def build_domain_vibescript_editor_candidate(
             }
             return execution
         try:
-            validated = adapter.validate_result(prepared, execution)
+            validated = _validate_domain_candidate(
+                adapter, prepared, execution, cancellation_check)
         except DomainRuntimeFailure as exc:
             retained = retain_candidate(
                 prepared,
@@ -5714,16 +5795,42 @@ def make_provider_tool_runner(
             },
         )
         document_phase_started = time.monotonic()
+        owner_elapsed = None
         try:
             raw = _on_document_thread(
                 document_thread_dispatch,
-                lambda: service.registry.call(tool_name, **args),
+                lambda: _start_service_tool(
+                    service, tool_name, args,
+                    asynchronous=document_thread_dispatch is not None,
+                ),
             )
+            owner_elapsed = time.monotonic() - document_phase_started
+            if isinstance(raw, Future):
+                pending = raw
+                while True:
+                    if cancellation_check is not None and cancellation_check():
+                        _on_document_thread(document_thread_dispatch, pending.cancel)
+                        raw = tool_failure(
+                            tool_name, 'TOOL_CANCELLED', 'native_call',
+                            'Simulation playback was cancelled.',
+                        )
+                        break
+                    try:
+                        # Provider-thread wait only: the player completes on Qt
+                        # after native generation and exact frame adoption.
+                        raw = pending.result(timeout=0.1)
+                        break
+                    except FutureTimeout:
+                        continue
             payload = dict(raw) if isinstance(raw, dict) else {"value": raw}
             payload.setdefault("ok", payload.get("error") in (None, ""))
         except ToolArgumentValidationError as exc:
+            if owner_elapsed is None:
+                owner_elapsed = time.monotonic() - document_phase_started
             payload = exc.payload
         except Exception as exc:
+            if owner_elapsed is None:
+                owner_elapsed = time.monotonic() - document_phase_started
             payload = tool_failure(
                 tool_name,
                 "TOOL_HANDLER_EXCEPTION",
@@ -5733,7 +5840,7 @@ def make_provider_tool_runner(
                 observed={"exception_type": exc.__class__.__name__},
             )
         document_thread_elapsed = round(
-            time.monotonic() - document_phase_started,
+            owner_elapsed,
             4,
         )
         payload.setdefault(

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainPublication.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainPublication.py
@@ -17,7 +17,10 @@ from VibeCADDocumentReferences import (
     DocumentReferenceError,
     resolve_reference_target,
 )
-from VibeCADDocumentChangeBatch import flush_document_change_batch
+from VibeCADDocumentChangeBatch import (
+    flush_document_change_batch,
+    rolling_back_document_change_batch,
+)
 import VibeCADReferenceContracts as reference_contracts
 import VibeCADScriptedPublication as scripted_publication
 import VibeCADVibeScriptDomains as contracts
@@ -420,9 +423,7 @@ def compact_persisted_input_snapshots(doc: Any) -> dict[str, Any]:
     invalid_objects: list[str] = []
     before_bytes = 0
     after_bytes = 0
-    for obj in list(getattr(doc, "Objects", []) or []):
-        if PROP_INPUT_SNAPSHOTS not in _properties(obj):
-            continue
+    for obj in doc.findObjects(Property=PROP_INPUT_SNAPSHOTS):
         raw = str(getattr(obj, PROP_INPUT_SNAPSHOTS, "") or "")
         if raw not in compacted_by_raw:
             compacted: str | None = raw
@@ -729,7 +730,7 @@ def migrate_assembly_dependency_anchors(doc: Any) -> dict[str, Any]:
 
     migrated: list[str] = []
     created: list[str] = []
-    for assembly in list(getattr(doc, "Objects", []) or []):
+    for assembly in doc.findObjects(Property=contracts.PROP_PROGRAM_DOMAIN):
         if str(getattr(assembly, "TypeId", "") or "") != "Assembly::AssemblyObject":
             continue
         if (
@@ -946,13 +947,18 @@ def _ensure_native_simulation_view_provider(obj: Any) -> None:
 
         if not bool(App.GuiUp):
             return
-        view = getattr(obj, "ViewObject", None)
-        if view is None:
-            return
-        from CommandCreateSimulation import ViewProviderSimulation
+        import FreeCADGui as Gui
 
-        if not isinstance(getattr(view, "Proxy", None), ViewProviderSimulation):
-            ViewProviderSimulation(view)
+        def attach() -> None:
+            view = getattr(obj, "ViewObject", None)
+            if view is None:
+                return
+            from CommandCreateSimulation import ViewProviderSimulation
+
+            if not isinstance(getattr(view, "Proxy", None), ViewProviderSimulation):
+                ViewProviderSimulation(view)
+
+        Gui.runOnMainThread(attach)
     except ImportError:
         return
 
@@ -999,10 +1005,8 @@ class AssemblyBOMRestoreProxy:
             ):
                 raise RuntimeError("The managed Assembly BOM target belongs to another program.")
             encoded = str(getattr(target, PROP_ASSEMBLY_BOM_VALIDATION, "") or "")
-            if not encoded or len(encoded.encode("utf-8")) > 1_000_000:
-                raise RuntimeError(
-                    "The accepted Assembly BOM validation is missing or exceeds 1 MB."
-                )
+            if not encoded:
+                raise RuntimeError("The accepted Assembly BOM validation is missing.")
             data = json.loads(encoded)
             if not isinstance(data, dict) or str(data.get("schema") or "") != (
                 "vibecad-assembly-bom-v1"
@@ -1443,34 +1447,40 @@ def mark_programs_stale_from_sources(
 
     excluded = set(excluded_programs)
     affected: dict[tuple[str, str, str], tuple[Any, Any, str]] = {}
+    # Shared outputs often reference hundreds of changed components. Read each
+    # output's metadata and input membership once, not once per source edge.
+    input_membership: dict[int, tuple[Any, tuple[str, str, str], set[int]] | None] = {}
     for source, property_name in tuple(changes or ()):
         changed_property = str(property_name or "")
         if not source_property_affects_vibescript_snapshot(changed_property):
             continue
         label_only = changed_property == "Label"
         for output in list(getattr(source, "InList", []) or []):
-            properties = _properties(output)
-            if not ({PROP_INPUT_OBJECTS, PROP_NESTED_INPUT_OBJECTS} & properties):
+            output_id = id(output)
+            if output_id not in input_membership:
+                input_membership[output_id] = None
+                properties = _properties(output)
+                if not ({PROP_INPUT_OBJECTS, PROP_NESTED_INPUT_OBJECTS} & properties):
+                    continue
+                document = getattr(output, "Document", None)
+                key = (
+                    str(getattr(document, "Uid", "") or ""),
+                    str(getattr(output, contracts.PROP_PROGRAM_ID, "") or ""),
+                    str(getattr(output, contracts.PROP_PROGRAM_DOMAIN, "") or ""),
+                )
+                if document is None or not all(key) or key in excluded:
+                    continue
+                inputs = {
+                    id(item)
+                    for property_name in (PROP_INPUT_OBJECTS, PROP_NESTED_INPUT_OBJECTS)
+                    for item in (getattr(output, property_name, []) or [])
+                }
+                input_membership[output_id] = (document, key, inputs)
+            membership = input_membership[output_id]
+            if membership is None:
                 continue
-            inputs = [
-                *list(getattr(output, PROP_INPUT_OBJECTS, []) or []),
-                *list(getattr(output, PROP_NESTED_INPUT_OBJECTS, []) or []),
-            ]
-            if not any(item is source for item in inputs):
-                continue
-            document = getattr(output, "Document", None)
-            document_uid = str(getattr(document, "Uid", "") or "")
-            program_id = str(getattr(output, contracts.PROP_PROGRAM_ID, "") or "")
-            domain = str(getattr(output, contracts.PROP_PROGRAM_DOMAIN, "") or "")
-            key = (document_uid, program_id, domain)
-            if (
-                document is None
-                or not document_uid
-                or not program_id
-                or not domain
-                or key in excluded
-                or (label_only and domain != "assembly")
-            ):
+            document, key, inputs = membership
+            if id(source) not in inputs or (label_only and key[2] != "assembly"):
                 continue
             affected.setdefault(key, (document, source, changed_property))
 
@@ -2011,6 +2021,33 @@ def _capture_timeline_resource_reconciliation(
         "resource_keys": keys,
         "direct_roots": direct_roots,
     }
+
+
+def _reconcile_assembly_occurrence_resources(
+    doc: Any,
+    operation: Any,
+    captured: Mapping[str, Any],
+    final_resources: list[Any],
+    *,
+    staged: bool,
+    context: str,
+) -> list[Any]:
+    """Finish occurrence resources, preserving an already staged replacement."""
+
+    # The caller has just captured the exact graph and verified the occurrence's
+    # History role. With no old/new resources and no staged mutation, there is
+    # nothing to reconcile. Do not snapshot and rewrite the whole History for
+    # every ordinary component. A staged fastener replacement must still finish,
+    # even if its final graph happens to be empty.
+    if not staged and not captured["resources"] and not final_resources:
+        return []
+    if not staged:
+        _stage_timeline_resource_reconciliation(doc, operation, captured, context=context)
+    released = _finalize_timeline_resource_reconciliation(
+        doc, operation, captured, final_resources,
+        key_for_resource=_assembly_timeline_resource_key, context=context,
+    )
+    return _remove_reconciled_timeline_resources(doc, released, context=context)
 
 
 def _stage_timeline_resource_reconciliation(
@@ -3978,6 +4015,52 @@ def _configure_joint_while_suspended(
     obj.Proxy.setJointConnectors(obj, references)
 
 
+def _rebase_assembly_configuration_dependencies(
+    doc: Any,
+    output_type: str,
+    items: list[Mapping[str, Any]],
+    existing: Mapping[str, Any],
+    outputs: Mapping[str, Any],
+) -> None:
+    """Rebase changed retained consumers before installing later dependencies.
+
+    Configuration runs by type, so all component/joint/motion inputs are already
+    published at the next phase boundary. One native closure move carries shared
+    downstream consumers and owned resources with their original state intact.
+    """
+    retained = [item for item in items if item["type"] == output_type
+                and str(item["name"]) in existing]
+    if not retained:
+        return
+    timeline = doc.getObject("VibeCADTimeline")
+    positions = {id(obj): index for index, obj in enumerate(timeline.Operations)}
+    moving = []
+    latest = None
+    latest_position = -1
+    for item in retained:
+        obj = existing[str(item["name"])]
+        position = positions[id(obj)]
+        data = item.get("assembly_data") or {}
+        if output_type == "joint":
+            names = [connector["component_output"] for connector in data.get("connectors", [])]
+        elif output_type == "motion":
+            names = [data["joint_output"]]
+        else:
+            names = data.get("motion_outputs", [])
+        move = False
+        for name in names:
+            dependency = outputs[str(name)]
+            dependency_position = positions[id(dependency)]
+            if dependency_position > position:
+                move = True
+                if dependency_position > latest_position:
+                    latest, latest_position = dependency, dependency_position
+        if move:
+            moving.append(obj)
+    if moving:
+        doc.reorderTimelineOperationDependentClosuresAfter(moving, latest)
+
+
 def _configure_joint(
     obj: Any,
     item: Mapping[str, Any],
@@ -4320,7 +4403,15 @@ def _configure_assembly_simulation(
     collision = data.get("collision_summary")
     if (
         not isinstance(collision, Mapping)
-        or collision.get("status") not in {"complete", "incomplete"}
+        or collision.get("status") not in {"complete", "incomplete", "not_checked"}
+        or (
+            collision.get("status") == "not_checked"
+            and (
+                collision.get("evaluation_mode") != "off"
+                or collision.get("analysis_complete") is not False
+                or collision.get("collision_free") is not False
+            )
+        )
     ):
         raise RuntimeError(
             "An Assembly simulation has no authenticated collision summary."
@@ -13564,10 +13655,8 @@ def migrate_partdesign_component_occurrence_links(doc: Any) -> dict[str, Any]:
     """Replace legacy forward dependency links with exact object-name metadata."""
 
     migrated: list[str] = []
-    for root in list(getattr(doc, "Objects", []) or []):
+    for root in doc.findObjects(Property=PROP_PARTDESIGN_COMPONENT_OCCURRENCES):
         properties = _properties(root)
-        if PROP_PARTDESIGN_COMPONENT_OCCURRENCES not in properties:
-            continue
         if (
             str(getattr(root, contracts.PROP_PROGRAM_DOMAIN, "") or "")
             != "partdesign"
@@ -14563,6 +14652,31 @@ def _materialize_partdesign_native_history(
     internalize_restored_objects: bool = False,
     build_timeline_blocks: bool = True,
 ) -> dict[str, Any]:
+    from VibeCADCooperativeExecution import run_document_thread_steps
+
+    return run_document_thread_steps(
+        _iter_materialize_partdesign_native_history(
+            doc, root, prepared, validated,
+            existing_bodies=existing_bodies,
+            preserve_existing_tips=preserve_existing_tips,
+            internalize_restored_objects=internalize_restored_objects,
+            build_timeline_blocks=build_timeline_blocks,
+        ),
+        dispatch=None,
+    )
+
+
+def _iter_materialize_partdesign_native_history(
+    doc: Any,
+    root: Any,
+    prepared: Mapping[str, Any],
+    validated: Mapping[str, Any],
+    *,
+    existing_bodies: Mapping[str, Any] | None = None,
+    preserve_existing_tips: bool = False,
+    internalize_restored_objects: bool = False,
+    build_timeline_blocks: bool = True,
+) -> Iterator[Any]:
     history = validated.get("partdesign_native_history")
     if not isinstance(history, Mapping):
         return {"available": False, "bodies": {}, "created_objects": []}
@@ -14667,6 +14781,7 @@ def _materialize_partdesign_native_history(
                     and callable(classify_internal)
                 ):
                     classify_internal(obj)
+            yield {"phase": "publication_history", "message": "Creating native history objects"}
 
         for specification in object_specs:
             original_name = str(specification["name"])
@@ -14693,6 +14808,7 @@ def _materialize_partdesign_native_history(
                 )
             setattr(obj, PROP_PARTDESIGN_HISTORY_KEY, original_name)
             _hide_property(obj, PROP_PARTDESIGN_HISTORY_KEY)
+            yield {"phase": "publication_history", "message": "Restoring native history objects"}
 
         for specification in object_specs:
             original_name = str(specification["name"])
@@ -14799,6 +14915,7 @@ def _materialize_partdesign_native_history(
                 authored_objects,
                 output_name=output_name,
             )
+        yield {"phase": "publication_history", "message": "Linking native history objects"}
 
     for body_specification in list(history.get("outputs") or []):
         output_name = str(body_specification["output_name"])
@@ -14814,6 +14931,7 @@ def _materialize_partdesign_native_history(
             output_items[output_name],
             output_name=output_name,
         )
+        yield {"phase": "publication_history", "message": "Checking published history"}
 
     return {
         "available": True,
@@ -15441,6 +15559,20 @@ def _publish_partdesign_design_candidate(
     validated: Mapping[str, Any],
     doc: Any,
 ) -> dict[str, Any]:
+    from VibeCADCooperativeExecution import run_document_thread_steps
+
+    return run_document_thread_steps(
+        _iter_publish_partdesign_design_candidate(service, prepared, validated, doc),
+        dispatch=None,
+    )
+
+
+def _iter_publish_partdesign_design_candidate(
+    service: Any,
+    prepared: Mapping[str, Any],
+    validated: Mapping[str, Any],
+    doc: Any,
+) -> Iterator[Any]:
     """Publish one complete program as one Design-global History operation."""
 
     import PartDesign
@@ -15773,7 +15905,7 @@ def _publish_partdesign_design_candidate(
             [str(item["name"]) for item in items],
             [str(item["type"]) for item in items],
         )
-        bodies = list(PartDesign.finalizeDesignScriptOperationEdit(edit))
+        bodies = list(PartDesign.adoptDesignScriptOperationEdit(edit))
         if len(bodies) != len(body_items):
             raise RuntimeError(
                 "The Design VibeScript operation did not publish one Body per "
@@ -15796,7 +15928,8 @@ def _publish_partdesign_design_candidate(
             str(item["name"]): body
             for item, body in zip(body_items, bodies)
         }
-        restored_native_history = _materialize_partdesign_native_history(
+        yield {"phase": "publication_adoption", "message": "Adopted native Body output states"}
+        restored_native_history = yield from _iter_materialize_partdesign_native_history(
             doc,
             root,
             prepared,
@@ -15806,7 +15939,7 @@ def _publish_partdesign_design_candidate(
             internalize_restored_objects=True,
             build_timeline_blocks=False,
         )
-        for item in items:
+        for output_index, item in enumerate(items):
             name = str(item["name"])
             output_type = str(item["type"])
             body = bodies_by_output.get(name)
@@ -15870,6 +16003,11 @@ def _publish_partdesign_design_candidate(
                             )
                         _set_view_visibility(target, False)
                     _set_view_visibility(published, True)
+                yield {
+                    "event": "vibescript_domain_publication_progress", "domain": "partdesign",
+                    "phase": "publishing", "completed": output_index + 1, "total": len(items),
+                    "current_output": name, "output_type": output_type,
+                }
                 continue
             carrier = _PartDesignShapeCarrier(item)
             if published is None:
@@ -15943,6 +16081,12 @@ def _publish_partdesign_design_candidate(
                 # operation but intentionally have no physical Body identity.
                 _set_view_visibility(published, True)
 
+            yield {
+                "event": "vibescript_domain_publication_progress", "domain": "partdesign",
+                "phase": "publishing", "completed": output_index + 1, "total": len(items),
+                "current_output": name, "output_type": output_type,
+            }
+
         _set_partdesign_component_occurrences(
             root,
             [
@@ -16002,7 +16146,7 @@ def _publish_partdesign_design_candidate(
             _flush_publication_observers(prepared)
             doc.commitTransaction()
             transaction_open = False
-    except Exception as publication_error:
+    except BaseException as publication_error:
         abort_error = None
         if transaction_open and hasattr(doc, "abortTransaction"):
             try:
@@ -16545,6 +16689,8 @@ def _assert_publication_document_intact(
     prepared: Mapping[str, Any],
     doc: Any,
     targets: Any = (),
+    *,
+    cache: dict[str, Any] | None = None,
 ) -> None:
     """Reject a slice if its exact live document targets were replaced."""
 
@@ -16567,7 +16713,17 @@ def _assert_publication_document_intact(
     resolve = getattr(doc, "getObject", None)
     if not callable(resolve):
         return
-    for target in tuple(targets or ()):
+    checked = None
+    removal_generation = getattr(doc, "getObjectRemovalGeneration", None)
+    if cache is not None and callable(removal_generation):
+        generation = removal_generation()
+        if cache.get("document") is not doc or cache.get("generation") != generation:
+            cache.clear()
+            cache.update(document=doc, generation=generation, targets={})
+        checked = cache["targets"]
+    for target in targets or ():
+        if checked is not None and checked.get(id(target)) is target:
+            continue
         try:
             name = str(getattr(target, "Name", "") or "")
             attached = not name or resolve(name) is target
@@ -16578,6 +16734,16 @@ def _assert_publication_document_intact(
                 "A live document target changed between publication slices; "
                 "the candidate was rolled back."
             )
+        if checked is not None and name:
+            # Hold the exact wrapper, so Python object-id reuse cannot make a
+            # new target inherit an earlier target's successful validation.
+            checked[id(target)] = target
+
+
+def _abort_publication_transaction(document: Any) -> None:
+    """Replay native rollback without collecting already discarded deltas."""
+    with rolling_back_document_change_batch(str(getattr(document, "Uid", "") or "")):
+        document.abortTransaction()
 
 
 def _flush_publication_observers(prepared: Mapping[str, Any]) -> None:
@@ -16588,12 +16754,22 @@ def _flush_publication_observers(prepared: Mapping[str, Any]) -> None:
         flush_document_change_batch(document_uid)
 
 
+def publication_item_count(
+    prepared: Mapping[str, Any], validated: Mapping[str, Any]
+) -> int:
+    total = len(list(validated.get("outputs") or []))
+    if str(getattr(prepared.get("pack"), "domain", "")) == "assembly":
+        total += len(list(validated.get("assembly_members") or []))
+    return total
+
+
 def iter_publish_candidate(
     service: Any,
     prepared: dict[str, Any],
     validated: dict[str, Any],
     *,
     progress_callback: Any | None = None,
+    complete_progress: bool = True,
 ) -> Iterator[Any]:
     """Yield between bounded live-document publication slices."""
 
@@ -16605,9 +16781,7 @@ def iter_publish_candidate(
     begin_mutation = getattr(active_document, "beginCooperativeMutation", None)
     end_mutation = getattr(active_document, "endCooperativeMutation", None)
     mutation_supported = bool(callable(begin_mutation) and callable(end_mutation))
-    total = len(list(validated.get("outputs") or []))
-    if str(getattr(prepared.get("pack"), "domain", "")) == "assembly":
-        total += len(list(validated.get("assembly_members") or []))
+    total = publication_item_count(prepared, validated)
     progress = PublicationProgress(
         domain=str(getattr(prepared.get("pack"), "domain", "")),
         total=total,
@@ -16646,15 +16820,16 @@ def iter_publish_candidate(
                 progress.fail()
                 raise
             else:
-                progress.finish()
                 succeeded = True
-                return result
         finally:
             if batch_started:
                 end_batch(document_uid, commit=succeeded)
     finally:
         if mutation_started:
             end_mutation()
+    if complete_progress:
+        progress.finish()
+    return result
 
 
 def _drain_publication_steps(steps: Iterator[Any]) -> dict[str, Any]:
@@ -16723,7 +16898,9 @@ def _iter_publish_candidate_unbatched(
     }
     _assert_publication_document_intact(service, prepared, doc)
     if domain == "partdesign":
-        return _publish_partdesign_candidate(service, prepared, validated, doc)
+        return (yield from _iter_publish_partdesign_design_candidate(
+            service, prepared, validated, doc
+        ))
     if domain == "material":
         return _publish_material_candidate(service, prepared, validated, doc)
     if domain == "cam":
@@ -16854,6 +17031,7 @@ def _iter_publish_candidate_unbatched(
     }
     _assert_publication_document_intact(service, prepared, doc)
     outputs: dict[str, Any] = {}
+    target_identity_cache: dict[str, Any] = {}
     created: list[Any] = []
     removed: list[str] = []
     assembly_dependency_anchor: Any | None = None
@@ -17027,16 +17205,25 @@ def _iter_publish_candidate_unbatched(
                 output_type=output_type,
             )
 
+        rebased_assembly_types: set[str] = set()
         for output_index, item in enumerate(configure_order):
             if output_index:
                 _assert_publication_document_intact(
                     service,
                     prepared,
                     doc,
-                    tuple(outputs.values()),
+                    outputs.values(),
+                    cache=target_identity_cache,
                 )
             output_name = str(item["name"])
             output_type = str(item["type"])
+            if (prepared["pack"].domain == "assembly"
+                    and output_type in {"joint", "motion", "simulation"}
+                    and output_type not in rebased_assembly_types):
+                _rebase_assembly_configuration_dependencies(
+                    doc, output_type, configure_order, existing, outputs,
+                )
+                rebased_assembly_types.add(output_type)
             adopted_occurrence = False
             occurrence_reconciliation: dict[str, Any] | None = None
             occurrence_reconciliation_staged = False
@@ -17357,29 +17544,13 @@ def _iter_publish_candidate_unbatched(
                     )
                     final_occurrence_resources.append(fastener_source)
 
-                if not occurrence_reconciliation_staged:
-                    _stage_timeline_resource_reconciliation(
+                removed.extend(
+                    _reconcile_assembly_occurrence_resources(
                         doc,
                         obj,
                         occurrence_reconciliation,
-                        context=(
-                            f"Assembly occurrence {output_name!r} resource graph"
-                        ),
-                    )
-                released = _finalize_timeline_resource_reconciliation(
-                    doc,
-                    obj,
-                    occurrence_reconciliation,
-                    final_occurrence_resources,
-                    key_for_resource=_assembly_timeline_resource_key,
-                    context=(
-                        f"Assembly occurrence {output_name!r} resource graph"
-                    ),
-                )
-                removed.extend(
-                    _remove_reconciled_timeline_resources(
-                        doc,
-                        released,
+                        final_occurrence_resources,
+                        staged=occurrence_reconciliation_staged,
                         context=(
                             f"Assembly occurrence {output_name!r} resource graph"
                         ),
@@ -17504,7 +17675,8 @@ def _iter_publish_candidate_unbatched(
             service,
             prepared,
             doc,
-            tuple(outputs.values()),
+            outputs.values(),
+            cache=target_identity_cache,
         )
         if prepared["pack"].domain != "assembly":
             # Configure the complete output graph before publishing any new
@@ -17549,7 +17721,8 @@ def _iter_publish_candidate_unbatched(
             service,
             prepared,
             doc,
-            tuple(outputs.values()),
+            outputs.values(),
+            cache=target_identity_cache,
         )
         if assembly_dependency_anchor is not None and assembly_item is not None:
             # Publish the anchor with the Assembly root in creation order, but
@@ -17578,7 +17751,8 @@ def _iter_publish_candidate_unbatched(
             service,
             prepared,
             doc,
-            tuple(outputs.values()),
+            outputs.values(),
+            cache=target_identity_cache,
         )
         if assembly is not None and any(obj is assembly for obj in created):
             _configure_new_assembly_presentation(
@@ -17613,7 +17787,8 @@ def _iter_publish_candidate_unbatched(
             service,
             prepared,
             doc,
-            tuple(outputs.values()),
+            outputs.values(),
+            cache=target_identity_cache,
         )
         if prepared["pack"].domain == "robot":
             retired_robot_trajectories = _extract_robot_trajectories(retired)
@@ -17626,7 +17801,7 @@ def _iter_publish_candidate_unbatched(
         created_names = [str(getattr(obj, "Name", "") or "") for obj in created]
         if transaction_open and hasattr(doc, "abortTransaction"):
             try:
-                doc.abortTransaction()
+                _abort_publication_transaction(doc)
             except Exception:
                 pass
         if assembly_bom_rollbacks:

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainRuntime.py
@@ -37,6 +37,7 @@ from VibeCADDocumentReferences import (
     resolve_reference_target,
 )
 from VibeCADCooperativeExecution import run_document_thread_steps
+from VibeCADPublicationProgress import PublicationProgress
 from VibeCADMechanismEngine import (
     MECHANISM_SCENARIO_SCHEMA,
     MECHANISM_SOLVE_REPORT_SCHEMA,
@@ -47,6 +48,7 @@ from VibeCADMechanismEngine import (
     normalize_mechanism_solve_report,
     normalize_mechanism_static_check,
     normalize_mechanism_verification_report,
+    quaternion_rotation_distance_degrees,
     solver_validation_scope,
 )
 from VibeCADMechanismGeometry import (
@@ -67,12 +69,9 @@ WORKER_SCHEMA = "vibecad-vibescript-domain-worker-v2"
 _PROGRAM_ID = re.compile(r"^[0-9a-f]{32}$")
 _PROGRAM_NAME = re.compile(r"^[A-Za-z][A-Za-z0-9 ._-]{0,119}$")
 _ASYNC_PUBLICATION_KEY = "_vibecad_domain_publication"
-_STRUCTURED_DEFINITION_LIMIT = 1_000_000
-_MAX_REFERENCE_SHAPES = 128
 _MAX_REFERENCE_BREP_BYTES = 256 * 1024 * 1024
 _PARTDESIGN_NATIVE_HISTORY_SCHEMA = "vibecad-partdesign-native-history-v1"
 _MAX_PARTDESIGN_NATIVE_HISTORY_BYTES = 256 * 1024 * 1024
-_MAX_PARTDESIGN_NATIVE_HISTORY_OBJECTS = 16_384
 _PARTDESIGN_NATIVE_HISTORY_TYPES = frozenset(
     {
         "Sketcher::SketchObject",
@@ -115,7 +114,6 @@ _SKETCHER_PROFILE_ENDPOINT_MATCH_TOLERANCE_MM = 1.0e-6
 _ASSEMBLY_SIMULATION_TRACE_SCHEMA = "vibecad-assembly-simulation-trace-v1"
 _MAX_ASSEMBLY_SIMULATION_TRACE_BYTES = 64 * 1024 * 1024
 _ASSEMBLY_EXPLODED_VIEW_SCHEMA = "vibecad-assembly-exploded-view-v1"
-_MAX_ASSEMBLY_HIERARCHY_JSON_BYTES = 8 * 1024 * 1024
 _PLACEMENT_MATRIX_FIELDS = (
     "A11",
     "A12",
@@ -1040,10 +1038,6 @@ def _input_references(value: Any) -> list[dict[str, str]]:
             walk(child)
 
     walk(value)
-    if len(result) > _MAX_REFERENCE_SHAPES:
-        raise ValueError(
-            f"A program may reference at most {_MAX_REFERENCE_SHAPES} document objects."
-        )
     return result
 
 
@@ -1812,18 +1806,7 @@ def _finalize_assembly_hierarchy(
         if key not in {"nodes", "_detached_shapes"}
     }
     descriptor["nodes"] = nodes
-    encoded = json.dumps(
-        descriptor,
-        ensure_ascii=True,
-        sort_keys=True,
-        separators=(",", ":"),
-        allow_nan=False,
-    ).encode("utf-8")
-    if len(encoded) > _MAX_ASSEMBLY_HIERARCHY_JSON_BYTES:
-        raise ValueError(
-            "The authenticated Assembly source hierarchy exceeds the 8 MiB metadata limit. "
-            "Remove unrelated scalar properties or split the source into smaller modules."
-        )
+    _validate_json_serializable(descriptor)
     return descriptor, total_bytes
 
 
@@ -2763,11 +2746,13 @@ def prepare_candidate(captured: Mapping[str, Any]) -> dict[str, Any]:
             "api_exports": list(pack.api_exports),
             "output_types": list(pack.output_types),
             "compatibility_methods": list(compatibility_methods),
-            "max_operations": 200_000,
+            # Source line/call counts are not a measure of model validity or
+            # resource use. Large generated programs must not hit a size quota.
+            "max_operations": 0,
             "max_seconds": float(captured["timeout_seconds"]),
             "memory_limit_bytes": int(captured["memory_limit_bytes"]),
-            # Source-authored Python is bounded by its trace operation and
-            # source-time budgets. RLIMIT_CPU covers trusted CAD kernels too,
+            # Source-authored Python retains the configured source-time limit.
+            # RLIMIT_CPU covers trusted CAD kernels too,
             # so applying that same deadline would kill healthy native work.
             "cpu_limit_seconds": 0,
             "output_limit_bytes": 256 * 1024 * 1024,
@@ -2882,42 +2867,28 @@ def _worker_progress(prepared: Mapping[str, Any]) -> dict[str, Any] | None:
     return value
 
 
-def _worker_progress_activity(prepared: Mapping[str, Any]) -> object | None:
-    """Return a cheap token that changes whenever worker progress is published."""
-
-    path = Path(str(prepared["staging"])) / "progress.json"
-    try:
-        status = path.stat()
-    except OSError:
-        return None
-    return (
-        int(status.st_mtime_ns),
-        int(status.st_ctime_ns),
-        int(status.st_size),
-        int(status.st_ino),
-    )
-
-
 def execute_candidate(
     prepared: Mapping[str, Any],
     *,
     cancellation_check: Callable[[], bool] | None,
 ) -> dict[str, Any]:
-    from VibeCADScriptedProcess import run_process
+    from VibeCADHostIsolation import execute_staged_script
 
-    code = (
-        "import os,runpy,sys;"
-        "sys.path.insert(0,os.getcwd());"
-        "runpy.run_path('worker.py',run_name='__main__')"
+    domain = str(getattr(prepared.get("pack"), "domain", "") or "")
+    cpu_slots = (
+        max(1, ((os.cpu_count() or 1) * 3) // 4)
+        if domain == "assembly"
+        else 1
     )
-    process = run_process(
-        [str(prepared["freecadcmd_executable"]), "--safe-mode", "-c", code],
-        cwd=str(prepared["staging"]),
+    process = execute_staged_script(
+        executable=str(prepared["freecadcmd_executable"]),
+        module_root=Path(__file__).resolve().parent,
+        staging=str(prepared["staging"]),
+        script="worker.py",
         environment=_worker_environment(prepared),
         cancellation_check=cancellation_check,
-        timeout_seconds=float(prepared["timeout_seconds"]),
         memory_limit_bytes=int(prepared["memory_limit_bytes"]),
-        activity_check=lambda: _worker_progress_activity(prepared),
+        cpu_slots=cpu_slots,
     )
     progress = _worker_progress(prepared)
     if progress is not None:
@@ -3112,10 +3083,12 @@ def _validate_shape_class(output_type: str, facts: Mapping[str, Any]) -> None:
         )
 
 
-def _detached_shape_facts(shape: Any, *, max_subelements: int) -> dict[str, Any]:
+def _detached_shape_facts(
+    shape: Any, *, max_subelements: int, assume_valid: bool = False,
+) -> dict[str, Any]:
     from vibescript_part_worker import part_shape_facts
 
-    return part_shape_facts(shape, max_subelements=max_subelements)
+    return part_shape_facts(shape, max_subelements=max_subelements, assume_valid=assume_valid)
 
 
 def _finite_vector(value: Any, label: str) -> list[float]:
@@ -3320,15 +3293,7 @@ def _validate_spreadsheet_execution(
             prepared,
             f"outputs.{name}.definition",
         )
-        encoded_definition = json.dumps(
-            definition,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded_definition) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(f"Spreadsheet output {name!r} definition is too large.")
+        _validate_json_serializable(definition)
 
         validation = item.get("sheet_validation")
         if not isinstance(validation, dict) or set(validation) != validation_fields:
@@ -3578,17 +3543,7 @@ def _validate_spreadsheet_execution(
                 )
             _validate_definition_value(sample["value"], prepared, f"{path}.value")
 
-        encoded_validation = json.dumps(
-            validation,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded_validation) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(
-                f"Spreadsheet output {name!r} native validation is too large."
-            )
+        _validate_json_serializable(validation)
         expected_global_item = {
             "name": name,
             "type": "sheet",
@@ -3749,15 +3704,7 @@ def _validate_material_execution(
             context=f"outputs.{name}.definition",
         )
         _validate_definition_value(definition, prepared, f"outputs.{name}.definition")
-        encoded_definition = json.dumps(
-            definition,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded_definition) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(f"Material output {name!r} definition is too large.")
+        _validate_json_serializable(definition)
 
         validation = item.get("material_validation")
         specific_fields = (
@@ -3916,15 +3863,7 @@ def _validate_material_execution(
             raise ValueError(f"The Material worker reported inconsistent {field}.")
     if global_validation.get("outputs") != expected_summaries:
         raise ValueError("The Material worker global output summary is inconsistent.")
-    encoded_validation = json.dumps(
-        global_validation,
-        ensure_ascii=True,
-        sort_keys=True,
-        separators=(",", ":"),
-        allow_nan=False,
-    ).encode("utf-8")
-    if len(encoded_validation) > _STRUCTURED_DEFINITION_LIMIT:
-        raise ValueError("The Material worker validation summary is too large.")
+    _validate_json_serializable(global_validation)
     return dict(global_validation)
 
 
@@ -4570,15 +4509,7 @@ def _validate_mesh_execution(
             prepared,
             f"outputs.{name}.mesh_data",
         )
-        encoded_data = json.dumps(
-            data,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded_data) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(f"Mesh output {name!r} native readback is too large.")
+        _validate_json_serializable(data)
         item["definition"] = definition
         item["mesh_data"] = data
         item["facts"] = observed
@@ -5087,17 +5018,7 @@ def _validate_meshpart_execution(
             prepared,
             f"outputs.{name}.meshpart_data",
         )
-        encoded = json.dumps(
-            data,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(
-                f"MeshPart output {name!r} native conversion data is too large."
-            )
+        _validate_json_serializable(data)
         item["definition"] = definition
         expected_summaries.append(expected_summary)
     expected_counts = {
@@ -6833,11 +6754,14 @@ def _assembly_placement_delta(
         "translation_distance_mm",
         "rotation_degrees",
     }
-    if not isinstance(value, dict) or set(value) != fields:
+    if not isinstance(value, dict) or set(value) not in (fields, fields | {"rotation_metric"}):
         raise ValueError(
             f"{label} must contain exactly translation_mm, "
-            "translation_distance_mm, and rotation_degrees."
+            "translation_distance_mm, and rotation_degrees, with optional rotation_metric."
         )
+    metric = value.get("rotation_metric")
+    if "rotation_metric" in value and metric != "quaternion_chord_v1":
+        raise ValueError(f"{label}.rotation_metric is unsupported.")
     initial_native = _assembly_native_placement_from_matrix(
         initial["matrix"], f"{label} initial matrix"
     )
@@ -6861,24 +6785,28 @@ def _assembly_placement_delta(
     )[0]
     initial_quaternion = [float(number) for number in initial_native.Rotation.Q]
     solved_quaternion = [float(number) for number in solved_native.Rotation.Q]
-    dot = abs(
-        sum(
-            initial_quaternion[index] * solved_quaternion[index]
-            for index in range(4)
-        )
+    expected_rotation = quaternion_rotation_distance_degrees(initial_quaternion, solved_quaternion)
+    # Older workers used 2*acos(dot(q1,q2)). Near identity, roundoff in
+    # quaternion normalization and the four-term dot product is amplified by
+    # acos. Allow a conservative 16-ulp dot-product error for stored results;
+    # new chord-metric results retain the tighter angular check.
+    rotation_tolerance = (
+        1.0e-7 if metric else math.degrees(2.0 * math.acos(1.0 - 16 * math.ulp(1.0)))
     )
-    expected_rotation = math.degrees(2.0 * math.acos(max(-1.0, min(1.0, dot))))
     rotation = _assembly_close_numbers(
         [value.get("rotation_degrees")],
         [expected_rotation],
         f"{label}.rotation_degrees",
-        absolute_tolerance=1.0e-7,
+        absolute_tolerance=rotation_tolerance,
     )[0]
-    return {
+    result = {
         "translation_mm": translation,
         "translation_distance_mm": distance,
         "rotation_degrees": rotation,
     }
+    if metric:
+        result["rotation_metric"] = metric
+    return result
 
 
 def _assembly_validate_placement_fact(
@@ -9682,8 +9610,7 @@ def _validate_assembly_execution(
             or type(estimated_frame_limit) is not int
             or estimated_frame_limit
             != math.ceil((end_time - start_time) / time_step) + 2
-            or not 2 <= estimated_frame_limit <= 10_000
-            or estimated_frame_limit * len(components) > 100_000
+            or estimated_frame_limit < 2
             or collision_mode not in {"full", "off"}
         ):
             raise ValueError(
@@ -9827,7 +9754,6 @@ def _validate_assembly_execution(
         if (
             not isinstance(raw_frames, list)
             or not 2 <= len(raw_frames) <= estimated_frame_limit
-            or len(raw_frames) * len(component_names) > 100_000
         ):
             raise ValueError(f"{context} has an invalid frame or pose count.")
         frames: list[dict[str, Any]] = []
@@ -10194,15 +10120,7 @@ def _validate_assembly_execution(
             prepared,
             f"outputs.{item['name']}.assembly_data",
         )
-        encoded = json.dumps(
-            data,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(f"Output {item['name']!r} assembly metadata is too large.")
+        _validate_json_serializable(data)
     return dict(validation)
 
 
@@ -10618,10 +10536,10 @@ def _validate_sketcher_execution(
         raise ValueError("api.sketch must serialize exactly geometry and constraints.")
     geometry = arguments[0]
     constraints = arguments[1]
-    if not isinstance(geometry, list) or not 1 <= len(geometry) <= 4096:
-        raise ValueError("A Sketcher definition must contain 1-4096 geometry values.")
-    if not isinstance(constraints, list) or len(constraints) > 16384:
-        raise ValueError("A Sketcher definition may contain at most 16384 constraints.")
+    if not isinstance(geometry, list) or not geometry:
+        raise ValueError("A Sketcher definition must contain geometry values.")
+    if not isinstance(constraints, list):
+        raise ValueError("A Sketcher definition must contain a constraint list.")
     _exact_mapping(
         properties,
         path="api.sketch.properties",
@@ -11270,15 +11188,7 @@ def _validate_sketcher_execution(
     )
     if any(constraint_issues.values()):
         raise ValueError("An accepted Sketcher candidate reports constraint issues.")
-    encoded = json.dumps(
-        validation,
-        ensure_ascii=True,
-        sort_keys=True,
-        separators=(",", ":"),
-        allow_nan=False,
-    ).encode("utf-8")
-    if len(encoded) > _STRUCTURED_DEFINITION_LIMIT:
-        raise ValueError("The Sketcher native validation is too large.")
+    _validate_json_serializable(validation)
     item["sketch_validation"] = dict(validation)
     return dict(validation)
 
@@ -11871,15 +11781,7 @@ def _validate_draft_execution(
             prepared,
             f"outputs.{name}.draft_data",
         )
-        encoded = json.dumps(
-            data,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(f"Draft output {name!r} native readback is too large.")
+        _validate_json_serializable(data)
 
     expected_summary = [
         {
@@ -12574,15 +12476,7 @@ def _validate_surface_execution(
             prepared,
             f"outputs.{name}.surface_data",
         )
-        encoded_data = json.dumps(
-            data,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded_data) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(f"Surface output {name!r} native readback is too large.")
+        _validate_json_serializable(data)
 
         for reference_payload, reference_path in _surface_definition_references(
             definition,
@@ -12699,6 +12593,51 @@ def _validate_surface_execution(
     return dict(validation)
 
 
+def _validate_json_serializable(value: Any) -> None:
+    """Check strict JSON values without formatting and discarding their text."""
+    active: set[int] = set()
+
+    def check(item: Any) -> None:
+        if item is None or isinstance(item, (str, bool)):
+            return
+        if isinstance(item, int):
+            # Preserve the interpreter's integer-conversion contract, including
+            # IntEnum handling and its configured large-integer digit policy.
+            int.__repr__(item)
+            return
+        if isinstance(item, float):
+            if not math.isfinite(item):
+                raise ValueError("Out of range float values are not JSON compliant")
+            return
+        if not isinstance(item, (dict, list, tuple)):
+            raise TypeError(
+                f"Object of type {type(item).__name__} is not JSON serializable"
+            )
+        identity = id(item)
+        if identity in active:
+            raise ValueError("Circular reference detected")
+        active.add(identity)
+        try:
+            if isinstance(item, dict):
+                # Keep sort_keys=True's mixed-key rejection as well as JSON's
+                # key-type and finite-number rules. No encoded payload is built.
+                for key, child in sorted(item.items()):
+                    if key is not None and not isinstance(key, (str, int, float)):
+                        raise TypeError(
+                            "keys must be str, int, float, bool or None, "
+                            f"not {type(key).__name__}"
+                        )
+                    check(key)
+                    check(child)
+            else:
+                for child in item:
+                    check(child)
+        finally:
+            active.remove(identity)
+
+    check(value)
+
+
 def _validate_definition_value(
     value: Any,
     prepared: Mapping[str, Any],
@@ -12730,7 +12669,9 @@ def _validate_definition_value(
     if isinstance(value, str):
         if value.startswith(("/", "\\")) or _DRIVE_PATH.match(value):
             raise ValueError(f"{path} cannot contain a raw filesystem path.")
-        if ".." in Path(value.replace("\\", "/")).parts:
+        # Most definition strings are identifiers, not paths. Only parse when
+        # a parent segment is possible; retain the exact platform path check.
+        if ".." in value and ".." in Path(value.replace("\\", "/")).parts:
             raise ValueError(f"{path} cannot traverse a filesystem path.")
         return
     if isinstance(value, list):
@@ -12871,15 +12812,7 @@ def _validate_robot_execution(
             raise ValueError(
                 f"Robot output {name!r} native readback disagrees with its definition."
             )
-        encoded = json.dumps(
-            data,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(f"Robot output {name!r} native readback is too large.")
+        _validate_json_serializable(data)
         if str(item["type"]) != "simulation":
             continue
         if (
@@ -15243,15 +15176,11 @@ def _techdraw_projection_state(
         "TechDraw::DrawProjGroupItem",
     }:
         raise ValueError(f"{path} has an unsupported projection contract.")
-    for count_field, maximum in (
-        ("edge_count", 200_000),
-        ("face_count", 50_000),
-        ("vertex_count", 250_000),
-    ):
+    for count_field in ("edge_count", "face_count", "vertex_count"):
         value = data.get(count_field)
         minimum = 1 if count_field == "edge_count" else 0
-        if type(value) is not int or not minimum <= int(value) <= maximum:
-            raise ValueError(f"{path}.{count_field} is outside its bounded range.")
+        if type(value) is not int or value < minimum:
+            raise ValueError(f"{path}.{count_field} is below its required minimum.")
     edge_count = int(data["edge_count"])
     face_count = int(data["face_count"])
     classes = data.get("edge_classes")
@@ -16153,7 +16082,6 @@ def _validate_partdesign_native_history(
     }
     body_names: set[str] = set()
     document_object_names: set[str] = set()
-    total_objects = 0
     total_content_bytes = 0
     for history_index, history in enumerate(histories):
         path = f"partdesign_native_history.outputs[{history_index}]"
@@ -16184,9 +16112,6 @@ def _validate_partdesign_native_history(
         raw_objects = history.get("objects")
         if not isinstance(raw_objects, list):
             raise ValueError(f"{path}.objects must be an array.")
-        total_objects += len(raw_objects)
-        if total_objects > _MAX_PARTDESIGN_NATIVE_HISTORY_OBJECTS:
-            raise ValueError("Part Design native history contains too many objects.")
 
         if any(not isinstance(item, Mapping) for item in raw_objects):
             raise ValueError(f"{path}.objects contains a malformed entry.")
@@ -16276,6 +16201,26 @@ def _validate_partdesign_native_history(
     }
 
 
+def _prepare_brep_outputs(outputs: list[Any], staging: Path) -> dict[int, Any]:
+    """Import independent artifacts once on the native application compute pool."""
+    paths = {}
+    for index, item in enumerate(outputs):
+        if not isinstance(item, dict):
+            raise ValueError(f"Worker output {index} is malformed.")
+        if item.get("artifact_kind") != "brep":
+            continue
+        path = (staging / str(item.get("artifact_path") or "")).resolve()
+        if staging not in path.parents or not path.is_file():
+            raise ValueError(f"BREP output {item.get('name')!r} is missing.")
+        paths[index] = str(path)
+    if not paths:
+        return {}
+    import Part
+
+    shapes = Part.readBrepShapes(list(paths.values()))
+    return dict(zip(paths, shapes, strict=True))
+
+
 def validate_candidate(
     prepared: Mapping[str, Any], execution: Mapping[str, Any]
 ) -> dict[str, Any]:
@@ -16300,13 +16245,14 @@ def validate_candidate(
             "Worker outputs do not exactly match the declared output order."
         )
     staging = Path(str(prepared["staging"])).resolve()
+    detached_breps = _prepare_brep_outputs(outputs, staging)
     validated: list[dict[str, Any]] = []
     partdesign_material_resolver = None
     if pack.domain == "partdesign":
         from vibescript_partdesign_worker import PartDesignMaterialResolver
 
         partdesign_material_resolver = PartDesignMaterialResolver()
-    for declaration, raw in zip(expected, outputs):
+    for output_index, (declaration, raw) in enumerate(zip(expected, outputs)):
         if not isinstance(raw, dict) or raw.get("type") != declaration["type"]:
             raise ValueError(f"Output {declaration['name']!r} has the wrong type.")
         item = dict(raw)
@@ -16325,15 +16271,7 @@ def validate_candidate(
                 prepared,
                 f"outputs.{declaration['name']}.operation_diagnostics",
             )
-        encoded = json.dumps(
-            definition,
-            ensure_ascii=True,
-            sort_keys=True,
-            separators=(",", ":"),
-            allow_nan=False,
-        ).encode("utf-8")
-        if len(encoded) > _STRUCTURED_DEFINITION_LIMIT:
-            raise ValueError(f"Output {declaration['name']!r} definition is too large.")
+        _validate_json_serializable(definition)
         output_type = str(item["type"])
         if item.get("artifact_kind") == "brep":
             import Part
@@ -16341,10 +16279,7 @@ def validate_candidate(
             path = (staging / str(item.get("artifact_path") or "")).resolve()
             if staging not in path.parents or not path.is_file():
                 raise ValueError(f"BREP output {declaration['name']!r} is missing.")
-            shape = Part.Shape()
-            shape.importBrep(str(path))
-            if shape.isNull() or not shape.isValid():
-                raise ValueError(f"BREP output {declaration['name']!r} is invalid.")
+            shape = detached_breps[output_index]
             reported_facts = dict(item.get("facts") or {})
             detail_limit = int(reported_facts.get("subelement_detail_limit", -1))
             if not 0 <= detail_limit <= 256:
@@ -16352,7 +16287,9 @@ def validate_candidate(
                     f"BREP output {declaration['name']!r} reported an invalid topology "
                     "detail limit."
                 )
-            facts = _detached_shape_facts(shape, max_subelements=detail_limit)
+            facts = _detached_shape_facts(
+                shape, max_subelements=detail_limit, assume_valid=True
+            )
             for key in ("solids", "shells", "faces", "wires", "edges", "vertices"):
                 if int(reported_facts.get(key, -1)) != int(facts[key]):
                     raise ValueError(
@@ -16618,7 +16555,7 @@ def validate_candidate(
         )
     elif pack.domain == "assembly":
         raw_members = execution.get("assembly_members", [])
-        if not isinstance(raw_members, list) or len(raw_members) > 8192:
+        if not isinstance(raw_members, list):
             raise ValueError("The Assembly worker returned malformed owned members.")
         public_names = {str(item["name"]) for item in validated}
         member_names: set[str] = set()
@@ -16679,17 +16616,7 @@ def validate_candidate(
                 raise ValueError(
                     f"Assembly-owned member {name!r} has the wrong definition type."
                 )
-            encoded = json.dumps(
-                definition,
-                ensure_ascii=True,
-                sort_keys=True,
-                separators=(",", ":"),
-                allow_nan=False,
-            ).encode("utf-8")
-            if len(encoded) > _STRUCTURED_DEFINITION_LIMIT:
-                raise ValueError(
-                    f"Assembly-owned member {name!r} definition is too large."
-                )
+            _validate_json_serializable(definition)
             member_names.add(name)
             assembly_members.append(member)
         assembly_validation = _validate_assembly_execution(
@@ -17458,17 +17385,55 @@ class DeclarativeDomainAdapter:
     ) -> dict[str, Any]:
         """Publish in bounded document slices while preserving legacy APIs."""
 
-        return run_document_thread_steps(
+        progress = PublicationProgress(
+            domain=str(self.pack.domain or ""),
+            total=publication_item_count(prepared, validated),
+            callback=progress_callback,
+        )
+        result = run_document_thread_steps(
             iter_publish_candidate(
                 service,
                 prepared,
                 validated,
                 progress_callback=progress_callback,
+                complete_progress=False,
             ),
             dispatch=document_thread_dispatch,
             cancellation_check=cancellation_check,
             progress_callback=progress_callback,
         )
+
+        document_name = str(prepared.get("document_name") or "")
+        document_uid = str(prepared.get("document_uid") or "")
+        if document_name and document_uid:
+            try:
+                progress.finalizing()
+                invoke = document_thread_dispatch or (lambda operation: operation())
+
+                def capture_completion_waiter() -> Callable[[], None]:
+                    document = service._active_document()
+                    if (
+                        document is None
+                        or str(getattr(document, "Name", "") or "") != document_name
+                        or str(getattr(document, "Uid", "") or "") != document_uid
+                    ):
+                        raise RuntimeError(
+                            "The publication document changed before presentation completed."
+                        )
+                    waiter = getattr(document, "waitForPresentationReady", None)
+                    if not callable(waiter):
+                        raise RuntimeError(
+                            "The VibeCAD native presentation completion API is unavailable."
+                        )
+                    return waiter
+
+                completion_waiter = invoke(capture_completion_waiter)
+                completion_waiter()
+            except BaseException:
+                progress.fail()
+                raise
+        progress.finish()
+        return result
 
     def inspect(
         self, captured: dict[str, Any], contract: dict[str, Any]
@@ -23293,11 +23258,113 @@ class TechDrawDomainAdapter(DeclarativeDomainAdapter):
         return description
 
 
+def _run_assembly_validation_job() -> None:
+    """Trusted entry point run by the existing persistent isolation worker."""
+    request = _read_json(Path("host-validation-input.json"), "Assembly validation request")
+    prepared = dict(request["prepared"])
+    prepared["pack"] = contracts.get_vibescript_pack(prepared.pop("workbench"))
+    response: dict[str, Any] = {"request_id": request["request_id"]}
+    try:
+        if prepared["pack"] is None or prepared["pack"].domain != "assembly":
+            raise ValueError("The isolated validator requires the Assembly contract.")
+        response["result"] = validate_candidate(prepared, request["execution"])
+    except Exception as exc:
+        import traceback
+
+        response["error"] = {
+            "type": type(exc).__name__,
+            "message": str(exc),
+            "traceback": traceback.format_exc(),
+        }
+        if isinstance(exc, DomainRuntimeFailure):
+            response["error"]["payload"] = exc.payload
+    _atomic_json(Path("host-validation-result.json"), response)
+
+
+def _validate_assembly_candidate_isolated(
+    prepared: Mapping[str, Any], execution: Mapping[str, Any],
+    *, cancellation_check: Callable[[], bool] | None = None,
+) -> dict[str, Any]:
+    """Keep CPU-heavy Assembly reauthorization off the GUI interpreter's GIL."""
+    from VibeCADHostIsolation import execute_staged_script
+
+    if execution.get("ok") is not True:
+        raise DomainRuntimeFailure(dict(execution))
+    staging = Path(str(prepared["staging"])).resolve()
+    request_id = uuid.uuid4().hex
+    detached = {
+        key: prepared[key]
+        for key in ("expected_outputs", "worker_request", "resolved_references")
+        if key in prepared
+    }
+    detached.update(workbench=prepared["pack"].workbench, staging=str(staging))
+    # Input remains untrusted, including JSON's non-finite extension. The exact
+    # validator in the worker rejects it with the same domain-specific rules.
+    atomic_write_text(staging / "host-validation-input.json", json.dumps({
+        "request_id": request_id, "prepared": detached, "execution": dict(execution),
+    }, ensure_ascii=True, separators=(",", ":")))
+    # Load this installed validator, not a candidate's staged Python module.
+    atomic_write_text(staging / "host-validation.py", (
+        "import runpy\n"
+        f"runpy.run_path({str(Path(__file__).resolve())!r}, "
+        "run_name='__vibecad_validation__')['_run_assembly_validation_job']()\n"
+    ))
+    process = execute_staged_script(
+        staging=staging,
+        script="host-validation.py",
+        environment=_worker_environment(prepared),
+        cancellation_check=cancellation_check,
+        memory_limit_bytes=int(prepared.get("memory_limit_bytes") or 0),
+        executable=prepared.get("freecadcmd_executable"),
+        cpu_slots=1,
+    )
+    if process.get("cancelled"):
+        raise DomainRuntimeFailure(_failure(
+            str(prepared.get("tool_name") or "vibescript.build_program"),
+            "RUN_CANCELLED", "external_process",
+            "VibeScript result validation was cancelled.",
+            observed=process, cancelled=True,
+        ))
+    if not process.get("started") or process.get("returncode") != 0:
+        raise RuntimeError(
+            "Assembly result validation worker failed: "
+            + str(process.get("error") or process.get("stderr") or process)
+        )
+    response = _read_json(staging / "host-validation-result.json", "Assembly validation result")
+    if response.get("request_id") != request_id:
+        raise ValueError("The Assembly validation result belongs to a different request.")
+    error = response.get("error")
+    if isinstance(error, dict):
+        if error.get("type") == "DomainRuntimeFailure":
+            raise DomainRuntimeFailure(error["payload"])
+        exception = {
+            "ValueError": ValueError, "TypeError": TypeError,
+            "OverflowError": OverflowError, "RecursionError": RecursionError,
+        }.get(error.get("type"), RuntimeError)
+        raise exception(str(error.get("message") or "Assembly validation failed."))
+    result = response.get("result")
+    if not isinstance(result, dict) or result.get("ok") is not True:
+        raise ValueError("The Assembly validation worker returned no validated result.")
+    return result
+
+
 @dataclass
 class AssemblyDomainAdapter(DeclarativeDomainAdapter):
     """Dedicated adapter for native linked-component Assembly programs."""
 
     production_ready: bool = True
+
+    def validate_result(
+        self, prepared: dict[str, Any], execution: dict[str, Any]
+    ) -> dict[str, Any]:
+        return _validate_assembly_candidate_isolated(prepared, execution)
+
+    def validate_result_with_cancellation(
+        self, prepared: dict[str, Any], execution: dict[str, Any],
+        *, cancellation_check: Callable[[], bool] | None,
+    ) -> dict[str, Any]:
+        return _validate_assembly_candidate_isolated(
+            prepared, execution, cancellation_check=cancellation_check)
 
     def describe_api(self) -> dict[str, Any]:
         from vibescript_assembly_api import (
@@ -24305,5 +24372,6 @@ def install_builtin_adapters() -> None:
 from VibeCADVibeScriptDomainPublication import (  # noqa: E402
     delete_live_program,
     iter_publish_candidate,
+    publication_item_count,
     publish_candidate,
 )

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomains.py
@@ -6093,13 +6093,26 @@ def universal_tool_specs() -> tuple[dict[str, Any], ...]:
         {
             "name": "vibescript.read_source",
             "description": (
-                "List programs when program is omitted, or read one source and state. "
+                "Search or page programs when program is omitted (query, offset, limit), "
+                "or read one exact program's source and state. "
                 "Use line bounds for a slice and include_logs only for diagnostics."
             ),
             "parameters": {
                 "type": "object",
                 "properties": {
                     "program": program,
+                    "query": _property_schema(
+                        "Program-index search across program, domain, label and output names; omit program.",
+                        type="string",
+                    ),
+                    "offset": _property_schema(
+                        "Program-index offset; omit program. Follow next_read for further pages.",
+                        type="integer", minimum=0, default=0,
+                    ),
+                    "limit": _property_schema(
+                        "Programs per response (not a document limit); omit program.",
+                        type="integer", minimum=1, maximum=100, default=20,
+                    ),
                     "line_start": _property_schema(
                         "First source line (1-based).",
                         type="integer",

--- a/src/Mod/VibeCAD/tool_impl/service/assembly_play_simulation.py
+++ b/src/Mod/VibeCAD/tool_impl/service/assembly_play_simulation.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import Future
 from typing import Any
 
 
@@ -163,6 +164,35 @@ def run(
     autoplay: bool = True,
     time_seconds: float | None = None,
 ) -> dict[str, Any]:
+    return _run(service, simulation, presentation, hidden_components, camera,
+                autoplay, time_seconds, asynchronous=False)
+
+
+def run_async(
+    service: Any,
+    simulation: dict[str, Any],
+    presentation: dict[str, Any] | None = None,
+    hidden_components: list[dict[str, Any]] | None = None,
+    camera: str = "",
+    autoplay: bool = True,
+    time_seconds: float | None = None,
+):
+    """Start on the document owner; return completed evidence through a Future."""
+    return _run(service, simulation, presentation, hidden_components, camera,
+                autoplay, time_seconds, asynchronous=True)
+
+
+def _failure(exc):
+    return {
+        "ok": False,
+        "failure_code": "SIMULATION_PLAYBACK_FAILED",
+        "failure_stage": "native_call",
+        "error": str(exc),
+    }
+
+
+def _run(service, simulation, presentation, hidden_components, camera,
+         autoplay, time_seconds, *, asynchronous):
     try:
         import FreeCAD as App
 
@@ -170,7 +200,8 @@ def run(
             raise RuntimeError("Assembly simulation playback requires the GUI")
         import FreeCADGui as Gui
 
-        if Gui.Control.activeTaskDialog() is not None:
+        active_task = Gui.Control.activeTaskDialog()
+        if active_task is not None and not asynchronous:
             return {
                 "ok": False,
                 "failure_code": "NATIVE_TASK_ACTIVE",
@@ -210,61 +241,103 @@ def run(
             )
             for index, reference in enumerate(hidden_components or [])
         ]
-        from CommandCreateSimulation import _simulationFrameTime, openSimulation
+        from CommandCreateSimulation import openSimulation
 
-        panel = openSimulation(
-            obj,
-            autoplay=bool(autoplay),
-            time_seconds=time_seconds,
-            presentation=presentation_obj,
-            hidden_components=hidden_objects,
-            camera=camera,
-        )
-        assembly = obj.Proxy.getAssembly(obj)
-        frame = int(panel.form.frameSlider.value())
-        collision_summary, frame_collisions = _collision_result(obj, frame)
-        displayed_time = _simulationFrameTime(obj, frame)
-        return {
-            "ok": True,
-            "simulation": dict(simulation),
-            "assembly": {
-                "document_uid": str(getattr(obj.Document, "Uid", "") or ""),
-                "object_name": str(getattr(assembly, "Name", "") or ""),
-            },
-            "playing": bool(autoplay),
-            "frame": frame,
-            "time_seconds": displayed_time,
-            "frame_kind": "input" if displayed_time is None else "solver_output",
-            "frame_count": int(assembly.numberOfFrames()),
-            "collision_alert": (
-                None
-                if collision_summary.get("status") == "unavailable"
-                else not bool(collision_summary["collision_free"])
-            ),
-            "collision_alert_reason": (
-                None
-                if collision_summary.get("status") == "unavailable"
-                else (
-                    "analysis_incomplete"
-                    if not bool(collision_summary.get("analysis_complete", True))
-                    else (
-                        "collision_detected"
-                        if not bool(collision_summary["collision_free"])
-                        else None
-                    )
-                )
-            ),
-            "collision_summary": collision_summary,
-            "displayed_frame_collisions": frame_collisions,
-            "presentation": dict(presentation) if presentation is not None else None,
-            "hidden_component_count": len(hidden_objects),
-            "camera": str(camera or ""),
-            "temporary_state_policy": "placements_visibility_and_camera_restored_when_task_closes",
-        }
+        opener = openSimulation
+        if asynchronous and (autoplay or time_seconds is not None):
+            from CommandCreateSimulation import openSimulationAsync
+            opener = openSimulationAsync
+        if active_task is not None:
+            from CommandCreateSimulation import (
+                findSimulationPlayback, controlSimulationPlaybackAsync,
+            )
+            panel = findSimulationPlayback(
+                obj, presentation=presentation_obj,
+                hidden_components=hidden_objects, camera=camera,
+            )
+            if panel is None:
+                return {
+                    "ok": False,
+                    "failure_code": "NATIVE_TASK_ACTIVE",
+                    "failure_stage": "precondition",
+                    "error": "Close the active task before playing a different simulation or presentation.",
+                }
+            pending = controlSimulationPlaybackAsync(
+                panel, autoplay=bool(autoplay), time_seconds=time_seconds,
+            )
+        else:
+            pending = opener(
+                obj,
+                autoplay=bool(autoplay),
+                time_seconds=time_seconds,
+                presentation=presentation_obj,
+                hidden_components=hidden_objects,
+                camera=camera,
+            )
+
+        def finish(panel):
+            return _playback_result(obj, panel, simulation, presentation, hidden_objects, camera, autoplay)
+
+        if not isinstance(pending, Future):
+            return finish(pending)
+        result = Future()
+
+        def complete(_done):
+            if not result.set_running_or_notify_cancel():
+                return
+            try:
+                result.set_result(finish(pending.result()))
+            except Exception as exc:
+                result.set_result(_failure(exc))
+
+        result.add_done_callback(lambda done: pending.cancel() if done.cancelled() else None)
+        pending.add_done_callback(complete)
+        return result
     except Exception as exc:
-        return {
-            "ok": False,
-            "failure_code": "SIMULATION_PLAYBACK_FAILED",
-            "failure_stage": "native_call",
-            "error": str(exc),
-        }
+        return _failure(exc)
+
+
+def _playback_result(obj, panel, simulation, presentation, hidden_objects, camera, autoplay):
+    from CommandCreateSimulation import _simulationFrameTime
+
+    assembly = obj.Proxy.getAssembly(obj)
+    frame = int(panel.form.frameSlider.value())
+    collision_summary, frame_collisions = _collision_result(obj, frame)
+    displayed_time = _simulationFrameTime(obj, frame)
+    return {
+        "ok": True,
+        "simulation": dict(simulation),
+        "assembly": {
+            "document_uid": str(getattr(obj.Document, "Uid", "") or ""),
+            "object_name": str(getattr(assembly, "Name", "") or ""),
+        },
+        "playing": bool(autoplay),
+        "frame": frame,
+        "time_seconds": displayed_time,
+        "frame_kind": "input" if displayed_time is None else "solver_output",
+        "frame_count": int(assembly.numberOfFrames()),
+        "collision_alert": (
+            None
+            if collision_summary.get("status") == "unavailable"
+            else not bool(collision_summary["collision_free"])
+        ),
+        "collision_alert_reason": (
+            None
+            if collision_summary.get("status") == "unavailable"
+            else (
+                "analysis_incomplete"
+                if not bool(collision_summary.get("analysis_complete", True))
+                else (
+                    "collision_detected"
+                    if not bool(collision_summary["collision_free"])
+                    else None
+                )
+            )
+        ),
+        "collision_summary": collision_summary,
+        "displayed_frame_collisions": frame_collisions,
+        "presentation": dict(presentation) if presentation is not None else None,
+        "hidden_component_count": len(hidden_objects),
+        "camera": str(camera or ""),
+        "temporary_state_policy": "placements_visibility_and_camera_restored_when_task_closes",
+    }

--- a/src/Mod/VibeCAD/tool_impl/service/assembly_stop_simulation.py
+++ b/src/Mod/VibeCAD/tool_impl/service/assembly_stop_simulation.py
@@ -93,7 +93,12 @@ def run(service: Any) -> dict[str, Any]:
         }
         dialog.reject()
         Gui.updateGui()
-        if Gui.Control.activeTaskDialog() is dialog:
+        current = Gui.Control.activeTaskDialog()
+        if current is not None and any(
+            widget is previous
+            for widget in current.getDialogContent()
+            for previous in content
+        ):
             return {
                 "ok": False,
                 "failure_code": "SIMULATION_PLAYBACK_REMAINED_OPEN",

--- a/src/Mod/VibeCAD/vibecad_tests/native_assembly_playback_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_assembly_playback_gui_integration.py
@@ -54,6 +54,34 @@ def _process_events(rounds: int = 20) -> None:
         QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 25)
 
 
+def _wait_document_ready(document) -> None:
+    """Wait for native work, not a machine-dependent count of event passes."""
+    loop = QtCore.QEventLoop()
+    poll = QtCore.QTimer()
+    watchdog = QtCore.QTimer()
+    watchdog.setSingleShot(True)
+    timed_out = False
+
+    def check():
+        if not any((document.Restoring, document.Recomputing, document.RecomputePending,
+                    document.CooperativeMutationActive, document.PresentationUpdateActive)):
+            loop.quit()
+
+    def timeout():
+        nonlocal timed_out
+        timed_out = True
+        loop.quit()
+
+    poll.timeout.connect(check)
+    watchdog.timeout.connect(timeout)
+    poll.start(10)
+    watchdog.start(120000)  # Test watchdog only; never cancels production work.
+    loop.exec()
+    poll.stop()
+    watchdog.stop()
+    assert not timed_out, 'Document did not finish its pending native work'
+
+
 def _select_assemble_ribbon(main_window) -> None:
     tabs = main_window.findChild(QtWidgets.QTabBar, "VibeCADRibbonTabs")
     assert tabs is not None
@@ -131,11 +159,15 @@ def _run() -> None:
             source = document.addObject("Part::Feature", f"PlaybackSource{index + 1}")
             source.Shape = Part.makeBox(20.0, 12.0, 8.0)
             sources.append(source)
+        _wait_document_ready(document)
         document.recompute()
+        _wait_document_ready(document)
         document.saveAs(str(path))
+        _wait_document_ready(document)
 
         Gui.runCommand("Assembly_CreateAssembly")
         _process_events(24)
+        _wait_document_ready(document)
         assembly = next(
             obj for obj in document.Objects if obj.TypeId == "Assembly::AssemblyObject"
         )
@@ -182,6 +214,7 @@ def _run() -> None:
                 ],
             )
             document.finalizeProvisionalTimelineOperationBlock(drive, [drive])
+            _wait_document_ready(document)
             document.recompute()
             document.commitTransaction()
         except Exception:
@@ -193,6 +226,7 @@ def _run() -> None:
                 old_solve_preference,
             )
         _process_events(16)
+        _wait_document_ready(document)
 
         VibeGui._connect_document_observer()
         main_window = Gui.getMainWindow()
@@ -297,6 +331,7 @@ def _run() -> None:
         assert simulation is not None
         document.save()
         _process_events(12)
+        _wait_document_ready(document)
         # Establish a clean presentation baseline explicitly.  Assembly edit
         # contextual-panel refreshes can dirty the GUI document independently
         # of the just-saved App document; playback must preserve the baseline
@@ -411,6 +446,7 @@ def _run() -> None:
         frame_before_save = paused["frame"]
         document.save()
         _process_events(20)
+        _wait_document_ready(document)
         active_after_save = active_native_assembly_playback_summary(assembly)
         assert active_after_save["active"] is True
         assert active_after_save["frame"] == frame_before_save
@@ -472,6 +508,7 @@ def _run() -> None:
         }
         document.save()
         _process_events(20)
+        _wait_document_ready(document)
         assert (
             active_native_assembly_playback_summary(assembly)["frame"]
             == (dirty_opened["frame"])
@@ -533,7 +570,12 @@ def _run() -> None:
                 Gui.activeDocument().resetEdit()
             except (AttributeError, RuntimeError):
                 pass
-            App.closeDocument(document.Name)
+            try:
+                _wait_document_ready(document)
+                App.closeDocument(document.Name)
+            except Exception:
+                traceback.print_exc()
+                exit_code = 1
         if temporary is not None:
             temporary.cleanup()
         application.exit(exit_code)

--- a/src/Mod/VibeCAD/vibecad_tests/partdesign_vibescript_schema_sha256.json
+++ b/src/Mod/VibeCAD/vibecad_tests/partdesign_vibescript_schema_sha256.json
@@ -16,7 +16,7 @@
   "vibescript.read_geometry": "8ffe996294d5f9c31d6ee53d54cc94a87285d189ac5102a5aec102f32d1500bc",
   "vibescript.read_operation": "95069faa7a073ebd136b1a4cefe64c9f5551c32040eab23c5abaa8803294fb86",
   "vibescript.read_placement": "469936e55f12758be15812cde342e9253b1ac1bfb382dbb1c02fb831145f9a48",
-  "vibescript.read_source": "b5b72c876053a26ebe500265ab533007cd255e3520fa2a616a489c0263bf1150",
+  "vibescript.read_source": "f75acfce3fef66aa1f93bfed179e3c603fcc36261d7cffa2ecc7b37f5e02c6ea",
   "vibescript.reconfigure_program": "6bdbe00d377ede388898b0db2ea070b179c5cf430965a66cc48c52853711e4cf",
   "vibescript.set_inputs": "a92a5163cb2572aa552586745720e99045a2416f712b0a9398894b28058c400d"
 }

--- a/src/Mod/VibeCAD/vibecad_tests/test_animation_encoder.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_animation_encoder.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+import importlib.util
+from pathlib import Path
+
+from PIL import Image
+import pytest
+
+
+def encoder():
+    path = Path(__file__).resolve().parents[2] / 'Assembly' / 'AnimationEncoder.py'
+    spec = importlib.util.spec_from_file_location('AnimationEncoder', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.encode_animation
+
+
+def frames(tmp_path):
+    paths = []
+    for index, color in enumerate(('red', 'green', 'blue')):
+        path = tmp_path / f'{index}.png'
+        Image.new('RGB', (16, 12), color).save(path)
+        paths.append(str(path))
+    return paths
+
+
+def test_gif_roundtrip_preserves_every_frame_and_timing(tmp_path):
+    paths = frames(tmp_path)
+    destination = tmp_path / 'motion.gif'
+    encoder()(paths, destination, 10, (16, 12))
+    with Image.open(destination) as result:
+        assert result.n_frames == 3
+        assert result.info['loop'] == 0
+        for index, color in enumerate(((255, 0, 0), (0, 128, 0), (0, 0, 255))):
+            result.seek(index)
+            assert result.info['duration'] == 100
+            assert result.convert('RGB').getpixel((4, 4)) == color
+
+
+def test_encoder_checks_cancellation_between_frames(tmp_path):
+    calls = []
+    def check():
+        calls.append(True)
+        if len(calls) == 3:
+            raise RuntimeError('cancelled')
+    with pytest.raises(RuntimeError, match='cancelled'):
+        encoder()(frames(tmp_path), tmp_path / 'motion.gif', 10, (16, 12), check=check)
+    assert len(calls) == 3
+
+
+@pytest.mark.parametrize('suffix', ['.gif', '.mp4', '.avi'])
+def test_rejects_wrong_frame_dimensions(tmp_path, suffix):
+    with pytest.raises(ValueError, match='dimensions'):
+        encoder()(frames(tmp_path), tmp_path / ('motion' + suffix), 10, (18, 12))
+
+
+def test_video_roundtrip_has_all_frames(tmp_path):
+    import cv2
+    destination = tmp_path / 'motion.mp4'
+    encoder()(frames(tmp_path), destination, 10, (16, 12))
+    capture = cv2.VideoCapture(str(destination))
+    try:
+        assert capture.isOpened()
+        assert int(capture.get(cv2.CAP_PROP_FRAME_COUNT)) == 3
+        for _ in range(3):
+            ok, frame = capture.read()
+            assert ok and frame.shape[:2] == (12, 16)
+    finally:
+        capture.release()

--- a/src/Mod/VibeCAD/vibecad_tests/test_animation_export.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_animation_export.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+import importlib.util
+from pathlib import Path
+import sys
+import threading
+import time
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT / 'VibeCAD'))
+from VibeCADNativeBackground import NativeBackgroundManager
+
+
+def load_export():
+    import PySide6
+    sys.modules.setdefault('PySide', PySide6)
+    path = ROOT / 'Assembly' / 'AnimationExport.py'
+    spec = importlib.util.spec_from_file_location('AnimationExport', path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def wait_until(predicate):
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(.001)
+    pytest.fail('Export did not complete')
+
+
+@pytest.mark.parametrize('outcome', ['success', 'cancel', 'encoder_failure', 'capture_failure'])
+def test_export_publication_and_cleanup_are_detached_and_atomic(tmp_path, outcome):
+    module = load_export()
+    owner = threading.get_ident()
+    calls = []
+    target = tmp_path / 'movie.gif'
+    target.write_bytes(b'original')
+    manager = NativeBackgroundManager()
+    def execute(**kwargs):
+        import json
+        assert threading.get_ident() != owner
+        calls.append('encode')
+        request = json.loads((Path(kwargs['staging']) / 'animation.json').read_text())
+        Path(request['output']).write_bytes(b'encoded')
+        return {'returncode': 1 if outcome == 'encoder_failure' else 0,
+                'cancelled': False, 'error': 'codec failed'}
+    job = module.AnimationExportJob(
+        manager, document_uid='doc', output=target, frame_count=3,
+        fps=10, size=(16, 12), execute=execute, isolation={},
+    )
+    wait_until(lambda: not job.staging_ready.empty())
+    staging = job.staging_ready.get_nowait()
+    assert staging.parent == tmp_path
+    if outcome == 'cancel':
+        manager.cancel(job.job_id)
+        # Cancellation must not delete files while native PNG encoding is live.
+        time.sleep(.02)
+        assert staging.exists()
+    job.finish_capture('capture failed' if outcome == 'capture_failure' else '')
+    wait_until(lambda: not manager.snapshot(job.job_id).worker_active)
+    snapshot = manager.snapshot(job.job_id)
+    assert snapshot.phase == ('completed' if outcome == 'success' else
+                              'cancelled' if outcome == 'cancel' else 'failed')
+    assert target.read_bytes() == (b'encoded' if outcome == 'success' else b'original')
+    assert not staging.exists()
+    assert calls == ([] if outcome in {'cancel', 'capture_failure'} else ['encode'])
+    if outcome == 'encoder_failure':
+        assert 'codec failed' in snapshot.error['message']
+
+
+@pytest.mark.parametrize('close', [False, True])
+def test_controller_waits_for_pose_and_png_before_advancing(tmp_path, close):
+    from concurrent.futures import Future
+    from types import SimpleNamespace
+    from PySide6 import QtCore
+    app = QtCore.QCoreApplication.instance() or QtCore.QCoreApplication([])
+    module = load_export()
+    calls, pending = [], []
+    live = True
+    class Panel(QtCore.QObject):
+        playbackClosed = QtCore.Signal()
+        def _ownsLiveTaskContext(self):
+            return live
+        def requestFrameAsync(self, frame, **kwargs):
+            calls.append(('pose', frame))
+            future = Future()
+            pending.append(future)
+            return future
+    panel = Panel()
+    panel.form = SimpleNamespace(frameSlider=SimpleNamespace(value=lambda: 2))
+    png_ready = False
+    viewer = SimpleNamespace(
+        startFrameExport=lambda path, w, h: calls.append(('png', Path(path).name)) or 7,
+        finishFrameExport=lambda token: png_ready,
+        cancelFrameExport=lambda token: calls.append(('cancel png', token)),
+    )
+    import queue
+    stages = queue.Queue()
+    stages.put(tmp_path)
+    job = SimpleNamespace(
+        staging_ready=stages, frame_count=3, size=(16, 12), job_id='job',
+        finish_capture=lambda error='': calls.append(('capture done', error)),
+        manager=SimpleNamespace(
+            snapshot=lambda token: SimpleNamespace(terminal=False, cancel_requested=False,
+                                                   progress_message='Cancelled'),
+            cancel=lambda token: calls.append(('cancel job', token)),
+        ),
+    )
+    controller = module.AnimationExportController(panel, viewer, job)
+    controller.timer.stop()
+    controller.tick()
+    assert calls == [('pose', 0)]
+    controller.tick()
+    assert len(calls) == 1
+    pending[0].set_result(0)
+    controller.tick()
+    assert calls[-1] == ('png', 'frame_00000.png')
+    controller.tick()
+    assert calls[-1][0] == 'png'
+    if close:
+        live = False
+        panel.playbackClosed.emit()
+        assert calls[-1] == ('cancel png', 7)
+        controller.tick()
+        assert not any(call[0] == 'capture done' for call in calls)
+    png_ready = True
+    controller.tick()
+    assert calls[-1] == (('capture done', '') if close else ('pose', 1))
+    controller.timer.stop()
+    panel.playbackClosed.disconnect(controller.cancel)

--- a/src/Mod/VibeCAD/vibecad_tests/test_assembly_solver_policy.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_assembly_solver_policy.py
@@ -1,11 +1,48 @@
 from __future__ import annotations
 
 import sys
+import ast
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
 
 from VibeCADAssemblySolverPolicy import set_joint_connectors_without_auto_solve
+
+
+@pytest.mark.parametrize("prop", ["Offset1", "Offset2", "Distance", "Angle", "Reference1"])
+@pytest.mark.parametrize("transacting", [False, True])
+def test_joint_replay_does_not_launch_interactive_work(prop, transacting):
+    """Execute the production callback; transaction replay owns restored values."""
+    source = Path(__file__).resolve().parents[2] / "Assembly" / "JointObject.py"
+    tree = ast.parse(source.read_text(encoding="utf-8"))
+    joint_class = next(node for node in tree.body if isinstance(node, ast.ClassDef)
+                       and node.name == "Joint")
+    callback = next(node for node in joint_class.body if isinstance(node, ast.FunctionDef)
+                    and node.name == "onChanged")
+    calls = []
+    namespace = {
+        "App": SimpleNamespace(isRestoring=lambda: False),
+        "_jointInteractionUsable": lambda joint: True,
+        "JointUsingPreSolve": [],
+        "solveIfAllowed": lambda assembly: calls.append("solve"),
+    }
+    exec(compile(ast.Module(body=[callback], type_ignores=[]), str(source), "exec"), namespace)
+    joint = SimpleNamespace(
+        Document=SimpleNamespace(Transacting=transacting),
+        Reference1=(object(), [""]), Reference2=(object(), [""]),
+        JointType=prop if prop in {"Distance", "Angle"} else "Fixed",
+        Angle=0.0, recompute=lambda: calls.append("recompute"),
+    )
+    proxy = SimpleNamespace(
+        getAssembly=lambda joint: SimpleNamespace(Type="Assembly"),
+        updateJCSPlacements=lambda joint: calls.append("connectors"),
+    )
+    namespace["onChanged"](proxy, joint, prop)
+    if transacting:
+        assert calls == []
+    else:
+        assert calls
 
 
 class _Preferences:

--- a/src/Mod/VibeCAD/vibecad_tests/test_assembly_validation_isolation.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_assembly_validation_isolation.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Assembly validation uses the existing native isolation boundary."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+import VibeCADHostIsolation as isolation
+import VibeCADVibeScriptDomainRuntime as runtime
+
+
+def test_adapter_does_not_validate_on_host_interpreter(tmp_path, monkeypatch):
+    pack = runtime.contracts.get_vibescript_pack('AssemblyWorkbench')
+    prepared = dict(pack=pack, staging=tmp_path, expected_outputs=[],
+                    resolved_references=[], worker_request={}, memory_limit_bytes=123456)
+    expected = {'ok': True, 'outputs': [], 'assembly_members': []}
+    calls = []
+
+    def host_validation(*args):
+        raise AssertionError('CPU validation ran on the GUI interpreter')
+
+    def execute(**kwargs):
+        calls.append(kwargs)
+        request = json.loads((Path(kwargs['staging']) / 'host-validation-input.json').read_text())
+        assert request['prepared']['workbench'] == 'AssemblyWorkbench'
+        assert request['execution'] == {'ok': True}
+        (Path(kwargs['staging']) / 'host-validation-result.json').write_text(json.dumps({
+            'request_id': request['request_id'], 'result': expected,
+        }))
+        return {'started': True, 'returncode': 0}
+
+    monkeypatch.setattr(runtime, 'validate_candidate', host_validation)
+    monkeypatch.setattr(isolation, 'execute_staged_script', execute)
+    assert runtime.AssemblyDomainAdapter(pack).validate_result(prepared, {'ok': True}) == expected
+    assert len(calls) == 1
+    assert calls[0]['cpu_slots'] == 1
+    assert calls[0]['memory_limit_bytes'] == 123456
+
+
+def test_session_validation_propagates_cancellation(tmp_path, monkeypatch):
+    import VibeCADSession as session
+
+    pack = runtime.contracts.get_vibescript_pack('AssemblyWorkbench')
+    prepared = dict(pack=pack, staging=tmp_path, tool_name='vibescript.build_program')
+    cancelled = lambda: True
+
+    def execute(**kwargs):
+        assert kwargs['cancellation_check'] is cancelled
+        return {'started': True, 'returncode': -1, 'cancelled': True}
+
+    monkeypatch.setattr(isolation, 'execute_staged_script', execute)
+    with pytest.raises(runtime.DomainRuntimeFailure) as error:
+        session._validate_domain_candidate(
+            runtime.AssemblyDomainAdapter(pack), prepared, {'ok': True}, cancelled)
+    assert error.value.payload['cancelled'] is True
+    assert error.value.payload['failure_code'] == 'RUN_CANCELLED'
+
+
+def test_session_validation_preserves_existing_adapter_contract():
+    import VibeCADSession as session
+
+    class ExistingAdapter:
+        def validate_result(self, prepared, execution):
+            return prepared, execution
+
+    prepared, execution = {}, {'ok': True}
+    assert session._validate_domain_candidate(
+        ExistingAdapter(), prepared, execution, None) == (prepared, execution)
+
+
+@pytest.mark.parametrize('response,exception,message', [
+    ({'request_id': 'old-request', 'result': {'ok': True}}, ValueError, 'different request'),
+    ({'result': {'ok': False}}, ValueError, 'no validated result'),
+    ({'error': {'type': 'ValueError', 'message': 'bad pose'}}, ValueError, 'bad pose'),
+    ({'error': {'type': 'TypeError', 'message': 'bad definition'}}, TypeError, 'bad definition'),
+])
+def test_isolated_validation_rejects_bad_results(tmp_path, monkeypatch, response, exception, message):
+    pack = runtime.contracts.get_vibescript_pack('AssemblyWorkbench')
+
+    def execute(**kwargs):
+        request = json.loads((tmp_path / 'host-validation-input.json').read_text())
+        (tmp_path / 'host-validation-result.json').write_text(json.dumps(
+            {'request_id': request['request_id'], **response}))
+        return {'started': True, 'returncode': 0}
+
+    monkeypatch.setattr(isolation, 'execute_staged_script', execute)
+    with pytest.raises(exception, match=message):
+        runtime.AssemblyDomainAdapter(pack).validate_result(
+            dict(pack=pack, staging=tmp_path), {'ok': True})
+
+
+def test_worker_failure_cannot_accept_previous_result(tmp_path, monkeypatch):
+    pack = runtime.contracts.get_vibescript_pack('AssemblyWorkbench')
+    (tmp_path / 'host-validation-result.json').write_text(json.dumps({'result': {'ok': True}}))
+    monkeypatch.setattr(isolation, 'execute_staged_script', lambda **kwargs:
+                        {'started': True, 'returncode': 1, 'error': 'worker stopped'})
+    with pytest.raises(RuntimeError, match='worker stopped'):
+        runtime.AssemblyDomainAdapter(pack).validate_result(
+            dict(pack=pack, staging=tmp_path), {'ok': True})

--- a/src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Both provider-facing routes retain completed-result semantics."""
+from concurrent.futures import Future
+import sys
+from types import SimpleNamespace
+import pytest
+
+from tool_impl.service import assembly_play_simulation as tool
+
+
+def test_service_playback_returns_completion_not_a_pending_frame(monkeypatch):
+    pending = Future()
+    document = SimpleNamespace(Uid='doc')
+    assembly = SimpleNamespace(Name='Assembly', numberOfFrames=lambda: 22)
+    obj = SimpleNamespace(
+        VibeCADVibeScriptOutputType='simulation', Document=document,
+        Proxy=SimpleNamespace(getAssembly=lambda obj: assembly),
+    )
+    calls = []
+    monkeypatch.setitem(sys.modules, 'FreeCAD', SimpleNamespace(GuiUp=True))
+    monkeypatch.setitem(sys.modules, 'FreeCADGui', SimpleNamespace(
+        Control=SimpleNamespace(activeTaskDialog=lambda: None)))
+    monkeypatch.setitem(sys.modules, 'VibeCADDocumentReferences', SimpleNamespace(
+        resolve_reference_target=lambda *a, **kw: obj))
+    monkeypatch.setitem(sys.modules, 'CommandCreateSimulation', SimpleNamespace(
+        _simulationFrameTime=lambda obj, frame: 0.2,
+        openSimulation=lambda *a, **kw: calls.append('synchronous'),
+        openSimulationAsync=lambda *a, **kw: pending))
+    result = tool.run_async(SimpleNamespace(_active_document=lambda: document),
+                            {'document_uid': 'doc', 'object_name': 'Simulation'},
+                            time_seconds=0.2, autoplay=False)
+    assert isinstance(result, Future) and not result.done() and calls == []
+    pending.set_result(SimpleNamespace(form=SimpleNamespace(frameSlider=SimpleNamespace(value=lambda: 3))))
+    payload = result.result()
+    assert payload['ok'] and payload['frame'] == 3 and payload['time_seconds'] == 0.2
+    assert payload['assembly'] == {'document_uid': 'doc', 'object_name': 'Assembly'}
+
+
+def test_session_validates_arguments_before_starting_async_playback(monkeypatch):
+    from VibeCADSession import _start_service_tool
+    from VibeCADTools import ToolRegistry, ToolArgumentValidationError
+
+    registry = ToolRegistry()
+    registry.register_spec(tool.TOOL_SPEC, lambda **args: {'legacy': True})
+    service = SimpleNamespace(registry=registry)
+    calls = []
+    pending = Future()
+    monkeypatch.setattr(tool, 'run_async', lambda *args, **kwargs: calls.append(kwargs) or pending)
+    with pytest.raises(ToolArgumentValidationError):
+        _start_service_tool(service, 'assembly.play_simulation', {'simulation': 'invalid'}, asynchronous=True)
+    assert calls == []
+    arguments = {'simulation': {'document_uid': 'doc', 'object_name': 'Simulation'}}
+    assert _start_service_tool(service, 'assembly.play_simulation', arguments, asynchronous=True) is pending
+    assert calls == [arguments]
+    assert _start_service_tool(service, 'assembly.play_simulation', arguments, asynchronous=False) == {'legacy': True}
+
+
+@pytest.mark.parametrize('matching_player', [True, False])
+def test_service_seeks_exact_active_player_without_reopening(monkeypatch, matching_player):
+    document = SimpleNamespace(Uid='doc')
+    obj = SimpleNamespace(VibeCADVibeScriptOutputType='simulation', Document=document)
+    panel = object()
+    pending = Future()
+    calls = []
+    monkeypatch.setitem(sys.modules, 'FreeCAD', SimpleNamespace(GuiUp=True))
+    monkeypatch.setitem(sys.modules, 'FreeCADGui', SimpleNamespace(
+        Control=SimpleNamespace(activeTaskDialog=lambda: object())))
+    monkeypatch.setitem(sys.modules, 'VibeCADDocumentReferences', SimpleNamespace(
+        resolve_reference_target=lambda *a, **kw: obj))
+    monkeypatch.setitem(sys.modules, 'CommandCreateSimulation', SimpleNamespace(
+        findSimulationPlayback=lambda *a, **kw: panel if matching_player else None,
+        controlSimulationPlaybackAsync=lambda *a, **kw: calls.append((a, kw)) or pending,
+        openSimulation=lambda *a, **kw: pytest.fail('Must not reopen an active task'),
+        openSimulationAsync=lambda *a, **kw: pytest.fail('Must not regenerate'),
+    ))
+    monkeypatch.setattr(tool, '_playback_result', lambda *args: {'ok': True, 'frame': 11})
+    result = tool.run_async(SimpleNamespace(_active_document=lambda: document),
+                            {'document_uid': 'doc', 'object_name': 'Simulation'},
+                            time_seconds=1.0, autoplay=False)
+    if matching_player:
+        assert isinstance(result, Future) and not result.done()
+        assert calls == [((panel,), {'autoplay': False, 'time_seconds': 1.0})]
+        pending.set_result(panel)
+        assert result.result() == {'ok': True, 'frame': 11}
+    else:
+        assert result['failure_code'] == 'NATIVE_TASK_ACTIVE'
+        assert calls == []
+
+
+@pytest.mark.parametrize('closes', [True, False])
+def test_stop_checks_actual_task_contents_after_reject(monkeypatch, closes):
+    from tool_impl.service import assembly_stop_simulation as stop
+    widget = SimpleNamespace(property=lambda key: {
+        'vibecadSavedAssemblySimulationPlayback': True,
+        'vibecadSimulationDocumentUid': 'doc',
+        'vibecadSimulationObjectName': 'Simulation',
+    }.get(key))
+    active = True
+    def reject():
+        nonlocal active
+        active = not closes
+    def dialog():
+        return SimpleNamespace(getDialogContent=lambda: [widget], reject=reject) if active else None
+    monkeypatch.setitem(sys.modules, 'FreeCAD', SimpleNamespace(GuiUp=True))
+    monkeypatch.setitem(sys.modules, 'FreeCADGui', SimpleNamespace(
+        Control=SimpleNamespace(activeTaskDialog=dialog), updateGui=lambda: None))
+    result = stop.run(None)
+    assert result['ok'] is closes
+    if not closes:
+        assert result['failure_code'] == 'SIMULATION_PLAYBACK_REMAINED_OPEN'

--- a/src/Mod/VibeCAD/vibecad_tests/test_codex_runtime_package.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_codex_runtime_package.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Keep the adapter and all portable runtime targets on the verified release."""
+
+import ast
+from pathlib import Path
+import re
+import json
+import pytest
+
+
+def test_codex_runtime_release_is_consistent():
+    root = Path(__file__).resolve().parents[4]
+    adapter = ast.parse((root / "src/Mod/VibeCAD/VibeCADCodex.py").read_text())
+    version = next(
+        ast.literal_eval(node.value)
+        for node in adapter.body
+        if isinstance(node, ast.Assign)
+        and any(isinstance(t, ast.Name) and t.id == "CODEX_APP_SERVER_VERSION"
+                for t in node.targets)
+    )
+    installer = (root / "package/rattler-build/scripts/install_vibecad_codex_runtime.sh").read_text()
+    assert version == "0.153.4"
+    assert f'codex_version="{version}"' in installer
+    archives = re.findall(r'archive="([^"]+)"\s+archive_sha256="([a-f0-9]{64})"', installer)
+    assert len(archives) == 6
+    assert len({name for name, _ in archives}) == 6
+    assert all(name.startswith('codex-app-server-package-') for name, _ in archives)
+
+
+def test_complete_runtime_resolves_packaged_entrypoint_and_requires_companion(tmp_path, monkeypatch):
+    import VibeCADCodex as codex
+    monkeypatch.delenv(codex.CODEX_APP_SERVER_ENV, raising=False)
+    monkeypatch.setattr(codex, 'bundled_runtime_root', lambda: tmp_path)
+    (tmp_path / 'bin').mkdir()
+    binary = tmp_path / 'bin' / codex._runtime_binary_name()
+    binary.write_bytes(b'executable fixture')
+    helper = binary.with_name('codex-code-mode-host' + binary.suffix)
+    helper.write_bytes(b'companion fixture')
+    (tmp_path / 'codex-package.json').write_text(json.dumps({
+        'layoutVersion': 1, 'version': codex.CODEX_APP_SERVER_VERSION,
+        'entrypoint': 'bin/' + binary.name}))
+    (tmp_path / codex.CODEX_RUNTIME_MANIFEST).write_text(json.dumps({
+        'version': codex.CODEX_APP_SERVER_VERSION}))
+    assert codex.resolve_runtime_command().executable == binary
+    helper.unlink()
+    with pytest.raises(codex.CodexAppServerError, match='companion'):
+        codex.resolve_runtime_command()

--- a/src/Mod/VibeCAD/vibecad_tests/test_document_restore_rendering.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_document_restore_rendering.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 import sys
+import pytest
 
 import VibeCADGui as gui
 
@@ -77,6 +78,9 @@ class _Document:
             None,
         )
 
+    def findObjects(self, *, Property):
+        return [obj for obj in self.Objects if hasattr(obj, Property)]
+
     def recompute(self, objects=None, *_args) -> int:
         if self.Recomputing:
             self.recursive_recompute_calls += 1
@@ -141,7 +145,7 @@ def test_restored_pending_geometry_is_recomputed_and_redrawn(monkeypatch) -> Non
     assert pending.State == ["Up-to-date"]
     assert clean.State == ["Up-to-date"]
     assert view.redraw_calls == 1
-    assert document._gui_updates == [True]
+    assert document._gui_updates == []
     assert document._gui_document.Modified is False
 
 
@@ -207,7 +211,7 @@ def test_restored_projection_hydration_is_sliced_per_view() -> None:
     assert attempted == {"FirstProjection", "SecondProjection"}
 
 
-def test_non_3d_restored_view_flushes_gui_without_redraw_warning(
+def test_non_3d_restored_view_does_not_drain_the_event_loop(
     monkeypatch,
 ) -> None:
     document = _Document([_Object("DrawingPage", ["Up-to-date"])])
@@ -232,7 +236,7 @@ def test_non_3d_restored_view_flushes_gui_without_redraw_warning(
 
     gui._redraw_document_view(document)
 
-    assert gui_updates == [True]
+    assert gui_updates == []
     assert warnings == []
 
 
@@ -401,8 +405,46 @@ def test_open_scheduler_waits_for_restore_then_makes_document_render_ready(
     callbacks.pop(0)[1]()
 
     assert view.redraw_calls == 2
-    assert document._gui_updates == [True, True]
+    assert document._gui_updates == []
     assert document.Uid not in gui._pending_document_render_refreshes
+
+
+@pytest.mark.parametrize("native_state", ["CooperativeMutationActive", "PresentationUpdateActive", "RecomputePending"])
+def test_restore_geometry_waits_for_native_update(monkeypatch, native_state) -> None:
+    document = _Document([_Object("PendingFeature", ["Touched"])])
+    _install_gui_document(monkeypatch, document)
+    setattr(document, native_state, True)
+    assert gui._document_render_refresh_blocked(document) is True
+    assert gui._recompute_pending_document_geometry_slice(document) == (False, True)
+    assert document.recompute_calls == 0
+    setattr(document, native_state, False)
+    assert gui._recompute_pending_document_geometry_slice(document) == (True, False)
+    assert document.recompute_calls == 1
+
+
+def test_restore_geometry_queues_independent_pending_objects_together(monkeypatch) -> None:
+    document = _Document([_Object("First", ["Touched"]), _Object("Second", ["Touched"])])
+    _install_gui_document(monkeypatch, document)
+    monkeypatch.setattr(gui, "_warn", lambda message: None)
+    queued = []
+    def enqueue(*args):
+        queued.append(args)
+        document.RecomputePending = True
+        return 1
+    document.recomputeAsync = enqueue
+    attempted = set()
+    assert gui._recompute_pending_document_geometry_slice(document, attempted) == (False, True)
+    # One document request lets native dependency waves share the work.
+    # Passing a list enqueues separate recursive requests for every object.
+    assert queued == [()]
+    assert document.recompute_calls == 0
+    assert gui._recompute_pending_document_geometry_slice(document, attempted) == (False, True)
+    assert len(queued) == 1
+    document.RecomputePending = False
+    # Failed native work must be reported, not queued forever.
+    document.Objects[0].State = ["Invalid", "Touched"]
+    assert gui._recompute_pending_document_geometry_slice(document, attempted) == (False, False)
+    assert len(queued) == 1
 
 
 def test_open_scheduler_defers_render_during_atomic_document_change(

--- a/src/Mod/VibeCAD/vibecad_tests/test_domain_artifact_batch.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_domain_artifact_batch.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Shared native artifact preparation must submit independent outputs together."""
+import sys
+from types import SimpleNamespace
+
+import pytest
+import VibeCADVibeScriptDomainRuntime as runtime
+
+
+def test_brep_outputs_are_one_native_parallel_batch(tmp_path, monkeypatch):
+    paths = [tmp_path / "first.brep", tmp_path / "second.brep"]
+    for path in paths:
+        path.touch()
+    calls = []
+    shapes = [object(), object()]
+    def load(values):
+        calls.append(values)
+        return shapes
+    monkeypatch.setitem(sys.modules, "Part", SimpleNamespace(readBrepShapes=load))
+    outputs = [{"name": "first", "artifact_kind": "brep", "artifact_path": paths[0].name},
+               {"name": "metadata", "artifact_kind": "json"},
+               {"name": "second", "artifact_kind": "brep", "artifact_path": paths[1].name}]
+    assert runtime._prepare_brep_outputs(outputs, tmp_path) == {0: shapes[0], 2: shapes[1]}
+    assert calls == [[str(path) for path in paths]]
+    outputs[2]["artifact_path"] = "../outside.brep"
+    with pytest.raises(ValueError):
+        runtime._prepare_brep_outputs(outputs, tmp_path)
+    assert len(calls) == 1

--- a/src/Mod/VibeCAD/vibecad_tests/test_domain_json_validation.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_domain_json_validation.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Strict worker-data validation must inspect values, not format disposable JSON."""
+
+import json
+
+import pytest
+
+import VibeCADVibeScriptDomainRuntime as runtime
+
+
+def test_validation_does_not_encode_discarded_text(monkeypatch):
+    def forbidden(*args, **kwargs):
+        raise AssertionError('Validation formatted JSON that no caller consumes')
+
+    monkeypatch.setattr(runtime.json.JSONEncoder, 'iterencode', forbidden)
+    runtime._validate_json_serializable({
+        'frames': [{'matrix': [float(i) for i in range(16)]} for _ in range(1000)],
+        'label': '\ud800',
+    })
+
+
+@pytest.mark.parametrize('value', [
+    None, True, False, 42, -42, 10**5000, 1.25, float('nan'), float('inf'),
+    float('-inf'), 'text', '\ud800', [1, 2], (1, 2), {1, 2}, b'text', object(),
+    {'a': [None, {'b': 2}]}, {1: 'a', 2: 'b'}, {True: 'a'}, {None: 'a'},
+    {1.25: 'a'}, {float('nan'): 'a'}, {(1,): 'a'}, {'a': 1, 2: 'b'},
+], ids=lambda value: type(value).__name__)
+def test_validation_matches_strict_encoder(value):
+    encoder = json.JSONEncoder(ensure_ascii=True, sort_keys=True, allow_nan=False)
+    try:
+        for _chunk in encoder.iterencode(value):
+            pass
+    except (TypeError, ValueError) as error:
+        with pytest.raises(type(error)):
+            runtime._validate_json_serializable(value)
+    else:
+        runtime._validate_json_serializable(value)
+
+
+def test_cycles_rejected_but_shared_values_allowed():
+    child = {'values': [1, 2, 3]}
+    runtime._validate_json_serializable([child, child])
+    child['cycle'] = child
+    with pytest.raises(ValueError, match='Circular reference'):
+        runtime._validate_json_serializable(child)

--- a/src/Mod/VibeCAD/vibecad_tests/test_host_isolation_runtime.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_host_isolation_runtime.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Contracts for the process-lifetime native isolation runtime."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from io import StringIO
+from contextlib import contextmanager
+
+import pytest
+
+
+@pytest.mark.parametrize("raises", [False, True])
+def test_windows_job_enters_and_leaves_its_numerical_lease(tmp_path, monkeypatch, raises):
+    import VibeCADIsolationWorker as worker
+    import VibeCADNumericalRuntime as numerical
+
+    (tmp_path / "worker.py").touch()
+    calls = []
+
+    @contextmanager
+    def scope(slots, memory):
+        calls.append(("enter", slots, memory))
+        try:
+            yield slots
+        finally:
+            calls.append(("leave", slots, memory))
+
+    def execute(*args, **kwargs):
+        assert calls == [("enter", 3, 1024)]
+        assert worker.os.environ["OPENBLAS_NUM_THREADS"] == "1"
+        if raises:
+            raise RuntimeError("job failed")
+
+    monkeypatch.setattr(worker.sys, "platform", "win32")
+    monkeypatch.setattr(worker.App, "listDocuments", lambda: {}, raising=False)
+    monkeypatch.setattr(worker.runpy, "run_path", execute)
+    monkeypatch.setattr(numerical, "numerical_thread_limits", scope)
+    before = dict(worker.os.environ)
+    request = {"working_directory": str(tmp_path), "script": "worker.py",
+               "environment": {}, "memory_limit_bytes": 1024}
+    if raises:
+        with pytest.raises(RuntimeError, match="job failed"):
+            worker._run(request, 3)
+    else:
+        assert worker._run(request, 3)["returncode"] == 0
+    assert calls == [("enter", 3, 1024), ("leave", 3, 1024)]
+    assert dict(worker.os.environ) == before
+
+
+def test_completion_record_starts_on_its_own_line_after_native_progress(monkeypatch):
+    import VibeCADIsolationWorker as worker
+    output = StringIO()
+    monkeypatch.setattr(worker.sys, "__stdout__", output)
+    output.write("\r\t\t(5 %)")
+    record = f"{worker.PROTOCOL} RESULT 7 {worker._encode({'returncode': 0})}"
+    worker._write(record)
+    # QProcess consumes newline-delimited records and matches their prefix.
+    records = output.getvalue().split("\n")
+    assert any(line.startswith(f"{worker.PROTOCOL} RESULT 7 ") for line in records)
+    assert records.count(record) == 1
+
+
+def test_staged_script_uses_the_configured_process_lifetime_pool(
+    tmp_path: Path,
+) -> None:
+    import VibeCADHostIsolation as isolation
+
+    executable = tmp_path / "bin" / "FreeCADCmd.exe"
+    executable.parent.mkdir()
+    executable.touch()
+    module_root = tmp_path / "Mod" / "VibeCAD"
+    module_root.mkdir(parents=True)
+    (module_root / "VibeCADIsolationWorker.py").touch()
+    staging = tmp_path / "job"
+    staging.mkdir()
+    (staging / "worker.py").write_text("raise SystemExit(0)\n", encoding="utf-8")
+
+    configured: list[tuple[str, str, int]] = []
+    submitted: list[tuple[str, object, int, int]] = []
+
+    def execute(
+        request: str,
+        cancellation_check: object,
+        memory_limit: int,
+        cpu_slots: int,
+    ):
+        submitted.append((request, cancellation_check, memory_limit, cpu_slots))
+        response = base64.urlsafe_b64encode(
+            json.dumps(
+                {
+                    "schema": isolation.RESPONSE_SCHEMA,
+                    "returncode": 0,
+                    "stdout": "worker output",
+                },
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).decode("ascii")
+        return {
+            "job_id": 17,
+            "status": "completed",
+            "response": response,
+            "diagnostic": "",
+            "output_tail": "native output",
+            "memory_exceeded": False,
+            "observed_memory_bytes": 123,
+        }
+
+    app = SimpleNamespace(
+        configureHostIsolationRuntime=lambda exe, root, workers=0: configured.append(
+            (exe, root, workers)
+        )
+        or {"workers": 3, "ready": 3},
+        executeHostIsolationRequest=execute,
+    )
+    cancelled = lambda: False
+
+    result = isolation.execute_staged_script(
+        app=app,
+        executable=executable,
+        module_root=module_root,
+        staging=staging,
+        script="worker.py",
+        environment={"VIBECAD_TEST": "1"},
+        cancellation_check=cancelled,
+        memory_limit_bytes=456,
+    )
+
+    assert configured == [(str(executable.resolve()), str(module_root.resolve()), 0)]
+    assert len(submitted) == 1
+    encoded_request, actual_cancellation, actual_limit, actual_cpu_slots = submitted[0]
+    request = json.loads(base64.urlsafe_b64decode(encoded_request).decode("utf-8"))
+    assert request == {
+        "schema": isolation.REQUEST_SCHEMA,
+        "working_directory": str(staging.resolve()),
+        "script": "worker.py",
+        "environment": {"VIBECAD_TEST": "1"},
+        "memory_limit_bytes": 456,
+    }
+    assert actual_cancellation is cancelled
+    assert actual_limit == 456
+    assert actual_cpu_slots == 1
+    assert result.pop("elapsed_seconds") >= 0.0
+    assert result == {
+        "started": True,
+        "returncode": 0,
+        "stdout": "worker output",
+        "stderr": "native output",
+        "cancelled": False,
+        "timed_out": False,
+        "memory_exceeded": False,
+        "cpu_exceeded": False,
+        "cancelled_by": None,
+        "limit_reached": None,
+        "termination_reason": "process_exit",
+        "timeout_mode": "none",
+        "activity_observations": 0,
+        "memory_limit_bytes": 456,
+        "observed_memory_bytes": 123,
+        "job_id": 17,
+        "worker_pid": 0,
+        "worker_sequence": 0,
+    }
+
+
+def test_cancelled_pool_job_is_reported_without_a_process_fallback(
+    tmp_path: Path,
+) -> None:
+    import VibeCADHostIsolation as isolation
+
+    executable = tmp_path / "FreeCADCmd.exe"
+    executable.touch()
+    module_root = tmp_path / "module"
+    module_root.mkdir()
+    (module_root / "VibeCADIsolationWorker.py").touch()
+    staging = tmp_path / "job"
+    staging.mkdir()
+    (staging / "worker.py").touch()
+
+    app = SimpleNamespace(
+        configureHostIsolationRuntime=lambda *_args: {"workers": 1, "ready": 1},
+        executeHostIsolationRequest=lambda *_args: {
+            "job_id": 9,
+            "status": "cancelled",
+            "response": "",
+            "diagnostic": "Isolation job was cancelled",
+            "output_tail": "",
+            "memory_exceeded": False,
+            "observed_memory_bytes": 0,
+        },
+    )
+
+    result = isolation.execute_staged_script(
+        app=app,
+        executable=executable,
+        module_root=module_root,
+        staging=staging,
+        script="worker.py",
+        environment={},
+        cancellation_check=None,
+        memory_limit_bytes=0,
+    )
+
+    assert result["started"] is True
+    assert result["cancelled"] is True
+    assert result["cancelled_by"] == "host"
+    assert result["termination_reason"] == "host_cancellation_request"

--- a/src/Mod/VibeCAD/vibecad_tests/test_mechanism_engine.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_mechanism_engine.py
@@ -132,6 +132,61 @@ def _scenario() -> dict:
     }
 
 
+@pytest.mark.parametrize('field', ['components', 'joints', 'motions'])
+def test_scenario_accepts_ten_thousand_model_entries(field) -> None:
+    scenario = _scenario()
+    if field == 'components':
+        scenario['components'].extend(
+            _component(f'Extra{index}')
+            for index in range(10_000 - len(scenario['components']))
+        )
+    else:
+        template = scenario['joints'][1]  # Revolute joint supports an angular drive.
+        scenario['joints'] = [dict(template, id=f'Joint{index}') for index in range(10_000)]
+        if field == 'motions':
+            scenario['motions'] = [dict(id=f'Motion{index}', label='',
+                joint_id=f'Joint{index}', motion_type='angular', formula='time')
+                for index in range(10_000)]
+            scenario['simulation'] = dict(id='Simulation', label='',
+                motion_ids=[motion['id'] for motion in scenario['motions']],
+                start_time_s=0.0, end_time_s=1.0, time_step_s=0.1,
+                error_tolerance=1.0e-6, frames_per_second=30)
+    assert len(normalize_mechanism_scenario(scenario)[field]) == 10_000
+
+
+@pytest.mark.parametrize('component_count,step', [(10_000, 0.1), (20, 0.00001)])
+def test_simulation_schedule_is_not_limited_by_model_or_frame_count(component_count, step):
+    scenario = _scenario()
+    scenario['components'].extend(_component(f'Extra{i}')
+        for i in range(component_count - len(scenario['components'])))
+    scenario['motions'] = [dict(id='Drive', label='', joint_id='Joint2',
+                               motion_type='angular', formula='time')]
+    scenario['simulation'] = dict(id='Simulation', label='', motion_ids=['Drive'],
+        start_time_s=0.0, end_time_s=1.0, time_step_s=step,
+        error_tolerance=1.0e-6, frames_per_second=30)
+    assert normalize_mechanism_scenario(scenario)['simulation']['time_step_s'] == step
+
+
+@pytest.mark.parametrize('degrees', [0.0, 1e-9, 1e-6, 30.0, 179.999999, 180.0])
+def test_rotation_distance_resolves_small_angles_and_quaternion_sign(degrees):
+    import math
+    from VibeCADMechanismEngine import quaternion_rotation_distance_degrees
+    half = math.radians(degrees) / 2
+    for scale in (1.0, -1.0, 7.0):
+        rotated = [0.0, 0.0, scale * math.sin(half), scale * math.cos(half)]
+        assert quaternion_rotation_distance_degrees([0, 0, 0, 1], rotated) == pytest.approx(
+            degrees, abs=1e-12)
+
+
+def test_solve_report_accepts_ten_thousand_occurrences() -> None:
+    scenario = _scenario()
+    report = _solve_report(scenario)
+    report['component_occurrences']['Part1'] = [
+        _solved_occurrence(f'Occurrence{index}') for index in range(10_000)]
+    normalized = normalize_mechanism_solve_report(scenario, report)
+    assert len(normalized['component_occurrences']['Part1']) == 10_000
+
+
 def test_simulation_collision_mode_is_additive_and_defaults_to_full() -> None:
     scenario = _scenario()
     scenario["motions"] = [

--- a/src/Mod/VibeCAD/vibecad_tests/test_mechanism_geometry_scale.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_mechanism_geometry_scale.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from itertools import combinations
+import random
+
+import pytest
+
+import VibeCADMechanismGeometry as geometry
+
+
+@pytest.mark.parametrize('count', [337, 10_000])
+def test_collision_summary_accepts_large_assemblies(count):
+    names = [f'Component_{index}' for index in range(count)]
+    frames = [dict(frame_index=index + 1, nominal_time_s=index / 10,
+                   collisions=[]) for index in range(22)]
+    frames[-1]['collisions'] = [dict(first_component=names[0],
+        second_component=names[-1], interference_volume_mm3=1.0,
+        common_solid_count=1)]
+    summary = geometry.summarize_dynamic_collision_frames(names, frames)
+    assert summary['component_count'] == count
+    assert summary['possible_pair_count'] == count * (count - 1) // 2
+    assert summary['evaluated_frame_count'] == 22
+    assert summary['colliding_pair_count'] == 1
+    assert summary['first_collision']['frame_index'] == 22
+
+
+@pytest.mark.parametrize('names', [[], 'Body', ['Body', 'Body'], ['bad name']])
+def test_collision_summary_preserves_identifier_validation(names):
+    with pytest.raises(geometry.MechanismGeometryError):
+        geometry.summarize_dynamic_collision_frames(names,
+            [dict(frame_index=1, nominal_time_s=0, collisions=[])])
+
+
+def test_explicit_pairs_are_limited_by_identifiers_not_fixed_count():
+    names = [f'Component_{index}' for index in range(337)]
+    pairs = list(combinations(names, 2))
+    assert geometry._component_pairs(pairs, component_names=set(names)) == pairs
+    for bad_pair in [(names[0], names[0]), (names[0], 'Unknown'), pairs[0]]:
+        with pytest.raises(geometry.MechanismGeometryError):
+            geometry._component_pairs(pairs + [bad_pair], component_names=set(names))
+
+
+def test_static_preparation_accepts_large_assemblies(monkeypatch):
+    components = {f'Component_{index}': object() for index in range(10_000)}
+    monkeypatch.setattr(geometry, '_placed_shape', lambda value, **kwargs: value)
+    monkeypatch.setattr(geometry, '_bounds', lambda shape, **kwargs: {})
+    placed, bounds = geometry._prepared_components(components)
+    assert placed == components
+    assert bounds.keys() == components.keys()
+
+
+def test_spatial_candidates_match_exhaustive_aabb_including_touching():
+    rng = random.Random(337)
+    bounds = {}
+    for index in range(337):
+        lo = [rng.randint(-10, 10) for _ in range(3)]
+        bounds[f'Component_{index}'] = dict(minimum_mm=lo,
+            maximum_mm=[value + rng.randint(0, 4) for value in lo])
+    expected = {pair for pair in combinations(bounds, 2)
+                if geometry._aabb_evidence(*(bounds[name] for name in pair))[
+                    'overlaps_or_touches']}
+    actual = list(geometry._overlapping_component_pairs(bounds))
+    assert set(actual) == expected
+    assert len(actual) == len(expected)
+
+
+@pytest.mark.parametrize('axis', [0, 1, 2])
+def test_sparse_ten_thousand_components_do_not_scan_all_pairs(axis, monkeypatch):
+    bounds = {}
+    for index in range(10_000):
+        lo = [0.0, 0.0, 0.0]
+        lo[axis] = index * 2.0
+        bounds[f'Component_{index}'] = dict(minimum_mm=lo,
+            maximum_mm=[value + 1 for value in lo])
+    calls = 0
+    original = geometry._aabb_evidence
+
+    def checked(*args):
+        nonlocal calls
+        calls += 1
+        return original(*args)
+
+    monkeypatch.setattr(geometry, '_aabb_evidence', checked)
+    assert list(geometry._overlapping_component_pairs(bounds)) == []
+    assert calls < len(bounds)

--- a/src/Mod/VibeCAD/vibecad_tests/test_model_size_limits.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_model_size_limits.py
@@ -1,0 +1,299 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Exercise production entry points beyond historical model-size ceilings."""
+from types import SimpleNamespace
+
+import pytest
+
+import VibeCADVibeScriptDomainRuntime as runtime
+
+
+def test_large_simulation_reaches_domain_postconditions(tmp_path, monkeypatch):
+    definition = {'domain': 'assembly', 'output_type': 'simulation',
+                  'frames': [{'values': [0.123456789] * 10_000} for _ in range(22)]}
+    prepared = dict(pack=SimpleNamespace(domain='assembly'), staging=tmp_path,
+                    expected_outputs=[dict(name='simulation', type='simulation')])
+    execution = dict(ok=True, schema=runtime.WORKER_SCHEMA, domain='assembly',
+                     outputs=[dict(name='simulation', type='simulation', definition=definition)])
+    calls = []
+
+    def validate(prepared, execution, outputs):
+        calls.append(outputs)
+        return {'validated': True}
+
+    monkeypatch.setattr(runtime, '_validate_assembly_execution', validate)
+    result = runtime.validate_candidate(prepared, execution)
+    assert calls and result['assembly_validation'] == {'validated': True}
+    assert result['outputs'][0]['definition'] == definition
+    definition['frames'][0]['values'][0] = float('nan')
+    with pytest.raises(ValueError, match='finite'):
+        runtime.validate_candidate(prepared, execution)
+
+
+def test_definition_serialization_validation_is_streamed(monkeypatch):
+    def forbidden(*args, **kwargs):
+        raise AssertionError('Validation must not allocate a second complete JSON payload')
+    monkeypatch.setattr(runtime.json, 'dumps', forbidden)
+    runtime._validate_json_serializable({'values': list(range(100_001))})
+    with pytest.raises(ValueError):
+        runtime._validate_json_serializable({'value': float('nan')})
+
+
+def test_definition_paths_only_parse_possible_parent_segments(monkeypatch):
+    original_path = runtime.Path
+    parsed = []
+
+    def track_path(value):
+        parsed.append(value)
+        return original_path(value)
+
+    monkeypatch.setattr(runtime, 'Path', track_path)
+    prepared = dict(pack=SimpleNamespace(domain='assembly'))
+    values = ['body_' + str(index) for index in range(5000)]
+    values += ['relative/name', 'relative\\name', 'segment..name', './relative']
+    runtime._validate_definition_value(values, prepared, 'definition')
+    assert parsed == ['segment..name']
+
+
+@pytest.mark.parametrize('value', [
+    '..', '../part', 'part/..', 'part/../other', 'part\\..\\other',
+    '/absolute', '\\absolute', 'C:/absolute', 'C:\\absolute',
+])
+def test_definition_paths_still_reject_absolute_and_parent_segments(value):
+    prepared = dict(pack=SimpleNamespace(domain='assembly'))
+    with pytest.raises(ValueError, match='filesystem path'):
+        runtime._validate_definition_value(value, prepared, 'definition')
+
+
+def test_placement_delta_preserves_legacy_roundoff_but_checks_new_metric(monkeypatch):
+    pose = SimpleNamespace(Base=[0.0, 0.0, 0.0], Rotation=SimpleNamespace(Q=[0, 0, 0, 1]))
+    monkeypatch.setattr(runtime, '_assembly_native_placement_from_matrix', lambda *args: pose)
+    fact = {'matrix': []}
+    legacy = dict(translation_mm=[0, 0, 0], translation_distance_mm=0,
+                  rotation_degrees=1.7075472925031877e-6)
+    assert runtime._assembly_placement_delta(fact, fact, legacy, 'test') == legacy
+    current = dict(legacy, rotation_metric='quaternion_chord_v1')
+    with pytest.raises(ValueError, match='rotation_degrees'):
+        runtime._assembly_placement_delta(fact, fact, current, 'test')
+    current['rotation_degrees'] = 0.0
+    assert runtime._assembly_placement_delta(fact, fact, current, 'test') == current
+    legacy['rotation_degrees'] = 0.01
+    with pytest.raises(ValueError, match='rotation_degrees'):
+        runtime._assembly_placement_delta(fact, fact, legacy, 'test')
+
+
+@pytest.mark.parametrize('node_count,element_count', [(100_001, 1), (2, 500_001)])
+def test_fem_native_readback_accepts_large_mesh(node_count, element_count):
+    from vibescript_fem_worker import _mesh_topology
+    point = SimpleNamespace(x=0.0, y=0.0, z=0.0)
+    mesh = SimpleNamespace(Nodes=dict.fromkeys(range(1, node_count + 1), point),
+        Edges=range(1, element_count + 1), Faces=[], Volumes=[],
+        getElementNodes=lambda _id: [1, 2])
+    topology = _mesh_topology(mesh)
+    assert topology['facts']['node_count'] == node_count
+    assert topology['facts']['element_count'] == element_count
+
+
+def test_sketch_api_accepts_large_geometry_and_constraint_lists():
+    from vibescript_sketcher_api import SketcherDomainAPI
+    api = SketcherDomainAPI(SketcherDomainAPI.exported_names, ['sketch'])
+    points = [api.point([float(i), 0.0]) for i in range(4097)]
+    value = api.sketch(points)
+    assert value is not None
+    constraints = [api.constraint('block', [points[0]], active=False) for _ in range(16_385)]
+    assert api.sketch(points, constraints) is not None
+
+
+def test_drawing_sources_accepts_large_assemblies():
+    from vibescript_techdraw_api import _references
+    sources = [dict(document_uid='document', object_name=f'Body{i}') for i in range(337)]
+    assert len(_references('view', sources)) == len(sources)
+    with pytest.raises(ValueError, match='duplicate'):
+        _references('view', sources + [sources[0]])
+
+
+def test_host_reference_capture_accepts_ten_thousand_objects():
+    sources = [dict(document_uid='doc', object_name=f'Body{i}') for i in range(10_000)]
+    assert runtime._input_references({'parts': sources + sources}) == sources
+
+
+def test_assembly_api_accepts_ten_thousand_named_components():
+    from vibescript_assembly_api import AssemblyDomainAPI, _PUBLISHABLE_TYPES
+    api = AssemblyDomainAPI(AssemblyDomainAPI.exported_names, _PUBLISHABLE_TYPES)
+    components = {f'Part{i}': api.component(dict(document_uid='doc', object_name='Body'),
+                  grounded=(i == 0)) for i in range(10_000)}
+    assert len(api.assembly(components).properties['components']) == 10_000
+
+
+def _large_bom():
+    from VibeCADAssemblyBOM import plan_assembly_bom
+    sources = [dict(output_name=f'Part{i}', reference=dict(document_uid='doc',
+               object_name=f'Body{i}', label=f'Part {i}')) for i in range(10_000)]
+    return plan_assembly_bom(sources,
+        columns=[dict(kind='builtin', key='name', heading='Name', native_name='Name')],
+        detail_subassemblies=True, detail_parts=True, only_parts=False, row_overrides=[])
+
+
+def test_detailed_bom_accepts_ten_thousand_rows():
+    result = _large_bom()
+    assert result['row_count'] == 10_000
+    assert result['occurrence_path_count'] == 10_000
+
+
+def test_large_accepted_bom_can_be_restored(monkeypatch):
+    import json
+    import VibeCADVibeScriptDomainPublication as publication
+    data = _large_bom()
+    encoded = json.dumps(data)
+    assert len(encoded) > 1_000_000
+    target = SimpleNamespace(TypeId='Assembly::BomObject')
+    setattr(target, publication.PROP_ASSEMBLY_BOM_VALIDATION, encoded)
+    owner = SimpleNamespace()
+    setattr(owner, publication.PROP_ASSEMBLY_BOM_RESTORE_TARGET, target)
+    restored = []
+    monkeypatch.setattr(publication, '_ensure_assembly_bom_restore_properties', lambda obj: None)
+    monkeypatch.setattr(publication, '_unfreeze_object', lambda *args: None)
+    monkeypatch.setattr(publication, '_freeze_object', lambda *args: None)
+    monkeypatch.setattr(publication, '_populate_assembly_bom_without_recomputing',
+                        lambda obj, value: restored.append(value))
+    monkeypatch.setattr(publication, '_assembly_bom_live_readback', lambda *args: 'same')
+    monkeypatch.setattr(publication, '_assembly_bom_expected_readback', lambda *args: 'same')
+    publication.AssemblyBOMRestoreProxy().onDocumentRestored(owner)
+    assert restored == [data]
+    assert getattr(owner, publication.PROP_ASSEMBLY_BOM_RESTORE_ERROR) == ''
+
+
+def test_drawing_page_accepts_more_than_128_contents():
+    from vibescript_techdraw_api import TechDrawDomainAPI
+    api = TechDrawDomainAPI()
+    template = api.template()
+    contents = [api.annotation([f'Note {i}']) for i in range(129)]
+    contents.append(api.view([dict(document_uid='doc', object_name='Body')]))
+    assert api.page(template, contents) is not None
+
+
+def test_native_bom_reads_large_tables_but_honors_explicit_cell_budget():
+    from VibeCADNativeAssemblyBomState import read_bom_table, NativeAssemblyBomStateError
+    sheet = SimpleNamespace(getUsedRange=lambda: ('A1', 'A10001'),
+                            getContents=lambda address: address)
+    result = read_bom_table(sheet)
+    assert result['row_count'] == 10_000
+    with pytest.raises(NativeAssemblyBomStateError):
+        read_bom_table(sheet, maximum_cells=100)
+
+
+def test_threaded_fastener_creation_does_not_scan_document_count(monkeypatch):
+    import VibeCADFasteners as fasteners
+    monkeypatch.setattr(fasteners, 'resolve_fastener', lambda **kwargs: {'model_thread': True})
+
+    class Document:
+        @property
+        def Objects(self):
+            raise AssertionError('Counting document objects is unrelated to this fastener')
+
+        def addObject(self, *args):
+            raise RuntimeError('reached native creation')
+
+    with pytest.raises(RuntimeError, match='reached native creation'):
+        fasteners.create_fastener_feature(Document(), standard='ISO4762', nominal_thread='M6')
+
+
+def test_large_hierarchy_capture_and_worker_validation(tmp_path, monkeypatch):
+    import sys
+    import FreeCAD
+    import VibeCADAssemblyHierarchy as hierarchy
+    from vibescript_assembly_worker import _load_assembly_hierarchy
+    from .test_native_assembly_bom import _Document
+
+    matrix = [float(i // 4 == i % 4) for i in range(16)]
+    monkeypatch.setattr(FreeCAD, 'Placement',
+                        lambda: SimpleNamespace(toMatrix=lambda: SimpleNamespace(A=matrix)),
+                        raising=False)
+    monkeypatch.setitem(sys.modules, 'Part', SimpleNamespace())
+    document = _Document()
+    root = document.add('Root', 'App::Part')
+    root.Group = [document.add(f'Module{i}', 'App::Part') for i in range(10_000)]
+    captured = hierarchy.capture_assembly_hierarchy(root, detach_shapes=False)
+    assert captured['counts']['nodes'] == 10_001
+    assert captured['counts']['occurrences'] == 10_000
+    loaded = _load_assembly_hierarchy(tmp_path, captured, context='test')
+    assert len(loaded['nodes']) == 10_001
+    preview = hierarchy.hierarchy_context(captured)
+    assert len(preview['occurrence_paths']) <= 256
+    assert preview['occurrence_paths_omitted'] == 10_000 - len(preview['occurrence_paths'])
+    captured['limits'] = dict(maximum_depth=16, nodes=512, occurrences=2048,
+                              joints=1024, shape_artifacts=256)
+    assert len(_load_assembly_hierarchy(tmp_path, captured, context='old')['nodes']) == 10_001
+
+
+def test_hierarchy_metadata_serialization_does_not_add_a_byte_ceiling(tmp_path, monkeypatch):
+    import sys
+    import VibeCADAssemblyHierarchy as hierarchy
+    monkeypatch.setitem(sys.modules, 'Part', SimpleNamespace())
+    value = dict(schema=hierarchy.ASSEMBLY_HIERARCHY_SCHEMA,
+                 nodes=[dict(node_id='n0000', label='x' * (8 * 1024 * 1024 + 1))],
+                 _detached_shapes={})
+    descriptor, size = runtime._finalize_assembly_hierarchy(value, staging=tmp_path,
+                                                          reference_index=0)
+    assert descriptor['nodes'] == value['nodes'] and size == 0
+
+
+def test_native_bom_source_graph_accepts_large_assembly(monkeypatch):
+    from .test_native_assembly_bom import _Document
+    from VibeCADNativeAssemblyBomState import _source_graph
+    monkeypatch.setattr('VibeCADNativeAssemblyBomState._timeline_active', lambda obj: True)
+    document = _Document()
+    root = document.add('Root', 'App::Part')
+    root.Group = [document.add(f'Body{i}', 'Part::Feature') for i in range(10_000)]
+    root.OutList = root.Group
+    assert len(_source_graph(root)) == 10_001
+
+
+def test_partdesign_history_validation_accepts_more_than_16384_objects(tmp_path):
+    import base64
+    import hashlib
+    import json
+
+    content = b'<Object/>'
+    records = [dict(name=f'Feature{i}', label=f'Feature {i}', type_id='PartDesign::Feature',
+                    content=base64.b64encode(content).decode(),
+                    content_sha256=hashlib.sha256(content).hexdigest(), links={}, visible=False)
+               for i in range(16_385)]
+    payload = dict(schema=runtime._PARTDESIGN_NATIVE_HISTORY_SCHEMA, outputs=[dict(
+        output_name='Result', body_name='Body', body_label='Body', representation='body',
+        tip_name=records[-1]['name'], objects=records)])
+    encoded = json.dumps(payload).encode()
+    (tmp_path / 'history.json').write_bytes(encoded)
+    metadata = dict(schema=payload['schema'], artifact_path='history.json',
+                    artifact_bytes=len(encoded), artifact_sha256=hashlib.sha256(encoded).hexdigest(),
+                    outputs=['Result'])
+    prepared = dict(staging=tmp_path, expected_outputs=[dict(name='Result', type='body')])
+    validated = runtime._validate_partdesign_native_history(prepared, dict(partdesign_native_history=metadata))
+    assert len(validated['outputs'][0]['objects']) == 16_385
+    metadata['artifact_sha256'] = '0' * 64
+    with pytest.raises(ValueError, match='digest'):
+        runtime._validate_partdesign_native_history(prepared, dict(partdesign_native_history=metadata))
+
+
+def test_large_drawing_projection_still_requires_aligned_metadata(tmp_path, monkeypatch):
+    import vibescript_techdraw_worker as worker
+
+    edge_count, face_count, vertex_count = 200_001, 50_001, 250_001
+    vector = [0.0, 0.0, 1.0]
+    snapshot = dict(edges=SimpleNamespace(Edges=range(edge_count)),
+                    faces=SimpleNamespace(Faces=range(face_count)),
+                    edge_classes=[0] * edge_count, edge_visibility=[True] * edge_count,
+                    source_indices=[0] * edge_count, centroid=vector)
+    descriptors = dict(coordinate_space='view', view_scale=1.0,
+                       edges=[{}] * edge_count, vertices=[{}] * vertex_count)
+    view = SimpleNamespace(getPrecomputedProjection=lambda: snapshot,
+                           getProjectedElementDescriptors=lambda: descriptors,
+                           TypeId='TechDraw::DrawViewPart', Direction=vector, XDirection=vector,
+                           X=0.0, Y=0.0, Scale=1.0)
+    monkeypatch.setattr(worker, '_write_shape_artifact', lambda *args, **kwargs: {})
+    monkeypatch.setattr(worker, '_shape_bounds_2d', lambda shape: [0, 0, 1, 1])
+    result = worker._projection_snapshot(view, tmp_path, output_index=0, suffix='view', source_keys=[])
+    assert (result['edge_count'], result['face_count'], result['vertex_count']) == (
+        edge_count, face_count, vertex_count)
+    snapshot['source_indices'].pop()
+    with pytest.raises(RuntimeError, match='edge-aligned'):
+        worker._projection_snapshot(view, tmp_path, output_index=0, suffix='view', source_keys=[])

--- a/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py
@@ -3329,7 +3329,7 @@ def test_provider_component_inventory_uses_model_facing_joint_names() -> None:
     ] == ["gears", "revolute"]
 
 
-def test_provider_omits_cross_domain_sources_when_active_domain_is_empty() -> None:
+def test_provider_indexes_cross_domain_sources_when_active_domain_is_empty() -> None:
     import VibeCADSession as session
 
     visible = session._provider_editable_sources_payload(
@@ -3350,11 +3350,10 @@ def test_provider_omits_cross_domain_sources_when_active_domain_is_empty() -> No
         }
     )
 
-    assert visible == {
-        "schema": "vibecad-editable-sources-v1",
-        "domain": "assembly",
-        "source_count": 0,
-    }
+    assert visible["domain"] == "assembly"
+    assert visible["source_count"] == 0
+    assert visible["program_index"]["program_count"] == 1
+    assert visible["program_index"]["programs"][0]["program"] == "Robot/partdesign/Components"
 
 
 def test_component_inventory_removes_generated_carrier_names() -> None:
@@ -5136,8 +5135,8 @@ def test_assembly_api_rejects_ambiguous_graphs_and_wrong_joint_parameters() -> N
     assert scoped_simulation.properties["motion_names"] == ("HingeDrive",)
     with pytest.raises(ValueError, match=r"api\.simulation.*greater than"):
         api.simulation(mechanism, [drive], start_time_s=1, end_time_s=1)
-    with pytest.raises(ValueError, match=r"api\.simulation.*10000 native frames"):
-        api.simulation(mechanism, [drive], end_time_s=100, time_step_s=0.001)
+    long_simulation = api.simulation(mechanism, [drive], end_time_s=100, time_step_s=0.001)
+    assert long_simulation.properties["estimated_frame_limit"] == 100_002
     with pytest.raises(ValueError, match=r"api\.exploded_view.*1 through 4096"):
         api.exploded_view(mechanism, [])
     with pytest.raises(ValueError, match=r"api\.exploded_view.*exactly one"):
@@ -5572,34 +5571,29 @@ def test_assembly_bom_planner_keeps_model_paths_exact_and_actionable() -> None:
         in unavailable_hierarchy.value.details["correction"]
     )
 
-    with pytest.raises(AssemblyBOMError) as oversized:
-        plan_assembly_bom(
-            [
-                {
-                    "output_name": f"Component{index:03d}",
-                    "reference": {
-                        "document_uid": "source-document",
-                        "object_name": f"Source{index:03d}",
-                        "source_kind": "shape",
-                        "label": "X" * 4096,
-                        "document_file_name": "large-module.FCStd",
-                        "bom_properties": [],
-                    },
-                }
-                for index in range(100)
-            ],
-            columns=[columns[1]],
-            detail_subassemblies=False,
-            detail_parts=False,
-            only_parts=False,
-            row_overrides=[],
-        )
-    assert oversized.value.details["stage"] == "bom_budget"
-    assert (
-        oversized.value.details["observed_contract_bytes"]
-        > (oversized.value.details["maximum_contract_bytes"])
+    large = plan_assembly_bom(
+        [
+            {
+                "output_name": f"Component{index:03d}",
+                "reference": {
+                    "document_uid": "source-document",
+                    "object_name": f"Source{index:03d}",
+                    "source_kind": "shape",
+                    "label": "X" * 4096,
+                    "document_file_name": "large-module.FCStd",
+                    "bom_properties": [],
+                },
+            }
+            for index in range(100)
+        ],
+        columns=[columns[1]],
+        detail_subassemblies=False,
+        detail_parts=False,
+        only_parts=False,
+        row_overrides=[],
     )
-    assert "split the design" in oversized.value.details["correction"]
+    assert large["row_count"] == 100
+    assert large["limits"]["contract_bytes"] == 0
 
 
 def test_assembly_occurrence_global_placement_failure_is_never_silently_local() -> None:
@@ -6454,6 +6448,9 @@ def test_generic_publication_accepts_non_assembly_and_cleans_failed_creations(
         def getObject(self, name):
             return self.objects.get(str(name))
 
+        def findObjects(self, *, Property):
+            return [obj for obj in self.objects.values() if Property in obj.PropertiesList]
+
         def removeObject(self, name):
             self.removed.append(str(name))
             self.objects.pop(str(name), None)
@@ -7082,6 +7079,29 @@ def test_source_operation_budget_excludes_trusted_domain_api_frames() -> None:
             max_operations=10,
             max_seconds=1.0,
         )
+
+
+def test_source_without_operation_ceiling_can_exceed_old_budget() -> None:
+    from vibescript_domain_worker import _execute_source
+
+    result, _stdout, budget = _execute_source(
+        source=(
+            "value = 0\n"
+            "for item in range(110_000):\n"
+            "    value += item\n"
+            "result = {'Value': value}\n"
+        ),
+        document_name="LargeSourceFixture",
+        document_objects=[],
+        inputs={},
+        api=object(),
+        expected_output_names=["Value"],
+        max_operations=0,
+        max_seconds=30.0,
+    )
+    assert result == {"Value": 110_000 * 109_999 // 2}
+    assert budget["operations"] > 200_000
+    assert budget["max_operations"] == 0
 
 
 def test_domain_context_merges_live_identity_without_losing_persisted_facts(

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from concurrent.futures import Future
 
 import pytest
 
@@ -55,7 +56,86 @@ def _context(
         active_document=lambda: document,
         active_surface_id=lambda: surface,
         edit_or_task_active=lambda: task_active,
+        document_thread_dispatch=lambda operation: operation(),
     )
+
+
+def test_async_runtime_preserves_pending_observation_until_completion(monkeypatch):
+    context = _context()
+    pending = Future()
+    monkeypatch.setattr(runtime_module, 'open_native_assembly_playback_async',
+                        lambda *args: pending, raising=False)
+    observed = []
+    monkeypatch.setattr(context.state, 'cancel_mutation', lambda ticket: observed.append(ticket))
+    ticket = context.state.begin_call(context.document_uid, 'assembly.playback')
+    runtime = NativeAssemblyPlaybackRuntime(context)
+    result = runtime.control_async(
+        {'operation': 'show', 'simulation': {'object_name': 'Simulation'}}, ticket=ticket
+    )
+    assert result is pending and observed == []
+    pending.set_result({'operation': 'show'})
+    assert observed == [ticket]
+
+
+def test_pending_playback_dispatch_failure_does_not_leave_a_waiter_running():
+    pending = Future()
+    def disconnected(operation):
+        raise RuntimeError('document owner closed')
+    context = SimpleNamespace(document_thread_dispatch=disconnected)
+    result = playback_module._playback_completion(context, pending, lambda value: value)
+    pending.set_result({'frame': 3})
+    with pytest.raises(RuntimeError, match='document owner closed'):
+        result.result(timeout=0)
+
+
+def test_cancel_after_player_ready_closes_only_the_unaccepted_launch():
+    callbacks = []
+    pending = Future()
+    result = playback_module._playback_completion(
+        SimpleNamespace(document_thread_dispatch=callbacks.append), pending,
+        lambda value: pytest.fail('Cancelled launch must not be registered'),
+        cancel_completed=lambda: callbacks.append('closed owned player'),
+    )
+    pending.set_result(object())
+    result.cancel()
+    assert len(callbacks) == 2
+    callbacks[0]()
+    callbacks[1]()
+    assert callbacks[-1] == 'closed owned player' and result.cancelled()
+
+
+def test_native_launch_accepts_fresh_wrappers_for_the_same_task(monkeypatch):
+    context = _context()
+    assembly, simulation = SimpleNamespace(numberOfFrames=lambda: 22), object()
+    form = SimpleNamespace(frameSlider=SimpleNamespace(value=lambda: 3),
+                           destroyed=SimpleNamespace(connect=lambda callback: None))
+    panel = SimpleNamespace(form=form, playback_only=True, assembly=assembly,
+                            simFeaturePy=simulation, document_was_modified=False,
+                            _ownsLiveTaskContext=lambda: True)
+    state = SimpleNamespace(solver_state=None, components=(), grounded_joints=(),
+                            regular_joints=(), simulation_records=())
+    calls = []
+    monkeypatch.setattr(playback_module, '_validate_open', lambda *args: (state, assembly, simulation, 3, 2.2))
+    monkeypatch.setattr(playback_module, '_document_graph', lambda doc: ())
+    monkeypatch.setattr(playback_module, '_active_camera', lambda doc: '')
+    monkeypatch.setattr(playback_module, '_gui_modified', lambda doc: False)
+    monkeypatch.setattr(playback_module, '_transaction_open', lambda doc: False)
+    monkeypatch.setattr(playback_module, 'read_current_selection', lambda doc: ())
+    monkeypatch.setattr(playback_module, 'capture_assembly_simulation_state', lambda obj: state)
+    monkeypatch.setattr(playback_module, 'read_active_assembly', lambda doc: assembly)
+    monkeypatch.setattr(playback_module, 'same_assembly', lambda a, b: a is b)
+    monkeypatch.setattr(playback_module, '_status', lambda session, operation: {'ok': True})
+    monkeypatch.setattr(playback_module, '_active_task_dialog', lambda: SimpleNamespace(
+        getDialogContent=lambda: [form], reject=lambda: calls.append('reject')))
+    pending = Future()
+    result = playback_module.open_native_assembly_playback_async(
+        context, SimpleNamespace(mode='hold'), opener=lambda *args: pending)
+    try:
+        pending.set_result(panel)
+        assert result.result() == {'ok': True}
+        assert calls == []
+    finally:
+        playback_module._SESSIONS.pop(context.document_uid, None)
 
 
 def test_schema_exactly_maps_the_complete_player_lifecycle() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_dispatch.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_dispatch.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from concurrent.futures import Future
 
 import pytest
 
@@ -59,7 +60,10 @@ def _dispatcher(handler, **overrides):
     name = definition.name
     registry = NativeCapabilityRegistry()
     registry.register_definition(definition)
-    registry.register_implementation(NativeCapabilityImplementation(name, handler))
+    implementation_options = {}
+    if 'async_handler' in overrides:
+        implementation_options['async_handler'] = overrides['async_handler']
+    registry.register_implementation(NativeCapabilityImplementation(name, handler, **implementation_options))
     operations = overrides.get(
         "operations",
         tuple(variant.operation for variant in definition.variants),
@@ -109,6 +113,45 @@ def _dispatcher(handler, **overrides):
 
 def _arguments(value: int) -> str:
     return json.dumps({"operation": "read", "value": value})
+
+
+def test_async_dispatch_preserves_contract_and_validates_only_after_completion():
+    completion = Future()
+    calls = []
+    dispatcher, _state, _debug = _dispatcher(
+        lambda call: calls.append('synchronous') or {'value': 1},
+        async_handler=lambda call: calls.append('asynchronous') or completion,
+    )
+    response = dispatcher.call_async('test.execute', _arguments(2), 'async-1',
+                                     document_dispatch=lambda work: work())
+    assert isinstance(response, Future) and not response.done()
+    assert calls == ['asynchronous']
+    pending = dispatcher.call_async('test.execute', _arguments(2), 'async-1',
+                                    document_dispatch=lambda work: work())
+    assert pending['error_code'] == 'NATIVE_CALL_IN_PROGRESS'
+    completion.set_result({'value': 2})
+    assert response.result() == {'ok': True, 'value': 2}
+    assert dispatcher.call('test.execute', _arguments(2), 'async-1') == response.result()
+    assert dispatcher.call('test.execute', _arguments(1), 'sync-1')['value'] == 1
+
+
+def test_async_dispatch_rejects_a_read_side_effect_after_completion():
+    completion = Future()
+    dispatcher, state, _debug = _dispatcher(lambda call: {}, async_handler=lambda call: completion)
+    response = dispatcher.call_async('test.execute', _arguments(2), 'async-1',
+                                     document_dispatch=lambda work: work())
+    state.note_structural_change(_Document.Uid)
+    completion.set_result({'value': 2})
+    assert response.result()['ok'] is False
+
+
+def test_async_dispatch_cancellation_reaches_pending_handler():
+    completion = Future()
+    dispatcher, _state, _debug = _dispatcher(lambda call: {}, async_handler=lambda call: completion)
+    response = dispatcher.call_async('test.execute', _arguments(2), 'async-1',
+                                     document_dispatch=lambda work: work())
+    assert response.cancel()
+    assert completion.cancelled()
 
 
 def _mutation_definition() -> NativeCapabilityDefinition:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_session.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_session.py
@@ -537,6 +537,9 @@ class _Dispatcher:
         self.calls.append((name, arguments, call_id))
         return dict(self.result)
 
+    def call_async(self, name, arguments, call_id, *, document_dispatch):
+        return self.call(name, arguments, call_id)
+
 
 class _Ledger:
     def __init__(self) -> None:
@@ -705,6 +708,34 @@ def test_provider_runner_dispatches_call_id_and_records_concise_trace() -> None:
         "native_tool_started",
         "native_tool_completed",
     ]
+
+
+def test_provider_runner_waits_for_deferred_payload_outside_owner_dispatch():
+    from concurrent.futures import Future
+
+    runner, dispatcher, _ledger, _traces, _events = _provider_runner()
+    inside_owner = False
+
+    class Pending(Future):
+        def result(self, timeout=None):
+            assert not inside_owner, 'A pending tool must not wait on the GUI owner'
+            self.set_result({'ok': True, 'value': 4})
+            return super().result(timeout)
+
+    pending = Pending()
+
+    def owner(operation):
+        nonlocal inside_owner
+        inside_owner = True
+        try:
+            return operation()
+        finally:
+            inside_owner = False
+
+    runner._document_dispatch = owner
+    dispatcher.call_async = lambda *args, **kwargs: pending
+    result = runner('state.read', '{"operation":"active"}', 'deferred-owner')
+    assert result['ok'] and result['value'] == 4
 
 
 def test_provider_runner_waits_off_document_thread_before_a_dependent_call() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_state.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_state.py
@@ -677,6 +677,57 @@ def test_document_change_batch_reports_the_outermost_commit_outcome() -> None:
     assert outcomes == [("document-outcome", False)]
 
 
+@pytest.mark.parametrize("commit", [True, False])
+def test_native_mutation_observer_uses_the_existing_service_batch(monkeypatch, commit):
+    import VibeCADGui as gui
+    import VibeCADVibeScriptDomainPublication as publication
+    from VibeCADCore import VibeCADService
+    from VibeCADDocumentChangeBatch import document_change_batch_active
+
+    service = object.__new__(VibeCADService)
+    service._native_document_states = NativeDocumentStateStore()
+    document = SimpleNamespace(Uid="native-mutation-batch", Restoring=False)
+    source = SimpleNamespace(Document=document, Name="Source")
+    invalidations, metadata, snapshots, scans, queued = [], [], [], [], []
+    monkeypatch.setattr(gui, "get_service", lambda: service)
+    monkeypatch.setattr(gui.App, "isRestoring", lambda: False, raising=False)
+    monkeypatch.setattr(gui, "_queue_zero_delay_callback", queued.append)
+    monkeypatch.setattr(gui, "_native_authority_selector_refresh_scheduled", False)
+    monkeypatch.setattr(service, "_invalidate_native_read_contexts", invalidations.append)
+    monkeypatch.setattr(service, "_sync_native_authority_metadata_if_active", metadata.append)
+    monkeypatch.setattr(
+        service, "invalidate_vibescript_reference_snapshots_many",
+        lambda objects, **kwargs: snapshots.append(objects),
+    )
+    monkeypatch.setattr(
+        publication, "mark_programs_stale_from_sources",
+        lambda changes, **kwargs: scans.append((changes, kwargs)) or [],
+    )
+    observer = gui._VibeCADDocumentObserver()
+    observer.slotCooperativeMutationChanged(document, True)
+    # Publication nests its origin/outcome inside the native ownership epoch.
+    service.begin_document_change_batch(
+        document.Uid, origin_program_id="publisher", origin_domain="assembly",
+    )
+    try:
+        for _ in range(100):
+            observer.slotChangedObject(source, "Shape")
+        assert invalidations == metadata == snapshots == scans == queued == []
+    finally:
+        service.end_document_change_batch(document.Uid, commit=commit)
+        observer.slotCooperativeMutationChanged(document, False)
+
+    assert not document_change_batch_active(document.Uid)
+    assert not service.document_change_batch_active(document.Uid)
+    assert service._native_document_states.current_revision(document.Uid) == int(commit)
+    assert invalidations == metadata == ([document.Uid] if commit else [])
+    assert snapshots == ([(source,)] if commit else [])
+    assert scans == ([(((source, "Shape"),), {
+        "excluded_programs": frozenset({(document.Uid, "publisher", "assembly")}),
+    })] if commit else [])
+    assert len(queued) == 1
+
+
 def test_document_observer_batches_dependency_invalidation_and_stale_scans(
     monkeypatch,
 ) -> None:
@@ -698,7 +749,7 @@ def test_document_observer_batches_dependency_invalidation_and_stale_scans(
             return None
 
         @staticmethod
-        def invalidate_vibescript_reference_snapshots_many(objects):
+        def invalidate_vibescript_reference_snapshots_many(objects, **kwargs):
             invalidated.append(tuple(objects))
 
     monkeypatch.setattr(gui, "get_service", lambda: Service())
@@ -755,7 +806,7 @@ def test_document_observer_discards_dependency_work_after_rollback(
             return None
 
         @staticmethod
-        def invalidate_vibescript_reference_snapshots_many(objects):
+        def invalidate_vibescript_reference_snapshots_many(objects, **kwargs):
             invalidated.append(tuple(objects))
 
     monkeypatch.setattr(gui, "get_service", lambda: Service())
@@ -773,6 +824,126 @@ def test_document_observer_discards_dependency_work_after_rollback(
 
     assert invalidated == []
     assert stale_scans == []
+
+
+@pytest.mark.parametrize("callback", ["slotChangedObject", "slotCreatedObject", "slotDeletedObject"])
+@pytest.mark.parametrize("fail_abort", [False, True])
+def test_publication_abort_skips_only_discarded_advisory_observer_work(
+    monkeypatch, callback, fail_abort,
+):
+    import VibeCADGui as gui
+    import VibeCADVibeScriptDomainPublication as publication
+    import VibeCADDocumentChangeBatch as batches
+
+    calls = []
+    document = SimpleNamespace(Uid="discard-rollback", Restoring=False)
+    source = SimpleNamespace(Document=document)
+    other = SimpleNamespace(Document=SimpleNamespace(Uid="other-document", Restoring=False))
+    service = SimpleNamespace(
+        note_native_object_property_change=lambda *args: calls.append(args[0]),
+        note_native_object_created=lambda obj: calls.append(obj),
+        note_native_object_deleted=lambda obj: calls.append(obj))
+    monkeypatch.setattr(gui, "get_service", lambda: service)
+    monkeypatch.setattr(gui.App, "isRestoring", lambda: False, raising=False)
+    observer = gui._VibeCADDocumentObserver()
+    monkeypatch.setattr(observer, "_refresh_native_authority_selector", lambda uid: None)
+    def notify(obj):
+        args = (obj, "VibeCADPublishedRevision") if callback == "slotChangedObject" else (obj,)
+        getattr(observer, callback)(*args)
+    def abort():
+        for _ in range(100):
+            notify(source)
+        notify(other)
+        if fail_abort:
+            raise RuntimeError("native rollback failure")
+    document.abortTransaction = abort
+    batches.begin_document_change_batch(document.Uid)
+    try:
+        notify(source)  # Ordinary changes within an open batch remain observed.
+        if fail_abort:
+            with pytest.raises(RuntimeError, match="native rollback failure"):
+                publication._abort_publication_transaction(document)
+        else:
+            publication._abort_publication_transaction(document)
+        notify(source)  # The rollback scope must not leak after an exception.
+        assert calls == [source, other, source]
+    finally:
+        batches.end_document_change_batch(document.Uid, commit=False)
+
+
+def test_rollback_notification_scope_is_thread_local_and_nested():
+    import threading
+    import VibeCADDocumentChangeBatch as batches
+
+    batches.begin_document_change_batch("scope-rollback")
+    try:
+        with batches.rolling_back_document_change_batch("scope-rollback"):
+            assert batches.document_change_batch_rolling_back("scope-rollback")
+            seen = []
+            thread = threading.Thread(target=lambda: seen.append(
+                batches.document_change_batch_rolling_back("scope-rollback")))
+            thread.start()
+            thread.join()
+            assert seen == [False]
+            with batches.rolling_back_document_change_batch("scope-rollback"):
+                assert batches.document_change_batch_rolling_back("scope-rollback")
+            assert batches.document_change_batch_rolling_back("scope-rollback")
+        assert not batches.document_change_batch_rolling_back("scope-rollback")
+    finally:
+        batches.end_document_change_batch("scope-rollback", commit=False)
+
+
+def test_publication_abort_without_batch_keeps_notifications():
+    import VibeCADDocumentChangeBatch as batches
+    import VibeCADVibeScriptDomainPublication as publication
+
+    calls = []
+    document = SimpleNamespace(Uid="unbatched-rollback")
+    def abort():
+        calls.append(batches.document_change_batch_rolling_back(document.Uid))
+    document.abortTransaction = abort
+    publication._abort_publication_transaction(document)
+    assert calls == [False]
+
+
+def test_dependency_batch_handles_a_source_deleted_before_flush(monkeypatch) -> None:
+    import threading
+    import VibeCADGui as gui
+    import VibeCADVibeScriptDomainPublication as publication
+    from VibeCADCore import VibeCADService
+
+    document = SimpleNamespace(Uid="deleted-batch-source")
+
+    class Source:
+        Document = document
+        alive = True
+
+        @property
+        def Name(self):
+            if not self.alive:
+                raise ReferenceError("Underlying object deleted")
+            return "Removed"
+
+    removed = Source()
+    live = SimpleNamespace(Name="Live", Document=document)
+    service = object.__new__(VibeCADService)
+    service._vibescript_reference_cache_lock = threading.RLock()
+    service._vibescript_reference_snapshots = {
+        name: {"dependencies": {(document.Uid, name)}}
+        for name in ("Removed", "Live", "Untouched")
+    }
+    scans = []
+    monkeypatch.setattr(gui, "get_service", lambda: service)
+    monkeypatch.setattr(
+        publication, "mark_programs_stale_from_sources",
+        lambda changes, **kwargs: scans.append(changes) or [],
+    )
+    gui._defer_vibescript_dependency_change(document.Uid, removed, "Shape")
+    gui._defer_vibescript_dependency_change(document.Uid, live, "Shape")
+    removed.alive = False
+    gui._finish_vibescript_dependency_batch(document.Uid, True)
+    assert set(service._vibescript_reference_snapshots) == {"Untouched"}
+    assert scans == [((live, "Shape"),)]
 
 
 def test_bulk_stale_propagation_scans_each_document_once(monkeypatch) -> None:
@@ -793,7 +964,16 @@ def test_bulk_stale_propagation_scans_each_document_once(monkeypatch) -> None:
     document = Document()
     first_source = SimpleNamespace(Name="SourceA", InList=[])
     second_source = SimpleNamespace(Name="SourceB", InList=[])
-    output = SimpleNamespace(
+
+    class Output(SimpleNamespace):
+        input_reads = 0
+
+        @property
+        def VibeCADVibeScriptInputObjects(self):
+            self.input_reads += 1
+            return [first_source, second_source]
+
+    output = Output(
         Name="DependentOutput",
         TypeId="Part::Feature",
         Document=document,
@@ -804,7 +984,6 @@ def test_bulk_stale_propagation_scans_each_document_once(monkeypatch) -> None:
             publication.contracts.PROP_PROGRAM_REVISION,
             publication.reference_contracts.PROP_DERIVED_STATE,
         ],
-        VibeCADVibeScriptInputObjects=[first_source, second_source],
         VibeCADVibeScriptNestedInputObjects=[],
         VibeCADVibeScriptProgramId="program-a",
         VibeCADVibeScriptDomain="part",
@@ -827,6 +1006,7 @@ def test_bulk_stale_propagation_scans_each_document_once(monkeypatch) -> None:
 
     assert result == ["DependentOutput"]
     assert document.object_reads == 1
+    assert output.input_reads == 1
     assert len(marked) == 1
     assert marked[0][0] is output
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_numerical_runtime.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_numerical_runtime.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import pytest
+
+from VibeCADNumericalRuntime import numerical_thread_count
+
+
+@pytest.mark.parametrize("slots,available,limit,used,expected", [
+    (1, 128 << 30, 0, 0, 1),
+    (3, 8 << 30, 0, 0, 3),
+    (6, 8 << 30, 0, 0, 6),
+    (42, 128 << 30, 0, 0, 42),
+    (42, 1 << 30, 0, 0, 4),
+    (42, 128 << 30, 2 << 30, 1 << 30, 4),
+    (3, 0, 0, 0, 1),
+    (42, 128 << 30, 1 << 30, 2 << 30, 1),
+])
+def test_numerical_threads_follow_cpu_lease_and_memory_headroom(
+    slots, available, limit, used, expected
+):
+    assert numerical_thread_count(slots, available, limit, used) == expected

--- a/src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_partdesign_vibescript_v2.py
@@ -1180,6 +1180,7 @@ def test_unchanged_saved_partdesign_source_gets_private_compatibility_runtime(
     prepared = runtime.prepare_candidate(capture)
     assert prepared["source"] == source
     assert prepared["worker_request"]["compatibility_methods"] == ["pad"]
+    assert prepared["worker_request"]["max_operations"] == 0
     runtime.abandon_prepared_candidate(prepared)
 
 

--- a/src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py
@@ -1,0 +1,810 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Exercise the production joint callbacks without requiring a Coin context."""
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+from contextlib import contextmanager
+import threading
+from concurrent.futures import Future
+import pytest
+
+
+def _method(class_name, method_name, filename='JointObject.py', **globals_):
+    source = Path(__file__).resolve().parents[2] / 'Assembly' / filename
+    tree = ast.parse(source.read_text(encoding='utf-8'))
+    cls = next(node for node in tree.body if isinstance(node, ast.ClassDef) and node.name == class_name)
+    method = next(node for node in cls.body if isinstance(node, ast.FunctionDef) and node.name == method_name)
+    namespace = dict(globals_)
+    exec(compile(ast.Module(body=[method], type_ignores=[]), str(source), 'exec'), namespace)
+    return namespace[method_name]
+
+
+class _Signal:
+    def __init__(self):
+        self.callbacks = []
+
+    def connect(self, callback):
+        self.callbacks.append(callback)
+
+    def disconnect(self, callback):
+        self.callbacks.remove(callback)
+
+    def emit(self, *args):
+        for callback in tuple(self.callbacks):
+            callback(*args)
+
+
+@pytest.mark.parametrize('playback_only', [False, True])
+def test_generation_keeps_full_solver_and_persisted_playback_entries_distinct(playback_only):
+    calls = []
+    panel = SimpleNamespace(
+        _ownsLiveTaskContext=lambda: True, generation_state='ready',
+        animationTimer=SimpleNamespace(stop=lambda: None),
+        _cancelPendingFrame=lambda: None, _setGenerationState=lambda *args: calls.append(args),
+        presentation=None, playback_only=playback_only, simFeaturePy=object(),
+        assembly=SimpleNamespace(
+            startSimulation=lambda sim: calls.append(('full', sim)) or 11,
+            startSimulationPlayback=lambda sim: calls.append(('playback', sim)) or 12),
+        generationTimer=SimpleNamespace(start=lambda: calls.append('timer')),
+        generationFinished=_Signal())
+    _method('TaskAssemblyCreateSimulation', 'runKinematicsAsync', 'CommandCreateSimulation.py')(panel)
+    assert calls == [('running',), ('playback' if playback_only else 'full', panel.simFeaturePy), 'timer']
+    assert panel.generation_request == (12 if playback_only else 11)
+
+
+@pytest.mark.parametrize('fail', [False, True])
+def test_playback_camera_fit_does_not_request_blocking_animation(fail):
+    calls = []
+    animation = True
+    def set_animation(value):
+        nonlocal animation
+        animation = value
+    def fit():
+        assert not animation, 'Camera setup requested blocking animation'
+        calls.append('fit')
+        if fail:
+            raise RuntimeError('camera unavailable')
+    panel = SimpleNamespace(presentation_visibility=[], requested_camera_method='viewFront',
+        view=SimpleNamespace(viewFront=lambda: calls.append(('front', animation)),
+                             fitAll=fit, isAnimationEnabled=lambda: animation,
+                             setAnimationEnabled=set_animation))
+    activate = _method('TaskAssemblyCreateSimulation', '_activatePlaybackPresentation',
+                       'CommandCreateSimulation.py')
+    if fail:
+        with pytest.raises(RuntimeError, match='camera unavailable'):
+            activate(panel)
+    else:
+        activate(panel)
+    assert calls == [('front', False), 'fit']
+    assert animation, 'Camera setup changed the view animation preference'
+
+
+def test_joint_marker_updates_use_retained_coin_fields():
+    values = []
+    class UncachedTransform:
+        def __getattr__(self, name):
+            raise AssertionError('Repeated Coin field lookup: ' + name)
+    class Identity:
+        def __mul__(self, placement):
+            return placement
+    marker = SimpleNamespace(transform=UncachedTransform(),
+        _translation=SimpleNamespace(setValue=lambda *args: values.append(('position', args))),
+        _rotation=SimpleNamespace(setValue=lambda *args: values.append(('rotation', args))))
+    update = _method('SoSwitchMarker', 'set_marker_placement', 'SoSwitchMarker.py',
+                     UtilsAssembly=SimpleNamespace(getGlobalPlacement=lambda ref: Identity()))
+    placement = SimpleNamespace(Base=SimpleNamespace(x=1, y=2, z=3),
+                                Rotation=SimpleNamespace(Q=(0, 0, 0, 1)))
+    update(marker, placement, None)
+    assert values == [('position', (1, 2, 3)), ('rotation', (0, 0, 0, 1))]
+
+
+def _playback_controls(**namespace):
+    source = Path(__file__).resolve().parents[2] / 'Assembly' / 'CommandCreateSimulation.py'
+    names = {'findSimulationPlayback', 'controlSimulationPlaybackAsync', '_simulationTaskDialog',
+             '_simulationRequestedFrame', '_simulationFrameTime', 'openSimulationAsync'}
+    methods = [node for node in ast.parse(source.read_text(encoding='utf-8')).body
+               if isinstance(node, ast.FunctionDef) and node.name in names]
+    namespace['Future'] = Future
+    exec(compile(ast.Module(body=methods, type_ignores=[]), str(source), 'exec'), namespace)
+    assert names <= namespace.keys(), 'Exact-player reuse helpers are missing'
+    return namespace
+
+
+def test_async_open_completes_when_generation_already_presented_the_last_frame():
+    calls = []
+    simulation = object()
+    panel = SimpleNamespace(
+        generationFinished=_Signal(), frameFinished=_Signal(), playbackClosed=_Signal(),
+        rejectPlaybackRequested=_Signal(), generation_error='', frame_error='',
+        assembly=SimpleNamespace(numberOfFrames=lambda: 6),
+        form=SimpleNamespace(frameSlider=SimpleNamespace(value=lambda: 5)),
+        runKinematicsAsync=lambda: panel.generationFinished.emit(True),
+        setFrameValue=lambda frame: calls.append(('frame', frame)),
+        animationTimerStartForward=lambda: calls.append('play'),
+        graphics_frame_active=True,
+    )
+    dialog = object()
+    controls = _playback_controls(
+        openSimulation=lambda *args, **kwargs: panel,
+        Gui=SimpleNamespace(
+            Control=SimpleNamespace(activeTaskDialog=lambda: dialog)
+        ),
+    )
+    result = controls['openSimulationAsync'](simulation, autoplay=True)
+    assert result.done()
+    assert result.result() is panel
+    assert calls == ['play']
+
+
+def test_player_control_waits_for_seek_before_play_and_preserves_player_on_failure():
+    calls = []
+    pending = Future()
+    panel = SimpleNamespace(
+        simFeaturePy=SimpleNamespace(aTimeStart=SimpleNamespace(Value=0),
+                                     cTimeStepOutput=SimpleNamespace(Value=0.1)),
+        assembly=SimpleNamespace(numberOfFrames=lambda: 22),
+        form=SimpleNamespace(frameSlider=SimpleNamespace(value=lambda: 21)),
+        requestFrameAsync=lambda frame: calls.append(frame) or pending,
+        animationTimerStartForward=lambda: calls.append('play'),
+    )
+    control = _playback_controls()['controlSimulationPlaybackAsync']
+    result = control(panel, time_seconds=1.0, autoplay=True)
+    assert calls == [11] and not result.done()
+    pending.set_result(11)
+    assert result.result() is panel and calls == [11, 'play']
+    pending = Future()
+    result = control(panel, time_seconds=0.0, autoplay=True)
+    pending.set_exception(RuntimeError('edited inputs'))
+    with pytest.raises(RuntimeError, match='edited inputs'):
+        result.result()
+    assert calls == [11, 'play', 1]
+    pending = Future()
+    result = control(panel, time_seconds=0.2)
+    result.cancel()
+    assert pending.cancelled()
+
+
+def test_active_player_lookup_requires_exact_dialog_objects_and_presentation():
+    simulation, presentation, hidden, form = object(), object(), object(), object()
+    panel = SimpleNamespace(simFeaturePy=simulation, form=form, _ownsLiveTaskContext=lambda: True)
+    binding = (lambda: panel, presentation, (hidden,), 'front')
+    namespace = _playback_controls(
+        _simulationPlayback=binding,
+        Gui=SimpleNamespace(Control=SimpleNamespace(activeTaskDialog=lambda:
+            SimpleNamespace(getDialogContent=lambda: [form]))))
+    find = namespace['findSimulationPlayback']
+    args = dict(presentation=presentation, hidden_components=[hidden], camera='front')
+    assert find(simulation, **args) is panel
+    assert find(object(), **args) is None
+    assert find(simulation, **dict(args, camera='top')) is None
+    assert find(simulation, **dict(args, hidden_components=[object()])) is None
+    panel._ownsLiveTaskContext = lambda: False
+    assert find(simulation, **args) is None
+    panel._ownsLiveTaskContext = lambda: True
+    namespace['Gui'].Control.activeTaskDialog = lambda: SimpleNamespace(getDialogContent=lambda: [
+        SimpleNamespace(isAncestorOf=lambda widget: False)])
+    assert find(simulation, **args) is None
+
+
+def test_cancellation_uses_hosted_form_not_transient_native_wrapper():
+    calls = []
+    form = object()
+    panel = SimpleNamespace(form=form, _closing=False)
+    current = SimpleNamespace(getDialogContent=lambda: [form],
+                              reject=lambda: calls.append('reject'))
+    namespace = _playback_controls(
+        Gui=SimpleNamespace(Control=SimpleNamespace(activeTaskDialog=lambda: current)))
+    cancel = _method('TaskAssemblyCreateSimulation', '_rejectOwnedPlayback',
+                     filename='CommandCreateSimulation.py',
+                     QtCore=SimpleNamespace(Slot=lambda *a: lambda function: function),
+                     _simulationTaskDialog=namespace['_simulationTaskDialog'])
+    cancel(panel, object())  # same native task, a different Python wrapper
+    assert calls == ['reject']
+    current.getDialogContent = lambda: []  # a replacement task must be untouched
+    cancel(panel, object())
+    assert calls == ['reject']
+
+
+def _async_open_fixture():
+    source = Path(__file__).resolve().parents[2] / 'Assembly' / 'CommandCreateSimulation.py'
+    tree = ast.parse(source.read_text(encoding='utf-8'))
+    methods = [node for node in tree.body if isinstance(node, ast.FunctionDef)
+               and node.name in {'openSimulationAsync', '_simulationFrameTime', '_simulationRequestedFrame'}]
+    calls = []
+    dialog = object()
+    simulation = SimpleNamespace(aTimeStart=SimpleNamespace(Value=0), cTimeStepOutput=SimpleNamespace(Value=0.1))
+    panel = SimpleNamespace(
+        generationFinished=_Signal(), frameFinished=_Signal(), playbackClosed=_Signal(),
+        rejectPlaybackRequested=_Signal(), generation_error='', frame_error='',
+        assembly=SimpleNamespace(numberOfFrames=lambda: 22),
+        runKinematicsAsync=lambda: calls.append('generate'),
+        setFrameValue=lambda frame: calls.append(('frame', frame)),
+        onFrameChanged=lambda frame: calls.append(('request', frame)),
+        animationTimerStartForward=lambda: calls.append('play'),
+        form=SimpleNamespace(frameSlider=SimpleNamespace(value=lambda: 21)),
+    )
+    def reject(owner):
+        calls.append(('reject', owner))
+        panel.playbackClosed.emit()
+    panel.rejectPlaybackRequested.connect(reject)
+    namespace = dict(Future=Future, openSimulation=lambda *a, **kw: panel,
+                     Gui=SimpleNamespace(Control=SimpleNamespace(activeTaskDialog=lambda: dialog)))
+    exec(compile(ast.Module(body=methods, type_ignores=[]), str(source), 'exec'), namespace)
+    assert 'openSimulationAsync' in namespace, 'Nonblocking simulation opener is missing'
+    return namespace['openSimulationAsync'], simulation, panel, dialog, calls
+
+
+def test_async_player_launch_waits_for_exact_displayed_frame():
+    launch, simulation, panel, _, calls = _async_open_fixture()
+    result = launch(simulation, time_seconds=0.2, autoplay=True)
+    assert calls == ['generate'] and not result.done()
+    panel.generationFinished.emit(True)
+    assert calls == ['generate', ('frame', 3)] and not result.done()
+    panel.frameFinished.emit(21, True)
+    assert not result.done()
+    panel.frameFinished.emit(3, True)
+    assert result.result() is panel and calls[-1] == 'play'
+    assert not panel.generationFinished.callbacks and not panel.frameFinished.callbacks
+    assert not panel.playbackClosed.callbacks
+
+
+@pytest.mark.parametrize('failure', ['generation', 'frame', 'closed', 'cancel'])
+def test_async_player_launch_terminates_on_failure_or_close(failure):
+    launch, simulation, panel, dialog, calls = _async_open_fixture()
+    result = launch(simulation, time_seconds=0.2)
+    if failure == 'generation':
+        panel.generation_error = 'invalid motion'
+        panel.generationFinished.emit(False)
+    elif failure == 'frame':
+        panel.generationFinished.emit(True)
+        panel.frame_error = 'stale inputs'
+        panel.frameFinished.emit(3, False)
+    elif failure == 'closed':
+        panel.playbackClosed.emit()
+    else:
+        result.cancel()
+    assert result.done()
+    if failure != 'cancel':
+        with pytest.raises(RuntimeError):
+            result.result()
+    if failure != 'closed':
+        assert ('reject', dialog) in calls
+    assert not panel.generationFinished.callbacks and not panel.frameFinished.callbacks
+    assert not panel.playbackClosed.callbacks
+
+
+def test_exact_frame_future_waits_for_adoption_and_reports_interruption():
+    calls = []
+    class Slider:
+        def blockSignals(self, blocked):
+            return False
+        def setValue(self, frame):
+            calls.append(('slider', frame))
+    panel = SimpleNamespace(
+        _ownsLiveTaskContext=lambda: True, background_frames=True, frame_request=None,
+        assembly=SimpleNamespace(numberOfFrames=lambda: 22), frame_error='',
+        frameFinished=_Signal(), playbackClosed=_Signal(), cancelFrameRequested=_Signal(),
+        stopAnimation=lambda: calls.append('stop'), _cancelPendingFrame=lambda: None,
+        form=SimpleNamespace(frameSlider=Slider()),
+    )
+    def request(frame):
+        calls.append(('request', frame))
+        panel.frame_request = 88
+    panel.onFrameChanged = request
+    seek = _method('TaskAssemblyCreateSimulation', 'requestFrameAsync',
+                   filename='CommandCreateSimulation.py', Future=Future)
+    result = seek(panel, 3)
+    assert not result.done() and calls[-1] == ('request', 3)
+    panel.frameFinished.emit(3, True)
+    assert result.result() == 3 and not panel.frameFinished.callbacks
+    result = seek(panel, 4)
+    panel.frame_error = 'superseded'
+    panel.frameFinished.emit(4, False)
+    with pytest.raises(RuntimeError, match='superseded'):
+        result.result()
+    result = seek(panel, 5)
+    panel.playbackClosed.emit()
+    with pytest.raises(RuntimeError, match='closed'):
+        result.result()
+    with pytest.raises(RuntimeError, match='out of range'):
+        seek(panel, 0)
+    calls.clear()
+    result = seek(panel, 0, include_input=True)
+    assert ('slider', 0) not in calls
+    panel.frameFinished.emit(0, True)
+    assert result.result() == 0
+
+
+def test_provider_cancellation_reaches_qt_owner_without_cross_thread_cleanup():
+    from PySide6 import QtCore
+
+    app = QtCore.QCoreApplication.instance() or QtCore.QCoreApplication([])
+    launch, simulation, panel, dialog, _ = _async_open_fixture()
+    observed = []
+    owner_thread = threading.get_ident()
+
+    class Owner(QtCore.QObject):
+        reject = QtCore.Signal(object)
+
+        @QtCore.Slot(object)
+        def rejected(self, exact_dialog):
+            observed.append((threading.get_ident(), exact_dialog))
+            panel.playbackClosed.emit()
+
+    owner = Owner()
+    owner.reject.connect(owner.rejected)
+    panel.rejectPlaybackRequested = owner.reject
+    result = launch(simulation, time_seconds=0.2)
+    thread = threading.Thread(target=result.cancel)
+    thread.start()
+    thread.join(timeout=2)
+    assert not thread.is_alive() and result.cancelled()
+    assert observed == [] and panel.playbackClosed.callbacks
+    app.processEvents()
+    assert observed == [(owner_thread, dialog)]
+    assert not panel.playbackClosed.callbacks and not panel.frameFinished.callbacks
+
+
+def test_joint_owner_is_reused_until_native_structure_changes():
+    calls = []
+    owner = SimpleNamespace(Name='Assembly', ID=4)
+    document = SimpleNamespace(Uid='doc', generation=1)
+    document.getObjectStructureGeneration = lambda: document.generation
+    document.getObject = lambda name: owner if name == owner.Name else None
+    joint = SimpleNamespace(Document=document, ID=8)
+    utils = SimpleNamespace(_document_is_open=lambda doc: doc is document,
+        findOwningPartOrAssembly=lambda obj: calls.append(obj) or owner)
+    get_owner = _method('Joint', 'getAssembly', UtilsAssembly=utils)
+    proxy = SimpleNamespace()
+    for _ in range(100):
+        assert get_owner(proxy, joint) is owner
+    assert len(calls) == 1
+    document.generation += 1
+    assert get_owner(proxy, joint) is owner
+    assert len(calls) == 2
+    # A replaced target must not be confused with a saved object identity.
+    owner.ID += 1
+    assert get_owner(proxy, joint) is owner
+    assert len(calls) == 3
+
+
+def test_hidden_joint_markers_are_deferred_and_refreshed_on_show():
+    calls = []
+    joint = SimpleNamespace(Reference1='one', Reference2='two',
+                            Placement1=1, Placement2=2)
+    joint.ViewObject = SimpleNamespace(Visibility=False, Object=joint)
+    proxy = SimpleNamespace(switch_JCS1=1, switch_JCS2=2,
+        redrawJointPlacement=lambda *args: calls.append(args))
+    redraw = _method('ViewProviderJoint', 'redrawJointPlacements')
+    proxy.redrawJointPlacements = lambda obj: redraw(proxy, obj)
+    redraw(proxy, joint)
+    assert calls == []
+    joint.Placement1 = 3
+    joint.ViewObject.Visibility = True
+    changed = _method('ViewProviderJoint', 'onChanged')
+    changed(proxy, joint.ViewObject, 'Visibility')
+    assert calls == [(1, 3, 'one'), (2, 2, 'two')]
+
+
+def test_hidden_joint_property_changes_do_not_prepare_markers():
+    calls = []
+    joint = SimpleNamespace(ViewObject=SimpleNamespace(Visibility=False),
+                            Placement1=1, Reference1='one')
+    proxy = SimpleNamespace(switch_JCS1=1, redrawJointPlacement=lambda *args: calls.append(args))
+    update = _method('ViewProviderJoint', 'updateData')
+    update(proxy, joint, 'Placement1')
+    assert calls == []
+
+
+@pytest.mark.parametrize('prop', ['Label', 'Visibility', 'Placement1', 'Placement2',
+    'VibeCADVibeScriptDefinition', 'VibeCADProgramRevision', 'VibeCADTimelineRole',
+    'VibeCADTimelineOwner', '_GroupTouched'])
+def test_unhandled_joint_changes_do_not_resolve_history_or_assembly(prop):
+    changed = _method('Joint', 'onChanged',
+        App=SimpleNamespace(isRestoring=lambda: pytest.fail('Unrelated joint change queried application')))
+    changed(object(), object(), prop)
+
+
+@pytest.mark.parametrize('prop', ['Label', 'Visibility', 'Reference1', 'JointType',
+                                  'VibeCADVibeScriptDefinition'])
+def test_unhandled_joint_view_changes_do_not_resolve_gui_objects(prop):
+    update = _method('ViewProviderJoint', 'updateData')
+    update(object(), object(), prop)
+
+
+@pytest.mark.parametrize('prop,joint_type,expected', [
+    ('JointType', 'Angle', []),
+    ('Reference1', 'Fixed', ['recompute']),
+    ('Reference2', 'Fixed', ['recompute']),
+    ('Offset1', 'Fixed', ['owner', 'placements', 'solve']),
+    ('Offset2', 'Fixed', ['owner', 'placements', 'solve']),
+    ('Distance', 'Distance', ['owner', 'solve']),
+    ('Angle', 'Angle', ['owner', 'prevent_parallel', 'solve']),
+])
+def test_handled_joint_changes_preserve_edit_actions(prop, joint_type, expected):
+    calls = []
+    joint = SimpleNamespace(Document=SimpleNamespace(Transacting=False),
+        Reference1=object(), Reference2=object(), JointType=joint_type, Angle=30,
+        Label='Fixed joint', recompute=lambda: calls.append('recompute'))
+    assembly = SimpleNamespace(Type='Assembly')
+    proxy = SimpleNamespace(
+        getAssembly=lambda obj: calls.append('owner') or assembly,
+        updateJCSPlacements=lambda obj: calls.append('placements'),
+        preventParallel=lambda obj: calls.append('prevent_parallel'))
+    changed = _method('Joint', 'onChanged',
+        App=SimpleNamespace(isRestoring=lambda: False),
+        _jointInteractionUsable=lambda obj: True,
+        JointTypes=['Fixed', 'Angle', 'Distance'],
+        TranslatedJointTypes=['Fixed', 'Angle', 'Distance'], JointUsingPreSolve=[],
+        solveIfAllowed=lambda obj: calls.append('solve'))
+    changed(proxy, joint, prop)
+    assert calls == expected
+    assert joint.Label == ('Angle joint' if prop == 'JointType' else 'Fixed joint')
+
+
+def _presentation_scope():
+    source = Path(__file__).resolve().parents[2] / 'Assembly' / 'UtilsAssembly.py'
+    tree = ast.parse(source.read_text(encoding='utf-8'))
+    names = {'presentationPlacementChanges', 'isPresentationPlacementChange'}
+    methods = [node for node in tree.body if isinstance(node, ast.FunctionDef) and node.name in names]
+    assert len(methods) == 2, 'Shared transient placement scope is missing'
+    namespace = dict(contextmanager=contextmanager, _presentation_changes=threading.local())
+    exec(compile(ast.Module(body=methods, type_ignores=[]), str(source), 'exec'), namespace)
+    return namespace['presentationPlacementChanges'], namespace['isPresentationPlacementChange']
+
+
+def test_transient_placement_scope_is_exact_nested_and_thread_local():
+    scope, is_transient = _presentation_scope()
+    document = object()
+    part = SimpleNamespace(Document=document, ID=4)
+    other = SimpleNamespace(Document=document, ID=5)
+    foreign = SimpleNamespace(Document=object(), ID=4)
+    assert not is_transient(part, 'Placement')
+    observed = []
+    with scope(document, frozenset({4})):
+        assert is_transient(part, 'Placement')
+        assert is_transient(part, 'LinkPlacement')
+        assert not is_transient(part, 'Shape')
+        assert not is_transient(other, 'Placement')
+        assert not is_transient(foreign, 'Placement')
+        thread = threading.Thread(target=lambda: observed.append(is_transient(part, 'Placement')))
+        thread.start()
+        thread.join()
+        try:
+            with scope(document, frozenset({5})):
+                assert is_transient(other, 'Placement')
+                assert not is_transient(part, 'Placement')
+                raise ValueError('cancel frame')
+        except ValueError:
+            pass
+        assert is_transient(part, 'Placement')
+    assert observed == [False]
+    assert not is_transient(part, 'Placement')
+
+
+def test_transient_placement_scope_restores_native_flag_after_exception():
+    scope, _ = _presentation_scope()
+    assembly = SimpleNamespace(active=False)
+    def set_active(active):
+        old, assembly.active = assembly.active, active
+        return old
+    assembly.setSimulationPresentation = set_active
+    try:
+        with scope(object(), frozenset(), assembly):
+            assert assembly.active
+            with scope(object(), frozenset(), assembly):
+                raise ValueError('interrupted presentation')
+    except ValueError:
+        pass
+    assert not assembly.active
+
+
+def test_generate_button_submits_without_waiting_for_solver():
+    calls = []
+    panel = SimpleNamespace(
+        _ownsLiveTaskContext=lambda: True, generation_state='idle',
+        _cancelPendingFrame=lambda: None,
+        presentation=None, simFeaturePy=object(), playback_only=False,
+        animationTimer=SimpleNamespace(stop=lambda: calls.append('stop playback')),
+        generationTimer=SimpleNamespace(start=lambda: calls.append('watch completion')),
+        assembly=SimpleNamespace(startSimulation=lambda sim: calls.append('submit') or 42),
+        _setGenerationState=lambda state, error='': calls.append(state),
+    )
+    generate = _method('TaskAssemblyCreateSimulation', 'runKinematicsAsync',
+                       filename='CommandCreateSimulation.py')
+    generate(panel)
+    assert calls == ['stop playback', 'running', 'submit', 'watch completion']
+    assert panel.generation_request == 42
+
+
+def test_player_cancellation_addresses_only_its_own_request():
+    calls = []
+    assembly = SimpleNamespace(ID=7, cancelSimulation=lambda request: calls.append(request))
+    document = SimpleNamespace(getObject=lambda name: assembly)
+    panel = SimpleNamespace(
+        generation_request=42, generation_state='running', doc=document,
+        assembly_identity=('Assembly', 7, assembly), form=None,
+        generationTimer=SimpleNamespace(stop=lambda: None),
+        generationFinished=SimpleNamespace(emit=lambda result: None),
+    )
+    cancel = _method('TaskAssemblyCreateSimulation', 'cancelGeneration',
+                     filename='CommandCreateSimulation.py',
+                     UtilsAssembly=SimpleNamespace(_document_is_open=lambda doc: True))
+    cancel(panel)
+    assert calls == [42]
+    assert panel.generation_request is None
+
+
+def test_save_resume_uses_one_transient_frame_application_even_if_slider_changes():
+    calls = []
+    class Slider:
+        blocked = False
+        def blockSignals(self, blocked):
+            old, self.blocked = self.blocked, blocked
+            return old
+        def setValue(self, frame):
+            if not self.blocked:
+                calls.append(('slider callback', frame))
+    document = object()
+    panel = SimpleNamespace(
+        doc=document, _save_playback_state=(3, False, 1),
+        _ownsLiveTaskContext=lambda: True, _activatePlaybackPresentation=lambda: None,
+        assembly=SimpleNamespace(numberOfFrames=lambda: 5),
+        onFrameChanged=lambda frame: calls.append(('transient frame', frame)),
+        form=SimpleNamespace(frameSlider=Slider()), gui_doc=SimpleNamespace(Modified=True),
+    )
+    resume = _method('TaskAssemblyCreateSimulation', 'slotFinishSaveDocument',
+                     filename='CommandCreateSimulation.py')
+    resume(panel, document, 'unused')
+    assert calls == [('transient frame', 3)]
+    assert not panel.form.frameSlider.blocked
+    assert not panel.gui_doc.Modified
+
+
+def test_interactive_frame_request_does_not_apply_or_wait():
+    calls = []
+    panel = SimpleNamespace(
+        _ownsLiveTaskContext=lambda: True, background_frames=True,
+        presentation=object(),
+        _cancelPendingFrame=lambda: None,
+        assembly=SimpleNamespace(requestSimulationFrame=lambda frame: calls.append(('request', frame)) or 71),
+        frameTimer=SimpleNamespace(start=lambda: calls.append(('watch',))),
+    )
+    change = _method('TaskAssemblyCreateSimulation', 'onFrameChanged', filename='CommandCreateSimulation.py')
+    change(panel, 12)
+    assert calls == [('request', 12), ('watch',)]
+    assert panel.frame_request == 71 and panel.requested_frame == 12
+
+
+def test_interactive_frame_request_applies_cached_graphics_without_worker_polling():
+    calls = []
+    placement = SimpleNamespace(toMatrix=lambda: 'frame matrix')
+    panel = SimpleNamespace(
+        _ownsLiveTaskContext=lambda: True,
+        background_frames=True,
+        presentation=None,
+        assembly=SimpleNamespace(
+            getSimulationFrame=lambda frame: [('AnimatedLink', placement)]
+        ),
+        gui_doc=SimpleNamespace(
+            setPos=lambda name, matrix: calls.append(('transform', name, matrix))
+        ),
+        frameTimer=SimpleNamespace(start=lambda: calls.append('poll')),
+        _cancelPendingFrame=lambda: calls.append('cancel'),
+        _showFrameStatus=lambda frame: calls.append(('frame', frame)),
+        frameFinished=SimpleNamespace(
+            emit=lambda frame, ok: calls.append(('finished', frame, ok))
+        ),
+        _frameFailed=lambda error: calls.append(('failed', str(error))),
+        frame_request=None,
+    )
+    change = _method(
+        'TaskAssemblyCreateSimulation',
+        'onFrameChanged',
+        filename='CommandCreateSimulation.py',
+    )
+    change(panel, 12)
+    assert calls == [
+        ('transform', 'AnimatedLink', 'frame matrix'),
+        ('frame', 12),
+        ('finished', 12, True),
+    ]
+    assert panel.graphics_frame_active
+    assert panel.frame_request is None
+
+
+def test_frame_completion_updates_presentation_only_when_ready():
+    calls = []
+    scope, _ = _presentation_scope()
+    ready = [False, True]
+    panel = SimpleNamespace(
+        _ownsLiveTaskContext=lambda: True, frame_request=71, requested_frame=12,
+        doc=object(), playback_part_ids=frozenset(),
+        presentation=object(),
+        assembly=SimpleNamespace(finishSimulationFrame=lambda token: ready.pop(0),
+                                 setSimulationPresentation=lambda active: False),
+        frameTimer=SimpleNamespace(stop=lambda: calls.append('stop')),
+        _applyPlaybackPresentation=lambda: calls.append('presentation'),
+        _showFrameStatus=lambda frame: calls.append(('frame', frame)),
+        frameFinished=SimpleNamespace(emit=lambda frame, ok: calls.append(('finished', frame, ok))),
+    )
+    finish = _method('TaskAssemblyCreateSimulation', '_finishFrame', filename='CommandCreateSimulation.py',
+                     UtilsAssembly=SimpleNamespace(presentationPlacementChanges=scope))
+    finish(panel)
+    assert calls == [] and panel.frame_request == 71
+    finish(panel)
+    assert calls == ['presentation', 'stop', ('frame', 12), ('finished', 12, True)]
+    assert panel.frame_request is None
+
+
+def test_interactive_frame_completion_updates_only_graphics_when_ready():
+    calls = []
+    scope, _ = _presentation_scope()
+    ready = [None, [('AnimatedLink', SimpleNamespace(toMatrix=lambda: 'frame matrix'))]]
+    panel = SimpleNamespace(
+        _ownsLiveTaskContext=lambda: True, frame_request=71, requested_frame=12,
+        presentation=None, doc=object(), playback_part_ids=frozenset(),
+        assembly=SimpleNamespace(
+            takeSimulationFrame=lambda token: ready.pop(0),
+            finishSimulationFrame=lambda token: calls.append('document placements') or False,
+            setSimulationPresentation=lambda active: False,
+        ),
+        gui_doc=SimpleNamespace(
+            setPos=lambda name, matrix: calls.append(('transform', name, matrix))
+        ),
+        frameTimer=SimpleNamespace(stop=lambda: calls.append('stop')),
+        _showFrameStatus=lambda frame: calls.append(('frame', frame)),
+        frameFinished=SimpleNamespace(
+            emit=lambda frame, ok: calls.append(('finished', frame, ok))
+        ),
+        _frameFailed=lambda error: calls.append(('failed', str(error))),
+    )
+    finish = _method(
+        'TaskAssemblyCreateSimulation',
+        '_finishFrame',
+        filename='CommandCreateSimulation.py',
+        UtilsAssembly=SimpleNamespace(presentationPlacementChanges=scope),
+    )
+    finish(panel)
+    assert calls == [] and panel.frame_request == 71
+    finish(panel)
+    assert calls == [
+        ('transform', 'AnimatedLink', 'frame matrix'),
+        'stop',
+        ('frame', 12),
+        ('finished', 12, True),
+    ]
+    assert panel.frame_request is None
+
+
+def test_graphics_only_frame_restores_the_live_document_placement():
+    calls = []
+    placement = SimpleNamespace(toMatrix=lambda: 'document matrix')
+    component = SimpleNamespace(Name='AnimatedLink', ID=9, Placement=placement)
+    document = SimpleNamespace(getObject=lambda name: component)
+    panel = SimpleNamespace(
+        graphics_frame_active=True,
+        doc=document,
+        gui_doc=SimpleNamespace(
+            setPos=lambda name, matrix: calls.append((name, matrix))
+        ),
+        initialPlcs=SimpleNamespace(
+            parts=[('AnimatedLink', 9, component, object())]
+        ),
+    )
+    restore = _method(
+        'TaskAssemblyCreateSimulation',
+        '_restoreSimulationGraphics',
+        filename='CommandCreateSimulation.py',
+        UtilsAssembly=SimpleNamespace(_document_is_open=lambda doc: True),
+    )
+    restore(panel)
+    assert calls == [('AnimatedLink', 'document matrix')]
+    assert not panel.graphics_frame_active
+
+
+def test_playback_drops_ticks_while_a_frame_is_pending():
+    calls = []
+    panel = SimpleNamespace(
+        form=object(), _ownsLiveTaskContext=lambda: True,
+        animationTimer=SimpleNamespace(
+            stop=lambda: calls.append('stop'),
+            start=lambda delay: calls.append(('start', delay)),
+        ),
+        startFrm=1, endFrm=21, currentFrm=1, direction=1,
+        startTime=0.0, lastFrameTime=0.0, deltaTime=0.1,
+        background_frames=True, frame_request=71,
+        setFrameValue=lambda frame: calls.append(('request', frame)),
+    )
+    play = _method(
+        'TaskAssemblyCreateSimulation',
+        'playAnimation',
+        filename='CommandCreateSimulation.py',
+        time=SimpleNamespace(time=lambda: 0.35, perf_counter=lambda: 1.0),
+    )
+    play(panel)
+    assert calls == []
+
+
+def test_playback_advances_one_frame_without_elapsed_time_catch_up():
+    calls = []
+    class Slider:
+        def value(self):
+            return 3
+        def maximum(self):
+            return 20
+    panel = SimpleNamespace(
+        form=SimpleNamespace(frameSlider=Slider()), _ownsLiveTaskContext=lambda: True,
+        animationTimer=SimpleNamespace(
+            stop=lambda: calls.append('stop'),
+            start=lambda delay: calls.append(('start', delay)),
+        ),
+        startFrm=1, endFrm=20, currentFrm=1, direction=1,
+        startTime=0.0, lastFrameTime=0.0, deltaTime=0.1,
+        background_frames=True, frame_request=None,
+        setFrameValue=lambda frame: calls.append(frame),
+    )
+    play = _method(
+        'TaskAssemblyCreateSimulation',
+        'playAnimation',
+        filename='CommandCreateSimulation.py',
+        time=SimpleNamespace(time=lambda: 1000.0, perf_counter=lambda: 1.0),
+    )
+    play(panel)
+    assert calls == [4]
+
+
+def test_playback_pacing_drops_an_early_catch_up_tick():
+    calls = []
+    clock = iter([10.005, 10.017, 10.021])
+    panel = SimpleNamespace(
+        form=SimpleNamespace(frameSlider=SimpleNamespace(value=lambda: 3)),
+        _ownsLiveTaskContext=lambda: True,
+        animationTimer=SimpleNamespace(
+            stop=lambda: calls.append('stop'),
+            start=lambda delay: calls.append(('start', delay)),
+        ),
+        startFrm=1, endFrm=20, currentFrm=1, direction=1,
+        deltaTime=1.0 / 60.0, lastFrameTime=10.0,
+        background_frames=True, frame_request=None,
+        setFrameValue=lambda frame: calls.append(('frame', frame)),
+    )
+    play = _method(
+        'TaskAssemblyCreateSimulation',
+        'playAnimation',
+        filename='CommandCreateSimulation.py',
+        time=SimpleNamespace(perf_counter=lambda: next(clock)),
+    )
+    play(panel)
+    assert calls == []
+    play(panel)
+    assert calls == [('frame', 4)]
+    assert panel.lastFrameTime == 10.021
+
+
+def test_regeneration_requests_last_frame_even_when_slider_did_not_move():
+    calls = []
+    class Slider:
+        blocked = False
+        def blockSignals(self, active):
+            previous, self.blocked = self.blocked, active
+            return previous
+        def setMaximum(self, value):
+            assert self.blocked
+        def setValue(self, value):
+            assert self.blocked
+    slider = Slider()
+    panel = SimpleNamespace(
+        _ownsLiveTaskContext=lambda: True, generation_request=3, frame_error='',
+        assembly=SimpleNamespace(finishSimulation=lambda token: True, numberOfFrames=lambda: 22),
+        generationTimer=SimpleNamespace(stop=lambda: None),
+        form=SimpleNamespace(frameSlider=slider, groupBox_player=SimpleNamespace(show=lambda: None),
+                             SaveAnimationButton=SimpleNamespace(show=lambda: None)),
+        onFrameChanged=lambda frame: calls.append(frame),
+        _setGenerationState=lambda *args: None,
+        generationFinished=SimpleNamespace(emit=lambda result: calls.append(result)),
+    )
+    finish = _method('TaskAssemblyCreateSimulation', '_finishKinematicsAsync', filename='CommandCreateSimulation.py')
+    finish(panel)
+    assert calls == [21, True] and panel.background_frames
+    assert not slider.blocked

--- a/src/Mod/VibeCAD/vibecad_tests/test_source_context_paging.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_source_context_paging.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import copy
+import json
+from types import SimpleNamespace
+
+import pytest
+
+import VibeCADSession as session
+import VibeCADVibeScriptDomains as domains
+
+
+def inventory(count=45):
+    sources = [
+        {"program": f"Robot/assembly/Module{i:03}", "label": f"Module{i:03}",
+         "domain": "assembly", "status": "accepted", "current_revision": "a" * 64,
+         "affected_outputs": [{"name": f"part{j}", "object_name": f"Body{j}",
+                               "type_id": "PartDesign::Body", "visible": False}
+                              for j in range(10000)] if i == 0 else []}
+        for i in range(count)
+    ]
+    return {"schema": "vibecad-editable-sources-v1", "domain": "assembly",
+            "source_count": count, "sources": sources, "all_sources": sources,
+            "all_source_count": count}
+
+
+def test_large_document_context_is_a_small_discoverable_index():
+    context = {"editable_sources": inventory()}
+    before = copy.deepcopy(context)
+    prompt = session._provider_prompt("Inspect the robot", context)
+    state = json.JSONDecoder().raw_decode(prompt.split("\n", 1)[1])[0]["active_state"]
+    index = state["editable_sources"]["program_index"]
+    assert index["program_count"] == 45
+    assert len(index["programs"]) == 20
+    assert index["next_read"]["arguments"]["offset"] == 20
+    assert index["programs"][0]["output_count"] == 10000
+    assert "all_sources" not in state["editable_sources"]
+    assert len(prompt.encode()) < 16000
+    assert context == before
+
+
+def test_pages_cover_every_program_once_and_search_preserves_identity():
+    data = inventory()
+    programs = []
+    args = {"offset": 0, "limit": 7}
+    while args is not None:
+        page = session._paged_source_index_payload(data, **args)
+        programs.extend(p["program"] for p in page["programs"])
+        args = page["next_read"]["arguments"] if page["next_read"] else None
+    assert len(programs) == len(set(programs)) == 45
+    page = session._paged_source_index_payload(data, query="module044")
+    assert page["programs"][0]["program"] == "Robot/assembly/Module044"
+    assert page["programs"][0]["current_revision"] == "a" * 64
+    assert page["matched_count"] == 1
+    assert not session._paged_source_index_payload(data, query="absent")["programs"]
+
+
+def test_cross_domain_sources_remain_discoverable_when_active_domain_empty():
+    data = inventory(1)
+    data.update(source_count=0, sources=[], domain="partdesign")
+    result = session._provider_editable_sources_payload(data)
+    assert result["program_index"]["program_count"] == 1
+
+
+def test_read_source_schema_exposes_optional_index_pagination():
+    spec = next(s for s in domains.universal_tool_specs() if s["name"] == "vibescript.read_source")
+    assert {"offset", "limit", "query"} <= set(spec["parameters"]["properties"])
+    assert not spec["parameters"]["required"]
+
+
+def test_source_search_uses_provider_session_adapter_without_document_scan():
+    result = session._run_universal_vibescript_tool(
+        SimpleNamespace(), "AssemblyWorkbench", "vibescript.read_source",
+        {"query": "Module044", "limit": 1, "offset": 0},
+        editable_sources=inventory(), document_thread_dispatch=None,
+        cancellation_check=None, progress_callback=None,
+    )
+    assert result["ok"] is True
+    assert result["programs"][0]["program"] == "Robot/assembly/Module044"
+
+
+@pytest.mark.parametrize("args", [{"offset": -1}, {"limit": 0}, {"limit": 101}])
+def test_invalid_page_arguments_are_rejected(args):
+    with pytest.raises(ValueError):
+        session._paged_source_index_payload({}, **args)

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_definition_size.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_definition_size.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Definition validity must not depend on an arbitrary serialized byte quota."""
+
+import importlib
+import json
+
+import pytest
+
+from vibescript_domain_api import DomainValue
+from vibescript_domain_worker import _payload
+
+
+ENCODERS = ("fem", "meshpart", "cam", "inspection", "reverse_engineering",
+            "robot", "techdraw", "points")
+
+
+def test_shared_output_accepts_large_nested_definition():
+    child = DomainValue("part", "box", "solid", (1, 2, 3), {"label": "x" * 4096})
+    value = DomainValue("part", "compound", "compound", (tuple([child] * 300),), {})
+    expected = value.to_payload()
+    assert len(json.dumps(expected)) > 1_000_000
+    assert _payload(value) == expected
+    assert _payload(expected, serialized=True) == expected
+
+
+@pytest.mark.parametrize("domain", ENCODERS)
+def test_domain_encoder_accepts_large_definition(domain):
+    worker = importlib.import_module(f"vibescript_{domain}_worker")
+    value = {"definition": "x" * (4 * 1024 * 1024 + 1)}
+    assert json.loads(worker._encoded(value)) == value
+
+
+@pytest.mark.parametrize("domain", ENCODERS)
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), object()])
+def test_domain_encoder_still_rejects_invalid_json(domain, invalid):
+    worker = importlib.import_module(f"vibescript_{domain}_worker")
+    with pytest.raises(RuntimeError, match="JSON"):
+        worker._encoded({"invalid": invalid})
+
+
+@pytest.mark.parametrize("invalid", [float("nan"), float("inf"), object()])
+def test_shared_output_still_rejects_invalid_json(invalid):
+    with pytest.raises((ValueError, TypeError)):
+        _payload(DomainValue("part", "box", "solid", (invalid,), {}))
+
+
+@pytest.mark.parametrize("domain", ["fem", "cam", "techdraw"])
+def test_explicit_native_readback_limit_is_preserved(domain):
+    worker = importlib.import_module(f"vibescript_{domain}_worker")
+    with pytest.raises(RuntimeError, match="exceeds 10 JSON bytes"):
+        worker._encoded({"readback": "x" * 20}, limit=10)
+
+
+def test_mesh_revalidation_accepts_definition_above_old_ceiling():
+    from vibescript_domain_api import create_domain_api
+    from VibeCADVibeScriptDomains import get_vibescript_pack
+    from vibescript_mesh_worker import validate_mesh_definition
+
+    pack = get_vibescript_pack("MeshWorkbench")
+    api = create_domain_api(pack.domain, pack.api_exports, pack.output_types)
+    triangles = [[[i + 0.123456789, 0, 0], [i + 0.123456789, 1, 0],
+                  [i + 0.123456789, 0, 1]] for i in range(15_000)]
+    value = api.mesh(triangles)
+    assert len(json.dumps(value.to_payload())) > 1_000_000
+    assert validate_mesh_definition(value, require_domain_value=True) == value.to_payload()

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_file_io.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_file_io.py
@@ -178,28 +178,34 @@ def test_worker_result_uses_in_memory_progress_when_status_file_is_locked() -> N
     assert '(root / "progress.json").read_text' not in source
 
 
-def test_domain_execution_renews_its_lease_from_worker_progress(
+def test_domain_execution_uses_persistent_pool_without_a_wall_time_limit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    import VibeCADScriptedProcess as scripted
+    import VibeCADHostIsolation as isolation
     import VibeCADVibeScriptDomainRuntime as runtime
 
     observed: dict[str, object] = {}
 
-    def run_process(_command, **kwargs):
+    def execute_staged_script(**kwargs):
         observed.update(kwargs)
         return {
             "started": True,
-            "returncode": -1,
+            "returncode": 0,
             "cancelled": False,
-            "timed_out": True,
+            "timed_out": False,
             "memory_exceeded": False,
             "cpu_exceeded": False,
-            "timeout_mode": "inactivity",
+            "timeout_mode": "none",
+            "termination_reason": "process_exit",
         }
 
-    monkeypatch.setattr(scripted, "run_process", run_process)
+    monkeypatch.setattr(isolation, "execute_staged_script", execute_staged_script)
+    (tmp_path / "worker.py").touch()
+    (tmp_path / "result.json").write_text(
+        '{"ok":true,"outputs":[]}',
+        encoding="utf-8",
+    )
     prepared = {
         "tool_name": "vibescript.assembly.edit_source",
         "freecadcmd_executable": "FreeCADCmd",
@@ -211,13 +217,7 @@ def test_domain_execution_renews_its_lease_from_worker_progress(
 
     result = runtime.execute_candidate(prepared, cancellation_check=None)
 
-    activity_check = observed["activity_check"]
-    assert callable(activity_check)
-    assert activity_check() is None
-    (tmp_path / "progress.json").write_text('{"frame":1}', encoding="utf-8")
-    first = activity_check()
-    assert first is not None
-    (tmp_path / "progress.json").write_text('{"frame":22}', encoding="utf-8")
-    assert activity_check() != first
-    assert result["failure_code"] == "DOMAIN_EXECUTION_TIMEOUT"
-    assert "made no observable progress for 3600 seconds" in result["error"]
+    assert result["ok"] is True
+    assert observed["script"] == "worker.py"
+    assert observed["memory_limit_bytes"] == 1024
+    assert "timeout_seconds" not in observed

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py
@@ -11,6 +11,32 @@ import pytest
 from VibeCADPublicationProgress import PublicationProgress
 
 
+@pytest.mark.parametrize("kind,data", [
+    ("joint", {"connectors": [{"component_output": "new_input"}]}),
+    ("motion", {"joint_output": "new_input"}),
+    ("simulation", {"motion_outputs": ["new_input"]}),
+])
+def test_assembly_rebases_changed_dependencies_once_per_configuration_phase(kind, data):
+    from VibeCADVibeScriptDomainPublication import _rebase_assembly_configuration_dependencies
+
+    first, second, dependency = (SimpleNamespace(Name=name) for name in ("First", "Second", "NewInput"))
+    calls = []
+    timeline = SimpleNamespace(Operations=[first, second, dependency])
+    document = SimpleNamespace(
+        getObject=lambda name: timeline if name == "VibeCADTimeline" else None,
+        reorderTimelineOperationDependentClosuresAfter=lambda objects, target: calls.append((objects, target)),
+    )
+    items = [dict(name=name, type=kind, assembly_data=data) for name in ("first", "second", "new_output")]
+    existing = {"first": first, "second": second}
+    outputs = {"new_input": dependency}
+    _rebase_assembly_configuration_dependencies(document, kind, items, existing, outputs)
+    assert calls == [([first, second], dependency)]
+    calls.clear()
+    timeline.Operations = [dependency, first, second]
+    _rebase_assembly_configuration_dependencies(document, kind, items, existing, outputs)
+    assert calls == []
+
+
 def test_publication_progress_reports_items_and_bounds_ui_yields() -> None:
     events = []
     yields = []
@@ -161,6 +187,60 @@ def test_publication_holds_document_cooperative_mutation_for_its_full_lifetime(
     ]
 
 
+def test_cooperative_publication_waits_for_native_presentation_before_completion(
+    monkeypatch,
+) -> None:
+    import VibeCADVibeScriptDomainRuntime as runtime
+
+    calls = []
+    events = []
+
+    class Document:
+        Name = "Document"
+        Uid = "document-a"
+
+        @staticmethod
+        def waitForPresentationReady():
+            calls.append("presentation-ready")
+
+    class Service:
+        @staticmethod
+        def _active_document():
+            return Document()
+
+    def publication_steps(*_args, **kwargs):
+        assert kwargs["complete_progress"] is False
+        calls.append("publication")
+        yield {"event": "publication_slice"}
+        return {"ok": True}
+
+    monkeypatch.setattr(runtime, "iter_publish_candidate", publication_steps)
+    adapter = runtime.DeclarativeDomainAdapter(
+        SimpleNamespace(domain="assembly", workbench="Assembly")
+    )
+
+    result = adapter.publish_cooperatively(
+        Service(),
+        {"document_name": "Document", "document_uid": "document-a"},
+        {},
+        document_thread_dispatch=lambda operation: operation(),
+        cancellation_check=lambda: False,
+        progress_callback=events.append,
+    )
+
+    assert result == {"ok": True}
+    assert calls == ["publication", "presentation-ready"]
+    assert events[-1] == {
+        "event": "vibescript_domain_publication_progress",
+        "domain": "assembly",
+        "phase": "completed",
+        "completed": 0,
+        "total": 0,
+        "current_output": "",
+        "output_type": "",
+    }
+
+
 def test_publication_releases_cooperative_mutation_when_batch_setup_fails() -> None:
     from VibeCADVibeScriptDomainPublication import publish_candidate
 
@@ -231,7 +311,11 @@ def test_domain_adapter_cooperatively_dispatches_each_publication_step(
 
     assert result == {"ok": True, "outputs": ["Model"]}
     assert len(dispatches) == 3
-    assert [event["completed"] for event in events] == [1, 2]
+    assert [
+        event["completed"]
+        for event in events
+        if event.get("event") == "publication_slice"
+    ] == [1, 2]
 
 
 def test_large_assembly_publication_dispatches_all_307_members(
@@ -335,6 +419,46 @@ def test_large_assembly_publication_dispatches_all_307_members(
     assert publication_events[-1]["phase"] == "completed"
     assert publication_events[-1]["completed"] == 309
     assert all(event["total"] == 309 for event in publication_events)
+
+
+def test_publication_target_cache_checks_new_targets_and_invalidates_on_removal() -> None:
+    from VibeCADVibeScriptDomainPublication import _assert_publication_document_intact
+
+    objects = {}
+    lookups = []
+    epoch = [0]
+    document = SimpleNamespace(
+        Name="AssemblyDocument", Uid="document-a",
+        getObjectRemovalGeneration=lambda: epoch[0],
+        getObject=lambda name: (lookups.append(name), objects.get(name))[1],
+    )
+    service = SimpleNamespace(_active_document=lambda: document)
+    prepared = {"document_name": document.Name, "document_uid": document.Uid}
+    cache = {}
+    targets = []
+    for index in range(50):
+        obj = SimpleNamespace(Name=f"Member{index}")
+        objects[obj.Name] = obj
+        targets.append(obj)
+        _assert_publication_document_intact(service, prepared, document, targets, cache=cache)
+    assert len(lookups) == 50  # Each exact target crosses the native boundary once.
+
+    # Replacing an entry in the caller's target list must still validate it,
+    # even if its length and the document's removal generation are unchanged.
+    forged = SimpleNamespace(Name=targets[-1].Name)
+    with pytest.raises(RuntimeError, match="changed between publication slices"):
+        _assert_publication_document_intact(
+            service, prepared, document, [forged], cache=cache)
+
+    original = targets[0]
+    objects[original.Name] = SimpleNamespace(Name=original.Name)
+    epoch[0] += 1
+    with pytest.raises(RuntimeError, match="changed between publication slices"):
+        _assert_publication_document_intact(service, prepared, document, targets, cache=cache)
+
+    objects[original.Name] = original
+    _assert_publication_document_intact(service, prepared, document, targets, cache=cache)
+    assert len(lookups) == 102
 
 
 def test_publication_slice_validation_rejects_replaced_targets() -> None:

--- a/src/Mod/VibeCAD/vibecad_tests/test_vibescript_timeline_publication.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_vibescript_timeline_publication.py
@@ -583,6 +583,38 @@ def test_assembly_resource_keys_use_only_persisted_exact_identities() -> None:
     )
 
 
+@pytest.mark.parametrize("staged,old_count,new_count", [
+    (False, 0, 0), (True, 0, 0), (False, 1, 0), (False, 0, 1),
+])
+def test_assembly_occurrence_reconciles_only_actual_or_staged_resource_graphs(
+    monkeypatch, staged, old_count, new_count,
+) -> None:
+    operation = _Object("Occurrence", 1, "App::Link")
+    document = _DeletionDocument([operation])
+    captured = {"resources": [object() for _ in range(old_count)]}
+    final = [object() for _ in range(new_count)]
+    calls = []
+    retired = [object()] if old_count else []
+    monkeypatch.setattr(domain_publication, "_stage_timeline_resource_reconciliation",
+                        lambda *a, **kw: calls.append("stage"))
+    def finalize(doc, owner, snapshot, resources, **kwargs):
+        assert (doc, owner, snapshot, resources) == (document, operation, captured, final)
+        calls.append("finalize")
+        return retired
+    monkeypatch.setattr(domain_publication, "_finalize_timeline_resource_reconciliation", finalize)
+    monkeypatch.setattr(domain_publication, "_remove_reconciled_timeline_resources",
+                        lambda doc, resources, **kw: resources)
+    result = domain_publication._reconcile_assembly_occurrence_resources(
+        document, operation, captured, final, staged=staged, context="Occurrence resources",
+    )
+    if staged or old_count or new_count:
+        assert calls == (["finalize"] if staged else ["stage", "finalize"])
+        assert result == retired
+    else:
+        assert calls == []
+        assert result == []
+
+
 def test_resource_reconciliation_uses_exact_authored_keys_and_nested_owners() -> None:
     operation = _Object("Job", 1, "Path::FeaturePython")
     old_leaf = _Object("OldBit", 2, "Part::FeaturePython")

--- a/src/Mod/VibeCAD/vibescript_assembly_api.py
+++ b/src/Mod/VibeCAD/vibescript_assembly_api.py
@@ -590,12 +590,6 @@ def _named_values(
             f"requires at least {minimum} value(s)",
             value,
         )
-    if len(value) > 4096:
-        raise _error(
-            operation,
-            parameter,
-            "may contain at most 4096 named members",
-        )
     names: list[str] = []
     values: list[DomainValue] = []
     for raw_name, item in value.items():
@@ -1694,8 +1688,7 @@ class AssemblyDomainAPI:
         Prefer a stable-key mapping; mapped motions are owned by the simulation
         and do not consume public ``result`` outputs. The established sequence
         form remains supported and requires each motion as a top-level output.
-        The worker records an initial frame plus native time-series frames and
-        rejects simulations exceeding 100000 component-pose samples.
+        The worker records an initial frame plus native time-series frames.
         ``time_step_s`` controls trace density; ``frames_per_second`` is retained
         only as the live playback rate and does not add solver samples.
         ``collision_mode='off'`` skips dynamic collision analysis for playback;
@@ -1778,14 +1771,6 @@ class AssemblyDomainAPI:
         # output-time states.  The extra slot also covers a non-integral final
         # interval without relying on a hidden solver rounding rule.
         estimated_frames = math.ceil((end - start) / step) + 2
-        component_count = len(model.properties.get("components", ()))
-        if estimated_frames > 10_000 or estimated_frames * component_count > 100_000:
-            raise _error(
-                operation,
-                "time range/time_step_s",
-                "would exceed 10000 native frames or 100000 component-pose samples; "
-                "increase time_step_s or shorten the time range",
-            )
         motion_identities: dict[str, Any] = {}
         if motion_names is not None:
             motion_identities["motion_names"] = motion_names

--- a/src/Mod/VibeCAD/vibescript_assembly_worker.py
+++ b/src/Mod/VibeCAD/vibescript_assembly_worker.py
@@ -28,6 +28,7 @@ from VibeCADMechanismEngine import (
     mechanism_scenario_sha256,
     normalize_mechanism_static_check,
     normalize_mechanism_scenario,
+    quaternion_rotation_distance_degrees,
     solver_validation_scope,
 )
 from VibeCADMechanismGeometry import (
@@ -77,6 +78,8 @@ _MAX_SIMULATION_TRACE_BYTES = 64 * 1024 * 1024
 _EXPLODED_VIEW_SCHEMA = "vibecad-assembly-exploded-view-v1"
 _ASSEMBLY_BOM_SCHEMA = "vibecad-assembly-bom-v1"
 _ASSEMBLY_HIERARCHY_SCHEMA = "vibecad-assembly-source-hierarchy-v1"
+# Former producer limits are retained only to authenticate existing contracts.
+# They are not execution limits for the current worker.
 _MAX_HIERARCHY_NODES = 512
 _MAX_HIERARCHY_OCCURRENCES = 2048
 _MAX_HIERARCHY_JOINTS = 1024
@@ -405,8 +408,8 @@ def _load_assembly_hierarchy(root: Path, value: Any, *, context: str) -> dict[st
     }:
         raise ValueError(f"{context} has malformed top-level fields.")
     nodes_raw = value.get("nodes")
-    if not isinstance(nodes_raw, list) or not 1 <= len(nodes_raw) <= _MAX_HIERARCHY_NODES:
-        raise ValueError(f"{context}.nodes must contain 1-{_MAX_HIERARCHY_NODES} nodes.")
+    if not isinstance(nodes_raw, list) or not nodes_raw:
+        raise ValueError(f"{context}.nodes must contain at least one node.")
     nodes: list[dict[str, Any]] = []
     node_by_id: dict[str, dict[str, Any]] = {}
     occurrence_ids: set[str] = set()
@@ -446,7 +449,7 @@ def _load_assembly_hierarchy(root: Path, value: Any, *, context: str) -> dict[st
         )
         object_name = identity.get("object_name") if isinstance(identity, dict) else None
         if (
-            not re.fullmatch(r"n[0-9]{4}", node_id)
+            not re.fullmatch(r"n[0-9]{4,}", node_id)
             or node_id in node_by_id
             or kind not in {"assembly", "part", "shape"}
             or not isinstance(identity, dict)
@@ -500,7 +503,7 @@ def _load_assembly_hierarchy(root: Path, value: Any, *, context: str) -> dict[st
             name = str(occurrence_raw.get("name") or "")
             link_mode = str(occurrence_raw.get("link_mode") or "")
             if (
-                not re.fullmatch(r"o[0-9]{5}", occurrence_id)
+                not re.fullmatch(r"o[0-9]{5,}", occurrence_id)
                 or occurrence_id in occurrence_ids
                 or not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name)
                 or name in occurrence_names
@@ -512,7 +515,7 @@ def _load_assembly_hierarchy(root: Path, value: Any, *, context: str) -> dict[st
                 or len(occurrence_raw["type_id"]) > 256
                 or not isinstance(occurrence_raw.get("source_node_id"), str)
                 or not re.fullmatch(
-                    r"n[0-9]{4}", str(occurrence_raw.get("source_node_id") or "")
+                    r"n[0-9]{4,}", str(occurrence_raw.get("source_node_id") or "")
                 )
             ):
                 raise ValueError(f"{occurrence_context} has invalid occurrence identity.")
@@ -532,10 +535,6 @@ def _load_assembly_hierarchy(root: Path, value: Any, *, context: str) -> dict[st
             occurrence_ids.add(occurrence_id)
             occurrence_names.add(name)
             occurrence_count += 1
-            if occurrence_count > _MAX_HIERARCHY_OCCURRENCES:
-                raise ValueError(
-                    f"{context} exceeds {_MAX_HIERARCHY_OCCURRENCES} occurrences."
-                )
         clean = dict(raw)
         clean["bom_properties"] = properties
         clean["occurrences"] = occurrences
@@ -578,8 +577,6 @@ def _load_assembly_hierarchy(root: Path, value: Any, *, context: str) -> dict[st
                 raise ValueError(f"{node_context} BREP changed shape type during transfer.")
             loaded_shapes[node_id] = shape
             shape_count += 1
-            if shape_count > _MAX_HIERARCHY_SHAPES:
-                raise ValueError(f"{context} exceeds {_MAX_HIERARCHY_SHAPES} shapes.")
         elif kind == "shape":
             raise ValueError(f"{node_context} is a shape leaf without a BREP artifact.")
         grounded = raw.get("grounded_occurrence_paths", [])
@@ -592,8 +589,6 @@ def _load_assembly_hierarchy(root: Path, value: Any, *, context: str) -> dict[st
             if not isinstance(joints, list):
                 raise ValueError(f"{node_context}.joints must be a list.")
             joint_count += len(joints)
-            if joint_count > _MAX_HIERARCHY_JOINTS:
-                raise ValueError(f"{context} exceeds {_MAX_HIERARCHY_JOINTS} joints.")
         elif grounded or joints:
             raise ValueError(f"{node_context} is not an Assembly but contains joint state.")
         nodes.append(clean)
@@ -650,11 +645,6 @@ def _load_assembly_hierarchy(root: Path, value: Any, *, context: str) -> dict[st
                     "depth": depth + 1,
                 }
             )
-            if len(paths) > _MAX_HIERARCHY_OCCURRENCES:
-                raise ValueError(
-                    f"{context} expands beyond {_MAX_HIERARCHY_OCCURRENCES} stable "
-                    "occurrence paths."
-                )
             if source["kind"] in {"assembly", "part"}:
                 flatten(str(source["node_id"]), path, depth + 1)
         active.remove(node_id)
@@ -721,7 +711,11 @@ def _load_assembly_hierarchy(root: Path, value: Any, *, context: str) -> dict[st
         "shape_artifacts": shape_count,
         "maximum_depth": max((int(item["depth"]) for item in paths), default=0),
     }
-    if counts != expected_counts or limits != _EXPECTED_HIERARCHY_LIMITS:
+    # Older saved contracts carry the former capacity ceilings. They describe
+    # the producer, not the capacity of this worker. Accept either generation.
+    current_limits = dict.fromkeys(_EXPECTED_HIERARCHY_LIMITS, 0)
+    current_limits['maximum_depth'] = _MAX_HIERARCHY_DEPTH
+    if counts != expected_counts or limits not in (_EXPECTED_HIERARCHY_LIMITS, current_limits):
         raise ValueError(f"{context}.counts or limits is inconsistent.")
     return {
         "descriptor": {
@@ -1610,21 +1604,14 @@ def _placement_delta(initial: Any, solved: Any) -> dict[str, Any]:
             "The native Assembly solver returned a zero-length placement quaternion.",
             details={"stage": "native_solver_placement_delta"},
         )
-    dot = abs(
-        sum(
-            initial_quaternion[index]
-            * solved_quaternion[index]
-            / (initial_magnitude * solved_magnitude)
-            for index in range(4)
-        )
-    )
-    rotation_degrees = math.degrees(2.0 * math.acos(max(-1.0, min(1.0, dot))))
+    rotation_degrees = quaternion_rotation_distance_degrees(initial_quaternion, solved_quaternion)
     return {
         "translation_mm": translation,
         "translation_distance_mm": math.sqrt(
             sum(value * value for value in translation)
         ),
         "rotation_degrees": rotation_degrees,
+        "rotation_metric": "quaternion_chord_v1",
     }
 
 
@@ -3391,8 +3378,6 @@ def _execute_native_simulation(
         if (
             frame_count < 2
             or frame_count > estimated_limit
-            or frame_count > 10_000
-            or pose_count > 100_000
         ):
             raise AssemblyCandidateError(
                 f"Native Assembly simulation {simulation_output!r} returned "

--- a/src/Mod/VibeCAD/vibescript_cam_worker.py
+++ b/src/Mod/VibeCAD/vibescript_cam_worker.py
@@ -55,7 +55,6 @@ _REFERENCE_OPTIONAL_FIELDS = frozenset(
     }
 )
 _FACE = re.compile(r"Face([1-9][0-9]*)\Z")
-_MAX_DEFINITION_BYTES = 4 * 1024 * 1024
 _MAX_NATIVE_READBACK_BYTES = 256 * 1024 * 1024
 _MAX_REFERENCES = 128
 _MAX_COMMANDS = 2_000_000
@@ -204,7 +203,7 @@ def _fail(message: str, *, stage: str, **details: Any) -> CAMCandidateError:
 def _encoded(
     value: Any,
     *,
-    limit: int = _MAX_DEFINITION_BYTES,
+    limit: int | None = None,
     label: str = "definition",
 ) -> bytes:
     try:
@@ -221,7 +220,7 @@ def _encoded(
             stage="definition_contract",
             exception_type=type(exc).__name__,
         ) from exc
-    if len(payload) > limit:
+    if limit is not None and len(payload) > limit:
         raise _fail(
             f"A CAM {label} exceeds {limit} JSON bytes.",
             stage="definition_contract",

--- a/src/Mod/VibeCAD/vibescript_domain_worker.py
+++ b/src/Mod/VibeCAD/vibescript_domain_worker.py
@@ -25,7 +25,6 @@ REQUEST_ENV = "VIBECAD_VIBESCRIPT_DOMAIN_REQUEST"
 RESULT_ENV = "VIBECAD_VIBESCRIPT_DOMAIN_RESULT"
 SCHEMA = "vibecad-vibescript-domain-worker-v2"
 MAX_STDOUT_CHARS = 16_000
-MAX_DEFINITION_BYTES = 1_000_000
 MAX_PART_OUTPUT_SUBELEMENT_DETAILS = 256
 PART_OUTPUT_SUBELEMENT_DETAIL_BUDGET = 2_048
 
@@ -236,7 +235,9 @@ def _execute_source(
             )
         if source_active and event in {"line", "call"}:
             operations += 1
-            if operations > max_operations:
+            # Zero disables the count ceiling; explicit positive limits remain
+            # supported for callers that deliberately request bounded execution.
+            if max_operations > 0 and operations > max_operations:
                 raise RuntimeError(
                     f"VibeScript exceeded its {max_operations} operation budget."
                 )
@@ -465,17 +466,13 @@ def _payload(value: Any, *, serialized: bool = False) -> dict[str, Any]:
         payload = dict(value)
     else:
         raise TypeError("Every result value must come from the active domain api.")
-    encoded = json.dumps(
+    json.dumps(
         payload,
         ensure_ascii=True,
         sort_keys=True,
         separators=(",", ":"),
         allow_nan=False,
-    ).encode("utf-8")
-    if len(encoded) > MAX_DEFINITION_BYTES:
-        raise ValueError(
-            f"One VibeScript output definition exceeds {MAX_DEFINITION_BYTES} bytes."
-        )
+    )
     return payload
 
 
@@ -1092,7 +1089,7 @@ def _run(request: dict[str, Any], root: Path) -> dict[str, Any]:
             inputs=inputs,
             api=api,
             expected_output_names=expected_names,
-            max_operations=int(request.get("max_operations") or 200_000),
+            max_operations=int(request.get("max_operations") or 0),
             max_seconds=float(request.get("max_seconds") or 300.0),
         )
         (root / "source-stdout.txt").write_text(

--- a/src/Mod/VibeCAD/vibescript_fem_worker.py
+++ b/src/Mod/VibeCAD/vibescript_fem_worker.py
@@ -116,11 +116,7 @@ _REFERENCE_OPTIONAL_FIELDS = frozenset(
         "reference_contract_sha256",
     }
 )
-_MAX_DEFINITION_BYTES = 1_000_000
 _MAX_NATIVE_READBACK_BYTES = 256 * 1024 * 1024
-_MAX_REFERENCES = 128
-_MAX_NODES = 100_000
-_MAX_ELEMENTS = 500_000
 _MAX_RESULT_VALUES = 10_000_000
 _SUBELEMENT = re.compile(r"(Solid|Face|Edge|Vertex)([1-9][0-9]*)\Z")
 _REFERENCES: Mapping[tuple[str, str], Mapping[str, Any]] = MappingProxyType({})
@@ -273,7 +269,7 @@ def _sha256_file(path: Path, *, stage: str = "reference_resolution") -> str:
 def _encoded(
     value: Any,
     *,
-    limit: int = _MAX_DEFINITION_BYTES,
+    limit: int | None = None,
     label: str = "definition",
 ) -> bytes:
     try:
@@ -290,7 +286,7 @@ def _encoded(
             stage="definition_contract",
             exception_type=type(exc).__name__,
         ) from exc
-    if len(payload) > limit:
+    if limit is not None and len(payload) > limit:
         raise _fail(
             f"A FEM {label} exceeds {limit} JSON bytes.",
             stage="definition_contract",
@@ -592,11 +588,6 @@ def configure_fem_references(
 ) -> None:
     """Authenticate and import exact detached BREP inputs for FEM."""
 
-    if len(document_references) > _MAX_REFERENCES:
-        raise _fail(
-            f"FEM accepts at most {_MAX_REFERENCES} document references.",
-            stage="reference_resolution",
-        )
     import Part
 
     references: dict[tuple[str, str], Mapping[str, Any]] = {}
@@ -845,10 +836,9 @@ def _resolve_selection(
 
 def _mesh_topology(fem_mesh: Any) -> dict[str, Any]:
     nodes_mapping = dict(fem_mesh.Nodes)
-    if not 1 <= len(nodes_mapping) <= _MAX_NODES:
+    if not nodes_mapping:
         raise _fail(
-            f"Native FEM mesh contains {len(nodes_mapping)} nodes; the limit is "
-            f"1-{_MAX_NODES}.",
+            "Native FEM mesh contains no nodes.",
             stage="native_mesh_readback",
         )
     nodes = [
@@ -875,9 +865,9 @@ def _mesh_topology(fem_mesh: Any) -> dict[str, Any]:
             records.append([element_id, *connectivity])
         elements[name] = records
         total += len(records)
-    if not 1 <= total <= _MAX_ELEMENTS:
+    if not total:
         raise _fail(
-            f"Native FEM mesh contains {total} elements; the limit is 1-{_MAX_ELEMENTS}.",
+            "Native FEM mesh contains no elements.",
             stage="native_mesh_readback",
         )
     mins = [min(node[axis] for node in nodes) for axis in (1, 2, 3)]

--- a/src/Mod/VibeCAD/vibescript_inspection_worker.py
+++ b/src/Mod/VibeCAD/vibescript_inspection_worker.py
@@ -33,7 +33,6 @@ _OPERATION_OUTPUT = {
     "measurement": "measurement",
     "report": "report",
 }
-_MAX_DEFINITION_BYTES = 1_000_000
 _MAX_REFERENCES = 128
 _MAX_DISTANCE_COUNT = 2_000_000
 _MAX_ARTIFACT_BYTES = _MAX_DISTANCE_COUNT * 4
@@ -187,12 +186,6 @@ def _encoded(value: Any) -> bytes:
             stage="definition_contract",
             exception_type=type(exc).__name__,
         ) from exc
-    if len(payload) > _MAX_DEFINITION_BYTES:
-        raise _fail(
-            f"An Inspection definition exceeds {_MAX_DEFINITION_BYTES} JSON bytes.",
-            stage="definition_contract",
-            json_bytes=len(payload),
-        )
     return payload
 
 

--- a/src/Mod/VibeCAD/vibescript_mesh_worker.py
+++ b/src/Mod/VibeCAD/vibescript_mesh_worker.py
@@ -74,7 +74,6 @@ _ARGUMENT_COUNTS = {
     "diagnostics": 1,
 }
 _MAX_DEFINITION_DEPTH = 32
-_MAX_DEFINITION_BYTES = 1_000_000
 _MAX_SELF_INTERSECTION_SAMPLE = 64
 _MAX_SELF_INTERSECTION_DETAIL_FACETS = 128
 _MAX_ABS_COORDINATE = 1_000_000_000.0
@@ -604,13 +603,6 @@ def validate_mesh_definition(
         require_domain_value=require_domain_value,
     )
     encoded_payload = _encoded(payload)
-    if depth == 0 and len(encoded_payload.encode("utf-8")) > _MAX_DEFINITION_BYTES:
-        raise _fail(
-            f"{context} exceeds the {_MAX_DEFINITION_BYTES}-byte Mesh definition limit.",
-            stage="definition_contract",
-            path=context,
-            maximum_bytes=_MAX_DEFINITION_BYTES,
-        )
     operation = str(payload["operation"])
     arguments = list(payload["arguments"])
     properties = dict(payload["properties"])

--- a/src/Mod/VibeCAD/vibescript_meshpart_worker.py
+++ b/src/Mod/VibeCAD/vibescript_meshpart_worker.py
@@ -20,7 +20,6 @@ VALIDATION_SCHEMA = "vibecad-vibescript-meshpart-validation-v1"
 _EXPORTS = ("mesh_from_shape", "shape_from_mesh")
 _OUTPUT_TYPES = ("mesh", "solid", "shell", "face", "wire", "compound")
 _BREP_TYPES = frozenset(_OUTPUT_TYPES[1:])
-_MAX_DEFINITION_BYTES = 1_000_000
 _MAX_REFERENCE_COUNT = 128
 _MAX_REFERENCE_SEGMENTS = 4096
 _MAX_FACETS = 5_000_000
@@ -506,12 +505,6 @@ def _encoded(value: Any) -> bytes:
             stage="definition_contract",
             exception_type=type(exc).__name__,
         ) from exc
-    if len(result) > _MAX_DEFINITION_BYTES:
-        raise _fail(
-            f"A MeshPart definition exceeds {_MAX_DEFINITION_BYTES} JSON bytes.",
-            stage="definition_contract",
-            json_bytes=len(result),
-        )
     return result
 
 

--- a/src/Mod/VibeCAD/vibescript_points_worker.py
+++ b/src/Mod/VibeCAD/vibescript_points_worker.py
@@ -22,7 +22,6 @@ VALIDATION_SCHEMA = "vibecad-vibescript-points-validation-v1"
 ATTRIBUTE_SCHEMA = "vibecad-vibescript-point-attributes-f32le-v1"
 _EXPORTS = ("point_cloud",)
 _OUTPUT_TYPES = ("points",)
-_MAX_DEFINITION_BYTES = 1_000_000
 _MAX_POINTS = 2_000_000
 _MAX_DEDUPLICATE_POINTS = 500_000
 _MAX_ARTIFACT_BYTES = 256 * 1024 * 1024
@@ -620,12 +619,6 @@ def _encoded(value: Any) -> bytes:
             stage="definition_contract",
             exception_type=type(exc).__name__,
         ) from exc
-    if len(result) > _MAX_DEFINITION_BYTES:
-        raise _fail(
-            f"A Points definition exceeds {_MAX_DEFINITION_BYTES} JSON bytes.",
-            stage="definition_contract",
-            json_bytes=len(result),
-        )
     return result
 
 

--- a/src/Mod/VibeCAD/vibescript_reverse_engineering_worker.py
+++ b/src/Mod/VibeCAD/vibescript_reverse_engineering_worker.py
@@ -27,7 +27,6 @@ _EXPORTS = (
 )
 _OUTPUT_TYPES = ("curve", "surface", "brep", "mesh", "fit_metrics")
 _GEOMETRY_TYPES = frozenset(_OUTPUT_TYPES[:-1])
-_MAX_DEFINITION_BYTES = 1_000_000
 _MAX_POINTS = 2_000_000
 _MAX_FACETS = 5_000_000
 _MAX_BREP_FACETS = 100_000
@@ -225,12 +224,6 @@ def _encoded(value: Any) -> bytes:
             stage="definition_contract",
             exception_type=type(exc).__name__,
         ) from exc
-    if len(result) > _MAX_DEFINITION_BYTES:
-        raise _fail(
-            f"A Reverse Engineering definition exceeds {_MAX_DEFINITION_BYTES} JSON bytes.",
-            stage="definition_contract",
-            json_bytes=len(result),
-        )
     return result
 
 

--- a/src/Mod/VibeCAD/vibescript_robot_worker.py
+++ b/src/Mod/VibeCAD/vibescript_robot_worker.py
@@ -28,7 +28,6 @@ _OPERATION_OUTPUT = {
     "dressup": "dressup",
     "simulate": "simulation",
 }
-_MAX_DEFINITION_BYTES = 1_000_000
 _MAX_SIMULATION_SAMPLES = 100_000
 _SAMPLE_WIDTH = 15
 
@@ -160,12 +159,6 @@ def _encoded(value: Any) -> bytes:
             stage="definition_contract",
             exception_type=type(exc).__name__,
         ) from exc
-    if len(payload) > _MAX_DEFINITION_BYTES:
-        raise _fail(
-            f"A Robot definition exceeds {_MAX_DEFINITION_BYTES} JSON bytes.",
-            stage="definition_contract",
-            json_bytes=len(payload),
-        )
     return payload
 
 

--- a/src/Mod/VibeCAD/vibescript_sketcher_api.py
+++ b/src/Mod/VibeCAD/vibescript_sketcher_api.py
@@ -96,8 +96,6 @@ _POINTS_BY_GEOMETRY = {
 }
 _EXTERNAL_ENTITIES = frozenset({"x_axis", "y_axis", "origin"})
 _NAME = re.compile(r"^[A-Za-z][A-Za-z0-9_]{0,63}$")
-_MAX_GEOMETRY = 4096
-_MAX_CONSTRAINTS = 16384
 
 
 def _error(operation: str, parameter: str, reason: str, value: Any = None) -> ValueError:
@@ -1353,17 +1351,17 @@ class SketcherDomainAPI:
         invariants; the worker rejects a candidate that does not meet them.
         """
 
-        if not isinstance(geometry, (list, tuple)) or not 1 <= len(geometry) <= _MAX_GEOMETRY:
+        if not isinstance(geometry, (list, tuple)) or not geometry:
             raise _error(
                 "sketch",
                 "geometry",
-                f"must contain 1-{_MAX_GEOMETRY} geometry values",
+                "must contain at least one geometry value",
             )
-        if not isinstance(constraints, (list, tuple)) or len(constraints) > _MAX_CONSTRAINTS:
+        if not isinstance(constraints, (list, tuple)):
             raise _error(
                 "sketch",
                 "constraints",
-                f"must contain at most {_MAX_CONSTRAINTS} constraint values",
+                "must be a sequence of constraint values",
             )
         clean_geometry = [
             _geometry("sketch", f"geometry[{index}]", item)

--- a/src/Mod/VibeCAD/vibescript_techdraw_api.py
+++ b/src/Mod/VibeCAD/vibescript_techdraw_api.py
@@ -76,8 +76,6 @@ _PROJECTED_ELEMENT = re.compile(r"(?:Edge|Vertex|Face)[0-9]+\Z")
 _MAX_LABEL_CHARS = 256
 _MAX_TEXT_CHARS = 4096
 _MAX_FORMAT_CHARS = 512
-_MAX_SOURCES = 32
-_MAX_CONTENTS = 128
 _MAX_ANNOTATION_LINES = 64
 _MAX_EDITABLE_TEXTS = 64
 _MAX_REFERENCES = 3
@@ -229,11 +227,11 @@ def _reference(operation: str, parameter: str, value: Any) -> dict[str, str]:
 def _references(operation: str, value: Any) -> tuple[dict[str, str], ...]:
     if isinstance(value, (str, bytes)) or not isinstance(value, Sequence):
         raise _error(operation, "sources", "must be a sequence of document references")
-    if not 1 <= len(value) <= _MAX_SOURCES:
+    if not value:
         raise _error(
             operation,
             "sources",
-            f"must contain 1-{_MAX_SOURCES} references",
+            "must contain at least one reference",
         )
     result = tuple(
         _reference(operation, f"sources[{index}]", item)
@@ -740,11 +738,11 @@ class TechDrawDomainAPI:
         )
         if isinstance(contents, (str, bytes)) or not isinstance(contents, Sequence):
             raise _error("page", "contents", "must be a sequence of TechDraw values")
-        if not 1 <= len(contents) <= _MAX_CONTENTS:
+        if not contents:
             raise _error(
                 "page",
                 "contents",
-                f"must contain 1-{_MAX_CONTENTS} values",
+                "must contain at least one value",
             )
         clean_contents = tuple(
             _nested_value(

--- a/src/Mod/VibeCAD/vibescript_techdraw_worker.py
+++ b/src/Mod/VibeCAD/vibescript_techdraw_worker.py
@@ -87,12 +87,7 @@ _DIMENSION_TYPES = {
     "angle_3_point": "Angle3Pt",
     "area": "Area",
 }
-_MAX_DEFINITION_BYTES = 4 * 1024 * 1024
 _MAX_NATIVE_READBACK_BYTES = 64 * 1024 * 1024
-_MAX_REFERENCES = 128
-_MAX_PROJECTION_EDGES = 200_000
-_MAX_PROJECTION_FACES = 50_000
-_MAX_DESCRIPTOR_ITEMS = 250_000
 _MAX_MODEL_REFERENCE_SAMPLES = 64
 _REFERENCES: Mapping[tuple[str, str], Mapping[str, Any]] = MappingProxyType({})
 
@@ -203,7 +198,7 @@ def _fail(message: str, *, stage: str, **details: Any) -> TechDrawCandidateError
 def _encoded(
     value: Any,
     *,
-    limit: int = _MAX_DEFINITION_BYTES,
+    limit: int | None = None,
     label: str = "definition",
 ) -> bytes:
     try:
@@ -220,7 +215,7 @@ def _encoded(
             stage="definition_contract",
             exception_type=type(exc).__name__,
         ) from exc
-    if len(payload) > limit:
+    if limit is not None and len(payload) > limit:
         raise _fail(
             f"A TechDraw {label} exceeds {limit} JSON bytes.",
             stage="definition_contract",
@@ -457,13 +452,6 @@ def configure_techdraw_references(
 ) -> None:
     """Authenticate exact detached BREP inputs for worker-only projection."""
 
-    if len(document_references) > _MAX_REFERENCES:
-        raise _fail(
-            f"TechDraw accepts at most {_MAX_REFERENCES} document references.",
-            stage="reference_resolution",
-            reference_count=len(document_references),
-            maximum=_MAX_REFERENCES,
-        )
     from vibescript_part_worker import (
         configure_part_references,
         detached_reference_shape,
@@ -761,17 +749,11 @@ def _projection_snapshot(
     classes = [int(value) for value in snapshot["edge_classes"]]
     visibility = [bool(value) for value in snapshot["edge_visibility"]]
     source_indices = [int(value) for value in snapshot["source_indices"]]
-    if not 1 <= edge_count <= _MAX_PROJECTION_EDGES:
+    if not edge_count:
         raise _fail(
-            "Native TechDraw produced no edges or exceeded the projection edge limit.",
+            "Native TechDraw produced no edges.",
             stage="native_projection",
             edge_count=edge_count,
-        )
-    if face_count > _MAX_PROJECTION_FACES:
-        raise _fail(
-            "Native TechDraw exceeded the projection face limit.",
-            stage="native_projection",
-            face_count=face_count,
         )
     if not (
         len(classes) == len(visibility) == len(source_indices) == edge_count
@@ -797,10 +779,7 @@ def _projection_snapshot(
         )
     descriptor_edges = list(descriptors["edges"])
     descriptor_vertices = list(descriptors["vertices"])
-    if (
-        len(descriptor_edges) != edge_count
-        or len(descriptor_vertices) > _MAX_DESCRIPTOR_ITEMS
-    ):
+    if len(descriptor_edges) != edge_count:
         raise _fail(
             "Native TechDraw projected-element inventory is inconsistent.",
             stage="native_projection",

--- a/src/Tools/performance/PUBLICATION_SIMULATION_RESULTS.md
+++ b/src/Tools/performance/PUBLICATION_SIMULATION_RESULTS.md
@@ -1,0 +1,1636 @@
+# Publication and simulation measurements
+
+Measurements are evidence for the named stages only, not a whole-application
+responsiveness guarantee. Customer documents and traces remain outside Git.
+
+## Exact-player reuse and invalidation, September 8
+
+The same task-wrapper identity defect also affected Native launch verification,
+failed-launch cleanup and cancellation, plus the service stop postcondition.
+`activeTaskDialog()` returns a new Python wrapper per call; ownership now checks
+the exact hosted Qt widgets instead. A replacement task is not closed by cleanup
+of an older launch. Public signatures and task-conflict behavior are unchanged.
+
+Red: fresh-wrapper launch failed its exact postcondition, and an unclosed task
+was incorrectly reported stopped. Green: 39 tests passed in 5.31 s using:
+
+```powershell
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py -q --tb=short
+```
+
+The compiled-GUI Native lifecycle gate is not yet green: its first run stopped
+at a revision conflict following fixture creation/save, before playback launch.
+That must be attributed and the gate rerun; unit results do not replace it.
+
+The actual AI service previously rejected an already-open saved simulation,
+forcing close/reopen and another roughly 48 s generation. The additive reuse
+entry now waits for exact native frame adoption without regenerating. An
+isolated GUI replay on the 3,022-object robot completed three AI seeks in
+0.216, 0.248 and 0.354 s, then ran Play for three seconds without a frame error.
+Initial generation/adoption remained 48.26 s (68.27 process CPU seconds); this
+fix does not claim to accelerate the solve. Maximum heartbeat gap including
+opening was 0.641 s. Original document and project files were untouched.
+
+The first GUI replay caught a mismatch absent from the initial unit fixture:
+`Gui.Control.activeTaskDialog()` constructs a fresh Python wrapper on every
+call. Wrapper identity cannot prove task ownership. Lookup and queued player
+cancellation now verify the exact hosted Qt form instead. Unrelated tasks,
+objects and presentations remain protected. The GUI replay uses
+`VIBECAD_SIMULATION_PLAYBACK_ASYNC=1`, `VIBECAD_SIMULATION_AI_PLAYBACK=1`,
+`VIBECAD_SIMULATION_AI_RESEEK=1` and an explicit Python candidate source tree;
+it is not evidence of a rebuilt native package. The retained probe can run
+without candidate injection against the final archive.
+
+Native lifecycle regression: changing `jFramesPerSecond` invalidated solved
+channels even though the solver does not read it. The reuse assertion failed
+before the fix; all four Assembly native tests now pass (0.758 s). Real input
+placement edits still invalidate. The first invalidating object/property is
+retained in the Assembly log. This is not proof of the original user's exact
+stale-result cause. QMutex teardown warnings remain in the native test runner.
+
+Verification commands:
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd Assembly_tests_run
+build/authoritative-runtime-native/bin/Assembly_tests_run.exe
+$tests=(Get-ChildItem src/Mod/VibeCAD/vibecad_tests -Filter 'test_codex*.py').FullName
+.pixi/envs/default/python.exe -m pytest @tests src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py src/Mod/VibeCAD/vibecad_tests/test_assembly_solver_policy.py -q --tb=short
+```
+
+Use the configured native dependency and module directories on PATH and its
+matching Python home for the native command. Consolidated Python checks:
+130 passed in 8.67 s. Added regressions were red before implementation.
+The complete official Codex 0.153.4 Windows package installation and actual
+stdio app-server smoke passed (0.281 s handshake); final archive verification
+remains required. Six platform assets are pinned to official release digests.
+
+## Live publication rollback freeze, 2026-09-08
+
+Three nonblocking Python stack samples taken while the UI reported 894/1159
+showed MainThread in `JointObject.solveIfAllowed -> assembly.solve`, called by
+`Joint.onChanged` from the publisher's `doc.abortTransaction()`. Observer stacks
+also showed solver-induced property notifications. The operation coordinator
+and provider progress delivery were waiting for the document dispatcher.
+
+Read-only inspection of the live exception recovered the original failure:
+an existing joint at History position 1037 depended on a newly published
+component at position 1959. Native chronology validation rejected publication;
+rollback then triggered interactive solves while restoring joint offsets.
+The retained result confirms its connector changed from the old ground component
+to the newly added travel component. Do not
+weaken chronological validation or treat a worker-completed result as published.
+
+The joint callback now excludes `Document.Transacting` (native transaction
+replay, not merely an open command transaction), as it already excluded loading.
+This prevents recompute, presolve and autosolve from overwriting replayed state.
+Focused command:
+
+```
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_assembly_solver_policy.py -q --tb=short
+```
+
+Red: 5 failed, 9 passed. Green: 14 passed. These execute the production callback
+for offset, distance, angle and reference changes, both during replay and normal
+editing. The first isolated
+GUI attempt encountered a recovery dialog before opening its test copy and was
+stopped; it is not passing evidence. No document was saved. The user application
+was terminated only after explicit permission; the user reported needing recovery.
+
+The corrected isolated GUI lifecycle probe opened the 3,022-object robot copy,
+changed a real joint offset, aborted, then committed/undid/redid another change.
+It verified original poses after abort and exact offsets after undo and redo,
+waiting for native presentation completion between actions. Result: `ok=true`,
+zero interactive solve attempts; abort took 0.093 s. The solve observer records
+attempts without running the erroneous solver on a failing baseline. An earlier
+attempt called undo before presentation settled and correctly got a busy
+rejection; that attempt is not passing evidence. The permanent probe is
+`joint_transaction_replay_probe.py`.
+
+The same real-document probe against the unpatched packaged module failed as
+expected: four interactive solve attempts, one each during abort, undo, redo
+and restoration undo, all with `Document.Transacting=true`. The patched run
+recorded none. Both runs used disposable model copies and exited without saving.
+
+Dependency-order repair adds a batched counterpart to the existing native
+dependent-closure rebase. Publication plans once per joint/motion/simulation
+phase before changing retained references. Complete downstream blocks move
+after the latest required input without disabling chronology validation.
+
+```
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py src/Mod/VibeCAD/vibecad_tests/test_assembly_solver_policy.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py -q --tb=short
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run
+App_tests_run.exe --gtest_filter=DocumentTest.dependencyRebase*
+```
+
+Planner red: 3 failed, 11 passed (missing helper). Consolidated Python green:
+59 passed. Native red: missing batched API compilation failure. Native green:
+build succeeded; both shared-closure and existing single-root persistence tests
+passed (2/2), using the matched native build environment. Full-package replay
+is still required; these tests do not prove speed on the failed robot rebuild.
+
+## Baseline, 2026-09-08
+
+The full portable based on native revision `9e556e0b` with Python through
+`87243ed9` was exercised using `simulation_playback_probe.py` in an isolated
+GUI profile and a fresh disposable copy of the user's saved robot.
+
+The simulation contains 337 components, 22 frames and 7,414 recorded poses.
+
+| Stage | GUI callback wall time |
+| --- | ---: |
+| Open player, without generating | 0.273 s |
+| Generate simulation and display last frame | 39.487 s |
+| Display frame 1 | 0.626 s |
+| Display frame 11 | 0.740 s |
+| Display frame 21 | 0.605 s |
+
+Frame 11's Python profile attributes 0.476 s to 336 joint redraw callbacks,
+including 672 repeated owner resolutions (0.178 s) and 672 marker updates
+(0.225 s). Placement notifications invoke the VibeCAD object observer 672 times
+(0.219 s), including source-staleness propagation (0.075 s). These nested times
+must not be summed as independent costs.
+
+The reported 11m45s publication-heavy build still needs a stage-by-stage
+reproduction. It is not a measured publication-only duration.
+
+## Native solver executor repair
+
+`ASMTAssembly::runKINEMATIC` and `runPostDrag` did not copy the host executor
+into their newly created solver systems. `runPreDrag` already did. The new
+kinematic regression actually solves the four-bar fixture, verifies executor
+invocation, and compares every component's position and rotation at every frame
+against the serial solver. The existing sparse-solver test independently checks
+overlapping executor work and numerical correctness.
+
+The first test run also exposed a release-build parser defect: `assemblyFromFile`
+consumed the `Assembly` record inside `assert`, so release builds skipped that
+read and corrupted parsing. Consuming and validating the record unconditionally
+also repairs the three previously failing Backhoe fixture tests.
+
+Commands (after activating the MSVC x64 environment):
+
+```powershell
+.pixi/envs/default/Library/bin/cmake.exe --build build/ondsel-parallel-test -j 16
+build/ondsel-parallel-test/tests/test_run.exe --gtest_filter=OndselSolver.KinematicSimulationUsesHostExecutorAndPreservesEveryPose
+.pixi/envs/default/Library/bin/ctest.exe --test-dir build/ondsel-parallel-test --output-on-failure
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py -q --tb=short
+```
+
+Red: native executor call count was zero. Green: the kinematic test passes;
+all 38 Ondsel tests pass in 18.89 s. Joint owner-cache/hidden-marker tests
+failed before implementation and pass afterward. The transient-placement scope
+test likewise failed before implementation and passes afterward.
+
+These results do not yet validate the updated full application: native packaging,
+async generation, parallel frame preparation and the final GUI acceptance gates
+remain tracked in `PERFORMANCE.md`.
+
+## Detached generation ownership and cancellation
+
+The new native start method returns a request token; finish/cancel accept it so
+an older player cannot consume or cancel a newer job. The player retains its
+own token. A callback test failed before this wiring and passes afterward.
+`simulation_runtime_probe.py` now also exercises supersession against the real
+native API; its updated full-package run is still outstanding.
+
+Ondsel now accepts a host cancellation callback and checks it during setup,
+nonlinear iterations and integration steps. The real four-bar regression throws
+after the third recorded frame and verifies that no later frame is generated.
+The host connects this to its existing cancellation scope, not a timeout.
+Red: compilation failed because `setCancellationCheck` did not exist. Green:
+
+```powershell
+build/ondsel-parallel-test/tests/test_run.exe --gtest_filter=OndselSolver.KinematicSimulationHonorsCancellationBetweenFrames
+.pixi/envs/default/Library/bin/ctest.exe --test-dir build/ondsel-parallel-test --output-on-failure
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_simulation.py src/Mod/VibeCAD/vibecad_tests/test_assembly_solver_policy.py -q --tb=short
+```
+
+Results: cancellation regression passes, 39/39 Ondsel tests pass in 18.85 s,
+25 Python tests pass in 4.74 s. The native `Assembly` target builds successfully
+with these changes. These do not establish full-GUI acceptance or bound time
+spent inside an individual solver kernel.
+
+Saving during playback now resumes through the same transient-placement scope
+as an ordinary frame, once only, rather than applying directly and potentially
+again through the slider signal. Its focused regression failed before the fix.
+
+`retained_publication_probe.py` replays copied worker artifacts through the real
+validator, cooperative publisher, observer batching and Qt dispatcher, without
+rerunning the solver or accepting/saving the program. It records separate
+validation/publication profiles, GUI callback durations and heartbeat gaps.
+
+## First retained publication profile (instrumented, not a speed claim)
+
+The real saved candidate validated and published successfully: 3 public outputs
+plus 925 members, 3,022 document objects before and afterward. Copied document,
+manifest, request and result hashes were unchanged. No program acceptance or
+document save was performed.
+
+Validation took 9.53 s under profiling. Publication and presentation took 89.44 s,
+but the first probe spent 35.70 s inside per-object progress serialization;
+that total must not be presented as uninstrumented application performance.
+The probe now retains events but rate-limits compact snapshot writes. A second
+run is required for comparison; GUI profiling itself still adds overhead.
+
+Within the 62.43 s of profiled GUI callbacks, the leading production costs were:
+
+| Production path | Cumulative time | Calls |
+| --- | ---: | ---: |
+| Native provisional timeline resource reconciliation | 14.82 s | 338 |
+| Publication target-identity verification | 3.81 s | 935 |
+| Output configuration | 2.60 s | 928 |
+| Native staging of resource reconciliation | 1.78 s | 338 |
+| Output metadata | 1.49 s | 930 |
+
+These are nested measurements and must not be summed indiscriminately. Native
+reconciliation currently rebuilds and validates whole-document timeline indices,
+semantic blocks, topological order and dependency reachability for each staged
+resource owner. This is the next native optimization target; removing required
+integrity checks without equivalent transaction-scoped evidence is not a fix.
+
+## Low-overhead replay and native graph ordering
+
+The compact-progress replay completed successfully with the same 928 outputs
+and members and unchanged input hashes. Validation took 8.48 s; publication
+including presentation took 39.34 s. Of 24.25 s of profiled GUI callbacks, native
+resource reconciliation accounted for 14.03 s. These remain instrumented
+baseline measurements, not timings of the new native implementation.
+
+The native ordering implementation now captures reachable dependencies once
+into a value-only graph. It stops duplicate traversal at enrolled semantic
+blocks, uses a minimum-priority ready queue to preserve the prior stable order,
+and retains malformed/retired dependency and cycle rejection. The subsequent
+full reachability walk was redundant with the unchanged graph just validated;
+its checks now reside in the capture/order pass. Resource identities, metadata,
+state mapping, hidden consumers, canonical ownership and atomic application
+checks remain in place.
+
+Red: the new native test failed to compile before the graph kernel existed.
+Green commands, with the configured native Python/dependency environment:
+
+```powershell
+cmake --build build/authoritative-runtime-native --target App_tests_run --config Release -j 21
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=DocumentTest.*:SemanticDependencyOrder.*
+```
+
+All 74 tests passed (1.018 s), including reconciliation rollback/persistence,
+deleted-resource identity checks, 100 deterministic random-DAG comparisons
+against full transitive reachability, same-block cycles, cross-block cycle
+rejection, and untracked resource dependencies. The 10,000-block chain test
+visits exactly 9,999 edges. Updated-package GUI timing remains outstanding.
+
+## Detached native frames and in-memory result reuse
+
+The native simulation job now copies six solved channels per component into
+immutable frame tracks before owner adoption. Independent frame transforms run
+on HostRuntime; workers do not touch document, Qt or Coin objects. One current
+request token selects the frame eligible for owner adoption. New seeks cancel
+older requests; edits invalidate the result; document teardown does not join a
+worker. Only one requested frame is expanded into placements, rather than
+precomputing a matrix table for every component and frame.
+
+The fixed Rx * Ry * Rz playback rotation is composed directly as quaternions.
+Tests compare noncommuting rotations and static offsets against Ondsel's matrix
+calculation to 1e-12, and confirm the copied samples survive source mutation.
+Ondsel's general EulerAngles implementation remains unchanged.
+
+The 50-component native document test exercises actual generation, unchanged
+input reuse without another solve, generation/frame token supersession,
+cancellation, nested transient-presentation scopes, changed-input rejection,
+and closing an owner with work pending. The reuse assertion failed before its
+implementation. All four Assembly tests pass (0.772 s in the recorded run).
+The test executable prints QMutex teardown warnings after completion; normal
+packaged GUI shutdown remains an explicit verification requirement.
+
+```powershell
+cmake --build build/authoritative-runtime-native --target Assembly_tests_run --config Release -j 21
+build/authoritative-runtime-native/bin/Assembly_tests_run.exe
+```
+
+Run the executable with the configured host Python and native dependency/module
+directories on PATH. No portable binaries were overlaid or launched for these
+native tests. Source-level player tests cover nonblocking submission, readiness,
+transient scope restoration and save-resume behavior. Full-package GUI frame
+timings, retained-artifact reuse, asynchronous AI launch and export are still
+outstanding; these tests do not establish whole-player responsiveness.
+
+## Asynchronous provider integration (source verification)
+
+Both AI playback entry points now launch background generation and complete
+only after the requested native frame has applied. Native seek, step and pause
+use the same frame-completion contract. The provider runner waits outside the
+document dispatcher, without a solver deadline or model-visible polling loop.
+Public synchronous entry points remain intact for existing external callers;
+the application's asynchronous paths select their own handlers explicitly.
+
+The native dispatcher retains argument authorization, postcondition checks and
+cached call results across deferred completion. A duplicate pending call cannot
+replace its eventual result. Player futures terminate on generation/frame
+failure, cancellation or task closure. Cancellation is sent to the Qt owner and
+can reject only the exact launched dialog; task teardown is queued to avoid
+destroying the player inside a frame notification.
+
+Focused tests were red before the asynchronous opener, frame request and service
+entry existed. The final consolidated command below passed 143 tests (16.50 s),
+including a real Qt cross-thread cancellation check. The player suite alone
+passed 18 tests (1.39 s). The Qt check verifies queued owner delivery and signal
+cleanup; it is not a full FreeCAD GUI or performance test.
+
+```powershell
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py src/Mod/VibeCAD/vibecad_tests/test_native_dispatch.py src/Mod/VibeCAD/vibecad_tests/test_native_session.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_simulation.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_view.py src/Mod/VibeCAD/vibecad_tests/test_tool_surface_guardrails.py -q --tb=short
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py -q --tb=short
+```
+
+Packaged GUI launch/postconditions, real robot timings, animation export and
+remaining publication work are still outstanding. No new user instance has
+been launched from this intermediate source boundary.
+
+The retained `simulation_playback_probe.py` supports the optional environment
+setting `VIBECAD_SIMULATION_PLAYBACK_ASYNC=1`. It records submission duration,
+completion duration/CPU time, and GUI heartbeat gaps while checking exact
+adopted frame selection. Without the option it retains the legacy baseline
+path. The updated probe is syntax-checked but awaits the complete package.
+
+## Detached animation export (source and native checks)
+
+Save Animation now selects an asynchronous controller. It requests one exact
+native pose, captures the current viewport on its Qt owner, and submits detached
+pixels to HostRuntime for orientation, scaling, PNG compression and disk writes.
+Only one PNG is in flight per viewer. Frame preparation cannot advance until
+the preceding pose and PNG have completed. The input snapshot (frame zero) is
+still exported; the paused frame is restored asynchronously after capture.
+
+The existing background manager supervises final encoding on the existing
+persistent isolation pool. Staging, encoding, final atomic file replacement and
+cleanup all stay outside Qt. Cancellation waits outside Qt for acknowledgement
+that native PNG writing released staging before deleting it. Failure or accepted
+pre-commit cancellation does not overwrite an existing export. Public synchronous
+export methods remain available to external callers; no fallback selects them.
+
+GIF encoding streams one decoded frame at a time with per-frame palettes using
+Pillow's documented [GIF plugin APIs](https://pillow.readthedocs.io/en/stable/reference/plugins.html#module-PIL.GifImagePlugin),
+instead of retaining every decoded image. Roundtrip tests check frame count,
+colours and timing. Video checks exercise the installed MP4 encoder/decoder.
+The native framebuffer capture itself still renders on the owner: this change
+does not establish a bound on its render/readback latency.
+
+Red: the encoder/controller tests failed because their modules did not exist;
+frame-zero selection failed on the missing optional argument. The native image
+tests initially failed to compile before the helper existed. Green native build:
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd Gui_tests_run
+build/authoritative-runtime-native/bin/Gui_tests_run.exe --gtest_filter=AsyncImageExport.*
+```
+
+The ignored build wrapper configures VS x64 and the native dependency/Python
+environment, then invokes CMake's Gui_tests_run target. Three native image tests
+pass (29 ms): detached pixels/scaling, cancellation preserving existing output,
+and repeatable destination failure. The focused Python command passed 30 tests
+(2.65 s), including the actual Qt controller's single-frame sequencing and
+closing while a PNG is still in flight:
+
+```powershell
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_animation_encoder.py src/Mod/VibeCAD/vibecad_tests/test_animation_export.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py -q --tb=short
+```
+
+The packaged-GUI probe now accepts `VIBECAD_SIMULATION_EXPORT=1` alongside the
+async-player option. It calls the real Save Animation method with only its file
+chooser redirected to a disposable GIF, watches completion and validates frame
+count. It is syntax-checked, not yet executed on the updated package. Image
+orientation, real render latency, UI responsiveness and whole-player shutdown
+remain to be measured there; source/native checks are not substitutes.
+
+## Packaged GUI measurements (79b04224, September 8)
+
+The complete `pixi reinstall -e default vibecad`, `pixi install -e package`,
+and `pixi run -e package create_bundle` workflow completed successfully in
+`package/rattler-build`, including the bundled runtime smoke checks. The 7z
+was extracted and the following actual GUI probes used that exact package:
+
+- `simulation_runtime_probe.py`: pass; 50 grounded components, four generated
+  frames, result reuse, stale-input rejection, supersession, cancellation and
+  close with work pending; 2.59 s total.
+- `simulation_playback_probe.py` with `VIBECAD_SIMULATION_PLAYBACK_ASYNC=1` and
+  `VIBECAD_SIMULATION_EXPORT=1`: pass on the disposable robot, 3,022 objects.
+  Generation plus first adoption took 47.72 s (64.77 process CPU seconds).
+  Frame submissions took 3.1-3.4 ms; completions took 250-373 ms. Export took
+  10.70 s and decoded as 22 frames, 1516 by 536 pixels. The maximum heartbeat
+  gap including opening was 656 ms. The selected assembly was hidden in both
+  saved App and ViewProvider visibility; the identical frames therefore do
+  not prove visible moving-pose accuracy. No original document was changed.
+- `retained_publication_probe.py`: pass, 3 outputs plus 925 members. Validation
+  took 9.70 s and publication including presentation 40.17 s. The maximum
+  heartbeat gap was 6.16 s; the largest individually profiled adoption callback
+  was 234 ms. Reconciliation used 8.10 s, versus 14.03 s in the earlier callback
+  profile. Repeated target-identity checks used 4.37 s. Final presentation
+  spanned roughly 15.8 s, not necessarily one blocking callback. A concurrent
+  user-instance launch makes this run unsuitable for a clean total-speed claim.
+
+The retained publication probe now drains the existing native GUI event tracer
+to attribute callbacks outside Python-dispatched adoption. Its first attribution
+run passed: validation 9.67 s, publication 33.78 s, 928 outputs/members. The
+6.03 s maximum heartbeat gap preceded adoption, during validation, and includes
+a 3.31 s QTimer callback followed by a 2.53 s queued main-thread callback.
+Receiver identities do not yet identify their owning functions. Final
+presentation spanned 13.4 s with short recorded callbacks; the maximum gap must
+not be attributed to that finalization phase. No native trace events were lost.
+
+## Publication identity-cache boundary (September 8)
+
+An additive native removal-generation token now lets the publisher retain exact
+target checks across slices. New targets are checked once; removal or clear
+invalidates the operation-local cache. Property edits and object additions do
+not invalidate the identity of existing targets. Cached wrappers remain strongly
+referenced to prevent Python ID reuse, and document identity is checked on every
+call. Callers without a cache retain the existing validation behavior.
+
+Red: the Python test failed on the missing `cache` argument, and the native
+test failed compilation on the missing `getObjectRemovalGeneration` API.
+Green commands:
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=DocumentTest.*Generation*
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py -q --tb=short
+```
+
+The native test command used the build's matching host Python and Qt/DLL paths.
+Three native tests passed (1.51 s including application startup); 42 Python tests
+passed (5.70 s). Fifty incrementally added targets needed fifty lookups rather
+than 1,275, and replacing a target was still rejected. The full package replay
+has not yet measured the production speedup; this is not an end-to-end completion
+claim.
+
+## AI service playback reproduction (September 8)
+
+With `VIBECAD_SIMULATION_PLAYBACK_ASYNC=1` and
+`VIBECAD_SIMULATION_AI_PLAYBACK=1`, the packaged probe called the real
+`assembly.play_simulation` service entry on the 3,022-object robot. The assembly
+was made visible in the disposable document. Generation plus initial display
+took 47.90 s (66.17 process CPU seconds); three exact seeks completed in
+237-346 ms. Play ran for three seconds without a frame error and the owned
+diagnostic process closed. Maximum heartbeat gap including opening was 547 ms.
+This did not reproduce the user's subsequent stale-result error. A second
+run adds the intervening native geometry-capture calls. The original document
+and the user process were not modified.
+
+## Python context and Codex boundary (September 8)
+
+The model-facing source index now uses searchable pages through the existing
+`vibescript.read_source` tool (`query`, `offset`, `limit`); exact source-line reads
+remain available. Full internal source authority is unchanged. The latest saved
+successful robot request's active-state payload fell from 182,911 to 15,780 bytes,
+with all 26 programs discoverable. The failed 304,315-byte request was rejected
+before provider capture, so that exact failing packet was not measured.
+
+Codex packaging now pins 0.153.4 for all six targets. The staged Windows runtime
+passed handshake and model-list checks; the deployed application's signed-in
+account returned `gpt-6-astra`. The actual GUI startup probe also verified that
+the new tool parameters were loaded and a synthetic 10,000-output program
+produced an 805-byte initial prompt. This is a Python/runtime overlay on the
+verified package, not a newly generated 7z archive.
+
+Red/green: the four initial paging tests failed on the prior implementation;
+the runtime release test failed on 0.144.5. Consolidated green: 250 tests in 5.77 s:
+
+```powershell
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_source_context_paging.py src/Mod/VibeCAD/vibecad_tests/test_model_context_contract.py src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py src/Mod/VibeCAD/vibecad_tests/test_codex_subscription.py src/Mod/VibeCAD/vibecad_tests/test_codex_runtime_package.py -q
+```
+
+## Synchronous recompute owner/worker boundary (September 8)
+
+The actual GUI lifecycle fixture exposed a wait cycle in synchronous
+`Document::recompute`: its GUI caller waited for feature workers while a worker
+waited for an owner-thread notification. The compatibility entry now sends its
+coordinator through the existing HostRuntime document lane and services Qt
+events until completion. The document mutation lease remains active throughout;
+the public synchronous result and exception contract are retained.
+
+Red: `AsyncRecomputeTest.SynchronousGuiCallerKeepsEventsAndMutationLeaseLive`
+failed both event-liveness and mutation-lease assertions on the old code. Its
+watchdog releases the fixture so the regression fails instead of hanging.
+Green: all eight selected native tests passed in 798 ms:
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=AsyncRecomputeTest.*:HostWorkflowTest.*
+```
+
+The executable used the matching build-prefix Python, Qt and module paths.
+After rebuilding every native target together, the compiled GUI lifecycle gate
+passed generation, moving seek, step, bidirectional playback, pause, mutation
+rejection, save/dirty-save baselines, manual close, idempotency, pose restoration,
+selection preservation and stable Native revisions. The exact source gate was
+`src/Mod/VibeCAD/vibecad_tests/native_assembly_playback_gui_integration.py`.
+The earlier revision conflict did not reproduce in this completed run.
+
+A diagnostic crash before the full native rebuild was traced to a stale
+AssemblyGui module: debugger type layouts differed from AssemblyApp by 48 bytes.
+It was not a solver-vector defect. The consistent native tree passed the GUI
+gate; the final release-style portable must still be rebuilt and checked.
+
+## Independent Windows input measurement (2026-09-08)
+
+`window_input_probe.py` shares the existing `native_input_sender.py` with the
+retained-publication and simulation-playback probes. The separate sender posts
+window-local F23 messages; the native event filter measures queue age and the
+Qt event filter consumes the keys. It does not alter desktop focus or physical
+keyboard state. Explicit close signals the sender without waiting on the GUI;
+parent exit also terminates it.
+
+A disposable real Qt window check, run with the portable Python/Qt runtime via
+`<bundle>/bin/python.exe build/window_input_probe_check.py`, collected 12 samples
+and detected 719 ms queue age during a deliberate 750 ms owner-thread stall.
+Sender shutdown returned exit code 0, including an idempotent second close.
+This validates the measurement mechanism, not CAD performance. The diagnostic
+script is local; the reusable sampler and CAD probes remain in this directory.
+
+Syntax/diff checks passed:
+
+```text
+<bundle>/bin/python.exe -m py_compile src/Tools/performance/window_input_probe.py src/Tools/performance/retained_publication_probe.py src/Tools/performance/simulation_playback_probe.py
+git diff --check -- src/Tools/performance
+```
+
+The publication probe now distinguishes successful worker return from settled
+document presentation. It keeps profiling and collecting input through the
+existing document update/recompute/presentation flags and the quiet-period
+check, and reports success only afterward. Failed final checks reset `ok` to
+false. The full packaged robot runs with this instrumentation remain pending.
+
+## Simulation dependency-scoped invalidation (2026-09-09)
+
+The native lifecycle regression reproduced the stale-generated-results error
+after creating and moving an unrelated object in the assembly's document.
+The prior observers invalidated on every new/deleted object and almost every
+property change, but missed linked inputs in other documents.
+
+Generation now captures the input dependency/placement-ancestor identity set
+once on the document owner thread. Application-level change/deletion observers
+check that set, preserving solved frames for unrelated edits while rejecting
+changed linked inputs. Presentation and FPS exceptions use exact object identity
+rather than document-local numeric IDs. No public API or stored format changes.
+
+Red: `AssemblyObjectTest.DetachedSimulationAndFrameLifecycle` failed in 219 ms
+with `Simulation frames require current asynchronously generated results`.
+Green: all four Assembly native tests passed in 944 ms, including unrelated
+creation/change/deletion, cross-document source placement invalidation, reuse,
+supersession, cancellation and frame transform/parallel executor checks.
+The first cross-document fixture needed `setAllowExternal(true)` on its link;
+without it the fixture itself correctly threw before generation.
+
+Exact build and test commands (matching native module and dependency paths):
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd Assembly_tests_run
+$native = (Resolve-Path build/authoritative-runtime-native).Path
+$prefix = (Resolve-Path build/performance-system/package/rattler-build/.pixi/bld/vibecad/FIH7JWrkDlw).Path
+$mods = (Get-ChildItem "$native/Mod" -Directory).FullName -join ';'
+$env:PATH = "$native/bin;$mods;$prefix/host;$prefix/host/Library/bin;$prefix/bld/Library/bin;$env:PATH"
+$env:PYTHONHOME = "$prefix/host"
+$env:PYTHONPATH = "$native/Ext;$native/Mod;$mods"
+& "$native/bin/Assembly_tests_run.exe"
+```
+
+Both commands exited 0. The executable printed two `QMutex: destroying locked
+mutex` shutdown warnings, also observed before this fix; their cause is not
+established. Full packaged GUI acceptance for this change is still pending.
+
+## Release-style portable lifecycle check (2026-09-09)
+
+The complete rebuild and portable packaging finished successfully. The archive
+contains 47,666 files and is 582,587,725 bytes. It includes the synchronous
+recompute correction and complete Codex runtime, but predates the dependency-
+scoped simulation invalidation commit. A separate full rebuild includes that
+later correction; do not label the earlier archive the final handoff.
+
+The actual moving-mechanism GUI gate passed against the extracted archive with
+no production module overlays. It verified generation, seek, step, bidirectional
+playback, pause, mutation rejection, save baselines, manual close, idempotency,
+restored poses, selection and stable Native revisions. It exited its event loop
+normally. A concurrent rebuild means this run establishes correctness, not an
+uncontended performance baseline.
+
+The first attempt exposed fixed event-pass counts in the test setup: it tried
+playback during a pending recompute, then tried closing the busy document during
+failure cleanup. The corrected fixture waits on native pending-work flags in a
+Qt event loop, with a test-only watchdog that fails without cancelling work.
+The green run reported no recompute-busy warnings. No production guard was
+removed or bypassed.
+
+Commands:
+
+```powershell
+# In package/rattler-build, with the pixi executable directory on PATH:
+pixi reinstall -e default vibecad
+$env:BUILD_TAG='v26.3.1-RC6-build1'
+$env:MAKE_PORTABLE_ARCHIVE='true'
+$env:MAKE_INSTALLER='false'
+pixi run -e package create_bundle
+# Extract the archive to a new directory, then use the isolated local runner:
+build/run-packaged-edit-check.ps1 -Name packaged-lifecycle-0d17f735-ready-20260909 -Bundle <extracted-bundle> -Script build/packaged_playback_lifecycle_probe.py
+```
+
+The local launch script schedules the retained
+`native_assembly_playback_gui_integration.py` gate after GUI bootstrap. The
+archive's own Python/Qt/native modules execute the test; there are no source
+overlays or mocked production commands. The final archive still requires this
+same check plus the full robot publication/playback checks.
+
+## Complete retained-candidate rollback/retry (2026-09-09)
+
+The extracted portable at native revision `25b67eee` opened the fresh saved
+3,022-object robot copy, validated the retained 1,159-item candidate, cancelled
+after 900 published items, verified rollback, then retried successfully through
+settled presentation. The output document contained 3,253 objects. Original
+document, request, result and manifest hashes were unchanged. The portable
+application closed normally afterward.
+
+Rollback comparison checked every object's name/type, outgoing links, placement,
+label, visibility and program revision. It does not claim byte-for-byte equality
+of every arbitrary property. The optional probe mode is
+`VIBECAD_PUBLICATION_CANCEL_AFTER=900`, alongside the existing retained working-
+candidate settings. It exercises the real cooperative cancellation exception,
+native abort, then re-captures the native document revision before retrying.
+
+Correctness passed; responsiveness did not. This was a profiled run concurrent
+with compilation and is not an uncontended benchmark:
+
+- Initial ready-to-replay span: 224.34 s including document opening.
+- Detached candidate validation: 15.28 s.
+- Complete successful retry including its presentation waiter: 116.80 s.
+- Final presentation/check completion: 485.44 s from probe startup.
+- Maximum independent input queue delay: 15,188 ms; maximum heartbeat gap: 15.39 s.
+- The largest Qt timer callback was 15,144.55 ms, coincident with validation.
+- The real cancellation dispatch took 9,729.87 ms; native abort accounted for
+  9.67 s cumulatively. This is not the earlier lightweight abort fixture.
+
+Across cancellation and retry, the owner-thread profile recorded 84.45 s in
+457 native History block publications, 21.21 s in 896 native resource
+reconciliation finalizations, and 17.99 s in 457 object creations. About 10.95 s
+was diagnostic progress serialization; do not attribute that to production.
+The retained probe now includes opt-in rollback/retry and independent input;
+native events and cProfile files remain local. A process snapshot was captured
+during the run, but mismatched/partial native symbol resolution must not be
+treated as an authoritative function-level stack diagnosis.
+
+## Native History dependency traversal (2026-09-09)
+
+`DocumentTimeline::publishProvisionalOperationBlock` validated the complete
+transitive ancestry again for every tracked operation. Since the outer pass
+already validates each tracked node, after checking an edge's History order it
+can stop traversal at another tracked node. That node's outgoing edges are
+checked independently. Untracked intermediate objects still require traversal;
+structural-edge exclusions and malformed/forward-dependency rejection remain.
+No cache, extra worker pool, public API or persisted format was added.
+
+Red: the native 50-operation chain fixture observed 1,274 structural-edge checks
+for publication of one additional dependent operation, failing its linear
+300-check bound. The invalid untracked-bridge fixture already passed. Green:
+all 75 `DocumentTest` cases passed in 1,070 ms, including the bounded traversal
+and untracked bridge cases, History ownership, rollback, persistence and
+dependency rebasing. This is algorithmic/native correctness evidence, not yet
+the large packaged publication benchmark.
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run
+# With the matching native/Python/module paths documented above:
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=DocumentTest.semanticPublication*
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=DocumentTest.*
+```
+
+The focused pre-fix run exited 1; the rebuilt full Document group exited 0.
+The full release-style rebuild of the earlier dependency-invalidation commit
+also completed and reinstalled successfully, but predates this History change.
+Do not package that intermediate environment as the final combined handoff.
+
+## Empty occurrence graphs and validation isolation (2026-09-09)
+
+Ordinary Assembly component occurrences with no old or final owned resources
+were still staging and finalizing a complete History resource reconciliation.
+The caller already captures the exact resource graph and validates the native
+operation role. An empty, unstaged graph now does not enter reconciliation.
+Nonempty graphs and already-staged replacements still execute the existing
+native finalizer, including a staged replacement whose final graph is empty.
+No public method, stored contract, or native validation was changed.
+
+Red: after extracting the existing call sequence unchanged, the empty graph
+case observed `stage, finalize` instead of no work; the other three cases passed.
+Green: all 39 tests in these two suites pass (1.43 s, exit 0):
+
+```powershell
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_vibescript_timeline_publication.py src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py -q
+```
+
+The complete native `all` build also finished successfully for the preceding
+History traversal correction. The combined portable replay remains required.
+
+An isolated actual portable GUI ran the retained Assembly result through the
+production detached validator without opening a document: 3.47 s unprofiled,
+maximum independent input delay 140 ms; 12.64 s with cProfile, maximum 203 ms.
+A synthetic JSON workload in the same GUI observed at most 16 ms. Neither
+reproduced the full replay's 15.15 s Qt callback. These checks narrow the
+investigation; they do not disprove the full-document responsiveness failure
+or establish its cause. Both isolated processes exited normally.
+
+## Reproduced ribbon/worker interpreter contention (2026-09-09)
+
+The disposable full-robot replay with off-owner stack sampling again completed
+cancel/rollback/retry. During its initial publication validation, a main-thread
+sample caught `RobotWorkbench.Initialize -> import RobotGui`; subsequent input
+latency grew throughout the worker validation. The Assembly ribbon's
+`pageGroups` initializes the composed Robot workbench from its refresh timer.
+
+A separate, empty-document portable reproduction starts the same validator
+and activates Assembly concurrently. Input delay reaches 4,407 ms for a 4.20 s
+unprofiled validation, then 14,094 ms for a 14.13 s profiled validation. Replacing
+the validator with a synthetic JSON loop also reproduces approximately 5.2 s
+input delays. Without workbench activation, both workloads remain responsive
+as recorded above. These are diagnostic runs, not acceptance measurements.
+
+A Process Snapshot dump resolved with the **exact bundled python311.pdb**
+places the GUI in `take_gil -> PyEval_RestoreThread -> posix_do_stat` during
+Python import. The captured GIL interval is 5,000 microseconds, not a modified
+long timeslice. This confirms the owner-thread interpreter wait; it does not
+yet explain why handoff starves for the whole worker duration. FreeCAD symbol
+names from this older archive remain mismatched and are not used as evidence.
+Do not substitute worker-count or timer adjustments for this remaining fix.
+
+The retained playback/export probe now shows its target assembly for export,
+allows a combined AI playback/export run, and rejects an animation whose
+frames all have identical pixels. The previous hidden-assembly export cannot
+serve as visible-motion evidence. A passing combined run is still required.
+
+The cold-ribbon synthetic-workload reproduction measured 787 owner-thread
+import-path stat calls totaling 3.873 s; no individual measured call exceeded
+16 ms. This supports repeated interpreter handoff during imports, rather than
+one multi-second filesystem call. With Assembly selected before starting the
+worker, the first phase still overlapped deferred composed-workbench setup
+(4,000 ms maximum input delay), but the subsequent 26.48 s profiled validation
+observed only 62 ms maximum delay. Do not label this a fixed deadlock or change
+the interpreter timeslice on this evidence.
+
+The publication probe accepts `VIBECAD_PUBLICATION_PROFILE=0` for end-to-end
+timing without cProfile overhead. It keeps the original profiled default and
+all independent input, native callback, rollback and correctness checks.
+The report records which mode ran; Python profiles and wall-clock acceptance
+measurements must not be conflated.
+
+The stack-sampling replay also exposed a **probe-induced** stall: its profile
+attributes 131.02 s to 201 `Path.write_text` calls, and its longest GUI callback
+was 102.42 s. Do not attribute that callback to application publication. The
+publication and simulation probes now share a coalescing diagnostic writer;
+serialization and disk writes run outside the measured GUI, with at most one
+in-flight and one pending snapshot. Final completion is polled before exit.
+Blocked writes, coalescing, write-error propagation and closed-writer rejection
+are exercised by the focused helper tests (initial red: missing implementation;
+green: two tests, 0.11 s):
+
+```powershell
+.pixi/envs/default/python.exe -m pytest src/Tools/performance/test_async_report_writer.py -q
+.pixi/envs/default/python.exe -m py_compile src/Tools/performance/retained_publication_probe.py src/Tools/performance/simulation_playback_probe.py
+```
+
+This only corrects instrumentation. It does not fix or dismiss the separately
+reproduced cold-workbench/import wait or the earlier native rollback duration.
+
+## Combined portable lifecycle gate (2026-09-09)
+
+The complete release-style build installed successfully and the packaging
+command exited 0. The portable archive contains 47,666 files read by 7z and is
+582,564,783 bytes. Extraction exited 0; the launched application reports native
+`BuildRevisionHash=c15f99d3db3caeb2869242cd08e4beda54dc3f03`. Subsequent source
+commits only change the diagnostic probes and documentation.
+
+```powershell
+# From package/rattler-build, with the normal pixi binary directory on PATH:
+pixi reinstall -e default vibecad
+pixi install -e package
+$env:BUILD_TAG='v26.3.1-RC6-build1'
+$env:MAKE_PORTABLE_ARCHIVE='true'
+$env:MAKE_INSTALLER='false'
+pixi run -e package create_bundle
+```
+
+The Actions-pattern smoke checks passed for dependencies, provider subprocesses,
+Codex app-server 0.153.4, geometry worker and windowless provider execution.
+The exact extracted package then passed the compiled-GUI lifecycle gate and
+exited normally: generated, seek, step, bidirectional playback, pause, mutation
+blocking, baseline save, dirty-save clean state, manual close, idempotency,
+restored pose, selection preservation and stable revision. Recompute remains
+exercised; no guard was bypassed. The full robot replay and visible export are
+still separate acceptance requirements.
+
+## Combined portable robot replay and visible export (2026-09-09)
+
+The same extracted `c15f99d3` package completed the unprofiled 1,159-item
+publication with cancellation after item 900, exact pre/post rollback inventory
+equality (3,022 objects), and a successful retry through settled presentation.
+Detached validation took 3.578 s, retry publication 88.391 s, and the final
+presentation settled about 3.2 s after publication returned. The final document
+contained 3,253 objects; the copied source and input artifacts remained unchanged.
+The process exited normally with empty stderr.
+
+This is **not responsiveness acceptance**: cancellation occupied one owner
+callback for 8.078 s (8,016 ms independent input delay). A separate 3.529 s Qt
+callback overlapped cold workbench initialization and worker validation; one
+adoption callback lasted 1.493 s. These remain actionable failures. The earlier
+116.8 s replay ran with profiling and concurrent compilation, so these two
+durations are not a controlled speedup comparison.
+
+The visible 337-component robot simulation then passed the actual AI service
+entry points and GUI Play control. All 22 frames generated asynchronously;
+player submission took 0.421 s and generation/display completion took 47.950 s.
+Three exact-frame AI seeks completed in 0.221, 0.354 and 0.262 s. The probe made
+any second generation call fail, and the seeks and Play still succeeded.
+
+The asynchronous GIF export submitted in 0.074 s and completed in 12.736 s.
+The actual visible artifact contains 22 frames at 1516 x 536 pixels, with 20
+frames differing from frame zero. Visual inspection confirmed rendered robot
+geometry, not a blank export; numerous visible joint markers remain visible in
+this fixture. The process exited normally with empty stderr.
+
+Independent Windows input queued **after generation submission returned** and
+delivered before generation completed had a maximum delay of 78 ms across 188
+samples. A 2,110 ms sample labelled `async_generate` was queued earlier, during
+the probe's synchronous assembly visibility/camera/fit setup and player launch;
+the label records delivery-time phase, not enqueue-time phase. Do not attribute
+that delay to the generation worker. Maxima during Play and export were 203 ms
+and 312 ms respectively. Cancellation/edit/close of the large visible fixture
+and authenticated persisted-result reuse remain separate requirements.
+
+Reproduction uses `run-packaged-edit-check.ps1` with the exact extracted bundle,
+a disposable copy, and the retained production probes:
+
+```powershell
+$env:VIBECAD_PUBLICATION_WORKING_CANDIDATE='1'
+$env:VIBECAD_PUBLICATION_CANCEL_AFTER='900'
+$env:VIBECAD_PUBLICATION_PROFILE='0'
+# VIBECAD_PUBLICATION_ATTEMPT and VIBECAD_PUBLICATION_MANIFEST identify the
+# ignored copies; run src/Tools/performance/retained_publication_probe.py.
+
+$env:VIBECAD_SIMULATION_PLAYBACK_ASYNC='1'
+$env:VIBECAD_SIMULATION_AI_PLAYBACK='1'
+$env:VIBECAD_SIMULATION_AI_RESEEK='1'
+$env:VIBECAD_SIMULATION_EXPORT='1'
+# Run src/Tools/performance/simulation_playback_probe.py in a fresh process.
+```
+
+## Native Assembly status storm during cancellation (2026-09-09)
+
+Five process snapshots from a disposable repeat of the 900-item cancellation
+locate the owner inside `Transaction::apply -> TransactionDocumentObject::applyDel
+-> Document::_removeObject -> PropertyLinkBase::breakLinks`. Two samples enter
+`AssemblyObject::onChanged -> updateSolveStatus -> numberOfComponents`, including
+repeated History activity checks. Another is in `PropertyXLinkSubList::breakLink`.
+These are stack samples, not a statistical division of the total cancellation
+time. The repeat still completes exact rollback and successful publication.
+Windows CPU recording could not enable the profiling policy; no recorder was
+left running. Private snapshots remain in ignored local storage.
+
+Group-derived status now defers while transaction replay, cooperative mutation,
+or restore is active and refreshes once at the document's existing stable
+boundary. Closing a transaction inside an active lease does not flush early.
+Ordinary edits and the public `updateSolveStatus()` entry retain their behavior.
+The deferred refresh reads existing diagnostics without implicitly starting a
+new solve; it therefore cannot auto-ground newly published components during
+presentation completion. Connections disconnect on unsetup and destruction.
+
+Red: the real 50-component native rollback emitted 51 solver-status updates,
+including intermediate replay states, and publication emitted 50 updates inside
+the lease. Green: one final update for each batch, exact restored Group/DoF and
+immediate notification for a subsequent ordinary edit. A second red regression
+showed that merely delaying the old method still launched a solve at lease end
+(DoF became zero); the corrected projection leaves the component ungrounded and
+reports its unsolved DoF without starting computation.
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd Assembly_tests_run all
+# With the matching native/dependency environment documented above:
+& "$native/bin/Assembly_tests_run.exe"
+```
+
+The full native build exits 0. All six Assembly tests pass in 1.346 s, retaining
+the existing two test-process QMutex shutdown warnings. Full portable timing of
+this change is still required; coalesced notifications do not prove that the
+remaining link cleanup is responsive.
+
+## Complete portable verification of cd7581be (2026-09-09)
+
+The Actions-pattern `pixi reinstall -e default vibecad` exits 0. The complete
+`pixi run -e package create_bundle` exits 0 with portable archives enabled and
+installer creation disabled. Provider, geometry-worker, windowless-provider and
+Codex 0.153.4 smoke checks pass. Extraction exits 0. The probe records the actual
+application revision `cd7581bed8c57df15456e701270dfa822df73ef6`; production modules
+are not overlaid. Under Windows PowerShell, use `ErrorActionPreference=Continue`
+around native Pixi commands and check `LASTEXITCODE`: its success status is written
+to stderr, which `Stop` otherwise converts into a terminating wrapper error.
+
+The unprofiled 1,159-item replay passes cancellation after item 900, exact baseline
+inventory equality for 3,022 objects, and retry through settled presentation with
+3,253 objects. Validation takes 3.625 s; retry publication takes 87.406 s. This is
+essentially unchanged from the prior 88.391 s run, not an overall publication
+speedup claim. The process exits normally with empty stderr.
+
+The longest measured owner callback falls from 8.078 s to 2.234 s and coincides
+with rollback; independent Windows input there is delayed by 2,110 ms. A separate
+adoption callback still takes 1.484 s. The largest overall input delay is 3,641 ms
+at the cold validator/Workbench overlap, before publication starts. These pauses
+remain open; correct rollback and a smaller pause are not full responsiveness
+acceptance. Sampled peak working set during the run is about 1.52 GB decimal.
+
+## Joint visibility invalidated solved simulation frames (2026-09-09)
+
+The extended real-model probe uses `VIBECAD_SIMULATION_LIFECYCLE=1` with the
+asynchronous AI player, seek and export flags. In the cd7581be package, generation
+succeeded, 336 joints were hidden, then the first AI seek returned
+`SIMULATION_PLAYBACK_FAILED`: "Simulation frames require current asynchronously
+generated results". The observer recorded the joint group's `_GroupTouched`
+notifications. This is a real failed lifecycle gate, not a successful playback
+claim. A preceding probe attempt stopped on a test-harness getter typo before
+visibility testing; the retained probe now uses the exported `Joints` property.
+
+GroupExtension emits `_GroupTouched` on child visibility changes and execution.
+The solver does not read this derived notification. Native input observers now
+exempt that exact extension property; similarly named properties on unrelated
+objects are not exempted. Group membership, actual component/joint properties
+and linked-source edits remain observed. No GUI work moves to a worker.
+
+The 50-component native regression initially threw the exact stale-results
+exception on replay of the group notification. After the fix, all six Assembly
+tests pass in 1.342 s, including the existing real-placement and external-source
+invalidation checks. The two existing test-process QMutex shutdown warnings remain.
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd Assembly_tests_run
+# With the matching native/dependency environment documented above:
+& "$native/bin/Assembly_tests_run.exe"
+```
+
+Both the targeted build and final test command exit 0. Python compilation of the
+publication and simulation probes also passes. The GUI failure was preserved in
+ignored diagnostic storage and its disposable process closed. The fix still needs
+the next complete packaged robot replay; do not treat the cd7581be archive as fixed.
+
+## Native deletion link-query cache (2026-09-09)
+
+Cancellation snapshots also identify `PropertyLinkBase::breakLinks`. Previously
+every deletion enumerated every owner's properties and invoked each link
+property's cleanup, even if that owner had no reference to the deleted target.
+The native 50-target regression records 5,000 cleanup calls against a bound of
+100 (two properties on each of the 50 affected owners). This is an operation
+count, not a host-dependent elapsed-time assertion.
+
+The private owner-confined query now caches all property-link targets, including
+hidden links that are deliberately absent from the dependency DAG. Existing
+link mutation and dynamic-property removal invalidation clears it. Cleanup of
+the removed owner's outgoing links and the external-document link registry still
+runs; null/detached-target queries preserve the existing general contract.
+Coverage includes hidden link edits, transaction abort, dynamic links added or
+removed after a cached query, and outgoing-reference cleanup without a self-link.
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run
+# With the matching native/dependency environment documented above:
+& "$native/bin/App_tests_run.exe" '--gtest_filter=DocumentObjectTest.linkCleanup*'
+# Rebuild every native module after the private DocumentObject layout changes:
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run all
+```
+
+The initial test build exits 0; the red test command exits 1 with the 5,000 versus
+100 count failure, while the original compatibility test passes. The full native
+rebuild exits 0; both cleanup tests pass in 443 ms including application startup.
+All six Assembly tests pass. Packaged rollback timing remains an acceptance
+requirement; fewer property callbacks alone do not establish UI responsiveness.
+
+## Recompute completed but its dispatcher still waited (2026-09-09)
+
+The consolidated App suite stopped in
+`AsyncRecomputeTest.SynchronousGuiCallerKeepsEventsAndMutationLeaseLive`.
+A Windows process snapshot, decoded with the matching native symbols, shows
+`Document::recompute` in the Qt dispatcher wait with `count=1` and `complete=true`;
+the runtime workers are idle. The queued completion had run, but
+`processEvents(AllEvents | WaitForMoreEvents)` did not return to check its flag.
+The owned test process was stopped after preserving this evidence, not counted
+as a successful run.
+
+The completion callback now calls `events.quit()` after storing the result.
+[Qt's implementation](https://github.com/qt/qtbase/blob/6.8/src/corelib/kernel/qeventloop.cpp)
+routes this through the dispatcher's interrupt operation. The owner continues
+serving events until completion; computation remains on HostRuntime. There is
+no production polling timer or execution deadline. A test-only watchdog wakes
+the old implementation so the regression fails normally instead of hanging.
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run
+& "$native/bin/App_tests_run.exe" '--gtest_filter=AsyncRecomputeTest.SynchronousGuiCallerKeepsEventsAndMutationLeaseLive'
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run all
+& "$native/bin/App_tests_run.exe" '--gtest_filter=AsyncRecomputeTest.SynchronousGuiCallerKeepsEventsAndMutationLeaseLive:DocumentObjectTest.linkCleanup*'
+& "$native/bin/App_tests_run.exe"
+& "$native/bin/Assembly_tests_run.exe"
+```
+
+Red exits 1 because the watchdog had to interrupt the dispatcher after two
+seconds. The green full native build exits 0. All three focused tests pass;
+the recompute case takes 121 ms without the watchdog firing. The full App suite
+now terminates in 3.522 s: 589 pass, two skip, four fail. Three failures throw
+Windows' missing symlink-creation privilege error. The fourth,
+`DocumentObjectTest.getSubObjectList`, calls `BOPFeatures.finalize_result`, which
+imports `PartGui` in a console process. A separate native console reproduction
+confirms `ImportError: Cannot load Gui module in console application`. These
+failures are not reported as passes or silently excluded. All six Assembly
+tests pass in 1.447 s. The real-model packaged acceptance remains outstanding.
+
+## Exact document membership index (2026-09-09)
+
+Tracing the remaining publication work found that `Document::containsObject`
+used a linear search through `objectArray`. Semantic History validation calls
+this repeatedly while examining operations, owners and dependencies. The
+creation-order array is still retained; a private address set now answers
+membership without dereferencing the candidate pointer. Registration, removal,
+clear and restore keep the index consistent. Undo/redo use the same registration
+and removal paths. No public signature or document format changes.
+
+The native regression creates 5,000 objects and measures the median of three
+20,000-query runs for the first and last objects. Its relative-scaling check
+fails on the old implementation: first 94,100 ns, last 16,872,900 ns (about
+179x). With the index, first 111,600 ns and last 111,700 ns. This measures the
+membership primitive, not overall publication. The same test checks null and
+invalid pointers without dereferencing them, removal, undo/redo and clearing.
+
+```powershell
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run
+& "$native/bin/App_tests_run.exe" '--gtest_filter=DocumentObjectTest.membershipLookupDoesNotScanCreationOrder' '--gtest_output=xml:build/membership-index-red.xml'
+cmd /d /c build\authoritative-runtime-build.cmd App_tests_run all
+& "$native/bin/App_tests_run.exe" '--gtest_filter=DocumentObjectTest.membershipLookupDoesNotScanCreationOrder:DocumentObjectTest.linkCleanup*:AsyncRecomputeTest.SynchronousGuiCallerKeepsEventsAndMutationLeaseLive' '--gtest_output=xml:build/membership-index-green.xml'
+& "$native/bin/App_tests_run.exe"
+& "$native/bin/Assembly_tests_run.exe"
+```
+
+Both builds exit 0. Red exits 1 on the scaling assertion; green passes all four
+focused cases in 699 ms. The full App suite finishes in 3.653 s: 590 pass, two
+skip and the same four failures documented above. All six Assembly tests pass
+in 1.366 s. The intermediate d7c92dac package build was intentionally cancelled
+to include this core fix; it is not a failed compilation or a verified archive.
+The saved unprofiled trace places its remaining 1.484 s adoption callback at
+item 490 (`wing_deploy`); that identifies the step, not the cause of its cost.
+Repeat packaged timing before claiming this index removes that pause.
+
+## Combined 1bbfa624 portable publication (2026-09-09)
+
+The full `pixi reinstall -e default vibecad`, package-environment install,
+`create_bundle` with portable archive enabled, and archive extraction all exit 0.
+The 582,573,173-byte archive contains 48,260 files. Dependency, provider,
+windowless provider, geometry-worker and Codex 0.153.4 execution smokes pass.
+The actual GUI reports native revision
+`1bbfa6248ac5c0e6939755d9b2646e252fb6d5e0`; no source overlays are used.
+
+The retained publication probe runs with profiling disabled, working-candidate
+validation enabled and cancellation after item 900. The fresh robot opens with
+3,022 objects. Validation takes 3.562 s. Cancellation is exercised and rollback
+matches the complete original inventory before retrying all 1,159 outputs and
+members. Retry through publication/presentation takes **66.281 s**, versus
+87.406 s in cd7581be (24.2% less elapsed time). The final settled document has
+3,253 objects, the probe passes, stderr is empty, and its GUI exits normally.
+
+The largest measured publication callback is 0.750 s (native event 742.806 ms)
+at cancellation, previously 2.234 s. The next callback is 0.344 s; the previous
+1.484 s adoption pause is absent in this run. Input after validation peaks at
+640 ms during cancellation; the largest remaining non-cancellation sample is
+282 ms. These are improvements, not proof of a never-blocking interface.
+Cold Workbench/validation overlap still delays input by 3,594 ms (native
+dispatcher event 3,648 ms), and remains an acceptance issue.
+
+External five-second process samples peak at 1,560,088,576 bytes working set.
+One preparation interval consumes 97.9 CPU-seconds in 5.0 wall-seconds, showing
+actual concurrent native work rather than merely a configured thread count.
+This does not make live owner-side document mutation parallel. The packaged
+simulation lifecycle acceptance is run separately to avoid competing GUI tests.
+
+## Combined 1bbfa624 simulation acceptance (2026-09-09)
+
+The same extracted archive passes `simulation_playback_probe.py` on a separate
+fresh robot copy with `VIBECAD_SIMULATION_PLAYBACK_ASYNC`,
+`VIBECAD_SIMULATION_AI_PLAYBACK`, `VIBECAD_SIMULATION_AI_RESEEK`,
+`VIBECAD_SIMULATION_EXPORT`, and `VIBECAD_SIMULATION_LIFECYCLE` set to `1`.
+The 3,022-object document opens in 159.047 s. The active simulation has 337
+components and 22 frames (7,414 poses); generation/display takes 47.865 s and
+65.188 process CPU-seconds. This modest generation overlap is not a claim
+that the sequential kinematic frame dependency has been removed.
+
+All 336 joints are hidden without invalidating generated results. Three actual
+AI seeks complete in 47, 76 and 72 ms without calling generation again, and
+hidden marker callbacks remain absent. Showing the joints produces 672 exact
+marker-pose comparisons, all passing. Play advances to frame 15. The asynchronous
+GIF export completes in 12.428 s, contains 22 frames at 1516 by 536 pixels, and
+20 frames differ from frame zero. The exported image was visually inspected.
+Closing with a pending frame resolves that request without accepting it and
+restores all 337 original component poses exactly. The probe passes and exits.
+
+Input samples queued after generation submission stay within 63 ms; the
+2,047 ms sample labelled `async_generate` was queued before submission during
+the probe's camera/visibility setup. Similarly, the 719 ms sample labelled
+`play` completes during the preceding bulk marker-show/verification callback,
+before Play starts. Playback reaches 250 ms, export 281 ms, and close 235 ms.
+These setup/bulk-show costs remain distinct outstanding responsiveness work.
+Observed peak working set is 1,451,761,664 bytes. A bad-Reference2 warning names
+a joint in a different, older assembly; the active simulation completes all
+checks, but the warning is retained for attribution rather than suppressed.
+
+The independent `native_assembly_playback_gui_integration.py` gate also passes
+against this archive, without source overlays: generation, seek, step,
+bidirectional playback, pause, mutation blocking, baseline save, clean state
+after save, manual close, idempotency, exact restoration, selection preservation
+and stable revision. Its stderr is empty and the GUI exits normally.
+
+## Remove discarded validation work (2026-09-09)
+
+The retained validator profile attributes 5.99 profiled seconds to formatting
+JSON whose chunks are immediately discarded, and 1.51 seconds to constructing
+95,082 Path objects, mostly for ordinary identifiers. Validation now inspects
+JSON-supported values directly while preserving finite floats, allowed/sortable
+keys, shared values versus cycles, and the interpreter's integer-conversion
+policy. It does not allocate an encoded copy of the result. Definition strings
+only undergo path-component parsing when they contain a possible parent segment;
+absolute-path and traversal checks remain intact.
+
+```powershell
+& .pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_model_size_limits.py -k definition_paths -q
+& .pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_domain_json_validation.py -q
+& .pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_domain_json_validation.py src/Mod/VibeCAD/vibecad_tests/test_model_size_limits.py src/Mod/VibeCAD/vibecad_tests/test_domain_artifact_batch.py src/Mod/VibeCAD/vibecad_tests/test_domain_timeline_runtime.py -q
+```
+
+The path regression fails red with 5,004 parses instead of one; all nine
+path-rejection cases already pass. The JSON regression fails red because
+validation invokes the forbidden encoder; 26 compatibility cases pass. Green
+passes all 62 combined tests in 7.47 s. A pytest collection issue with displaying
+a 5,001-digit parameter was corrected by assigning type-based test IDs before
+the meaningful red run. The packaging environment does not contain pytest;
+these commands use the repository's development environment.
+
+The permanent retained-validation probe runs six separate processes using the
+same extracted 1bbfa624 Python/native runtime: three with its packaged module,
+then three with the source candidate. Packaged elapsed times are 3.334, 3.319,
+3.602 s; candidate times are 2.364, 2.364, 2.365 s (29.1% median reduction).
+All runs accept the same three public outputs, 42 frames and 18,774 poses,
+preserve the request/result bytes, and create no documents.
+
+The isolated cold-Workbench GUI probe explicitly loads the candidate Python
+module without changing the archive. Validation takes 2.593 s unprofiled, but
+input still waits up to 2,813 ms during concurrent imports. The profiled overlap
+reaches 7,969 ms. This source change reduces CPU work, but does not resolve
+the GUI interpreter contention. It is not yet included in a new full archive.
+
+## Isolate Assembly result validation (2026-09-09)
+
+Assembly's production adapter now runs the same result validator in the
+existing persistent isolation runtime. It does not start another pool or skip
+reauthorization. Only detached JSON crosses the boundary; live publication
+checks are unchanged. A request nonce prevents accepting a previous result,
+worker errors preserve validation exception details, and AI/editor entry points
+forward cancellation through an additive adapter capability. Legacy adapter
+signatures remain callable. Publication probes now exercise this adapter rather
+than bypassing it with direct validation.
+
+The original focused regression failed because validation executed on the host
+interpreter. The cancellation/legacy-adapter tests then failed red because the
+session bridge was absent. A test assertion initially used the wrong failure
+field; it was corrected to the existing `failure_code` contract.
+
+```powershell
+& .pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_assembly_validation_isolation.py src/Mod/VibeCAD/vibecad_tests/test_domain_json_validation.py src/Mod/VibeCAD/vibecad_tests/test_model_size_limits.py src/Mod/VibeCAD/vibecad_tests/test_domain_artifact_batch.py src/Mod/VibeCAD/vibecad_tests/test_domain_timeline_runtime.py src/Mod/VibeCAD/vibecad_tests/test_native_session.py src/Mod/VibeCAD/vibecad_tests/test_scripted_editor_architecture.py -q
+```
+
+Green: 109 passed in 19.33 s. Using the extracted 1bbfa624 runtime with the source
+validator explicitly loaded, the actual cold-Workbench GUI test validates three
+outputs in 4.453 s with 719 ms maximum independent input latency. Its profiled
+repeat takes 4.422 s with 297 ms maximum input latency. The prior direct-host
+candidate measured 2.593 s / 2,813 ms, and 8.047 s / 7,969 ms when profiled.
+This trades some transfer/start overhead for eliminating the measured long GIL
+contention. It is not a claim that cold Workbench initialization costs nothing.
+
+The permanent retained-result probe also exercises real native cancellation:
+
+```powershell
+$bundle = (Resolve-Path 'build/portable-publication-simulation-1bbfa624/VibeCAD-26.3.1-RC6-build1-Windows-x86_64').Path
+$env:PATH = "$bundle/bin;$env:PATH"
+$env:PYTHONNOUSERSITE = '1'
+& "$bundle/bin/python.exe" src/Tools/performance/assembly_retained_validation_probe.py --module-dir src/Mod/VibeCAD --attempt build/portable-edit-checks/publication-rollback-fixture-20260908/attempt --adapter --cancel-after 2.5
+```
+
+Cancellation returns at 2.932 s; the same-process retry succeeds in 4.400 s,
+validating 42 frames, 18,774 poses and three public outputs (largest definition
+1,543,146 bytes). It creates no documents and preserves retained request/result
+bytes. An earlier 0.25 s cancellation also passes. These are explicit source
+candidate checks against the prior archive, not a newly built final package.
+
+## Simulation setup attribution and local render coordinates (2026-09-09)
+
+The full robot GUI attribution run separates visibility, camera fitting and
+marker verification. Assembly visibility takes 6.8 ms, camera orientation
+2.5 ms, and native `fitAll` 1,554 ms. The native viewer's `animatedViewAll`
+uses a nested event loop excluding user input. Simulation setup now temporarily
+disables the existing per-view animation control around both orientation and
+fitting, restoring it in `finally`. No new viewer API or preference is needed.
+An experimental extra `fitAll` argument was removed after reading that existing
+control; its in-progress native build was deliberately stopped and superseded.
+
+Showing 336 joints takes 662 ms separately from the 225 ms verification pass.
+Profiling attributes 208 ms to repeated Coin field lookup. Retaining translation
+and rotation field wrappers with their owning transform reduces the candidate
+show pass to 504 ms. All 672 actual marker poses still match their independent
+expected placements. Hidden markers remain uncomputed. The actual AI service
+seek, playback and pending-frame close checks pass, restoring 337 exact baseline
+poses. Candidate camera setup takes 33 ms; this is a source-overlay measurement
+against archive `1bbfa624`, not final package acceptance.
+
+The permanent 50-object camera GUI regression fails on the old production path
+because setup enters a nested event loop (416 ms). The candidate eliminates that
+loop (1.4 ms), but its independent framing assertion exposed a second real bug:
+the rendered center is (113, 53) instead of the model's (59, 29). Native render
+preparation had omitted the old renderer's top-level location reset, so the
+scene graph applied root placement a second time. Both translated vertices and
+rotated normals are affected. The fix clears only the private mesh copy's root
+location, preserving nested compound placements and the original shape.
+
+Red/green commands:
+
+```powershell
+& .pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py -k camera_fit -q
+& .pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py src/Mod/VibeCAD/vibecad_tests/test_animation_export.py src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py -q
+& build/authoritative-runtime-build.cmd Part_tests_run
+& build/authoritative-runtime-native/bin/Part_tests_run.exe --gtest_filter=BRepMeshTest.renderCoordinatesExcludeOnlyTheRootPlacement
+& build/authoritative-runtime-build.cmd all
+& build/authoritative-runtime-native/bin/Part_tests_run.exe '--gtest_filter=BRepMeshTest.*'
+```
+
+Python camera cases fail red before the scoped toggle; the consolidated suite
+passes 36 tests in 2.63 s. The marker regression fails on repeated field lookup
+before caching. Native root-placement regression fails red with transformed
+vertices/normals; all nine native mesh tests pass after the correction (1.142 s,
+including startup). One initial test compared freshly constructed OCCT location
+identities instead of retaining the originals; that assertion was corrected.
+An initial build command used the nonexistent `Part_tests` target and was
+corrected to `Part_tests_run`. Native tests use the matching native-module and
+host-runtime environment documented in the earlier build evidence.
+
+The full native `all` build completes successfully. The rebuilt actual GUI
+passes the 50-object framing regression: center (59, 29), camera setup 1.1 ms,
+no nested event loop, animation setting restored, and clean automatic close.
+No errors are written to its stderr. The native Qt render-controller suite also
+passes all nine cases in 1.687 s:
+
+```powershell
+& build/authoritative-runtime-native/bin/RenderMeshController_Tests_run.exe
+& build/run-native-gui-diagnostic.ps1 -Name camera-fit-root-local-7fb65966-20260909 -Script src/Tools/performance/simulation_camera_fit_probe.py
+```
+
+The controller suite uses the matching host/native environment and Qt's
+offscreen platform; its expected missing-font-directory and unsupported
+QOpenGLWidget warnings are retained. The separate actual GUI check uses the
+Windows platform. Final full-archive acceptance is still pending.
+The export cancellation probe now covers frame preparation, PNG capture and
+encoding, followed by a full export retry. Its first run was deliberately
+stopped after finding a probe-local Python import shadowing the module binding;
+that instrumentation bug was corrected before rerunning. No user process or
+original document was touched.
+
+The subsequent native run passes cancellation at all three requested phases,
+but the full export retry fails with missing `psutil`: the local diagnostic
+launcher still selected an older portable Python runtime. The packaging recipe
+already declares this dependency and the verified `1bbfa624` archive contains
+it. The diagnostic launcher now accepts an explicit bundle argument, and the
+export probe checks this dependency before opening a large model. The rerun
+uses the rebuilt native modules with that complete matching Python/Qt bundle;
+this does not substitute for final newly packaged archive acceptance.
+
+The complete-runtime rerun passes (`ok: true`) and closes automatically:
+
+```powershell
+$env:VIBECAD_SIMULATION_PLAYBACK_ASYNC = '1'
+$env:VIBECAD_SIMULATION_AI_PLAYBACK = '1'
+$env:VIBECAD_SIMULATION_AI_RESEEK = '1'
+$env:VIBECAD_SIMULATION_LIFECYCLE = '1'
+$env:VIBECAD_SIMULATION_EXPORT = '1'
+$env:VIBECAD_SIMULATION_EXPORT_CANCEL = '1'
+& build/run-native-gui-diagnostic.ps1 -Name simulation-export-cancel-complete-runtime-20260909 -Script src/Tools/performance/simulation_playback_probe.py -Document build/simulation-publication-20260908-150322/Johhny5.FCStd -Bundle build/portable-publication-simulation-1bbfa624/VibeCAD-26.3.1-RC6-build1-Windows-x86_64
+```
+
+Generation/display takes 47.585 s (65.203 s process CPU); camera setup 32.9 ms;
+showing 336 joints 502 ms plus 226 ms independent verification of all 672 poses.
+Frame, PNG and encoding-phase cancellation each preserve the previous output,
+remove staging after worker completion and restore the selected frame 9. The
+complete retry exports 22 frames in 10.786 s, with 20 visibly changed frames.
+Closing with a pending frame restores all 337 baseline poses. Independent input
+delay is at most 344 ms during generation, 47 ms during seeks, 219 ms during
+playback and 250 ms during export. A 547 ms sample spans the bulk-marker check;
+the largest heartbeat gap is 765 ms including probe comparisons. Do not label
+that entire interval as generation or claim the remaining bulk work is free.
+
+The older assembly still emits a bad-Reference2 warning (this run at `j_pin_10`;
+the previous native run reported Reference1 at `j_pin_13`). It remains an open
+attribution item. This successful selected-simulation test does not establish
+that all older assemblies are valid. No provider/encoder error remains in the
+complete-runtime retry.
+
+## Remaining publication cost and export teardown (2026-09-09)
+
+The rebuilt-native reference-only audit completed in 164.078 s. All 30 older
+track-pin joints and both targets per joint were active and resolved after
+opening; stderr was empty. This rules out permanently absent saved references
+in that run, not the intermittent warning observed previously. Opt-in native
+reference diagnostics remain available for the next reproduction.
+
+The current native publication replay used the same protected 3,022-object
+document and retained 1,159-item candidate, cancelling after item 900 before
+retrying. It passed exact rollback and completed with 3,253 objects; source,
+request, result and manifest bytes remained unchanged. Isolated validation
+took 4.687 s and the profiled retry took 71.969 s through presentation.
+The profile attributes 49.300 s across 457 calls to
+`publishProvisionalTimelineOperationBlock`, across cancellation and retry.
+Prior-publication pruning rescans all History ownership for every publication
+record. The candidate shares one call-local membership census while retaining
+exact per-record identity, role, ownership, order and property-status checks.
+This is removal of repeated native work, not parallel live-document mutation.
+
+The cancellation callback was 1.172 s with cProfile enabled (previous
+unprofiled measurement: 0.750 s). The 1.813 s maximum input sample at replay
+startup overlaps probe fixture decoding/contract checks and cold Workbench
+activation; do not attribute that entire sample to the isolated validator.
+Evidence: ignored `publication-callback-profile-dea5265d-20260909` diagnostic.
+
+Document-close export coverage also passes against the complete rebuilt-native
+runtime. The actual AI player generates and seeks the robot, then its real
+export entry starts native PNG capture. Closing the disposable document with a
+pending image token cancels the export. The previous output is unchanged,
+staging is removed only after worker completion, the controller stops polling,
+and no restore frame is requested for the deleted player. The probe completed
+in 224.266 s and exited normally, with empty stderr. Player-close coverage and
+final archive repetition remain pending.
+
+```powershell
+$env:VIBECAD_SIMULATION_PLAYBACK_ASYNC = '1'
+$env:VIBECAD_SIMULATION_AI_PLAYBACK = '1'
+$env:VIBECAD_SIMULATION_AI_RESEEK = '1'
+$env:VIBECAD_SIMULATION_EXPORT = '1'
+$env:VIBECAD_SIMULATION_EXPORT_CLOSE = 'document'
+& build/run-native-gui-diagnostic.ps1 -Name simulation-export-document-close-dea5265d-20260909 -Script src/Tools/performance/simulation_playback_probe.py -Document build/simulation-publication-20260908-150322/Johhny5.FCStd -Bundle build/portable-publication-simulation-1bbfa624/VibeCAD-26.3.1-RC6-build1-Windows-x86_64
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_animation_export.py src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py -q
+```
+
+The `publication-joint-notification-green-20260909` replay passes exact
+900-item rollback and retry, preserving all fixture bytes and finishing with
+3,253 objects. Profiled retry time falls from 48.344 to 43.110 s. Across the
+same 29,264 calls, joint-change callback time falls from 6.433 to 0.948 s;
+owning-assembly lookups fall from 11,300 to 4,912. Marker property callback
+time falls from 1.232 to 0.439 s across 23,936 calls. Cancellation is still an
+oversized 1.187 s owner callback; this change does not claim to fix that pause.
+
+## Concurrent linked-source resolution (2026-09-09)
+
+The activity diagnostic catches `link_target_unresolved` for a published source
+link during recompute. Its saved `LinkedObject` points at a valid named source
+inside its program container. The native resolver calls `getSubName()`, which
+clears and rewrites shared strings/vectors on every read. It then passes the
+returned string pointer into subobject traversal. Simultaneous display reads
+can clear that storage between those steps, returning the link itself or a
+different object instead of the linked source. This can silently exclude a
+constraint during validity checks as well as produce the reported warning.
+
+The native regression warms ordinary dependency caches, leaves the document
+unchanged, and concurrently resolves one subobject link while reading its
+public sub-element cache. Before the fix it records 4,204, 4,527 and 3,932 wrong
+targets across three readers (12,663 failures in 60,000 target resolutions).
+The resolver now derives its traversal path into local storage directly from
+the unchanged link property. It no longer mutates or borrows display-cache
+storage. Existing APIs, sub-element parsing rules and property-change handling
+are retained; no retry, warning suppression or GUI-thread solve is introduced.
+
+```powershell
+build/authoritative-runtime-build.cmd App_tests_run
+# Red: exit 1; 12,663 target mismatches, regression takes 36 ms.
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=DocumentTest.concurrentLinkedSubobjectResolutionPreservesTarget
+build/authoritative-runtime-build.cmd FreeCADApp App_tests_run
+# Green: all 25 repetitions pass, 1.5 million target resolutions.
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=DocumentTest.concurrentLinkedSubobjectResolutionPreservesTarget --gtest_repeat=25
+# Green: 81 native document/dependency tests pass.
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=DocumentTest.*:SemanticDependencyOrder.*
+# Final consolidation: 115 document, dependency and Link tests pass.
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=DocumentTest.*:SemanticDependencyOrder.*:LinkTest.*
+```
+
+Commands use the matching native dependency/Python environment documented
+above. The actual robot lifecycle then passes in
+`simulation-link-resolution-green-20260909`, completing in 246.688 s and exiting
+automatically. Stderr is empty, with neither the bad-reference warning nor the
+new inactive-source diagnostic. The actual AI service generates and displays
+the simulation, performs exact seeks and playback, verifies marker poses,
+cancels export during frame preparation, PNG capture and encoding, then retries
+the complete animation. Full export takes 11.431 s. Closing with a pending frame
+restores all 337 baseline poses. Maximum independent input delay is 578 ms
+across the entire instrumented lifecycle (including bulk marker verification);
+the largest heartbeat gap is 750 ms. Final full-archive acceptance remains
+outstanding; this does not claim every owner callback is short.
+
+```powershell
+$env:VIBECAD_SIMULATION_PLAYBACK_ASYNC = '1'
+$env:VIBECAD_SIMULATION_AI_PLAYBACK = '1'
+$env:VIBECAD_SIMULATION_AI_RESEEK = '1'
+$env:VIBECAD_SIMULATION_LIFECYCLE = '1'
+$env:VIBECAD_SIMULATION_EXPORT = '1'
+$env:VIBECAD_SIMULATION_EXPORT_CANCEL = '1'
+$env:VIBECAD_SIMULATION_EXPORT_CLOSE = ''
+& build/run-native-gui-diagnostic.ps1 -Name simulation-link-resolution-green-20260909 -Script src/Tools/performance/simulation_playback_probe.py -Document build/simulation-publication-20260908-150322/Johhny5.FCStd -Bundle build/portable-publication-simulation-1bbfa624/VibeCAD-26.3.1-RC6-build1-Windows-x86_64
+```
+
+The consolidated Python command passes: 36 tests in 3.63 s. The new native
+membership-count regression was added first; the red build fails because
+`countSemanticMembers` is not yet present. The full native build then passes,
+and all 80 Document and semantic-dependency tests pass in 1.917 s, including the
+live-document ownership-change/provenance regression. No newly packaged
+archive is claimed here.
+
+```powershell
+build/authoritative-runtime-build.cmd App_tests_run # red: missing census helper
+build/authoritative-runtime-build.cmd all           # green: exit 0
+# Native test dependency/Python environment configured as above:
+build/authoritative-runtime-native/bin/App_tests_run.exe --gtest_filter=SemanticDependencyOrder.*:DocumentTest.*
+```
+
+The same profiled robot replay now passes in
+`publication-membership-green-20260909`: exact 900-item rollback, full retry,
+3,253 final objects and unchanged fixture bytes. The native History publication
+calls fall from **49.300 to 6.447 s** across the same 457 calls (86.9% less).
+The full retry through presentation falls from **71.969 to 48.344 s** (32.8%
+less). The overall owner-thread profile drops from 91.252 to 48.872 s.
+Stderr is empty and the diagnostic exits normally.
+
+Cancellation remains a separate oversized callback: 1.282 s profiled, with
+1,078 ms independent input delay. The next-largest owner callback is 219 ms.
+Do not claim that the ownership census fixes rollback latency or every UI
+pause; it removes the measured repeated History work without weakening its
+live-state checks.
+
+## Player teardown and joint notification filtering (2026-09-09)
+
+Player-close export coverage passes in
+`simulation-export-task-close-d12fbc13-20260909` (222.125 s, automatic exit).
+Rejecting the actual task while native PNG capture is pending cancels the
+export, restores all 337 baseline poses, preserves the previous animation,
+and removes staging after the worker finishes. The controller stops polling
+and does not attempt to restore a frame into the closed player.
+
+```powershell
+$env:VIBECAD_SIMULATION_PLAYBACK_ASYNC = '1'
+$env:VIBECAD_SIMULATION_AI_PLAYBACK = '1'
+$env:VIBECAD_SIMULATION_AI_RESEEK = '1'
+$env:VIBECAD_SIMULATION_LIFECYCLE = '0'
+$env:VIBECAD_SIMULATION_EXPORT = '1'
+$env:VIBECAD_SIMULATION_EXPORT_CANCEL = '0'
+$env:VIBECAD_SIMULATION_EXPORT_CLOSE = 'task'
+& build/run-native-gui-diagnostic.ps1 -Name simulation-export-task-close-d12fbc13-20260909 -Script src/Tools/performance/simulation_playback_probe.py -Document build/simulation-publication-20260908-150322/Johhny5.FCStd -Bundle build/portable-publication-simulation-1bbfa624/VibeCAD-26.3.1-RC6-build1-Windows-x86_64
+```
+
+This run reproduces the older assembly's Reference1 warning on two joints.
+The native diagnostic reports an unresolved moving part despite an existing
+target and two saved subreferences. Immediately repeated joint/target History
+checks pass. This establishes an intermittent runtime failure, not its cause;
+the target is not permanently absent from the saved document. Additional
+opt-in diagnostics record the failing activity-check stage during recompute.
+
+The publication profile attributes 6.433 s to 29,264 `Joint.onChanged` calls,
+including 11,300 owning-assembly lookups. Most notifications are metadata or
+playback placements for which that handler has no action. The handler now
+filters those properties before resolving History or ownership. Reference and
+joint-type handlers return after their existing work. The view-provider
+handler likewise ignores properties other than its two marker placements
+before resolving `ViewObject`. Existing editing behavior remains unchanged.
+
+Red: 14 focused unhandled-property cases failed before implementation. Green:
+45 playback-cache tests pass, including seven handled-property edit cases.
+The consolidated command passes 57 tests in 3.51 s; the native touched-area
+build exits 0. Actual publication timing is recorded separately after replay.
+
+```powershell
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py -q
+build/authoritative-runtime-build.cmd Assembly src/Mod/Assembly/AssemblyScripts
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_animation_export.py src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py -q
+```
+
+## Persisted native playback (2026-09-09)
+
+Previously, asynchronous playback reused solved channels only while the native
+Assembly object remained alive. Closing/reopening a document required another
+kinematic solve. The new additive `startSimulationPlayback` entry reuses private
+persisted channels for matching detached native inputs. Existing
+`startSimulation` and `generateSimulation` retain full-solver semantics. The
+human/AI read-only player selects the playback entry; authoring generation
+continues selecting the full solver.
+
+Input keys use the existing Ondsel serializer at round-trip double precision,
+canonical container ordering, component names/offsets, and producer revision.
+Hashing streams through the serializer without an input temporary file or a
+whole-text allocation. Cached channels are checked against their input key,
+dimensions, actual file length, finite samples, byte order and payload digest.
+Truncated/corrupt/missing data is regenerated asynchronously on the existing
+HostRuntime, with no synchronous GUI recovery path. File-size arithmetic, not
+an arbitrary component/frame ceiling, limits decoding. Atomic cache writes
+cannot replace a good entry with a partial one. An optional cache write failure
+is reported without throwing away the successful simulation; cancellation and
+solver failures still propagate.
+
+Cached poses do not masquerade as a complete ASMT engine: full solver data and
+diagnostics remain separate. The same observed input graph, object identity
+checks, request tokens, cancellation and pose application protect both sources.
+The legacy frame method remains available; the interactive player continues
+using parallel detached frame preparation and nonwaiting owner adoption.
+
+Red: the native cache test initially fails to compile because the cache API is
+absent; the input-key test then fails for the missing key API. The Python
+entry-selection test fails for read-only playback (one failure, one pass).
+Green: nine native cache/Assembly/frame tests and 59 Python playback tests pass.
+Native coverage checks unchanged-input reuse, retaining full solver identity,
+full-state requests after cached playback, corruption, truncation, invalid
+keys, producer/input changes, invalidating an in-flight cached frame and
+regenerating after a time-range edit, and independent frame preparation.
+The final native run passes all nine tests in 1.853 s; the consolidated Python
+export/service/playback/report-writer run passes 73 tests in 6.78 s. The complete
+native `all` build exits 0, not just the Assembly target.
+
+```powershell
+build/authoritative-runtime-build.cmd Assembly_tests_run
+build/authoritative-runtime-native/bin/Assembly_tests_run.exe
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py -q
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_animation_export.py src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py src/Tools/performance/test_async_report_writer.py -q
+build/authoritative-runtime-build.cmd all
+$env:VIBECAD_SIMULATION_PLAYBACK_ASYNC = '1'
+$env:VIBECAD_SIMULATION_AI_PLAYBACK = '1'
+$env:VIBECAD_SIMULATION_AI_RESEEK = '1'
+$env:VIBECAD_SIMULATION_LIFECYCLE = '1'
+$env:VIBECAD_SIMULATION_EXPORT = '1'
+$env:VIBECAD_SIMULATION_EXPORT_CANCEL = '1'
+$env:VIBECAD_SIMULATION_PERSISTED_REOPEN = '1'
+& build/run-native-gui-diagnostic.ps1 -Name simulation-persisted-reopen-20260909 -Script src/Tools/performance/simulation_playback_probe.py -Document build/simulation-publication-20260908-150322/Johhny5.FCStd -Bundle build/portable-publication-simulation-1bbfa624/VibeCAD-26.3.1-RC6-build1-Windows-x86_64
+```
+
+The rebuilt native GUI passes the real 3,022-object robot lifecycle in
+408.719 s with empty stderr and normal exit. Initial generation/display takes
+47.648 s (64.500 CPU s); after closing/reopening the same disposable document,
+playback preparation/display takes 0.571 s (0.797 CPU s), excluding document
+opening and the 0.442 s player submission. All 337 component poses match the
+generated baseline at frames 1, 11 and 21. All 672 joint-marker poses match;
+showing 336 joints takes 0.482 s. Frame/PNG/encoding export cancellation restores
+the selected frame. A successful 22-frame export follows in 11.340 s, then
+closing with a pending frame restores all 337 original poses.
+
+The maximum input sample is 1,219 ms at the probe's combined visibility
+restoration, player close and document close/reopen callback. The next-largest
+sample is 500 ms during initial player submission. This is not evidence of
+uniform sub-100-ms interaction. The probe now profiles these cleanup actions
+separately and records process CPU/RSS at event boundaries for final-archive
+acceptance. This native diagnostic is not the final packaged-build acceptance.
+
+## Discarded rollback notifications (2026-09-09)
+
+The remaining profiled cancellation callback took 1.187 s. Earlier attribution
+showed 10,808 VibeCAD GUI observer notifications consuming 0.889 s during native
+abort; their aggregate revision/cache/dependency work is subsequently discarded
+when the publication batch ends with `commit=False`.
+
+An explicit thread-local rollback scope now lets only VibeCAD's advisory
+object-created/deleted/changed observer skip this already-discarded work.
+The production cooperative publisher enters that scope around its existing
+native `abortTransaction` call. Native transaction replay and all other native
+or third-party observers still receive their ordinary notifications. The scope
+does not apply to normal undo/redo, other documents or other threads, and does
+not activate when no atomic batch exists. A failed abort cannot leak the scope.
+The existing outer batch still determines the commit/rollback outcome and
+performs its normal final refresh. Public entry points and defaults are retained.
+
+Seven new regression cases fail before implementation. Afterwards, the
+consolidated state, publication and progress suites pass 108 tests in 1.87 s,
+including the added unbatched compatibility case. The script build exits 0.
+
+```powershell
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_native_state.py -q -k 'publication_abort_skips or rollback_notification_scope'
+# Red: seven failures before the rollback scope and integration exist.
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_native_state.py src/Mod/VibeCAD/vibecad_tests/test_vibescript_timeline_publication.py src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py -q
+build/authoritative-runtime-build.cmd src/Mod/VibeCAD/VibeCADScripts
+$env:VIBECAD_PUBLICATION_ATTEMPT = (Resolve-Path build/native-diagnostics/publication-profile-fixture-dea5265d/attempt).Path
+$env:VIBECAD_PUBLICATION_MANIFEST = (Resolve-Path build/native-diagnostics/publication-profile-fixture-dea5265d/program.json).Path
+$env:VIBECAD_PUBLICATION_PROFILE = '1'
+$env:VIBECAD_PUBLICATION_CANCEL_AFTER = '900'
+$env:VIBECAD_PUBLICATION_WORKING_CANDIDATE = '1'
+& build/run-native-gui-diagnostic.ps1 -Name publication-rollback-observers-green-20260909 -Script src/Tools/performance/retained_publication_probe.py -Document build/simulation-publication-20260908-150322/Johhny5.FCStd -Bundle build/portable-publication-simulation-1bbfa624/VibeCAD-26.3.1-RC6-build1-Windows-x86_64
+```
+
+The actual run passes exact 900-item rollback, returns to the original 3,022
+objects, then retries all 1,159 publication items and finishes with 3,253
+objects. All source/request/result/manifest bytes remain unchanged. Stderr is
+empty and the process exits normally. The profiled cancellation callback falls
+from 1.187 to 0.453 s (61.8% less); native `abortTransaction` totals 0.438 s,
+including 0.257 s of native work. The next owner callback is 0.343 s. Full retry
+takes 42.750 s. The 1,562 ms maximum input sample occurs during replay startup,
+which also includes probe fixture checks and cold Workbench setup; it is not
+the rollback callback. Final unprofiled archive acceptance remains required.

--- a/src/Tools/performance/README.md
+++ b/src/Tools/performance/README.md
@@ -1,0 +1,223 @@
+# Packaged Windows GUI acceptance
+
+## Windows memory attribution
+
+Run `memory_lifecycle_probe.py` only in a separate packaged GUI with isolated
+preferences and a disposable `probe-document.FCStd`. Set
+`VIBECAD_ROUNDTRIP_COPY` to that copy and `VIBECAD_TRACE_PROBE_RESULT` to a JSON
+path in the same directory. It measures process-private commit and resident
+working set before opening and through two open/close cycles; it never saves
+the document. It closes only its own diagnostic process when finished.
+The sampling, observer logging and Python collection are diagnostic overhead,
+not a timing benchmark or a production cache-eviction policy.
+
+Run `blas_memory_probe.py` with the packaged `bin/python.exe` to isolate math
+library initialization from the application. It measures memory before and
+after loading `openblas.dll`, importing NumPy and multiplying a matrix, verifies
+the result, and reports the library configuration and thread count. An explicit
+`OPENBLAS_PROBE_DLL` path permits an isolated library-variant comparison; never
+replace DLLs in a user's running package. Thread environment experiments must
+be process-local, not machine-wide.
+
+Pass `--benchmark` to also measure a 2048-square matrix multiplication, a
+1024-square positive-definite solve with eight right-hand sides, and a
+512-square singular-value decomposition. Each has one warm-up and three timed
+runs with numerical verification outside the timed interval. Set
+`OMP_NUM_THREADS` in each fresh process when comparing the packaged OpenMP
+OpenBLAS build. The ordinary `OPENBLAS_NUM_THREADS` setting is not effective
+for that build. Keep the application worker pool unchanged during comparisons.
+These isolated kernels are not an end-to-end CAD benchmark; machine contention
+and coarse process CPU-time accounting affect the reported timings/core ratios.
+Do not infer a universal thread limit from one size or one run.
+
+Private commit is not resident physical RAM. A high private value alone does
+not prove a leak, and a small idle working set does not prove the committed
+allocation is free. Repeated-cycle retention and allocation provenance must be
+investigated separately. Keep raw reports local, not in git.
+
+## Document round trip
+
+This probe exercises the portable launcher's real environment and the GUI's
+open, Save, Close All, and reopen commands. It is not a substitute for solver,
+recompute, publication, workbench, or large-document acceptance.
+
+```powershell
+./src/Tools/performance/run_portable_roundtrip.ps1 `
+  -Bundle <complete-portable-directory> `
+  -Document <original.FCStd> -Name roundtrip-001
+```
+
+The launcher hashes and copies the input before launch. It only opens the
+`probe-document.FCStd` copy, isolates application preferences and agent data,
+and refuses to overwrite an existing run. Results default to the ignored
+`build/portable-validation-results` directory; `-ResultsRoot` overrides it.
+Never commit these outputs or customer documents. The original is never saved.
+Do not point the launcher at a development executable or a DLL-overlay package.
+
+Use `-BaselineReport <prior-roundtrip.json>` to compare exact object names,
+types, outgoing links, and states with a known-good application. Comparison
+normalizes self-document links and uses JSON-compatible lists. Saved invalid
+flags must remain unchanged; pre-existing invalid objects are not hidden.
+
+If a previously saved invalid flag clears during restoration, the strict run
+stops for inspection. To continue a separate diagnostic run, explicitly name
+the inspected objects with `-AllowClearedInvalidObjects <name>`. The report
+records these cleared flags at each inventory phase. New invalid objects still
+fail, and save/reopen must still preserve the complete opened inventory exactly.
+This option does not establish that the previously failed operation now solves
+correctly; retain the strict failure and investigate that separately.
+
+The benchmark measures a Qt heartbeat and window-local native input delivery.
+A separate bundled `pythonw.exe` posts F23 messages to this diagnostic window
+every 250 ms. It does not inject desktop keyboard input or change focus. Queue
+timestamps reveal input delayed while the GUI cannot run Python or timers.
+The helper stops through a named event, parent-process exit, or window-owner
+change. This helper is benchmark instrumentation, not a production worker.
+
+`roundtrip.json` reports integrity and responsiveness separately. `ok` requires
+both, including input samples and no measured heartbeat/input delay above
+100 ms. Failure is retained as failure; the probe never dismisses an unexpected
+save prompt or clears modified state to force a pass. Integrity failures leave
+the diagnostic window available for inspection. Successful runs close it.
+Screenshots are captured outside the timed interval; inspect them for shaded
+geometry, Tree, History, and display correctness.
+
+`-ProfileCallbacks` also writes `roundtrip.pstats` for Python callback
+attribution. Profiling adds overhead: use a separate unprofiled run for timing
+acceptance. The input sender, heartbeat, and observer diagnostics also add some
+overhead; compare runs with the same instrumentation. The opt-in production
+trace switch `VIBECAD_RESTORE_DETAIL_TRACE` is enabled by this launcher.
+
+`-ProfileCommandChecks` measures each instantiated command's `isActive()` check
+after the first open and records `command_checks` in the report. It does not
+execute commands or create additional actions. Checks are spread across probe
+ticks; use a separate run without this option for final timing acceptance.
+
+```powershell
+python -c "import pstats; pstats.Stats('<roundtrip.pstats>').strip_dirs().sort_stats('cumulative').print_stats(30)"
+```
+
+Keep original logs and failed reports. A successful build, runtime smoke test,
+or matching inventory alone does not establish responsiveness.
+
+For original FreeCAD corpus files that predate VibeCAD History, pass
+`-AllowTimelineMigration` explicitly. The probe then accepts exactly one new
+`App::DocumentTimeline` on first open and records its name as
+`timeline_migration`. Every original object must remain; any other addition or
+loss still fails. Reopen must preserve the complete migrated inventory. This
+option does not relax invalid-state, link round-trip, or responsiveness checks.
+
+`-TraceNativeEvents` adds C++/Qt event attribution to `roundtrip.json`: event
+type, receiver class/name, nesting depth, start time, and elapsed time. Native
+records are collected only with `VIBECAD_RESTORE_DETAIL_TRACE`; collection
+does no file I/O on the GUI thread. A 4,096-record diagnostic buffer reports
+overflow explicitly, and the probe drains it each tick. This is a trace-memory
+bound, not an operation limit. Use an untraced run for final timing acceptance.
+Named native scopes use the same buffer and clock, with `event_type: -1` and
+a `phase` label. Close scopes distinguish delete notifications, view-provider
+destruction, and viewer/provider-graph release; these scopes can overlap and
+their durations must not be added together as independent costs.
+`gui_event_trace_probe.py` checks recording and draining with one deliberately
+slow diagnostic event; set `VIBECAD_TRACE_PROBE_RESULT` to its ignored JSON path
+and run it in a fresh packaged GUI with tracing enabled.
+
+## Generated dependency workload
+
+`generate_boolean_document.py` creates 200 independent Box/Cylinder/Cut
+branches: 600 CAD features, plus the native History controller. It checks every
+result's solid count and analytic volume before saving, and records recompute
+wall time and whole-process CPU time. CPU time divided by wall time estimates
+average occupied cores; a configured worker count alone is not parallelism
+evidence. Run it through the complete portable **root** command launcher, or a
+native build's matching Python/DLL environment:
+
+```powershell
+$env:VIBECAD_GENERATED_DOCUMENT = '<ignored-output-directory>/parallel-600.FCStd'
+& '<portable-directory>/FreeCADCmd.exe' ./src/Tools/performance/generate_boolean_document.py
+```
+
+The generator refuses to overwrite an existing file. Feed the generated FCStd
+to the GUI round-trip launcher afterwards; headless geometry checks do not
+prove UI responsiveness. Retain the adjacent JSON measurements with the run.
+Add `-ExerciseGeneratedRecompute` to touch all 600 generated features and click the real
+History recompute button before saving. This records command-return and total
+CPU/wall time, waits for native recompute and presentation completion, and
+checks types, links, and invalid flags again (Touched may clear). It only accepts the named
+generated workload; do not enable it for a customer document.
+
+After the GUI run, check the saved copy's geometry through the same portable
+root command launcher without loading geometry synchronously into the GUI:
+
+```powershell
+$env:VIBECAD_VALIDATE_DOCUMENT = '<run-directory>/probe-document.FCStd'
+$env:VIBECAD_EXPECTED_GEOMETRY = '<generated-document-directory>/parallel-600.json'
+& '<portable-directory>/FreeCADCmd.exe' ./src/Tools/performance/validate_boolean_document.py
+```
+
+This read-only check compares object count and every result's solid count,
+volume, and face count with the generator's original measurements.
+
+## VibeScript edit and cancellation lifecycle
+
+Run `vibescript_edit_probe.py` through the complete portable GUI launcher with
+an isolated user profile. Set `VIBECAD_TRACE_PROBE_RESULT` to a new, ignored JSON
+report path. The probe creates its own 50-output document and project, exercises
+the real create, source-patch, and input-edit adapters, then cancels a patch
+during publication. It checks geometry, retained object identities, and rollback.
+It records phase events and GUI heartbeat gaps, then closes its own document
+and diagnostic instance. Do not inject it into a user's working session.
+
+The probe reuses the repository's native integration service fixture; production
+modules and the worker runtime come from the running build. A successful model
+assertion alone is not a responsiveness pass: inspect the recorded gaps and
+native traces as well. Initial object adoption and final projection costs are
+reported separately from the background worker duration.
+
+## Model-capacity and retained-result checks
+
+These Python-only checks use the packaged native kernel, without opening or
+modifying a user's GUI document. On Windows, use the portable's matching Python,
+DLLs and modules (not the system Python):
+
+```powershell
+$bundle = '<extracted-portable-directory>'
+$env:PYTHONHOME = "$bundle/bin"
+$env:PYTHONPATH = "$bundle/bin;$bundle/Mod/VibeCAD"
+$env:PATH = "$bundle/bin;$env:PATH"
+& "$bundle/bin/python.exe" src/Tools/performance/model_capacity_probe.py --module-dir src/Mod/VibeCAD
+& "$bundle/bin/python.exe" src/Tools/performance/large_definition_probe.py --module-dir src/Mod/VibeCAD
+& "$bundle/bin/python.exe" src/Tools/performance/collision_scale_probe.py --module-dir src/Mod/VibeCAD
+& "$bundle/bin/python.exe" src/Tools/performance/assembly_retained_validation_probe.py --module-dir src/Mod/VibeCAD --attempt '<retained-attempt-directory>'
+```
+
+The capacity probe captures and reloads 337 native leaf shapes and 2,437
+occurrences, then executes a small joint simulation through the real worker,
+host postconditions, publication and acceptance. `--components 3000` requests
+an expensive native simulation stress run; it is not the default smoke test.
+The large-definition probe validates a >1 MB mesh through worker and host.
+The collision probe measures sparse box fixtures, including 10,000 components;
+its timings are not representative of arbitrary aircraft or robot geometry.
+The retained-result probe reads an existing successful Assembly worker attempt
+and re-runs host validation, checking that request/result files and the native
+document list remain unchanged. It does **not** publish into a user's document.
+
+The capacity-fix batch passed 290 focused Python tests. Packaged checks passed:
+1,301,778-byte mesh worker/host validation; native hierarchy and small simulation
+publication; 10,000-component sparse collision analysis; and a retained simulation
+with 22 frames, 7,414 poses and a 1,259,836-byte largest definition. A separate
+3,000-component native stress run was stopped during recompute and is **not**
+passing evidence. These checks establish capacity/validation behavior, not GUI
+responsiveness for every model.
+
+Run the focused regression batch from the repository environment:
+
+```powershell
+.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_model_size_limits.py src/Mod/VibeCAD/vibecad_tests/test_mechanism_engine.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_bom.py src/Mod/VibeCAD/vibecad_tests/test_vibescript_definition_size.py src/Mod/VibeCAD/vibecad_tests/test_mechanism_geometry_scale.py src/Mod/VibeCAD/vibecad_tests/test_modeling_surface_architecture.py src/Mod/VibeCAD/vibecad_tests/test_domain_artifact_batch.py src/Mod/VibeCAD/vibecad_tests/test_native_model_fastener.py -q --tb=short
+```
+
+Removing fixed model-count and definition-size ceilings does not remove finite
+number, identity, connectivity, ownership, cycle, or artifact-integrity checks.
+AI previews remain bounded with omission counts. Existing memory-related guards
+(including the 64 MiB simulation trace and 256 MiB native artifact guards),
+recursive depth guards and explicitly requested read budgets remain. This is
+not a claim that every limit elsewhere in the platform has been removed.

--- a/src/Tools/performance/assembly_retained_validation_probe.py
+++ b/src/Tools/performance/assembly_retained_validation_probe.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Revalidate retained worker results without rebuilding or modifying a CAD document."""
+
+
+def main():
+    import argparse
+    import hashlib
+    import json
+    import os
+    from pathlib import Path
+    import sys
+    import threading
+    import time
+
+    dll_handles = [os.add_dll_directory(str(Path(sys.executable).parent))] if os.name == 'nt' else []
+    import FreeCAD as App
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--module-dir', type=Path, required=True)
+    parser.add_argument('--attempt', type=Path, required=True)
+    parser.add_argument('--adapter', action='store_true',
+                        help='Use the production adapter and persistent isolation pool.')
+    parser.add_argument('--cancel-after', type=float,
+                        help='Cancel adapter validation after this many seconds, then retry.')
+    args = parser.parse_args()
+    sys.path.insert(0, str(args.module_dir.resolve()))
+    import VibeCADVibeScriptDomainRuntime as runtime
+    from VibeCADVibeScriptDomains import get_vibescript_pack
+
+    assert Path(runtime.__file__).parent == args.module_dir.resolve()
+    started = time.perf_counter()
+    request_bytes = (args.attempt / 'request.json').read_bytes()
+    result_bytes = (args.attempt / 'result.json').read_bytes()
+    request = json.loads(request_bytes)
+    execution = json.loads(result_bytes)
+    assert execution['ok'] and request['domain'] == 'assembly'
+    prepared = dict(pack=get_vibescript_pack('AssemblyWorkbench'), staging=args.attempt,
+                    expected_outputs=request['expected_outputs'], worker_request=request,
+                    resolved_references=request.get('document_references', []))
+    original_documents = dict(App.listDocuments())
+    if args.cancel_after is not None:
+        if not args.adapter or args.cancel_after <= 0:
+            parser.error('--cancel-after requires --adapter and a positive duration')
+        cancelled = threading.Event()
+        timer = threading.Timer(args.cancel_after, cancelled.set)
+        timer.start()
+        try:
+            runtime.AssemblyDomainAdapter(prepared['pack']).validate_result_with_cancellation(
+                prepared, execution, cancellation_check=cancelled.is_set)
+        except runtime.DomainRuntimeFailure as exc:
+            assert exc.payload['cancelled']
+            assert exc.payload['failure_code'] == 'RUN_CANCELLED'
+            print(json.dumps(dict(cancelled=True, seconds=time.perf_counter() - started)), flush=True)
+        else:
+            raise AssertionError('Validation finished without exercising cancellation')
+        finally:
+            timer.cancel()
+            timer.join()
+        started = time.perf_counter()
+    validate = (runtime.AssemblyDomainAdapter(prepared['pack']).validate_result
+                if args.adapter else runtime.validate_candidate)
+    validated = validate(prepared, execution)
+    assert dict(App.listDocuments()) == original_documents
+    for filename, before in (('request.json', request_bytes), ('result.json', result_bytes)):
+        assert hashlib.sha256((args.attempt / filename).read_bytes()).digest() == hashlib.sha256(before).digest()
+    summary = validated['assembly_validation'].get('simulation') or {}
+    print(json.dumps(dict(ok=True, seconds=round(time.perf_counter() - started, 3),
+        output_count=len(validated['outputs']),
+        largest_definition_bytes=max(len(json.dumps(item['definition']).encode())
+                                     for item in validated['outputs']),
+        frame_count=summary.get('frame_count'), pose_count=summary.get('pose_count'),
+        document_modified=False, request_and_result_unchanged=True)), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/Tools/performance/async_report_writer.py
+++ b/src/Tools/performance/async_report_writer.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Coalesced diagnostic output: no serialization or disk I/O on the measured GUI."""
+from concurrent.futures import Future
+import json
+import threading
+
+
+class AsyncReportWriter:
+    """Own one diagnostic writer, at most one in-flight and one pending snapshot.
+
+    Submitted snapshots must not be mutated. Await the final Future by polling
+    from the probe's event loop before exiting; never wait on it in a GUI callback.
+    This is test instrumentation, not an application execution pool.
+    """
+
+    def __init__(self, path):
+        self._path = path
+        self._condition = threading.Condition()
+        self._pending = None
+        self._closed = False
+        self._thread = threading.Thread(target=self._run, name='performance-report', daemon=True)
+        self._thread.start()
+
+    def submit(self, snapshot):
+        future = Future()
+        with self._condition:
+            if self._closed:
+                raise RuntimeError('Report writer is closed')
+            if self._pending is not None:
+                self._pending[0].cancel()
+            self._pending = future, snapshot
+            self._condition.notify()
+        return future
+
+    def close(self):
+        """Drain pending output and exit without blocking the caller."""
+        with self._condition:
+            self._closed = True
+            self._condition.notify()
+
+    def _run(self):
+        while True:
+            with self._condition:
+                self._condition.wait_for(lambda: self._pending is not None or self._closed)
+                if self._pending is None:
+                    return
+                future, snapshot = self._pending
+                self._pending = None
+            if not future.set_running_or_notify_cancel():
+                continue
+            try:
+                self._path.write_text(json.dumps(snapshot, separators=(',', ':')), encoding='utf-8')
+            except Exception as error:
+                future.set_exception(error)
+            else:
+                future.set_result(None)

--- a/src/Tools/performance/blas_memory_probe.py
+++ b/src/Tools/performance/blas_memory_probe.py
@@ -1,0 +1,86 @@
+import ctypes
+import argparse
+import json
+import os
+from pathlib import Path
+import sys
+import time
+
+parser = argparse.ArgumentParser(description='Isolated packaged OpenBLAS memory measurement')
+parser.add_argument('--benchmark', action='store_true', help='Compare checked dense linear algebra kernels')
+arguments = parser.parse_args()
+
+class Counters(ctypes.Structure):
+    _fields_ = [('cb', ctypes.c_ulong), ('faults', ctypes.c_ulong)] + [
+        (name, ctypes.c_size_t) for name in ('peak_ws', 'ws', 'peak_paged', 'paged',
+                                          'peak_nonpaged', 'nonpaged', 'pagefile',
+                                          'peak_pagefile', 'private')]
+k = ctypes.WinDLL('kernel32')
+k.GetCurrentProcess.restype = ctypes.c_void_p
+p = ctypes.WinDLL('psapi')
+p.GetProcessMemoryInfo.argtypes = [ctypes.c_void_p, ctypes.POINTER(Counters), ctypes.c_ulong]
+def sample(phase):
+    c= Counters()
+    c.cb=ctypes.sizeof(c)
+    if not p.GetProcessMemoryInfo(k.GetCurrentProcess(), ctypes.byref(c), c.cb):
+        raise ctypes.WinError()
+    print(json.dumps({'phase': phase, 'private': c.private, 'working_set': c.ws}), flush=True)
+sample('before_dll')
+directory = Path(sys.executable).parent
+with os.add_dll_directory(str(directory)):
+    dll = ctypes.CDLL(os.environ.get('OPENBLAS_PROBE_DLL', str(directory / 'openblas.dll')))
+sample('after_dll')
+dll.openblas_get_config.restype = ctypes.c_char_p
+print(json.dumps({'config': dll.openblas_get_config().decode(),
+                  'threads': dll.openblas_get_num_threads()}), flush=True)
+import numpy as np
+sample('after_numpy')
+x=np.ones((1000,1000))
+y=x@x
+assert (y==1000).all()
+sample('after_matmul')
+
+if arguments.benchmark:
+    from statistics import median
+
+    def measure(name, operation, verify):
+        verify(operation())  # Warm up kernels; exclude validation from timings.
+        timings = []
+        for _ in range(3):
+            cpu = time.process_time()
+            wall = time.perf_counter()
+            result = operation()
+            elapsed = time.perf_counter() - wall
+            cpu_elapsed = time.process_time() - cpu
+            verify(result)
+            timings.append({'wall_seconds': elapsed, 'cpu_seconds': cpu_elapsed,
+                            'average_cpu_cores': cpu_elapsed / elapsed})
+            del result
+        print(json.dumps({'phase': 'benchmark', 'kernel': name,
+                          'threads': dll.openblas_get_num_threads(),
+                          'median_seconds': median(t['wall_seconds'] for t in timings),
+                          'runs': timings, 'correct': True}), flush=True)
+        sample('after_' + name)
+
+    rng = np.random.default_rng(187)
+    a = rng.standard_normal((2048, 2048))
+    b = rng.standard_normal((2048, 2048))
+    vector = rng.standard_normal(2048)
+    expected = a @ (b @ vector)
+    measure('matmul_2048', lambda: a @ b,
+            lambda result: np.testing.assert_allclose(result @ vector, expected, rtol=1e-9, atol=1e-8))
+    del a, b, vector, expected
+    a = rng.standard_normal((1024, 1024))
+    a = a.T @ a + 1024 * np.eye(1024)
+    expected = rng.standard_normal((1024, 8))
+    rhs = a @ expected
+    measure('solve_1024_8rhs', lambda: np.linalg.solve(a, rhs),
+            lambda result: np.testing.assert_allclose(result, expected, rtol=1e-9, atol=1e-10))
+    del a, expected, rhs
+    a = rng.standard_normal((512, 512))
+
+    def verify_svd(result):
+        u, s, vh = result
+        np.testing.assert_allclose((u * s) @ vh, a, rtol=1e-9, atol=1e-10)
+
+    measure('svd_512', lambda: np.linalg.svd(a, full_matrices=False), verify_svd)

--- a/src/Tools/performance/collision_scale_probe.py
+++ b/src/Tools/performance/collision_scale_probe.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Real-kernel collision scale check; run with packaged Python, never a live GUI."""
+
+
+def main():
+    import argparse
+    import json
+    import os
+    from pathlib import Path
+    import sys
+    import time
+
+    handles = [os.add_dll_directory(str(Path(sys.executable).parent))]
+    import FreeCAD as App
+    import Part
+    import psutil
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--module-dir', type=Path)
+    args = parser.parse_args()
+    if args.module_dir:
+        sys.path.insert(0, str(args.module_dir.resolve()))
+    import VibeCADMechanismGeometry as geometry
+    if args.module_dir:
+        assert Path(geometry.__file__).parent == args.module_dir.resolve(), geometry.__file__
+    from VibeCADMechanismGeometry import (
+        DynamicCollisionEvaluator, evaluate_dynamic_collisions,
+    )
+
+    box = Part.makeBox(1, 1, 1)
+    process = psutil.Process()
+    for count, frame_count in ((337, 22), (10_000, 1)):
+        start = time.perf_counter()
+        names = [f'Component_{index}' for index in range(count)]
+        components = dict.fromkeys(names, box)
+        definitions = dict.fromkeys(names, 'shared-unit-box')
+        placements = {
+            name: dict(position_mm=[index * 2.0, 0, 0], rotation_xyzw=[0, 0, 0, 1])
+            for index, name in enumerate(names)
+        }
+        # One real overlap, including the final component beyond the old cap.
+        placements[names[-1]] = dict(position_mm=[0.5, 0, 0], rotation_xyzw=[0, 0, 0, 1])
+        frames = [dict(frame_index=index,
+                       nominal_time_s=None if index == 0 else (index - 1) / 10,
+                       component_placements=placements)
+                  for index in range(frame_count + 1)]
+        result = evaluate_dynamic_collisions(components, frames,
+            definition_keys=definitions, frame_workers=2 if count == 337 else 1)
+        summary = result['summary']
+        assert summary['component_count'] == count, summary
+        assert summary['evaluated_frame_count'] == frame_count, summary
+        assert summary['colliding_pair_count'] == 1, summary
+        assert summary['colliding_frame_count'] == frame_count, summary
+        assert summary['pairs'][0]['second_component'] == names[-1], summary
+        assert summary['possible_pair_count'] == count * (count - 1) // 2
+        print(json.dumps(dict(event='scale', components=count, frames=frame_count,
+            seconds=time.perf_counter() - start, private_bytes=process.memory_info().private,
+            pair_count=summary['possible_pair_count'], colliding_pairs=1)), flush=True)
+
+    # Broad-phase rejection must not discard an authenticated rigid-pair result,
+    # and an explicit exclusion must still take precedence over that reuse.
+    evaluator = DynamicCollisionEvaluator({'First': box, 'Last': box},
+        definition_keys={'First': 'box', 'Last': 'box'})
+    pose = {name: dict(position_mm=[index * 10.0, 0, 0], rotation_xyzw=[0, 0, 0, 1])
+            for index, name in enumerate(evaluator.component_names)}
+    evidence = dict(first_component='First', second_component='Last',
+        interference_volume_mm3=1.0, common_solid_count=1)
+    reused = evaluator.evaluate_with_known_pairs(pose,
+        known_pair_results={('First', 'Last'): evidence})
+    assert reused['collisions'] == [evidence], reused
+    excluded = evaluator.evaluate_with_known_pairs(pose,
+        known_pair_results={('First', 'Last'): evidence}, excluded_pairs={('First', 'Last')})
+    assert excluded['collisions'] == [], excluded
+    fork = evaluator.fork()
+    assert fork.pair_count == evaluator.pair_count
+    assert fork.evaluate(pose)['collisions'] == []
+    assert not App.listDocuments()
+    print(json.dumps(dict(event='complete', ok=True)), flush=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/Tools/performance/generate_boolean_document.py
+++ b/src/Tools/performance/generate_boolean_document.py
@@ -1,0 +1,61 @@
+"""Generate a disposable independent-branch CAD workload, never a customer file."""
+import json
+import math
+import os
+from pathlib import Path
+import time
+
+import FreeCAD as App
+import Part
+
+output = Path(os.environ['VIBECAD_GENERATED_DOCUMENT']).resolve()
+if output.exists():
+    raise RuntimeError('Refusing to replace an existing generated document')
+output.parent.mkdir(parents=True, exist_ok=True)
+started = time.perf_counter()
+doc = App.newDocument('ParallelBoolean600')
+expected = {}
+for index in range(200):
+    length = 10 + index % 5
+    width = 12 + index % 7
+    height = 14 + index % 3
+    x, y = (index % 20) * 25, (index // 20) * 30
+    box = doc.addObject('Part::Box', f'Blank{index:03d}')
+    box.Length, box.Width, box.Height = length, width, height
+    box.Placement.Base = App.Vector(x, y, 0)
+    cylinder = doc.addObject('Part::Cylinder', f'Bore{index:03d}')
+    cylinder.Radius, cylinder.Height = 2, height + 2
+    cylinder.Placement.Base = App.Vector(x + length / 2, y + width / 2, -1)
+    result = doc.addObject('Part::Cut', f'Result{index:03d}')
+    result.Base, result.Tool = box, cylinder
+    box.Visibility, cylinder.Visibility = False, False
+    expected[result.Name] = height * (length * width - math.pi * 4)
+
+before = time.perf_counter()
+cpu_before = os.times()
+doc.recompute()
+recompute_seconds = time.perf_counter() - before
+cpu_after = os.times()
+recompute_cpu_seconds = (cpu_after.user + cpu_after.system
+                         - cpu_before.user - cpu_before.system)
+actual = {}
+for name, volume in expected.items():
+    obj = doc.getObject(name)
+    if obj.Shape.isNull() or len(obj.Shape.Solids) != 1:
+        raise RuntimeError(f'{name} did not produce one solid')
+    if not math.isclose(obj.Shape.Volume, volume, rel_tol=1e-8):
+        raise RuntimeError(f'{name} volume mismatch: {obj.Shape.Volume} != {volume}')
+    actual[name] = {'volume': obj.Shape.Volume, 'faces': len(obj.Shape.Faces)}
+doc.saveAs(str(output))
+report = {
+    'objects': len(doc.Objects), 'independent_branches': len(expected),
+    'recompute_seconds': recompute_seconds,
+    'recompute_cpu_seconds': recompute_cpu_seconds,
+    'average_cpu_cores': recompute_cpu_seconds / recompute_seconds,
+    'total_seconds': time.perf_counter() - started,
+    'runtime': dict(App.hostRuntimeStatus()), 'expected_results': actual,
+}
+output.with_suffix('.json').write_text(json.dumps(report, indent=2), encoding='utf-8')
+print('VIBECAD_GENERATED_WORKLOAD ' + json.dumps({key: value for key, value in report.items()
+                                               if key != 'expected_results'}), flush=True)
+App.closeDocument(doc.Name)

--- a/src/Tools/performance/gui_event_trace_probe.py
+++ b/src/Tools/performance/gui_event_trace_probe.py
@@ -1,0 +1,54 @@
+"""Exercise native event attribution in a fresh diagnostic GUI process."""
+import json
+import os
+from pathlib import Path
+import time
+import traceback
+
+import FreeCADGui as Gui
+from PySide6 import QtCore, QtWidgets
+
+
+class TraceReceiver(QtCore.QObject):
+    def event(self, event):
+        if event.type() == QtCore.QEvent.Type.User:
+            time.sleep(0.02)  # Deliberate diagnostic event, not production work.
+            return True
+        return super().event(event)
+
+
+def run():
+    result = {'ok': False}
+    try:
+        app = QtWidgets.QApplication.instance()
+        def drain():
+            return QtCore.QMetaObject.invokeMethod(
+                app, 'takePerformanceEvents', QtCore.Qt.ConnectionType.DirectConnection,
+                QtCore.Q_RETURN_ARG('QVariantMap'))
+        drain()
+        receiver = TraceReceiver()
+        receiver.setObjectName('performance_trace_contract')
+        QtCore.QCoreApplication.sendEvent(receiver, QtCore.QEvent(QtCore.QEvent.Type.User))
+        trace = drain()
+        records = [item for item in trace['events']
+                   if item['receiver_name'] == 'performance_trace_contract']
+        assert trace['enabled'] and trace['dropped'] == 0, trace
+        assert len(records) == 1 and records[0]['elapsed_ms'] >= 15, records
+        assert records[0]['event_type'] == int(QtCore.QEvent.Type.User), records
+        assert not drain()['events'], 'Drain retained already-consumed records'
+        QtCore.QMetaObject.invokeMethod(
+            app, 'recordPerformancePhase', QtCore.Qt.ConnectionType.DirectConnection,
+            QtCore.Q_ARG(str, 'diagnostic_phase'), QtCore.Q_ARG('qint64', 20_000_000))
+        phases = drain()['events']
+        assert len(phases) == 1 and phases[0]['phase'] == 'diagnostic_phase', phases
+        assert phases[0]['elapsed_ms'] == 20, phases
+        assert not drain()['events'], 'Drain retained already-consumed phases'
+        result = {'ok': True, 'record': records[0], 'phase': phases[0]}
+    except Exception:
+        result['error'] = traceback.format_exc()
+    Path(os.environ['VIBECAD_TRACE_PROBE_RESULT']).write_text(json.dumps(result, indent=2), encoding='utf-8')
+    print('VIBECAD_EVENT_TRACE_PROBE ' + json.dumps(result), flush=True)
+    QtCore.QTimer.singleShot(0, Gui.getMainWindow().close)
+
+
+QtCore.QTimer.singleShot(0, run)

--- a/src/Tools/performance/joint_transaction_replay_probe.py
+++ b/src/Tools/performance/joint_transaction_replay_probe.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Exercise native abort/undo/redo on an isolated copy of a real assembly.
+
+Use the packaged edit-check runner. VIBECAD_JOINT_SOURCE optionally selects a
+Python-only candidate module before restore. The solve observer records attempts
+without running the expensive erroneous solver during a failing baseline test.
+No document or project is saved.
+"""
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+import time
+import traceback
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from PySide6 import QtCore, QtGui, QtWidgets
+
+output = Path(os.environ['VIBECAD_TRACE_PROBE_RESULT']).resolve()
+source = Path(os.environ['VIBECAD_ROUNDTRIP_COPY']).resolve()
+if source.parent != output.parent or source.name != 'probe-document.FCStd' or App.listDocuments():
+    raise RuntimeError('Use a fresh process and an isolated document copy')
+
+if os.environ.get('VIBECAD_JOINT_SOURCE'):
+    spec = importlib.util.spec_from_file_location('JointObject', os.environ['VIBECAD_JOINT_SOURCE'])
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['JointObject'] = module
+    spec.loader.exec_module(module)
+
+started = time.monotonic()
+state = 'startup'
+quiet_since = None
+steps = None
+report = {'ok': False, 'pid': os.getpid(), 'events': [], 'solve_attempts': []}
+
+
+def event(name, **values):
+    report['events'].append(dict(event=name, seconds=time.monotonic() - started, **values))
+    output.write_text(json.dumps(report, indent=2), encoding='utf-8')
+
+
+def exercise(doc):
+    import JointObject
+    import Preferences
+    from VibeCADAssemblySolverPolicy import suspend_joint_autosolve
+
+    joints = [obj for obj in doc.Objects if isinstance(getattr(obj, 'Proxy', None), JointObject.Joint)
+              and obj.Reference1 and obj.Reference2 and JointObject._jointInteractionUsable(obj)]
+    assert joints, 'No live joint to exercise'
+    joint = joints[0]
+    original = joint.Offset1.copy()
+    changed = original.copy()
+    changed.Base.x += 0.125
+    before = {obj.Name: obj.Placement.copy() for obj in doc.Objects if 'Placement' in obj.PropertiesList}
+    solve = JointObject.solveIfAllowed
+    preferences = Preferences.preferences()
+    enabled = preferences.GetBool('SolveInJointCreation', True)
+    phase = 'edit'
+
+    def observe(assembly, storePrev=False):
+        if preferences.GetBool('SolveInJointCreation', True):
+            report['solve_attempts'].append(dict(phase=phase, transacting=doc.Transacting))
+
+    JointObject.solveIfAllowed = observe
+    try:
+        preferences.SetBool('SolveInJointCreation', True)
+        doc.openTransaction('Probe joint abort')
+        with suspend_joint_autosolve():
+            joint.Offset1 = changed
+        phase = 'abort'
+        now = time.monotonic()
+        doc.abortTransaction()
+        event('abort', elapsed_seconds=time.monotonic() - now)
+        yield
+        assert joint.Offset1.isSame(original)
+        assert all(doc.getObject(name).Placement.isSame(value) for name, value in before.items())
+        doc.openTransaction('Probe joint undo and redo')
+        with suspend_joint_autosolve():
+            joint.Offset1 = changed
+        doc.commitTransaction()
+        yield
+        phase = 'undo'
+        doc.undo()
+        yield
+        assert joint.Offset1.isSame(original)
+        phase = 'redo'
+        doc.redo()
+        yield
+        assert joint.Offset1.isSame(changed)
+        phase = 'restore'
+        doc.undo()
+        yield
+        assert joint.Offset1.isSame(original)
+        assert not report['solve_attempts'], report['solve_attempts']
+        report['ok'] = True
+        event('complete', joint=joint.Name, objects=len(doc.Objects))
+    finally:
+        JointObject.solveIfAllowed = solve
+        preferences.SetBool('SolveInJointCreation', enabled)
+
+
+def tick():
+    global state, quiet_since, steps
+    try:
+        if QtWidgets.QApplication.activeModalWidget() is not None:
+            raise RuntimeError('Unexpected modal dialog')
+        if state == 'startup':
+            state = 'opening'
+            QtCore.QCoreApplication.postEvent(QtWidgets.QApplication.instance(), QtGui.QFileOpenEvent(str(source)))
+            event('open')
+            return
+        doc = App.ActiveDocument
+        if doc is None or any((doc.Restoring, doc.Recomputing, doc.RecomputePending,
+                              doc.CooperativeMutationActive, doc.PresentationUpdateActive)):
+            quiet_since = None
+            return
+        if quiet_since is None:
+            quiet_since = time.monotonic()
+            return
+        if time.monotonic() - quiet_since < 2:
+            return
+        if steps is None:
+            steps = exercise(doc)
+        try:
+            next(steps)
+            quiet_since = None
+            return
+        except StopIteration:
+            pass
+    except Exception:
+        report['error'] = traceback.format_exc()
+        event('error')
+    timer.stop()
+    if App.ActiveDocument:
+        App.closeDocument(App.ActiveDocument.Name)
+    Gui.getMainWindow().close()
+
+
+timer = QtCore.QTimer(Gui.getMainWindow())
+timer.setInterval(500)
+timer.timeout.connect(tick)
+QtCore.QTimer.singleShot(5000, timer.start)
+event('ready')

--- a/src/Tools/performance/large_definition_probe.py
+++ b/src/Tools/performance/large_definition_probe.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Exercise large output serialization using real packaged CAD kernels."""
+
+
+def main():
+    import argparse
+    import json
+    import os
+    from pathlib import Path
+    import sys
+    import tempfile
+
+    handles = [os.add_dll_directory(str(Path(sys.executable).parent))]
+    import FreeCAD as App
+    import Mesh
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--module-dir', type=Path)
+    args = parser.parse_args()
+    if args.module_dir:
+        sys.path.insert(0, str(args.module_dir.resolve()))
+    import VibeCADVibeScriptDomains as domains
+    import vibescript_domain_worker as worker
+    import VibeCADVibeScriptDomainRuntime as runtime
+    if args.module_dir:
+        assert Path(runtime.__file__).parent == args.module_dir.resolve()
+
+    pack = domains.get_vibescript_pack("MeshWorkbench")
+    source = (
+        "triangles = []\n"
+        "for i in range(15000):\n"
+        "    x = i + 0.123456789\n"
+        "    triangles.append([[x,0,0], [x,1,0], [x,0,1]])\n"
+        "result = {'Mesh': api.mesh(triangles)}\n"
+    )
+    request = {
+        "schema": worker.SCHEMA, "domain": pack.domain,
+        "source": source, "inputs": {},
+        "expected_outputs": [{"name": "Mesh", "type": "mesh"}],
+        "api_exports": list(pack.api_exports), "output_types": list(pack.output_types),
+        "max_operations": 0, "max_seconds": 30.0,
+    }
+    with tempfile.TemporaryDirectory(prefix="vibecad-large-definition-") as directory:
+        response = worker._run(request, Path(directory))
+        assert response["ok"], response
+        output = response["outputs"][0]
+        definition_bytes = len(json.dumps(output["definition"]).encode("utf-8"))
+        assert definition_bytes > 1_000_000, definition_bytes
+        assert output["artifact_kind"] == "mesh_bms", output
+        mesh = Mesh.Mesh()
+        mesh.read(str(Path(directory) / output["artifact_path"]))
+        assert mesh.CountFacets == 15_000 and not mesh.hasCorruptedFacets()
+        validated = runtime.validate_candidate(dict(pack=pack, staging=directory,
+            expected_outputs=request['expected_outputs'], worker_request=request), response)
+        assert validated['outputs'][0]['name'] == 'Mesh'
+        print(json.dumps({"ok": True, "definition_bytes": definition_bytes,
+                          "facets": mesh.CountFacets, "host_validated": True,
+                          "budget": response["budget"]}), flush=True)
+    assert not App.listDocuments()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Tools/performance/memory_lifecycle_probe.py
+++ b/src/Tools/performance/memory_lifecycle_probe.py
@@ -1,0 +1,112 @@
+"""Read-only model lifecycle experiment; run only on an isolated disposable copy."""
+import ctypes
+import gc
+import json
+import os
+from pathlib import Path
+import time
+import traceback
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import VibeCADGui as runtime
+from PySide6 import QtCore, QtGui, QtWidgets
+
+output = Path(os.environ['VIBECAD_TRACE_PROBE_RESULT'])
+source = Path(os.environ['VIBECAD_ROUNDTRIP_COPY'])
+if source.parent != output.parent or source.name != 'probe-document.FCStd' or App.listDocuments():
+    raise RuntimeError('Use a fresh isolated instance and disposable probe document')
+
+class Counters(ctypes.Structure):
+    _fields_ = [('cb', ctypes.c_ulong), ('faults', ctypes.c_ulong)] + [
+        (name, ctypes.c_size_t) for name in ('peak_ws', 'ws', 'peak_paged', 'paged',
+                                          'peak_nonpaged', 'nonpaged', 'pagefile',
+                                          'peak_pagefile', 'private')]
+
+kernel = ctypes.WinDLL('kernel32', use_last_error=True)
+kernel.GetCurrentProcess.restype = ctypes.c_void_p
+psapi = ctypes.WinDLL('psapi', use_last_error=True)
+psapi.GetProcessMemoryInfo.argtypes = [ctypes.c_void_p, ctypes.POINTER(Counters), ctypes.c_ulong]
+start = time.monotonic()
+phase = 'startup'
+cycle = 0
+quiet_since = None
+phase_start = start
+report = {'pid': os.getpid(), 'events': [], 'samples': [], 'ok': False}
+
+def memory():
+    c = Counters()
+    c.cb = ctypes.sizeof(c)
+    if not psapi.GetProcessMemoryInfo(kernel.GetCurrentProcess(), ctypes.byref(c), c.cb):
+        raise ctypes.WinError(ctypes.get_last_error())
+    return {'private': c.private, 'working_set': c.ws, 'peak_working_set': c.peak_ws}
+
+def event(name, **kwargs):
+    entry = {'event': name, 'seconds': time.monotonic()-start, 'cycle': cycle,
+             **memory(), **kwargs}
+    report['events'].append(entry)
+    print('MEMORY_LIFECYCLE ' + json.dumps(entry), flush=True)
+    output.write_text(json.dumps(report, indent=2), encoding='utf-8')
+
+class Observer:
+    def slotFinishRestoreDocument(self, doc):
+        event('finish_restore', objects=len(doc.Objects))
+    def slotRecomputedDocument(self, doc):
+        event('recomputed', objects=len(doc.Objects))
+
+observer = Observer()
+App.addDocumentObserver(observer)
+main = Gui.getMainWindow()
+
+def tick():
+    global phase, cycle, phase_start, quiet_since
+    now = time.monotonic()
+    report['samples'].append({'seconds': now-start, 'phase': phase, **memory()})
+    try:
+        modal = QtWidgets.QApplication.activeModalWidget()
+        if modal:
+            raise RuntimeError('Unexpected modal: '+modal.windowTitle())
+        if phase == 'startup' and now-phase_start >= 10:
+            event('startup_idle', runtime=dict(App.hostRuntimeStatus()))
+            phase = 'opening'
+            cycle = 1
+            QtCore.QCoreApplication.postEvent(QtWidgets.QApplication.instance(), QtGui.QFileOpenEvent(str(source)))
+        elif phase == 'opening':
+            doc = App.ActiveDocument
+            busy = doc is None or any((doc.Restoring, doc.Recomputing, doc.RecomputePending,
+                                      doc.CooperativeMutationActive, doc.PresentationUpdateActive))
+            busy = busy or bool(runtime._pending_document_render_refreshes)
+            if busy:
+                quiet_since = None
+            elif quiet_since is None:
+                quiet_since = now
+            elif now-quiet_since >= 5:
+                event('opened_idle', objects=len(doc.Objects), undo_bytes=doc.UndoRedoMemSize)
+                phase = 'closing'
+                App.closeDocument(doc.Name)
+                event('close_returned')
+                phase_start = now
+        elif phase == 'closing' and not App.listDocuments() and now-phase_start >= 10:
+            event('closed_idle')
+            gc.collect()
+            event('closed_after_python_gc')
+            if cycle < 2:
+                cycle += 1
+                phase = 'opening'
+                quiet_since = None
+                QtCore.QCoreApplication.postEvent(QtWidgets.QApplication.instance(), QtGui.QFileOpenEvent(str(source)))
+            else:
+                report['ok'] = True
+                event('complete')
+                timer.stop()
+                main.close()
+    except Exception:
+        report['error'] = traceback.format_exc()
+        event('error', error=report['error'])
+        timer.stop()
+
+timer = QtCore.QTimer(main)
+timer.setInterval(1000)
+timer.timeout.connect(tick)
+timer.start()
+event('ready')

--- a/src/Tools/performance/model_capacity_probe.py
+++ b/src/Tools/performance/model_capacity_probe.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Real packaged-kernel capacity checks, isolated from any user's GUI/document."""
+
+
+def main():
+    import argparse
+    import json
+    import os
+    from pathlib import Path
+    import sys
+    import tempfile
+    import time
+
+    dll_handles = [os.add_dll_directory(str(Path(sys.executable).parent))] if os.name == 'nt' else []
+    import FreeCAD as App
+    import Part
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--module-dir', type=Path, required=True)
+    parser.add_argument('--components', type=int, default=2,
+                        help='Native simulation size; use 3000 for the expensive capacity stress run')
+    args = parser.parse_args()
+    if args.components < 2:
+        parser.error('--components must be at least 2 for the revolute joint')
+    sys.path.insert(0, str(args.module_dir.resolve()))
+    import VibeCADVibeScriptDomainRuntime as runtime
+    from VibeCADAssemblyHierarchy import capture_assembly_hierarchy, hierarchy_context
+    from VibeCADVibeScriptDomains import get_vibescript_pack
+    from vibescript_assembly_worker import _load_assembly_hierarchy
+    import vibescript_domain_worker as worker
+    from vibecad_tests.assembly_vibescript_api_integration import (
+        _Service, _document_objects, _reference_schema, resolve_modeling_surface,
+    )
+
+    assert Path(runtime.__file__).parent == args.module_dir.resolve()
+    started = time.perf_counter()
+
+    def report(event, **values):
+        print(json.dumps(dict(event=event, seconds=round(time.perf_counter() - started, 3),
+                              **values)), flush=True)
+
+    with tempfile.TemporaryDirectory(prefix='vibecad-model-capacity-') as directory:
+        root = Path(directory)
+        document = App.newDocument('ModelCapacity')
+        try:
+            group = document.addObject('App::Part', 'SourceHierarchy')
+            shapes = []
+            box = Part.makeBox(1, 1, 1)
+            for index in range(337):
+                obj = document.addObject('Part::Feature', f'Source{index}')
+                obj.Shape = box
+                group.addObject(obj)
+                shapes.append(obj)
+            for index in range(2100):
+                link = document.addObject('App::Link', f'Occurrence{index}')
+                link.setLink(shapes[index % len(shapes)])
+                group.addObject(link)
+            document.recompute()
+            captured = capture_assembly_hierarchy(group, detach_shapes=True)
+            descriptor, artifact_bytes = runtime._finalize_assembly_hierarchy(
+                captured, staging=root, reference_index=0)
+            loaded = _load_assembly_hierarchy(root, descriptor, context='native capacity')
+            # App::Part may also supply its aggregate Shape; every leaf must survive.
+            leaf_ids = {node['node_id'] for node in descriptor['nodes'] if node['kind'] == 'shape'}
+            assert len(leaf_ids) == 337
+            assert leaf_ids <= set(loaded['shapes'])
+            assert descriptor['counts']['occurrences'] == 2437
+            preview = hierarchy_context(descriptor)
+            assert len(preview['occurrence_paths']) == 256
+            assert preview['occurrence_paths_omitted'] == 2181
+            report('hierarchy_passed', **descriptor['counts'], artifact_bytes=artifact_bytes)
+
+            pack = get_vibescript_pack('AssemblyWorkbench')
+            source = (
+                f"members = {{'Part'+str(i): api.component(inputs['source'], "
+                f"grounded=(i != 1), placement=[i*3,0,0], label='Part '+str(i)+'x'*100) "
+                f"for i in range({args.components})}}\n"
+                "hinge = api.joint('revolute', api.connector(members['Part0']), "
+                "api.connector(members['Part1']))\n"
+                "model = api.assembly(members, {'Hinge':hinge})\n"
+                "drive = api.motion(hinge, 'initialValue + time')\n"
+                "simulation = api.simulation(model, {'Drive':drive}, end_time_s=0.1, "
+                "time_step_s=0.05, collision_mode='off')\n"
+                "result = {'Model':model, 'Simulation':simulation, 'Diagnostics':api.solve(model)}\n"
+            )
+            expected = [dict(name='Model', type='assembly'), dict(name='Simulation', type='simulation'),
+                        dict(name='Diagnostics', type='solver_diagnostics')]
+            service = _Service(document, root)
+            capture = dict(pack=pack, project_root=str(root), document_name=document.Name,
+                document_uid=str(document.Uid), document_revision='assembly-production-revision',
+                document_objects=_document_objects(document),
+                surface=resolve_modeling_surface('AssemblyWorkbench', 'vibescript').summary(),
+                freecad_home=App.getHomePath(), timeout_seconds=0.0,
+                memory_limit_bytes=2 * 1024 * 1024 * 1024,
+                operation='create_program', tool_name='vibescript.assembly.create_program',
+                arguments=dict(program_name='Capacity Simulation', source=source,
+                    input_schema=dict(type='object', properties={'source': _reference_schema()},
+                                      required=['source'], additionalProperties=False),
+                    inputs={'source': dict(document_uid=str(document.Uid), object_name=shapes[0].Name)},
+                    expected_outputs=expected))
+            prepared = runtime.prepare_candidate(capture)
+            prepared = runtime.finalize_candidate(prepared, runtime.capture_reference_inputs(service, prepared))
+            report('worker_start', components=args.components)
+            # This executable is the isolated test process. Use the actual worker
+            # entry point, then the actual host postcondition and publication code.
+            execution = worker._run(prepared['worker_request'], Path(prepared['staging']))
+            assert execution['ok'], execution
+            simulation = next(item for item in execution['outputs'] if item['name'] == 'Simulation')
+            definition_bytes = len(json.dumps(simulation['definition']).encode())
+            report('worker_complete', definition_bytes=definition_bytes)
+            if args.components >= 3000:
+                assert definition_bytes > 1_000_000
+            validated = runtime.validate_candidate(prepared, execution)
+            report('host_validated')
+            runtime.retain_candidate(prepared, status='validated')
+            publication = runtime.publish_candidate(service, prepared, validated)
+            accepted = runtime.accept_candidate(prepared, publication)
+            assert accepted['model_state']['status'] == 'accepted'
+            report('published', outputs=len(publication['outputs']), definition_bytes=definition_bytes)
+        finally:
+            if document.Name in App.listDocuments():
+                App.closeDocument(document.Name)
+    report('complete', ok=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/Tools/performance/native_input_sender.py
+++ b/src/Tools/performance/native_input_sender.py
@@ -1,0 +1,38 @@
+"""Window-local diagnostic input, independent of the measured GUI's Python GIL."""
+import ctypes
+from ctypes import wintypes
+import sys
+
+kernel = ctypes.WinDLL('kernel32', use_last_error=True)
+user = ctypes.WinDLL('user32', use_last_error=True)
+kernel.OpenProcess.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.DWORD)
+kernel.OpenProcess.restype = wintypes.HANDLE
+kernel.OpenEventW.argtypes = (wintypes.DWORD, wintypes.BOOL, wintypes.LPCWSTR)
+kernel.OpenEventW.restype = wintypes.HANDLE
+kernel.WaitForMultipleObjects.argtypes = (wintypes.DWORD, ctypes.POINTER(wintypes.HANDLE),
+                                        wintypes.BOOL, wintypes.DWORD)
+kernel.WaitForMultipleObjects.restype = wintypes.DWORD
+kernel.CloseHandle.argtypes = (wintypes.HANDLE,)
+user.PostMessageW.argtypes = (wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM)
+user.PostMessageW.restype = wintypes.BOOL
+user.GetWindowThreadProcessId.argtypes = (wintypes.HWND, ctypes.POINTER(wintypes.DWORD))
+user.GetWindowThreadProcessId.restype = wintypes.DWORD
+
+window, pid, stop_name = int(sys.argv[1]), int(sys.argv[2]), sys.argv[3]
+parent = kernel.OpenProcess(0x00100000, False, pid)
+stop = kernel.OpenEventW(0x00100000, False, stop_name)
+if not parent or not stop:
+    raise ctypes.WinError(ctypes.get_last_error())
+handles = (wintypes.HANDLE * 2)(parent, stop)
+try:
+    while kernel.WaitForMultipleObjects(2, handles, False, 250) == 258:
+        owner = wintypes.DWORD()
+        user.GetWindowThreadProcessId(window, ctypes.byref(owner))
+        if owner.value != pid:
+            break
+        for message, flags in ((0x0100, 1), (0x0101, 0xC0000001)):
+            if not user.PostMessageW(window, message, 0x86, flags):
+                raise ctypes.WinError(ctypes.get_last_error())
+finally:
+    kernel.CloseHandle(stop)
+    kernel.CloseHandle(parent)

--- a/src/Tools/performance/numerical_runtime_probe.py
+++ b/src/Tools/performance/numerical_runtime_probe.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Run with packaged Windows Python in a disposable process, never the live GUI."""
+
+
+def main():
+    import json
+    import os
+    from pathlib import Path
+    import sys
+    import time
+
+    handles = [os.add_dll_directory(str(Path(sys.executable).parent))]
+    import FreeCAD as App
+    import numpy as np
+    import psutil
+    from threadpoolctl import threadpool_info
+    from VibeCADNumericalRuntime import _controller, numerical_thread_limits
+
+    _controller()
+    pools = [p for p in threadpool_info() if p["internal_api"] == "openblas"]
+    assert pools and all(p["threading_layer"] == "pthreads" for p in pools), pools
+    assert all(p["num_threads"] == 1 for p in pools), pools
+    process = psutil.Process()
+    print(json.dumps({"event": "startup", "private_bytes": process.memory_info().private,
+                      "pools": pools, "runtime": App.hostRuntimeStatus()}), flush=True)
+    matrix = np.random.default_rng(512).normal(size=(1024, 1024))
+    vector = np.random.default_rng(513).normal(size=1024)
+    expected = matrix @ (matrix @ vector)
+    for slots in (1, 3, 8, 42, 3):
+        with numerical_thread_limits(slots, 2 << 30) as threads:
+            pools = [p for p in threadpool_info() if p["internal_api"] == "openblas"]
+            assert all(p["num_threads"] == threads for p in pools), pools
+            start = time.perf_counter()
+            result = matrix @ matrix
+            elapsed = time.perf_counter() - start
+            np.testing.assert_allclose(result @ vector, expected, rtol=1e-9, atol=1e-8)
+            print(json.dumps({"event": "job", "slots": slots, "threads": threads,
+                              "seconds": elapsed, "private_bytes": process.memory_info().private,
+                              "correct": True}), flush=True)
+        assert all(p["num_threads"] == 1 for p in threadpool_info()
+                   if p["internal_api"] == "openblas")
+    try:
+        with numerical_thread_limits(3, 2 << 30):
+            raise ValueError("probe cancellation/exception cleanup")
+    except ValueError:
+        pass
+    assert all(p["num_threads"] == 1 for p in threadpool_info()
+               if p["internal_api"] == "openblas")
+    print(json.dumps({"event": "complete", "ok": True}), flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/Tools/performance/portable_roundtrip_probe.py
+++ b/src/Tools/performance/portable_roundtrip_probe.py
@@ -1,0 +1,480 @@
+"""Disposable packaged-GUI diagnostic; never give this probe an original document."""
+import json
+import os
+import ctypes
+from ctypes import wintypes
+import subprocess
+import uuid
+from pathlib import Path
+import time
+import traceback
+import xml.etree.ElementTree as ET
+import zipfile
+import cProfile
+from functools import wraps
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from PySide6 import QtCore, QtGui, QtWidgets
+
+
+source = Path(os.environ['VIBECAD_ROUNDTRIP_COPY']).resolve()
+output = Path(os.environ['VIBECAD_ROUNDTRIP_REPORT']).resolve()
+if source.parent != output.parent or not source.name.startswith('probe-'):
+    raise RuntimeError('Use a probe-* document copy beside its diagnostic report')
+if App.listDocuments():
+    raise RuntimeError('Run in a fresh diagnostic process with no open documents')
+with zipfile.ZipFile(source) as archive:
+    root = ET.fromstring(archive.read('Document.xml'))
+expected_names = sorted(item.attrib['name'] for item in root.findall('./Objects/Object'))
+expected_invalid = sorted(item.attrib['name'] for item in root.findall('./Objects/Object')
+                          if item.attrib.get('Invalid') == '1')
+if not expected_names:
+    raise RuntimeError('Source has no native object inventory')
+baseline_path = os.environ.get('VIBECAD_ROUNDTRIP_BASELINE')
+baseline = json.loads(Path(baseline_path).read_text(encoding='utf-8')) if baseline_path else None
+
+main = Gui.getMainWindow()
+profiler = cProfile.Profile() if os.environ.get('VIBECAD_PROFILE_CALLBACKS') else None
+if profiler:
+    profiler.enable()
+user32 = ctypes.WinDLL('user32', use_last_error=True)
+user32.PostMessageW.argtypes = (ctypes.c_void_p, ctypes.c_uint, ctypes.c_size_t, ctypes.c_ssize_t)
+user32.PostMessageW.restype = ctypes.c_int
+kernel32 = ctypes.WinDLL('kernel32', use_last_error=True)
+kernel32.GetTickCount.restype = wintypes.DWORD
+kernel32.CreateEventW.argtypes = (ctypes.c_void_p, wintypes.BOOL, wintypes.BOOL, wintypes.LPCWSTR)
+kernel32.CreateEventW.restype = wintypes.HANDLE
+kernel32.SetEvent.argtypes = (wintypes.HANDLE,)
+kernel32.CloseHandle.argtypes = (wintypes.HANDLE,)
+stop_name = 'Local\\VibeCADInputProbe-' + uuid.uuid4().hex
+input_stop = kernel32.CreateEventW(None, True, False, stop_name)
+if not input_stop:
+    raise ctypes.WinError(ctypes.get_last_error())
+started = last_tick = time.perf_counter()
+phase = 'startup'
+document = None
+settled_since = None
+initial_inventory = None
+inventory = {}
+inventory_objects = []
+inventory_index = 0
+command_profile_names = None
+pending_input = None
+save_finished = False
+recompute_finished = False
+recompute_started = None
+recompute_cpu_started = None
+closing_name = None
+input_excluded_until = None
+trace_clock_offset = None
+report = {'ok': False, 'source': str(source), 'events': [], 'gaps': [], 'input': [],
+          'expected_count': len(expected_names), 'expected_invalid': expected_invalid,
+          'runtime': dict(App.hostRuntimeStatus())}
+
+
+def check_invalid_flags(expected, actual, allowed_cleared=()):
+    cleared = set(expected) - set(actual)
+    if set(actual) - set(expected) or cleared - set(allowed_cleared):
+        raise RuntimeError('Invalid object flags differ from those already saved in the input archive: '
+                           + repr({'expected': expected, 'actual': actual}))
+    return sorted(cleared)
+
+
+def event(name, **values):
+    report['events'].append({'event': name, 'seconds': time.perf_counter() - started, **values})
+    print('VIBECAD_ROUNDTRIP ' + json.dumps(report['events'][-1]), flush=True)
+
+
+if profiler:
+    # Correlate high-level Python callbacks with native event spans. cProfile's
+    # cumulative totals alone cannot identify which queued invocation stalled.
+    import VibeCADGui as gui_runtime
+
+    report['python_callbacks'] = []
+
+    def trace_callback(original):
+        @wraps(original)
+        def measured(*args, **kwargs):
+            before = time.perf_counter()
+            try:
+                return original(*args, **kwargs)
+            finally:
+                elapsed = 1000 * (time.perf_counter() - before)
+                if elapsed >= 8:
+                    report['python_callbacks'].append({
+                        'name': original.__name__, 'seconds': before - started,
+                        'elapsed_ms': elapsed,
+                    })
+        return measured
+
+    for name in ('_refresh_assistant_for_document_change',
+                 '_restore_partdesign_history_rendering',
+                 '_migrate_standard_fastener_timeline_resources',
+                 '_migrate_partdesign_component_timeline_resources'):
+        setattr(gui_runtime, name, trace_callback(getattr(gui_runtime, name)))
+
+
+class InputProbe(QtCore.QObject):
+    def eventFilter(self, watched, incoming):
+        global pending_input
+        if incoming.type() in (QtCore.QEvent.Type.KeyPress, QtCore.QEvent.Type.KeyRelease) and incoming.key() == QtCore.Qt.Key.Key_F23:
+            return True
+        if incoming.type() in (QtCore.QEvent.Type.KeyPress, QtCore.QEvent.Type.KeyRelease) and incoming.key() == QtCore.Qt.Key.Key_F24:
+            if pending_input and incoming.type() == QtCore.QEvent.Type.KeyPress:
+                posted, posted_phase = pending_input
+                report['input'].append({'phase': posted_phase,
+                                        'delivered_phase': phase,
+                                        'seconds': time.perf_counter() - started,
+                                        'milliseconds': 1000 * (time.perf_counter() - posted)})
+                pending_input = None
+            return True
+        return False
+
+
+input_probe = InputProbe(main)
+QtWidgets.QApplication.instance().installEventFilter(input_probe)
+
+
+class NativeInputProbe(QtCore.QAbstractNativeEventFilter):
+    def nativeEventFilter(self, event_type, message):
+        native = ctypes.cast(int(message), ctypes.POINTER(wintypes.MSG)).contents
+        if native.message == 0x0100 and native.wParam == 0x86:
+            if phase == 'diagnostic_screenshot' or (input_excluded_until is not None
+                    and ((native.time - input_excluded_until) & 0xffffffff) >= 0x80000000):
+                return False, 0
+            # MSG.time is stamped when Windows queues the message, not when
+            # Qt finally delivers it. The sender runs outside this process.
+            report.setdefault('independent_input', []).append({
+                'phase': phase,
+                'milliseconds': (kernel32.GetTickCount() - native.time) & 0xffffffff,
+                'seconds': time.perf_counter() - started,
+            })
+        return False, 0
+
+
+native_input_probe = NativeInputProbe()
+QtWidgets.QApplication.instance().installNativeEventFilter(native_input_probe)
+input_sender = subprocess.Popen([
+    str(Path(App.getHomePath()) / 'bin' / 'pythonw.exe'),
+    os.environ['VIBECAD_INPUT_SENDER'],
+    str(int(main.winId())), str(os.getpid()), stop_name,
+], creationflags=subprocess.CREATE_NO_WINDOW)
+
+
+def post_input():
+    global pending_input
+    if pending_input is None:
+        pending_input = (time.perf_counter(), phase)
+        # Exercise the Windows message dispatcher, not Qt's posted-event queue:
+        # a nested loop excluding user input can still drain posted QEvents.
+        # F24 is consumed by our application event filter; no desktop focus or
+        # physical keyboard state is changed by these window-local messages.
+        for message, flags in ((0x0100, 1), (0x0101, 0xC0000001)):
+            if not user32.PostMessageW(int(main.winId()), message, 0x87, flags):
+                raise ctypes.WinError(ctypes.get_last_error())
+
+
+def set_phase(value):
+    global phase, settled_since
+    phase = value
+    settled_since = None
+    event(value)
+    post_input()
+
+
+def open_copy():
+    QtCore.QCoreApplication.postEvent(QtWidgets.QApplication.instance(), QtGui.QFileOpenEvent(str(source)))
+
+
+def finish(error=None):
+    timer.stop()
+    if profiler:
+        profiler.disable()
+        profiler.dump_stats(str(output.with_suffix('.pstats')))
+    if input_sender.poll() is not None and error is None:
+        error = 'Independent Windows input sender exited before measurement completed'
+    kernel32.SetEvent(input_stop)
+    kernel32.CloseHandle(input_stop)
+    if error is None and not report['input']:
+        error = 'Native Windows input was never delivered to the diagnostic event filter'
+    report['ok'] = error is None
+    report['error'] = error
+    report['max_gap_ms'] = max((item['milliseconds'] for item in report['gaps']), default=0)
+    report['max_input_ms'] = max((item['milliseconds'] for item in report['input']), default=0)
+    report['max_independent_input_ms'] = max(
+        (item['milliseconds'] for item in report.get('independent_input', [])), default=0)
+    report['responsiveness_ok'] = bool(report.get('independent_input')) and max(
+        report['max_gap_ms'], report['max_independent_input_ms']) <= 100
+    report['integrity_ok'] = error is None
+    report['ok'] = report['integrity_ok'] and report['responsiveness_ok']
+    report['validation_scope'] = ('packaged GUI open/history-recompute/save/reopen/close'
+                                  if os.environ.get('VIBECAD_EXERCISE_GENERATED_RECOMPUTE')
+                                  else 'packaged GUI open/save/reopen/close')
+    if error is None and not report['responsiveness_ok']:
+        report['error'] = 'Input delivery or the 100 ms responsiveness gate failed; inspect timing records'
+    report['runtime_final'] = dict(App.hostRuntimeStatus())
+    event('complete', ok=report['ok'], error=report['error'])
+    # Persist only after measurement stops: the benchmark must not introduce
+    # repeated synchronous filesystem writes into the GUI events it measures.
+    output.write_text(json.dumps(report, indent=2), encoding='utf-8')
+    if error:
+        main.grab().save(str(output.with_suffix('.failure.png')))
+    if not error:
+        main.close()
+
+
+class SaveObserver:
+    def slotRecomputedDocument(self, recomputed):
+        global recompute_finished
+        if phase == 'recompute' and recomputed.Name == document.Name:
+            recompute_finished = True
+            event('recompute_finished')
+
+    def slotChangedObject(self, obj, prop):
+        if phase in ('save', 'close'):
+            report.setdefault('save_changes', []).append({
+                'seconds': time.perf_counter() - started, 'phase': phase,
+                'object': obj.Name, 'property': prop,
+                'after_finish': save_finished, 'stack': traceback.format_stack(limit=12),
+            })
+
+    def slotChangedDocument(self, doc, prop):
+        if phase in ('save', 'close'):
+            report.setdefault('save_changes', []).append({
+                'seconds': time.perf_counter() - started, 'phase': phase,
+                'document': doc.Name, 'property': prop,
+                'after_finish': save_finished, 'stack': traceback.format_stack(limit=12),
+            })
+
+    def slotFinishSaveDocument(self, saved, *args):
+        global save_finished
+        if phase == 'save' and saved.Name == document.Name:
+            save_finished = True
+            event('save_finished')
+
+
+save_observer = SaveObserver()
+App.addDocumentObserver(save_observer)
+
+
+class SaveGuiObserver:
+    def slotChangedObject(self, vp, prop):
+        if phase in ('save', 'close'):
+            report.setdefault('save_gui_changes', []).append({
+                'seconds': time.perf_counter() - started, 'phase': phase,
+                'object': vp.Object.Name, 'property': prop,
+                'after_finish': save_finished, 'stack': traceback.format_stack(limit=12),
+            })
+
+
+save_gui_observer = SaveGuiObserver()
+Gui.addDocumentObserver(save_gui_observer)
+
+
+def quiet():
+    return not any((document.Restoring, document.Recomputing, document.RecomputePending,
+                    document.CooperativeMutationActive, document.PresentationUpdateActive))
+
+
+def snapshot_step():
+    global inventory_index, command_profile_names
+    deadline = time.perf_counter() + 0.004
+    while inventory_index < len(inventory_objects):
+        obj = inventory_objects[inventory_index]
+        inventory[obj.Name] = {
+            'type': obj.TypeId,
+            'links': sorted(['$self' if target.Document == document else target.Document.Name, target.Name]
+                            for target in obj.OutList),
+            'state': list(obj.State),
+        }
+        inventory_index += 1
+        if time.perf_counter() >= deadline:
+            return False
+    if phase == 'inventory_open' and os.environ.get('VIBECAD_PROFILE_COMMANDS'):
+        if command_profile_names is None:
+            command_profile_names = list(Gui.Command.listAll())
+            report['command_checks'] = []
+        while command_profile_names:
+            name = command_profile_names.pop()
+            command = Gui.Command.get(name)
+            if command.getAction():
+                before = time.perf_counter()
+                active = command.isActive()
+                report['command_checks'].append({
+                    'name': name, 'active': active,
+                    'milliseconds': 1000 * (time.perf_counter() - before),
+                })
+            if time.perf_counter() >= deadline:
+                return False
+    return True
+
+
+def tick():
+    global last_tick, document, settled_since, initial_inventory
+    global inventory, inventory_objects, inventory_index
+    global closing_name, input_excluded_until
+    global recompute_started, recompute_cpu_started
+    global trace_clock_offset
+    now = time.perf_counter()
+    gap = 1000 * (now - last_tick)
+    last_tick = now
+    if gap >= 50:
+        report['gaps'].append({'phase': phase, 'milliseconds': gap, 'seconds': now - started,
+                               'status': main.statusBar().currentMessage()})
+    try:
+        if os.environ.get('VIBECAD_TRACE_NATIVE_EVENTS'):
+            timings = QtCore.QMetaObject.invokeMethod(
+                QtWidgets.QApplication.instance(), 'takePerformanceEvents',
+                QtCore.Qt.ConnectionType.DirectConnection, QtCore.Q_RETURN_ARG('QVariantMap'))
+            if not timings['enabled']:
+                raise RuntimeError('Native GUI event tracing is disabled')
+            if trace_clock_offset is None:
+                trace_clock_offset = timings['clock_ms'] - 1000 * (time.perf_counter() - started)
+            for item in timings['events']:
+                item['seconds'] = (item['start_ms'] - trace_clock_offset) / 1000
+            report.setdefault('gui_events', []).extend(timings['events'])
+            report['dropped_gui_events'] = report.get('dropped_gui_events', 0) + timings['dropped']
+        modal = QtWidgets.QApplication.activeModalWidget()
+        if modal is not None:
+            message = modal.text() if isinstance(modal, QtWidgets.QMessageBox) else modal.objectName()
+            raise RuntimeError('Diagnostic encountered a modal dialog: ' + modal.windowTitle() + ': ' + message)
+        post_input()
+        if phase == 'startup':
+            set_phase('open')
+            open_copy()
+        elif phase in ('open', 'reopen'):
+            if document is None:
+                document = next((doc for doc in App.listDocuments().values()
+                                 if doc.FileName and Path(doc.FileName).resolve() == source), None)
+            if document is None or not quiet():
+                settled_since = None
+                return
+            if settled_since is None:
+                settled_since = now
+            elif now - settled_since >= 1:
+                event('display_settled', objects=len(document.Objects))
+                inventory = {}
+                inventory_objects = list(document.Objects)
+                inventory_index = 0
+                set_phase('inventory_open' if phase == 'open' else 'inventory_reopen')
+        elif phase in ('inventory_open', 'inventory_reopen', 'inventory_after_recompute'):
+            if not snapshot_step():
+                return
+            report[phase] = inventory
+            if phase == 'inventory_open' and os.environ.get('VIBECAD_ALLOW_TIMELINE_MIGRATION'):
+                missing = set(expected_names) - set(inventory)
+                added = set(inventory) - set(expected_names)
+                # Ordinary FreeCAD documents acquire VibeCAD's native History
+                # controller on first open. Admit only that exact migration;
+                # never forgive a missing model object or unrelated addition.
+                if (not missing and len(added) == 1
+                        and all(inventory[name]['type'] == 'App::DocumentTimeline' for name in added)
+                        and not any(inventory[name]['type'] == 'App::DocumentTimeline'
+                                    for name in expected_names)):
+                    report['timeline_migration'] = sorted(added)
+                    expected_names.extend(added)
+                    expected_names.sort()
+            if sorted(inventory) != expected_names:
+                raise RuntimeError('Restored object names differ from the input archive: '
+                                   + repr({'missing': sorted(set(expected_names) - set(inventory)),
+                                           'added': sorted(set(inventory) - set(expected_names))}))
+            invalid = sorted(name for name, item in inventory.items() if 'Invalid' in item['state'])
+            cleared = check_invalid_flags(
+                expected_invalid, invalid,
+                json.loads(os.environ.get('VIBECAD_ALLOW_CLEARED_INVALID_OBJECTS', '[]')))
+            report.setdefault('cleared_saved_invalid_flags', {})[phase] = cleared
+            if phase in ('inventory_open', 'inventory_after_recompute'):
+                if phase == 'inventory_after_recompute' and any(
+                        inventory[name]['type'] != initial_inventory[name]['type']
+                        or inventory[name]['links'] != initial_inventory[name]['links']
+                        for name in inventory):
+                    raise RuntimeError('History recompute changed object types or links')
+                initial_inventory = inventory
+                report['opened_inventory'] = inventory
+                if baseline is not None:
+                    report['baseline_match'] = inventory == baseline['opened_inventory']
+                    if not report['baseline_match']:
+                        raise RuntimeError('Object types, links, or states differ from the known-good baseline')
+                if phase == 'inventory_open' and os.environ.get('VIBECAD_EXERCISE_GENERATED_RECOMPUTE'):
+                    blank = document.getObject('Blank000')
+                    if blank is None or blank.TypeId != 'Part::Box' or document.getObject('Result199') is None:
+                        raise RuntimeError('Recompute exercise requires the generated boolean workload')
+                    for index in range(200):
+                        document.getObject(f'Blank{index:03d}').touch()
+                        document.getObject(f'Bore{index:03d}').touch()
+                        document.getObject(f'Result{index:03d}').touch()
+                    set_phase('recompute_ready')
+                    return
+                document.Comment += '\nDisposable performance round-trip probe.'
+                set_phase('save')
+                before = time.perf_counter()
+                Gui.runCommand('Std_Save')
+                event('save_command_returned', milliseconds=1000 * (time.perf_counter() - before),
+                      finished_before_return=save_finished)
+            else:
+                report['reopened_inventory'] = inventory
+                if inventory != initial_inventory:
+                    raise RuntimeError('Object types, links, or states changed during save/reopen')
+                # Capture visual evidence outside the measured event-loop interval.
+                # QWidget.grab itself renders synchronously and must not be
+                # mistaken for a production stall introduced by the document.
+                timer.stop()
+                set_phase('diagnostic_screenshot')
+                before = time.perf_counter()
+                if not main.grab().save(str(output.with_suffix('.png'))):
+                    raise RuntimeError('Could not capture the restored GUI')
+                event('diagnostic_screenshot', milliseconds=1000 * (time.perf_counter() - before))
+                input_excluded_until = kernel32.GetTickCount()
+                last_tick = time.perf_counter()
+                timer.start()
+                set_phase('final_close')
+                before = time.perf_counter()
+                Gui.runCommand('Std_CloseAllWindows')
+                event('final_close_returned', milliseconds=1000 * (time.perf_counter() - before))
+        elif phase == 'recompute_ready':
+            button = main.findChild(QtWidgets.QToolButton, 'VibeCADFeatureTimelineRecompute')
+            if button is None:
+                raise RuntimeError('History recompute button is missing')
+            if button.isEnabled() and quiet():
+                set_phase('recompute')
+                recompute_started = time.perf_counter()
+                recompute_cpu_started = os.times()
+                button.click()
+                event('recompute_button_returned', milliseconds=1000 * (time.perf_counter() - recompute_started))
+        elif phase == 'recompute' and recompute_finished and quiet():
+            cpu = os.times()
+            report['recompute'] = {
+                'wall_seconds': time.perf_counter() - recompute_started,
+                'cpu_seconds': cpu.user + cpu.system - recompute_cpu_started.user - recompute_cpu_started.system,
+            }
+            inventory = {}
+            inventory_objects = list(document.Objects)
+            inventory_index = 0
+            set_phase('inventory_after_recompute')
+        elif phase == 'save' and save_finished and quiet():
+            set_phase('close')
+            closing_name = document.Name
+            inventory_objects = []
+            before = time.perf_counter()
+            Gui.runCommand('Std_CloseAllWindows')
+            event('close_command_returned', milliseconds=1000 * (time.perf_counter() - before))
+        elif phase == 'save' and not save_finished and quiet():
+            raise RuntimeError('Save did not complete and no document work remains: '
+                               'the request was cancelled, refused, or failed; round-trip is incomplete')
+        elif phase == 'close' and closing_name not in App.listDocuments():
+            document = None
+            set_phase('reopen')
+            open_copy()
+        elif phase == 'final_close' and not App.listDocuments():
+            finish()
+    except Exception:
+        finish(traceback.format_exc())
+
+
+timer = QtCore.QTimer(main)
+timer.setTimerType(QtCore.Qt.TimerType.PreciseTimer)
+timer.setInterval(16)
+timer.timeout.connect(tick)
+timer.start()
+event('ready')

--- a/src/Tools/performance/progress_status_probe.py
+++ b/src/Tools/performance/progress_status_probe.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Check live native status text while a background step has no new percentage."""
+
+import json
+import os
+from pathlib import Path
+import threading
+import time
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from PySide6 import QtCore, QtWidgets
+
+output = Path(os.environ["VIBECAD_TRACE_PROBE_RESULT"])
+main = Gui.getMainWindow()
+status_label = main.statusBar().findChild(QtWidgets.QLabel, "actionLabel")
+assert status_label is not None, "Native status-bar activity label is missing"
+release = threading.Event()
+started = threading.Event()
+finished = threading.Event()
+report = {"ok": False, "messages": []}
+
+
+def work():
+    progress = App.Base.ProgressIndicator()
+    try:
+        progress.start("Background progress diagnostic", 10)
+        started.set()
+        release.wait()
+    except Exception as exc:
+        report["error"] = str(exc)
+    finally:
+        progress.stop()
+        finished.set()
+
+
+worker = threading.Thread(target=work)
+begin = None
+
+
+def start_probe():
+    global begin
+    # Leave command-line file processing first: its outer progress scope would
+    # otherwise swallow this deliberately nested diagnostic scope.
+    begin = time.monotonic()
+    worker.start()
+
+
+def tick():
+    if begin is None:
+        return
+    elapsed = time.monotonic() - begin
+    message = status_label.text()
+    report["messages"].append({"seconds": elapsed, "text": message})
+    if not release.is_set() and elapsed >= 3:
+        report["ok"] = (started.is_set() and "Background progress diagnostic" in message
+                        and "Elapsed:" in message and "0 / 10" in message)
+        if not report["ok"]:
+            report.setdefault("error", "Missing live elapsed/count status before first completed step")
+        release.set()
+    if finished.is_set():
+        timer.stop()
+        worker.join()
+        output.write_text(json.dumps(report, indent=2), encoding="utf-8")
+        print("PROGRESS_STATUS " + json.dumps(report), flush=True)
+        main.close()
+
+
+timer = QtCore.QTimer(main)
+timer.setInterval(250)
+timer.timeout.connect(tick)
+timer.start()
+QtCore.QTimer.singleShot(0, start_probe)

--- a/src/Tools/performance/retained_publication_probe.py
+++ b/src/Tools/performance/retained_publication_probe.py
@@ -1,0 +1,336 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Replay a retained Assembly result in an isolated disposable GUI document.
+
+Set VIBECAD_PUBLICATION_ATTEMPT to an ignored COPY of the worker attempt and
+VIBECAD_PUBLICATION_MANIFEST to a copied program.json. Launch with the packaged
+edit-check runner and a disposable document. No solver, acceptance, or save runs.
+The production validator, publisher, observer batching and Qt dispatcher run
+unchanged. Profiles separate detached validation from GUI publication callbacks.
+Set VIBECAD_PUBLICATION_WORKING_CANDIDATE=1 to replay an unaccepted candidate
+against its accepted document revision; source, inputs and revisions are checked.
+Set VIBECAD_PUBLICATION_CANCEL_AFTER to an item count to cancel real publication,
+check rollback in the disposable document, then retry the same candidate.
+Set VIBECAD_PUBLICATION_PROFILE=0 for timing without cProfile overhead; native
+callback timing, progress and independent Windows input measurements remain on.
+"""
+import cProfile
+import hashlib
+import json
+import os
+from pathlib import Path
+import sys
+import threading
+import time
+import traceback
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from PySide6 import QtCore, QtGui, QtWidgets
+
+output = Path(os.environ['VIBECAD_TRACE_PROBE_RESULT']).resolve()
+source = Path(os.environ['VIBECAD_ROUNDTRIP_COPY']).resolve()
+attempt = Path(os.environ['VIBECAD_PUBLICATION_ATTEMPT']).resolve()
+manifest_path = Path(os.environ['VIBECAD_PUBLICATION_MANIFEST']).resolve()
+if source.parent != output.parent or source.name != 'probe-document.FCStd' or App.listDocuments():
+    raise RuntimeError('Use an isolated process and disposable probe-document.FCStd')
+if not attempt.is_relative_to(output.parent.parent) or not manifest_path.is_relative_to(output.parent.parent):
+    raise RuntimeError('Worker artifacts must be copies within portable-edit-checks')
+
+started = time.monotonic()
+stage = 'startup'
+quiet_since = None
+worker = None
+profiling = os.environ.get('VIBECAD_PUBLICATION_PROFILE', '1') != '0'
+lock = threading.Lock()
+report = {'ok': False, 'events': [], 'gui_callbacks': [], 'native_events': [],
+          'max_heartbeat_gap': 0.0, 'independent_input': [], 'profiling': profiling}
+report['native_build'] = App.ConfigGet('BuildRevisionHash')
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from window_input_probe import WindowInputProbe
+from async_report_writer import AsyncReportWriter
+report_writer = AsyncReportWriter(output)
+report_written = None
+input_probe = WindowInputProbe(Gui.getMainWindow(), lambda milliseconds:
+    report['independent_input'].append(dict(
+        phase=stage, seconds=time.monotonic() - started, milliseconds=milliseconds)))
+input_files = (source, manifest_path, attempt / 'request.json', attempt / 'result.json')
+input_hashes = [hashlib.sha256(path.read_bytes()).hexdigest() for path in input_files]
+gui_profile = cProfile.Profile()
+last_heartbeat = time.monotonic()
+last_report_write = 0.0
+last_progress_phase = None
+cancel_after = int(os.environ.get('VIBECAD_PUBLICATION_CANCEL_AFTER', '0'))
+cancel_requested = threading.Event()
+
+
+def event(name, **values):
+    global last_report_write, last_progress_phase, report_written
+    with lock:
+        now = time.monotonic()
+        report['events'].append(dict(event=name, seconds=now - started, **values))
+        phase = values.get('phase')
+        # Full pretty-printed snapshots per object turn the probe itself into
+        # quadratic work. Retain every event, but serialize only at boundaries
+        # or once per second using the compact native JSON encoder.
+        if name != 'progress' or (phase is not None and phase != last_progress_phase) or now - last_report_write >= 1:
+            snapshot = {key: list(value) if isinstance(value, list) else value
+                        for key, value in report.items()}
+            report_written = report_writer.submit(snapshot)
+            last_report_write = now
+        if name == 'progress' and phase is not None:
+            last_progress_phase = phase
+
+
+def heartbeat():
+    global last_heartbeat
+    now = time.monotonic()
+    with lock:
+        report['max_heartbeat_gap'] = max(report['max_heartbeat_gap'], now - last_heartbeat)
+    last_heartbeat = now
+
+
+def progress(value):
+    event('progress', **{key: value[key] for key in
+          ('phase', 'message', 'completed', 'total', 'elapsed_ms') if key in value})
+    if cancel_after and int(value.get('completed', 0)) >= cancel_after:
+        cancel_requested.set()
+
+
+def rollback_inventory(dispatch, service):
+    """Capture logical identity, links and poses in owner-thread-sized steps."""
+    from VibeCADVibeScriptDomains import PROP_PROGRAM_REVISION
+    names = dispatch(lambda: [obj.Name for obj in service._active_document().Objects])
+    result = {}
+    for name in names:
+        def capture(name=name):
+            document = service._active_document()
+            obj = document.getObject(name)
+            if obj is None:
+                raise RuntimeError('Object disappeared during rollback inventory: ' + name)
+            placement = getattr(obj, 'Placement', None)
+            return dict(type=obj.TypeId, label=obj.Label,
+                links=sorted((str(target.Document.Uid), target.Name) for target in obj.OutList),
+                placement=None if placement is None else (
+                    tuple(placement.Base), tuple(placement.Rotation.Q)),
+                revision=getattr(obj, PROP_PROGRAM_REVISION, None),
+                visibility=bool(obj.ViewObject.Visibility) if obj.ViewObject else None)
+        result[name] = dispatch(capture)
+    return result
+
+
+def run(prepared, execution, service, adapter, dispatch):
+    try:
+        import VibeCADVibeScriptDomainRuntime as runtime
+        before = time.monotonic()
+        if profiling:
+            validator = cProfile.Profile()
+            validated = validator.runcall(adapter.validate_result, prepared, execution)
+            validator.dump_stats(str(output.with_name('validation.pstats')))
+        else:
+            validated = adapter.validate_result(prepared, execution)
+        event('validated', elapsed_seconds=time.monotonic() - before,
+              outputs=len(validated['outputs']), members=len(validated.get('assembly_members', [])))
+
+        def invoke(operation):
+            def profiled():
+                begin = time.monotonic()
+                try:
+                    return operation()
+                finally:
+                    with lock:
+                        report['gui_callbacks'].append(time.monotonic() - begin)
+            return dispatch(profiled)
+
+        before = time.monotonic()
+        if cancel_after:
+            from VibeCADCooperativeExecution import CooperativeExecutionCancelled
+            original = rollback_inventory(invoke, service)
+            event('cancellation_replay_started', after_items=cancel_after)
+            try:
+                adapter.publish_cooperatively(service, prepared, validated,
+                    document_thread_dispatch=invoke,
+                    cancellation_check=cancel_requested.is_set,
+                    progress_callback=progress)
+            except CooperativeExecutionCancelled:
+                event('publication_cancelled')
+            else:
+                raise RuntimeError('Publication completed without exercising cancellation')
+            invoke(lambda: service._active_document().waitForPresentationReady)()
+            restored = rollback_inventory(invoke, service)
+            if restored != original:
+                changed = sorted(name for name in original.keys() | restored.keys()
+                                 if original.get(name) != restored.get(name))
+                raise RuntimeError('Publication rollback changed objects: ' + repr(changed[:20]))
+            report['rollback_ok'] = True
+            # Rollback may advance the native revision even when values match.
+            # Obtain the new revision through the real owner-thread service.
+            prepared = dict(prepared, document_revision=invoke(
+                lambda: str(service.provider_document_revision())))
+            validated = adapter.validate_result(prepared, execution)
+            event('rollback_verified_retry_started', objects=len(original))
+            before = time.monotonic()
+        adapter.publish_cooperatively(service, prepared, validated,
+            document_thread_dispatch=invoke, cancellation_check=lambda: False,
+            progress_callback=progress)
+        event('published', elapsed_seconds=time.monotonic() - before)
+        report['publication_ok'] = True
+    except BaseException:
+        report['error'] = traceback.format_exc()
+        event('failed', error=report['error'])
+
+
+def tick():
+    global stage, quiet_since, worker, last_heartbeat
+    try:
+        input_probe.check()
+        # Attribute native Qt callbacks as well as Python-dispatched adoption.
+        # The edit-check runner enables the application's existing tracer.
+        trace = QtCore.QMetaObject.invokeMethod(
+            QtWidgets.QApplication.instance(), 'takePerformanceEvents',
+            QtCore.Qt.ConnectionType.DirectConnection,
+            QtCore.Q_RETURN_ARG('QVariantMap'))
+        with lock:
+            report['native_events'].extend(
+                dict(item, probe_stage=stage, observed_seconds=time.monotonic() - started)
+                for item in trace['events'])
+            report['native_events_dropped'] = report.get('native_events_dropped', 0) + trace['dropped']
+        if QtWidgets.QApplication.activeModalWidget():
+            raise RuntimeError('Unexpected modal dialog in isolated publication probe')
+        if stage == 'startup':
+            stage = 'opening'
+            QtCore.QCoreApplication.postEvent(QtWidgets.QApplication.instance(),
+                                             QtGui.QFileOpenEvent(str(source)))
+            event('open_requested')
+        elif stage == 'opening':
+            doc = App.ActiveDocument
+            if doc is None or any((doc.Restoring, doc.Recomputing, doc.RecomputePending,
+                                  doc.CooperativeMutationActive, doc.PresentationUpdateActive)):
+                quiet_since = None
+                return
+            if quiet_since is None:
+                quiet_since = time.monotonic()
+                return
+            if time.monotonic() - quiet_since < 2:
+                return
+            import VibeCADGui
+            import VibeCADVibeScriptDomains as contracts
+            from VibeCADCore import get_service
+            from VibeCADModelingSurface import resolve_service_surface
+            from VibeCADVibeScriptDomainRuntime import AssemblyDomainAdapter
+            Gui.activateWorkbench('AssemblyWorkbench')
+            service = get_service()
+            manifest = json.loads(manifest_path.read_text(encoding='utf-8'))
+            request = json.loads((attempt / 'request.json').read_text(encoding='utf-8'))
+            execution = json.loads((attempt / 'result.json').read_text(encoding='utf-8'))
+            assert request['domain'] == 'assembly' and execution['ok']
+            working_candidate = os.environ.get('VIBECAD_PUBLICATION_WORKING_CANDIDATE') == '1'
+            assert request['revision'] == manifest[
+                'working_revision' if working_candidate else 'accepted_revision']
+            assert request['program_id'] == manifest['program_id']
+            assert request['document_uid'] == str(doc.Uid)
+            owners = [obj for obj in doc.Objects if
+                      getattr(obj, contracts.PROP_PROGRAM_ID, '') == request['program_id']
+                      and getattr(obj, contracts.PROP_PROGRAM_CONTRACT, '')]
+            assert len(owners) == 1, 'Expected exactly one portable contract owner'
+            assert getattr(owners[0], contracts.PROP_PROGRAM_REVISION) == manifest['accepted_revision']
+            pack = contracts.get_vibescript_pack('AssemblyWorkbench')
+            portable_contract = getattr(owners[0], contracts.PROP_PROGRAM_CONTRACT)
+            references = manifest.get('resolved_references', [])
+            if working_candidate:
+                candidate = manifest['latest_candidate']
+                assert candidate['revision'] == request['revision']
+                assert candidate['base_revision'] == manifest['accepted_revision']
+                assert request['source'] == manifest['source']
+                assert request['inputs'] == manifest['inputs']
+                assert request['expected_outputs'] == manifest['expected_outputs']
+                clean = contracts.validate_program_contract(pack, source=request['source'],
+                    input_schema=manifest['input_schema'], inputs=request['inputs'],
+                    expected_outputs=request['expected_outputs'])
+                contract_revision = contracts.program_revision(domain=pack.domain, **clean)
+                references = candidate.get('resolved_references', [])
+                revision = (contracts.program_revision_with_references(
+                    contract_revision=contract_revision, references=references)
+                    if references else contract_revision)
+                assert revision == request['revision'], 'Retained candidate contract digest mismatch'
+                portable_contract = contracts.encode_document_program_contract(pack,
+                    program_id=request['program_id'], label=manifest['label'],
+                    revision=revision, **clean)
+            surface = resolve_service_surface(service, service.active_workbench_name())
+            assert surface.available, surface.unavailable_reason
+            prepared = dict(pack=pack,
+                staging=attempt, expected_outputs=request['expected_outputs'],
+                worker_request=request, resolved_references=references,
+                program_id=request['program_id'], program_name=manifest['label'],
+                revision=request['revision'], document_name=doc.Name, document_uid=str(doc.Uid),
+                document_revision=str(service.provider_document_revision()),
+                surface=dict(workbench=surface.workbench, engine=surface.engine, surface_id=surface.surface_id),
+                document_program_contract=portable_contract)
+            VibeCADGui._ensure_document_thread_invoker()
+            report['max_heartbeat_gap'] = 0.0
+            last_heartbeat = time.monotonic()
+            event('replay_started', objects=len(doc.Objects))
+            stage = 'publishing'
+            # Profile the entire owner thread through validation as well as apply.
+            # A profiler around only adoption misses timer/queued callback stalls.
+            if profiling:
+                gui_profile.enable()
+            worker = threading.Thread(target=run, args=(prepared, execution, service,
+                AssemblyDomainAdapter(pack=prepared['pack']),
+                VibeCADGui._dispatch_to_document_thread), daemon=True)
+            worker.start()
+        elif stage == 'publishing' and not worker.is_alive():
+            if not report.get('publication_ok'):
+                raise RuntimeError(report.get('error', 'Publication did not succeed'))
+            stage = 'settling'
+            quiet_since = None
+            event('publication_worker_returned')
+        elif stage == 'settling':
+            doc = App.ActiveDocument
+            if doc is None or any((doc.Restoring, doc.Recomputing, doc.RecomputePending,
+                                  doc.CooperativeMutationActive, doc.PresentationUpdateActive)):
+                quiet_since = None
+                return
+            if quiet_since is None:
+                quiet_since = time.monotonic()
+                return
+            if time.monotonic() - quiet_since < 2:
+                return
+            if profiling:
+                gui_profile.disable()
+                gui_profile.dump_stats(str(output.with_name('main-thread.pstats')))
+            stage = 'finished'
+            assert [hashlib.sha256(path.read_bytes()).hexdigest() for path in input_files] == input_hashes
+            assert any(item['phase'] == 'publishing' for item in report['independent_input']), \
+                'No independent Windows input was measured during publication'
+            report['ok'] = True
+            event('complete', objects=len(App.ActiveDocument.Objects))
+            stage = 'reporting'
+        elif stage == 'reporting':
+            if not report_written.done():
+                return
+            report_written.result()
+            report_writer.close()
+            stage = 'finished'
+            timer.stop()
+            pulse.stop()
+            input_probe.close()
+            App.closeDocument(App.ActiveDocument.Name)
+            Gui.getMainWindow().close()
+    except Exception:
+        report['ok'] = False
+        report['error'] = traceback.format_exc()
+        event('failed', error=report['error'])
+        timer.stop()
+        pulse.stop()
+        input_probe.close()
+
+
+timer = QtCore.QTimer(Gui.getMainWindow())
+timer.setInterval(1000)
+timer.timeout.connect(tick)
+pulse = QtCore.QTimer(Gui.getMainWindow())
+pulse.setInterval(50)
+pulse.timeout.connect(heartbeat)
+pulse.start()
+QtCore.QTimer.singleShot(5000, timer.start)
+event('ready')

--- a/src/Tools/performance/run_portable_roundtrip.ps1
+++ b/src/Tools/performance/run_portable_roundtrip.ps1
@@ -1,0 +1,79 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Document,
+    [Parameter(Mandatory=$true)][string]$Name,
+    [Parameter(Mandatory=$true)][string]$Bundle,
+    [string]$BaselineReport,
+    [string]$ResultsRoot,
+    [switch]$ProfileCallbacks,
+    [switch]$ProfileCommandChecks,
+    [switch]$ExerciseGeneratedRecompute,
+    [switch]$TraceNativeEvents,
+    [switch]$AllowTimelineMigration,
+    [string[]]$AllowClearedInvalidObjects = @()
+)
+$ErrorActionPreference = 'Stop'
+$root = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+$bundle = (Resolve-Path -LiteralPath $Bundle).Path
+$exe = Join-Path $bundle 'VibeCAD.exe'
+$probe = Join-Path $PSScriptRoot 'portable_roundtrip_probe.py'
+if ($Name -notmatch '^[A-Za-z0-9_-]+$') { throw 'Use a simple diagnostic run name' }
+if (-not $ResultsRoot) { $ResultsRoot = Join-Path $root 'build/portable-validation-results' }
+$resultsRoot = [IO.Path]::GetFullPath($ResultsRoot)
+$run = [IO.Path]::GetFullPath((Join-Path $resultsRoot $Name))
+if (-not $run.StartsWith($resultsRoot + [IO.Path]::DirectorySeparatorChar, [StringComparison]::OrdinalIgnoreCase)) {
+    throw 'Diagnostic output must remain inside the results directory'
+}
+if (Test-Path -LiteralPath $run) { throw 'Use a new run name; existing diagnostic evidence is retained' }
+$source = (Resolve-Path -LiteralPath $Document).Path
+$required = @('VibeCAD.exe', 'bin/python311.dll', 'bin/pythonw.exe', 'bin/Qt6Core.dll',
+              'lib/qt6/plugins/platforms/qwindows.dll', 'Mod/VibeCAD/VibeCADGui.py')
+foreach ($relative in $required) {
+    if (-not (Test-Path -LiteralPath (Join-Path $bundle $relative) -PathType Leaf)) {
+        throw "Incomplete portable runtime: $relative"
+    }
+}
+New-Item -ItemType Directory -Path $run | Out-Null
+$copy = Join-Path $run 'probe-document.FCStd'
+$originalHash = (Get-FileHash -LiteralPath $source -Algorithm SHA256).Hash
+Copy-Item -LiteralPath $source -Destination $copy
+if ((Get-FileHash -LiteralPath $copy -Algorithm SHA256).Hash -ne $originalHash) { throw 'Copy checksum mismatch' }
+
+# The root portable launcher establishes Python and Qt from its own bundle.
+# Prevent inherited developer/test settings from injecting another runtime.
+foreach ($key in @('PYTHONHOME','PYTHONPATH','FC_PYTHONHOME','QT_PLUGIN_PATH',
+                   'QT_QPA_PLATFORM_PLUGIN_PATH','VIBECAD_DEV_ROOT','VIBECAD_DEV_COMMIT')) {
+    [Environment]::SetEnvironmentVariable($key, $null, 'Process')
+}
+$env:QT_QPA_PLATFORM = 'windows'
+$env:QT_FORCE_STDERR_LOGGING = '1'
+$env:PYTHONNOUSERSITE = '1'
+$env:PYTHONUSERBASE = Join-Path $run 'python-user'
+$env:FREECAD_USER_HOME = Join-Path $run 'freecad-user'
+$env:FREECAD_USER_DATA = Join-Path $run 'freecad-data'
+$env:FREECAD_USER_TEMP = Join-Path $run 'freecad-temp'
+$env:VIBECAD_HOME = Join-Path $run 'vibecad-data'
+$env:VIBECAD_AGENT_HOME = Join-Path $run 'agent'
+[Environment]::SetEnvironmentVariable('VIBECAD_AGENT_PORT', $null, 'Process')
+$env:VIBECAD_ROUNDTRIP_COPY = $copy
+$env:VIBECAD_ALLOW_CLEARED_INVALID_OBJECTS = ConvertTo-Json -InputObject @($AllowClearedInvalidObjects) -Compress
+$env:VIBECAD_ROUNDTRIP_REPORT = Join-Path $run 'roundtrip.json'
+$env:VIBECAD_INPUT_SENDER = Join-Path $PSScriptRoot 'native_input_sender.py'
+if ($BaselineReport) {
+    $env:VIBECAD_ROUNDTRIP_BASELINE = (Resolve-Path -LiteralPath $BaselineReport).Path
+} else {
+    [Environment]::SetEnvironmentVariable('VIBECAD_ROUNDTRIP_BASELINE', $null, 'Process')
+}
+$env:VIBECAD_RESTORE_DETAIL_TRACE = '1'
+[Environment]::SetEnvironmentVariable('VIBECAD_PROFILE_CALLBACKS', $(if ($ProfileCallbacks) { '1' } else { $null }), 'Process')
+[Environment]::SetEnvironmentVariable('VIBECAD_PROFILE_COMMANDS', $(if ($ProfileCommandChecks) { '1' } else { $null }), 'Process')
+[Environment]::SetEnvironmentVariable('VIBECAD_EXERCISE_GENERATED_RECOMPUTE', $(if ($ExerciseGeneratedRecompute) { '1' } else { $null }), 'Process')
+[Environment]::SetEnvironmentVariable('VIBECAD_TRACE_NATIVE_EVENTS', $(if ($TraceNativeEvents) { '1' } else { $null }), 'Process')
+[Environment]::SetEnvironmentVariable('VIBECAD_ALLOW_TIMELINE_MIGRATION', $(if ($AllowTimelineMigration) { '1' } else { $null }), 'Process')
+$argsList = @('--user-cfg', ('"' + (Join-Path $run 'user.cfg') + '"'),
+              '--log-file', ('"' + (Join-Path $run 'application.log') + '"'),
+              ('"' + $probe + '"'))
+$process = Start-Process -FilePath $exe -ArgumentList $argsList -WorkingDirectory $bundle `
+    -WindowStyle Hidden -RedirectStandardOutput (Join-Path $run 'stdout.log') `
+    -RedirectStandardError (Join-Path $run 'stderr.log') -PassThru
+[pscustomobject]@{ LauncherPid=$process.Id; Original=$source; OriginalSha256=$originalHash;
+                  Copy=$copy; Executable=$exe; Results=$run } | ConvertTo-Json

--- a/src/Tools/performance/simulation_camera_fit_probe.py
+++ b/src/Tools/performance/simulation_camera_fit_probe.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Actual GUI gate for immediate camera fitting before simulation capture.
+
+Run in a disposable empty GUI via the packaged or native diagnostic launcher.
+Creates 50 independent visible objects, checks final framing and verifies that
+fitAll does not enter a nested event loop. Does not save a document.
+"""
+import json
+import importlib.util
+import os
+from pathlib import Path
+import sys
+import time
+import traceback
+from types import SimpleNamespace
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import Part
+from PySide6 import QtCore
+
+candidate = os.environ.get('VIBECAD_SIMULATION_SOURCE')
+if candidate:
+    name = 'CommandCreateSimulation'
+    spec = importlib.util.spec_from_file_location(
+        name, Path(candidate) / 'Assembly' / 'CommandCreateSimulation.py')
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+from CommandCreateSimulation import TaskAssemblyCreateSimulation
+
+output = Path(os.environ['VIBECAD_TRACE_PROBE_RESULT'])
+if App.listDocuments():
+    raise RuntimeError('Use a disposable empty GUI for the camera fit probe')
+document = None
+state = 'create'
+ready_since = None
+queued_callback = []
+report = {'ok': False}
+
+
+def tick():
+    global document, state, ready_since
+    try:
+        if state == 'create':
+            document = App.newDocument('CameraFitProbe')
+            shape = Part.makeBox(10, 10, 10)
+            for index in range(50):
+                obj = document.addObject('Part::Feature', 'Part')
+                obj.Shape = shape
+                obj.Placement.Base = App.Vector(index % 10 * 12, index // 10 * 12, 0)
+            state = 'ready'
+        elif state == 'ready':
+            if document.RecomputePending or document.Recomputing or document.PresentationUpdateActive:
+                ready_since = None
+                return
+            if ready_since is None:
+                ready_since = time.monotonic()
+                return
+            if time.monotonic() - ready_since < 1:
+                return
+            view = Gui.activeDocument().activeView()
+            view.setCameraType('Orthographic')
+            view.setAnimationEnabled(True)
+            camera = view.getCameraNode()
+            camera.orientation.setValue(0, 0, 0, 1)
+            camera.height.setValue(1)
+            QtCore.QTimer.singleShot(0, lambda: queued_callback.append(True))
+            started = time.perf_counter()
+            panel = SimpleNamespace(view=view, presentation_visibility=[],
+                                    requested_camera_method='viewTop')
+            TaskAssemblyCreateSimulation._activatePlaybackPresentation(panel)
+            report['fit_seconds'] = time.perf_counter() - started
+            assert not queued_callback, 'Camera setup entered a nested event loop'
+            assert view.isAnimationEnabled(), 'Camera setup changed the view preference'
+            width, height = view.getSize()
+            fitted_height = camera.height.getValue()
+            position = camera.position.getValue().getValue()
+            report.update(objects=len(document.Objects), height=fitted_height,
+                          position=list(position), animation_preference_preserved=True)
+            assert fitted_height >= 58 - 1e-4
+            assert fitted_height * width / height >= 118 - 1e-4
+            assert abs(position[0] - 59) < 1e-4 and abs(position[1] - 29) < 1e-4, position
+            state = 'finish'
+        elif state == 'closing':
+            if any((document.RecomputePending, document.Recomputing,
+                    document.CooperativeMutationActive, document.PresentationUpdateActive)):
+                return
+            App.closeDocument(document.Name)
+            timer.stop()
+            Gui.getMainWindow().close()
+        elif state == 'finish':
+            assert queued_callback, 'Normal event processing did not resume'
+            report['ok'] = True
+            finish()
+    except Exception:
+        report['error'] = traceback.format_exc()
+        finish()
+
+
+def finish():
+    global state
+    output.write_text(json.dumps(report), encoding='utf-8')
+    print('SIMULATION_CAMERA_FIT ' + json.dumps(report), flush=True)
+    state = 'closing'
+
+
+timer = QtCore.QTimer(Gui.getMainWindow())
+timer.setInterval(100)
+timer.timeout.connect(tick)
+QtCore.QTimer.singleShot(3000, timer.start)

--- a/src/Tools/performance/simulation_playback_probe.py
+++ b/src/Tools/performance/simulation_playback_probe.py
@@ -1,0 +1,634 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Profile real native simulation playback in an isolated packaged GUI copy.
+
+Use run-packaged-edit-check.ps1 with a disposable document. Never inject this
+probe into a user's session. It opens the largest authenticated simulation,
+profiles generation and representative frame changes, and never saves.
+Set VIBECAD_SIMULATION_PLAYBACK_ASYNC=1 to measure the nonblocking player;
+leave it unset when collecting a comparable legacy baseline.
+Set VIBECAD_SIMULATION_EXPORT=1 with the async player to exercise its real
+animation-export entry point, native capture and persistent encoding worker.
+Set VIBECAD_SIMULATION_AI_PLAYBACK=1 with the async player to use the actual
+AI service entry, show its assembly, and exercise Play after exact seeks.
+VIBECAD_SIMULATION_READ_NAMES optionally supplies comma-separated object names
+for geometry-capture calls between generation and playback, without saving.
+VIBECAD_SIMULATION_LIFECYCLE=1 checks hidden joint markers, restored marker
+poses, and closing with a pending frame on the same real model.
+VIBECAD_SIMULATION_EXPORT_CANCEL=1 with export enabled cancels at frame
+preparation, native PNG capture and encoding, then retries a complete export.
+VIBECAD_SIMULATION_EXPORT_CLOSE=task or document closes that owner while native
+PNG capture is pending, verifying cancellation and cleanup after teardown.
+VIBECAD_SIMULATION_REFERENCE_AUDIT optionally supplies a joint-name prefix:
+audit those references after opening and exit without generating or playing.
+VIBECAD_SIMULATION_PERSISTED_REOPEN=1 closes/reopens the disposable document
+after sampling generated poses, then compares all sampled component poses from
+persisted playback. Native logs distinguish a cache hit from another solve.
+"""
+import cProfile
+import importlib.util
+import json
+import os
+from pathlib import Path
+import sys
+import time
+import traceback
+from concurrent.futures import Future
+from types import SimpleNamespace
+import psutil
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from PySide6 import QtCore, QtGui, QtWidgets
+
+output = Path(os.environ['VIBECAD_TRACE_PROBE_RESULT'])
+source = Path(os.environ['VIBECAD_ROUNDTRIP_COPY'])
+if source.parent != output.parent or source.name != 'probe-document.FCStd' or App.listDocuments():
+    raise RuntimeError('Use an isolated process and disposable probe-document.FCStd')
+App.setLogLevel('Assembly', 'Log')
+
+started = time.monotonic()
+process = psutil.Process()
+state = 'startup'
+quiet_since = None
+panel = None
+frames = []
+asynchronous = os.environ.get('VIBECAD_SIMULATION_PLAYBACK_ASYNC') == '1'
+export_animation = os.environ.get('VIBECAD_SIMULATION_EXPORT') == '1'
+if export_animation:
+    # Reject an incomplete diagnostic runtime before opening the large model.
+    # Export admission uses psutil; verification decodes the resulting GIF.
+    importlib.import_module('psutil')
+    importlib.import_module('PIL.Image')
+export_cancel_cases = (['frame', 'png', 'encoding']
+    if os.environ.get('VIBECAD_SIMULATION_EXPORT_CANCEL') == '1' else [])
+export_close = os.environ.get('VIBECAD_SIMULATION_EXPORT_CLOSE', '')
+if export_close not in {'', 'task', 'document'}:
+    raise RuntimeError('Export close must select task or document')
+if export_close:
+    export_cancel_cases = ['png']
+if export_cancel_cases and not export_animation:
+    raise RuntimeError('Export cancellation checks require animation export')
+export_case = None
+export_controller = None
+ai_playback = os.environ.get('VIBECAD_SIMULATION_AI_PLAYBACK') == '1'
+ai_reseek = os.environ.get('VIBECAD_SIMULATION_AI_RESEEK') == '1'
+lifecycle = os.environ.get('VIBECAD_SIMULATION_LIFECYCLE') == '1'
+persisted_reopen = os.environ.get('VIBECAD_SIMULATION_PERSISTED_REOPEN') == '1'
+reopened = False
+expected_reopen_poses = {}
+requested_frame = None
+if persisted_reopen and not asynchronous:
+    raise RuntimeError('Persisted playback verification requires asynchronous playback')
+if lifecycle and not asynchronous:
+    raise RuntimeError('The lifecycle probe requires asynchronous playback')
+joint_visibility = []
+marker_updates = []
+original_marker_update = None
+play_started = None
+captured_panel = None
+pending = None
+last_pulse = time.monotonic()
+report = {'pid': os.getpid(), 'events': [], 'ok': False,
+          'asynchronous': asynchronous, 'heartbeat_count': 0, 'max_heartbeat_gap_seconds': 0.0}
+report['native_build'] = App.ConfigGet('BuildRevisionHash')
+report['reference_audit_only'] = os.environ.get('VIBECAD_SIMULATION_REFERENCE_AUDIT', '')
+report['independent_input'] = []
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from window_input_probe import WindowInputProbe
+from async_report_writer import AsyncReportWriter
+report_writer = AsyncReportWriter(output)
+report_written = None
+input_probe = WindowInputProbe(Gui.getMainWindow(), lambda milliseconds:
+    report['independent_input'].append(dict(
+        phase=state, seconds=time.monotonic() - started, milliseconds=milliseconds)))
+
+
+class PlaybackChanges:
+    def slotChangedObject(self, obj, prop):
+        if state not in {'async_generate', 'frame', 'play', 'playing'}:
+            return
+        if prop in {'Placement', 'LinkPlacement', 'Label', 'Visibility'}:
+            return
+        # Record potential invalidations without writing a file per notification.
+        report.setdefault('non_pose_changes', []).append({
+            'seconds': time.monotonic() - started, 'stage': state,
+            'object': obj.Name, 'property': prop})
+
+
+changes = PlaybackChanges()
+App.addDocumentObserver(changes)
+
+
+def open_ai_player(simulation):
+    import CommandCreateSimulation
+    from VibeCADCore import get_service
+    from tool_impl.service import assembly_play_simulation
+    original = CommandCreateSimulation.openSimulationAsync
+
+    def observe(*args, **kwargs):
+        future = original(*args, **kwargs)
+        def capture(done):
+            global captured_panel
+            if not done.cancelled() and done.exception() is None:
+                captured_panel = done.result()
+        future.add_done_callback(capture)
+        return future
+
+    CommandCreateSimulation.openSimulationAsync = observe
+    try:
+        return assembly_play_simulation.run_async(
+            get_service(),
+            simulation={'document_uid': str(simulation.Document.Uid),
+                        'object_name': simulation.Name},
+            autoplay=False, time_seconds=0)
+    finally:
+        CommandCreateSimulation.openSimulationAsync = original
+
+
+def heartbeat():
+    global last_pulse
+    now = time.monotonic()
+    report['max_heartbeat_gap_seconds'] = max(report['max_heartbeat_gap_seconds'], now - last_pulse)
+    report['heartbeat_count'] += 1
+    last_pulse = now
+
+
+def watch(name, future):
+    before = time.perf_counter()
+    cpu = time.process_time()
+    def completed(done):
+        event(name + '_completed', elapsed_seconds=time.perf_counter() - before,
+              cpu_seconds=time.process_time() - cpu, cancelled=done.cancelled())
+    future.add_done_callback(completed)
+    return future
+
+
+def event(name, **values):
+    global report_written
+    entry = dict(event=name, seconds=round(time.monotonic() - started, 6),
+                 process_cpu_seconds=time.process_time(), rss_bytes=process.memory_info().rss,
+                 **values)
+    report['events'].append(entry)
+    print('SIMULATION_PLAYBACK ' + json.dumps(entry), flush=True)
+    snapshot = {key: list(value) if isinstance(value, list) else value
+                for key, value in report.copy().items()}
+    report_written = report_writer.submit(snapshot)
+
+
+def profile(name, function):
+    profiler = cProfile.Profile()
+    before = time.perf_counter()
+    cpu = time.process_time()
+    event(name + '_started')
+    try:
+        return profiler.runcall(function)
+    finally:
+        profiler.dump_stats(str(output.with_name(name + '.pstats')))
+        event(name + '_returned', elapsed_seconds=time.perf_counter() - before,
+              cpu_seconds=time.process_time() - cpu)
+
+
+def tick():
+    global state, quiet_since, panel, frames, pending, play_started
+    global joint_visibility, original_marker_update
+    global export_case, export_controller
+    global reopened, requested_frame
+    try:
+        input_probe.check()
+        modal = QtWidgets.QApplication.activeModalWidget()
+        if modal is not None and not (
+            state == 'export_wait' and isinstance(modal, QtWidgets.QProgressDialog)
+        ):
+            raise RuntimeError('Unexpected modal dialog in isolated playback probe')
+        if state == 'startup':
+            # Explicit Python-only candidate injection in this disposable process.
+            # Native verification must still use a complete matching package.
+            candidate = os.environ.get('VIBECAD_SIMULATION_SOURCE')
+            if candidate:
+                import sys
+                root = Path(candidate).resolve()
+                for name, relative in (
+                    ('SoSwitchMarker', 'Assembly/SoSwitchMarker.py'),
+                    ('CommandCreateSimulation', 'Assembly/CommandCreateSimulation.py'),
+                    ('tool_impl.service.assembly_play_simulation',
+                     'VibeCAD/tool_impl/service/assembly_play_simulation.py'),
+                ):
+                    spec = importlib.util.spec_from_file_location(name, root / relative)
+                    module = importlib.util.module_from_spec(spec)
+                    sys.modules[name] = module
+                    spec.loader.exec_module(module)
+                    if '.' in name:
+                        package, attribute = name.rsplit('.', 1)
+                        setattr(importlib.import_module(package), attribute, module)
+                if 'JointObject' in sys.modules:
+                    sys.modules['JointObject'].SoSwitchMarker = sys.modules['SoSwitchMarker'].SoSwitchMarker
+                event('python_candidate_loaded')
+            state = 'opening'
+            QtCore.QCoreApplication.postEvent(QtWidgets.QApplication.instance(),
+                                             QtGui.QFileOpenEvent(str(source)))
+            event('open_requested')
+        elif state == 'opening':
+            doc = App.ActiveDocument
+            if doc is None or any((doc.Restoring, doc.Recomputing, doc.RecomputePending,
+                                  doc.CooperativeMutationActive, doc.PresentationUpdateActive)):
+                quiet_since = None
+                return
+            if quiet_since is None:
+                quiet_since = time.monotonic()
+                return
+            if time.monotonic() - quiet_since < 2:
+                return
+            if report['reference_audit_only']:
+                entries = []
+                for joint in doc.Objects:
+                    if not joint.Name.startswith(report['reference_audit_only']):
+                        continue
+                    entry = {'joint': joint.Name, 'state': list(joint.State),
+                             'active': doc.isObjectUsableAtCurrentTimelinePosition(joint)}
+                    for name in ('Reference1', 'Reference2'):
+                        reference = getattr(joint, name, None)
+                        target = reference[0] if reference else None
+                        linked = target.getLinkedObject(True) if target else None
+                        entry[name] = dict(target=target.Name if target else None,
+                            subs=list(reference[1]) if reference else [],
+                            active=target.Document.isObjectUsableAtCurrentTimelinePosition(target) if target else False,
+                            linked=linked.Name if linked else None,
+                            linked_active=linked.Document.isObjectUsableAtCurrentTimelinePosition(linked) if linked else False)
+                    entries.append(entry)
+                assert entries, 'Reference audit did not match any joints'
+                event('reference_audit', entries=entries)
+                report['ok'] = True
+                event('complete')
+                state = 'reporting'
+                return
+            import CommandCreateSimulation
+            candidates = [obj for obj in doc.Objects
+                          if int(getattr(obj, 'VibeCADPoseCount', 0)) > 0]
+            if not candidates:
+                raise RuntimeError('No authenticated native simulation in test document')
+            simulation = max(candidates, key=lambda obj: int(obj.VibeCADPoseCount))
+            event('opened', objects=len(doc.Objects), simulation=simulation.Name,
+                  poses=int(simulation.VibeCADPoseCount))
+            if ai_playback or export_animation:
+                profile('setup_assembly_visibility', lambda: setattr(
+                    simulation.Proxy.getAssembly(simulation).ViewObject, 'Visibility', True))
+                camera_panel = SimpleNamespace(view=Gui.activeDocument().activeView(),
+                    presentation_visibility=[], requested_camera_method='viewAxonometric')
+                profile('setup_camera_fit', lambda:
+                    CommandCreateSimulation.TaskAssemblyCreateSimulation._activatePlaybackPresentation(
+                        camera_panel))
+            if asynchronous:
+                pending = profile('open_player_submit', lambda: watch('generate_and_display',
+                    open_ai_player(simulation) if ai_playback else
+                    CommandCreateSimulation.openSimulationAsync(simulation)))
+                state = 'async_generate'
+            else:
+                panel = profile('open_player', lambda: CommandCreateSimulation.openSimulation(simulation))
+                state = 'generate'
+        elif state == 'async_generate':
+            if not pending.done():
+                return
+            outcome = pending.result()
+            if ai_playback:
+                assert outcome['ok'], outcome
+                panel = captured_panel
+            else:
+                panel = outcome
+            pending = None
+            count = int(panel.assembly.numberOfFrames())
+            assert count >= 2 and panel.background_frames
+            if ai_reseek:
+                def unexpected_generation():
+                    raise AssertionError('Seeking the live player regenerated the simulation')
+                panel.runKinematicsAsync = unexpected_generation
+            read_names = os.environ.get('VIBECAD_SIMULATION_READ_NAMES', '').split(',')
+            if any(read_names):
+                from VibeCADCore import get_service
+                from VibeCADGeometryInspection import capture_geometry_read, discard_geometry_read
+                for name in filter(None, read_names):
+                    captured = capture_geometry_read(get_service(), {
+                        'reference': {'document_uid': str(panel.doc.Uid), 'object_name': name},
+                        'analysis_level': 'topology', 'include_subelements': False})
+                    discard_geometry_read(captured)
+                event('geometry_captures_completed', count=len(read_names))
+            frames = list(dict.fromkeys([1, max(1, count // 2), count - 1]))
+            event('generated', frames=count)
+            if lifecycle:
+                import JointObject
+                joint_visibility = [(obj, bool(obj.ViewObject.Visibility))
+                    for obj in panel.assembly.Joints
+                    if obj.ViewObject is not None
+                    and isinstance(obj.ViewObject.Proxy, JointObject.ViewProviderJoint)]
+                assert joint_visibility, 'No joint markers exercised'
+                for obj, _visible in joint_visibility:
+                    obj.ViewObject.Visibility = False
+                original_marker_update = JointObject.ViewProviderJoint.setJCSPosition
+
+                def observe_marker(self, *args):
+                    marker_updates.append(self.app_obj.Name)
+                    return original_marker_update(self, *args)
+
+                JointObject.ViewProviderJoint.setJCSPosition = observe_marker
+                event('joints_hidden', count=len(joint_visibility))
+            state = 'frame'
+        elif state == 'generate':
+            state = 'generating'
+            profile('generate', panel.runKinematics)
+            count = int(panel.assembly.numberOfFrames())
+            assert count >= 2
+            frames = list(dict.fromkeys([1, max(1, count // 2), count - 1]))
+            event('generated', frames=count)
+            state = 'frame'
+        elif state == 'frame':
+            if pending is not None:
+                if not pending.done():
+                    return
+                outcome = pending.result()
+                if ai_reseek:
+                    assert outcome['ok'], outcome
+                    assert int(panel.form.frameSlider.value()) == outcome['frame']
+                    event('ai_reseek_verified', frame=outcome['frame'])
+                else:
+                    assert int(panel.form.frameSlider.value()) == outcome
+                if persisted_reopen:
+                    poses = {name: App.Placement(part.Placement)
+                             for name, _id, part, _initial in panel.initialPlcs.parts}
+                    if reopened:
+                        expected = expected_reopen_poses[requested_frame]
+                        assert poses.keys() == expected.keys(), 'Reopen changed playback bindings'
+                        assert all(placement.isSame(expected[name], 1e-9)
+                                   for name, placement in poses.items()), 'Cached playback changed poses'
+                        event('persisted_poses_verified', frame=requested_frame, parts=len(poses))
+                    else:
+                        expected_reopen_poses[requested_frame] = poses
+                pending = None
+            if frames:
+                frame = frames.pop(0)
+                requested_frame = frame
+                if asynchronous:
+                    if ai_reseek:
+                        from VibeCADCore import get_service
+                        from tool_impl.service import assembly_play_simulation
+                        from CommandCreateSimulation import _simulationFrameTime
+                        pending = assembly_play_simulation.run_async(
+                            get_service(), simulation={
+                                'document_uid': str(panel.doc.Uid),
+                                'object_name': panel.simFeaturePy.Name},
+                            time_seconds=_simulationFrameTime(panel.simFeaturePy, frame),
+                            autoplay=False)
+                        assert isinstance(pending, Future), pending
+                        pending = watch('ai_reseek_' + str(frame), pending)
+                    else:
+                        pending = profile('frame_' + str(frame) + '_submit', lambda: watch(
+                            'frame_' + str(frame), panel.requestFrameAsync(frame)))
+                else:
+                    profile('frame_' + str(frame), lambda: panel.onFrameChanged(frame))
+            else:
+                if persisted_reopen and not reopened:
+                    state = 'reopen_cleanup'
+                    if original_marker_update is not None:
+                        import JointObject
+                        JointObject.ViewProviderJoint.setJCSPosition = original_marker_update
+                        original_marker_update = None
+                    def restore_visibility():
+                        for joint, visible in joint_visibility:
+                            joint.ViewObject.Visibility = visible
+                    profile('reopen_restore_joint_visibility', restore_visibility)
+                    joint_visibility = []
+                    marker_updates.clear()
+                    document_name = panel.doc.Name
+                    profile('reopen_close_player', Gui.Control.activeTaskDialog().reject)
+                    panel = None
+                    profile('reopen_close_document', lambda: App.closeDocument(document_name))
+                    reopened = True
+                    quiet_since = None
+                    state = 'opening'
+                    QtCore.QCoreApplication.postEvent(QtWidgets.QApplication.instance(),
+                                                     QtGui.QFileOpenEvent(str(source)))
+                    event('persisted_reopen_requested')
+                    return
+                state = 'markers' if lifecycle else ('play' if ai_playback else (
+                    'export' if export_animation and asynchronous else 'close'))
+        elif state == 'markers':
+            import JointObject
+            import UtilsAssembly
+            assert not marker_updates, 'Hidden joint graphics were regenerated'
+            JointObject.ViewProviderJoint.setJCSPosition = original_marker_update
+            original_marker_update = None
+            def show_markers():
+                for joint, _visible in joint_visibility:
+                    joint.ViewObject.Visibility = True
+            profile('show_joint_markers', show_markers)
+            verification_started = time.perf_counter()
+            checked = 0
+            for joint, _visible in joint_visibility:
+                proxy = joint.ViewObject.Proxy
+                assembly = joint.Proxy.getAssembly(joint)
+                for index in (1, 2):
+                    ref = getattr(joint, 'Reference' + str(index))
+                    if not ref:
+                        continue
+                    expected = assembly.getGlobalPlacement().inverse() * (
+                        UtilsAssembly.getGlobalPlacement(ref)
+                        * getattr(joint, 'Placement' + str(index)))
+                    marker = getattr(proxy, 'switch_JCS' + str(index))
+                    actual = App.Placement(
+                        App.Vector(*marker.transform.translation.getValue().getValue()),
+                        App.Rotation(*marker.transform.rotation.getValue().getValue()))
+                    assert actual.isSame(expected, 1e-4), joint.Name
+                    checked += 1
+            assert checked, 'No current joint marker poses compared'
+            event('joint_markers_verified', count=checked,
+                  verification_seconds=time.perf_counter() - verification_started)
+            state = 'play' if ai_playback else ('export' if export_animation else 'close')
+        elif state == 'play':
+            panel.animationTimerStartForward()
+            play_started = time.monotonic()
+            state = 'playing'
+            event('play_started')
+        elif state == 'playing':
+            assert not panel.frame_error, panel.frame_error
+            if time.monotonic() - play_started < 3:
+                return
+            panel.animationTimer.stop()
+            event('play_verified', frame=int(panel.form.frameSlider.value()))
+            state = 'export' if export_animation else 'close'
+        elif state == 'export':
+            import CommandCreateSimulation
+            dialog = CommandCreateSimulation.QFileDialog
+            destination = output.with_name('simulation.gif')
+            export_case = export_cancel_cases.pop(0) if export_cancel_cases else None
+            if export_case:
+                destination.write_bytes(b'previous accepted animation')
+            CommandCreateSimulation.QFileDialog = SimpleNamespace(
+                getSaveFileName=lambda *args: (str(destination), 'Animated GIF (*.gif)'))
+            try:
+                profile('export_submit', panel.saveAnimationAsync)
+            finally:
+                CommandCreateSimulation.QFileDialog = dialog
+            controller = panel.animation_export
+            export_controller = controller
+            assert controller is not None, 'Export did not submit an asynchronous controller'
+            pending = watch('animation_export', Future())
+            def export_finished(snapshot, future=pending, controller=controller):
+                if future.done():
+                    return
+                try:
+                    if export_close:
+                        assert not controller.timer.isActive(), 'Closed export kept polling'
+                        assert controller.restore is None, 'Closed player requested a frame restore'
+                    future.set_result(snapshot)
+                except Exception as error:
+                    future.set_exception(error)
+            controller.finished.connect(export_finished)
+            if export_case:
+                def cancel_export(controller=controller, stage=export_case):
+                    if controller.cancelled:
+                        return
+                    snapshot = controller.job.manager.snapshot(controller.job.job_id)
+                    event('export_cancel_requested', stage=stage,
+                          frame_pending=controller.frame is not None,
+                          image_pending=controller.image is not None,
+                          worker_active=snapshot.worker_active,
+                          progress_message=snapshot.progress_message)
+                    if export_close:
+                        try:
+                            assert controller.image is not None, 'No pending native capture at close'
+                            baseline = panel.initialPlcs
+                            document_name = panel.doc.Name
+                            if export_close == 'task':
+                                Gui.Control.activeTaskDialog().reject()
+                                assert all(part.Placement.isSame(placement, 1e-9)
+                                           for _name, _id, part, placement in baseline.parts), (
+                                    'Task close failed to restore original poses')
+                            else:
+                                App.closeDocument(document_name)
+                                assert document_name not in App.listDocuments()
+                            assert Gui.Control.activeTaskDialog() is None
+                            assert controller.cancelled, 'Owner close did not cancel export'
+                            event('export_owner_closed', owner=export_close)
+                        except Exception as error:
+                            pending.set_exception(error)
+                    else:
+                        controller.cancel()
+                if export_case == 'frame':
+                    original_request = panel.requestFrameAsync
+                    def request_then_cancel(*args, **kwargs):
+                        panel.requestFrameAsync = original_request
+                        future = original_request(*args, **kwargs)
+                        assert not future.done(), 'Frame preparation was not pending'
+                        QtCore.QTimer.singleShot(0, cancel_export)
+                        return future
+                    panel.requestFrameAsync = request_then_cancel
+                elif export_case == 'png':
+                    original_png = controller.start_png
+                    def capture_then_cancel(*args, **kwargs):
+                        controller.start_png = original_png
+                        token = original_png(*args, **kwargs)
+                        QtCore.QTimer.singleShot(0, cancel_export)
+                        return token
+                    controller.start_png = capture_then_cancel
+                else:
+                    controller.progress.connect(lambda _count, message:
+                        cancel_export() if message == 'Encoding animation on a background worker'
+                        else None)
+            state = 'export_wait'
+        elif state == 'export_wait':
+            # The export progress dialog is nonblocking but window-modal.
+            if not pending.done():
+                return
+            snapshot = pending.result()
+            if export_case:
+                assert snapshot.phase == 'cancelled', snapshot
+                assert not snapshot.worker_active
+                assert output.with_name('simulation.gif').read_bytes() == b'previous accepted animation'
+                assert not export_controller.staging.exists(), 'Cancelled capture retained staging'
+                if export_close:
+                    event('export_close_verified', owner=export_close)
+                    input_probe.check()
+                    assert report['independent_input'], 'No independent input was measured'
+                    report['ok'] = True
+                    event('complete')
+                    state = 'reporting'
+                    return
+                assert int(panel.form.frameSlider.value()) == export_controller.original_frame
+                assert not panel.frame_error, panel.frame_error
+                event('export_cancel_verified', stage=export_case,
+                      restored_frame=int(panel.form.frameSlider.value()))
+                pending = None
+                state = 'export'
+                return
+            assert snapshot.phase == 'completed', snapshot.error
+            from PIL import Image, ImageChops
+            with Image.open(output.with_name('simulation.gif')) as animation:
+                assert animation.n_frames == panel.assembly.numberOfFrames()
+                first = animation.convert('RGB')
+                changed = 0
+                for index in range(1, animation.n_frames):
+                    animation.seek(index)
+                    if ImageChops.difference(first, animation.convert('RGB')).getbbox():
+                        changed += 1
+                assert changed, 'Export contains no visible motion relative to frame zero'
+                event('export_verified', frames=animation.n_frames, size=animation.size,
+                      changed_frames=changed)
+            pending = None
+            state = 'close'
+        elif state == 'close':
+            state = 'closing'
+            if lifecycle:
+                for joint, visible in joint_visibility:
+                    joint.ViewObject.Visibility = visible
+                baseline = panel.initialPlcs
+                pending = panel.requestFrameAsync(1)
+                assert not pending.done(), 'The close check needs a pending frame'
+                Gui.Control.activeTaskDialog().reject()
+                assert pending.done(), 'Closing did not resolve the pending frame'
+                assert pending.cancelled() or pending.exception() is not None, (
+                    'A frame pending at close was accepted')
+                assert Gui.Control.activeTaskDialog() is None
+                assert all(part.Placement.isSame(placement, 1e-9)
+                           for _name, _id, part, placement in baseline.parts), (
+                    'Closing failed to restore the exact original poses')
+                event('close_pending_frame_verified', parts=len(baseline.parts))
+            elif Gui.Control.activeTaskDialog() is not None:
+                Gui.Control.activeTaskDialog().reject()
+            input_probe.check()
+            assert report['independent_input'], 'No independent Windows input was measured'
+            report['ok'] = True
+            event('complete')
+            state = 'reporting'
+        elif state == 'reporting':
+            if not report_written.done():
+                return
+            report_written.result()
+            report_writer.close()
+            timer.stop()
+            pulse.stop()
+            input_probe.close()
+            App.removeDocumentObserver(changes)
+            # Do not save the model or touch any source project artifacts.
+            if App.ActiveDocument:
+                App.closeDocument(App.ActiveDocument.Name)
+            Gui.getMainWindow().close()
+    except Exception:
+        if original_marker_update is not None:
+            import JointObject
+            JointObject.ViewProviderJoint.setJCSPosition = original_marker_update
+            original_marker_update = None
+        report['ok'] = False
+        report['error'] = traceback.format_exc()
+        event('error', error=report['error'])
+        timer.stop()
+        pulse.stop()
+        input_probe.close()
+
+
+timer = QtCore.QTimer(Gui.getMainWindow())
+timer.setInterval(1000)
+timer.timeout.connect(tick)
+pulse = QtCore.QTimer(Gui.getMainWindow())
+pulse.setInterval(50)
+pulse.timeout.connect(heartbeat)
+pulse.start()
+QtCore.QTimer.singleShot(5000, timer.start)
+event('ready')

--- a/src/Tools/performance/simulation_runtime_probe.py
+++ b/src/Tools/performance/simulation_runtime_probe.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Exercise the native detached simulation API in an isolated packaged GUI.
+
+No customer document is opened or saved. The ordinary playback probe separately
+measures the large saved model. This probe checks asynchronous completion,
+source invalidation, cancellation, and document destruction while work is live.
+"""
+import json
+import os
+from pathlib import Path
+import time
+import traceback
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from PySide6 import QtCore
+
+output = Path(os.environ['VIBECAD_TRACE_PROBE_RESULT'])
+report = {'ok': False, 'events': []}
+document = None
+assembly = None
+simulation = None
+stage = 'start'
+request = None
+frame_request = None
+frame_expected = None
+started = time.monotonic()
+
+
+def event(name, **data):
+    report['events'].append(dict(event=name, seconds=time.monotonic() - started, **data))
+    output.write_text(json.dumps(report, indent=2), encoding='utf-8')
+
+
+def tick():
+    global document, assembly, simulation, stage, request, frame_request, frame_expected
+    try:
+        if stage == 'start':
+            if App.listDocuments():
+                raise RuntimeError('This probe requires an isolated empty process')
+            Gui.activateWorkbench('AssemblyWorkbench')
+            import Part
+            import JointObject
+            import UtilsAssembly
+            from CommandCreateSimulation import Simulation
+            document = App.newDocument('SimulationRuntimeProbe')
+            assembly = document.addObject('Assembly::AssemblyObject', 'Assembly')
+            assert callable(getattr(assembly, 'startSimulation', None)), 'Native asynchronous simulation API missing'
+            source = document.addObject('Part::Feature', 'Source')
+            source.Shape = Part.makeBox(1, 1, 1)
+            group = UtilsAssembly.getJointGroup(assembly)
+            for index in range(50):
+                link = assembly.newObject('App::Link', 'Component')
+                link.setLink(source)
+                link.LinkPlacement = App.Placement(App.Vector(index * 2, 0, 0), App.Rotation())
+                ground = group.newObject('App::FeaturePython', 'Ground')
+                JointObject.GroundedJoint(ground, link)
+            simulation = assembly.newObject('App::FeaturePython', 'Simulation')
+            Simulation(simulation)
+            simulation.aTimeStart = 0
+            simulation.bTimeEnd = 0.2
+            simulation.cTimeStepOutput = 0.1
+            before = time.monotonic()
+            superseded = assembly.startSimulation(simulation)
+            request = assembly.startSimulation(simulation)
+            assert isinstance(request, int) and request != superseded
+            assembly.cancelSimulation(superseded)
+            try:
+                assembly.finishSimulation(superseded)
+            except RuntimeError as error:
+                assert 'superseded' in str(error)
+            else:
+                raise AssertionError('Superseded caller consumed the current simulation')
+            event('request_ownership_preserved')
+            event('submitted', callback_seconds=time.monotonic() - before)
+            stage = 'generation'
+        elif stage == 'generation':
+            if not assembly.finishSimulation(request):
+                event('owner_event_loop_alive')
+                return
+            assert assembly.numberOfFrames() >= 3
+            assembly.updateForFrame(1)
+            frame_expected = [(obj.Name, obj.ID, obj.Placement) for obj in assembly.Group if obj.isDerivedFrom('App::Link')]
+            assembly.updateForFrame(2)
+            superseded = assembly.requestSimulationFrame(2)
+            frame_request = assembly.requestSimulationFrame(1)
+            assembly.cancelSimulationFrame(superseded)
+            try:
+                assembly.finishSimulationFrame(superseded)
+            except RuntimeError as error:
+                assert 'superseded' in str(error)
+            else:
+                raise AssertionError('Superseded frame was adopted')
+            stage = 'frame'
+        elif stage == 'frame':
+            if not assembly.finishSimulationFrame(frame_request):
+                event('frame_event_loop_alive')
+                return
+            for name, object_id, expected in frame_expected:
+                current = document.getObject(name)
+                assert current.ID == object_id and current.Placement.isSame(expected, 1e-10)
+            cancelled = assembly.requestSimulationFrame(2)
+            assembly.cancelSimulationFrame(cancelled)
+            try:
+                assembly.finishSimulationFrame(cancelled)
+            except RuntimeError:
+                pass
+            else:
+                raise AssertionError('Cancelled frame was adopted')
+            event('parallel_frame_matches_synchronous_pose')
+            event('generated', frames=assembly.numberOfFrames())
+            assembly.startSimulation(simulation)
+            simulation.bTimeEnd = 0.3
+            stage = 'invalidated'
+        elif stage == 'invalidated':
+            try:
+                complete = assembly.finishSimulation()
+            except RuntimeError:
+                event('stale_result_rejected')
+            else:
+                if not complete:
+                    return
+                raise AssertionError('Changed simulation input was accepted')
+            assembly.startSimulation(simulation)
+            assembly.cancelSimulation()
+            try:
+                assembly.finishSimulation()
+            except RuntimeError:
+                event('cancelled')
+            else:
+                raise AssertionError('Cancelled simulation was accepted')
+            assembly.startSimulation(simulation)
+            App.closeDocument(document.Name)
+            document = None
+            stage = 'closed'
+        elif stage == 'closed':
+            report['ok'] = True
+            event('complete')
+            timer.stop()
+            Gui.getMainWindow().close()
+    except Exception:
+        report['error'] = traceback.format_exc()
+        event('failed')
+        timer.stop()
+        if document is not None:
+            App.closeDocument(document.Name)
+        Gui.getMainWindow().close()
+
+
+timer = QtCore.QTimer(Gui.getMainWindow())
+timer.timeout.connect(tick)
+timer.start(50)

--- a/src/Tools/performance/test_async_report_writer.py
+++ b/src/Tools/performance/test_async_report_writer.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+import json
+from pathlib import Path
+import threading
+
+import pytest
+
+from async_report_writer import AsyncReportWriter
+
+
+def test_blocked_disk_does_not_block_submit_and_pending_reports_coalesce(monkeypatch, tmp_path):
+    entered = threading.Event()
+    release = threading.Event()
+    writes = []
+    owner = threading.get_ident()
+
+    def blocked_write(path, text, **kwargs):
+        assert threading.get_ident() != owner
+        entered.set()
+        assert release.wait(5), 'Test did not release the simulated blocked disk'
+        writes.append(json.loads(text))
+
+    monkeypatch.setattr(Path, 'write_text', blocked_write)
+    writer = AsyncReportWriter(tmp_path / 'trace.json')
+    try:
+        first = writer.submit({'value': 1})
+        assert entered.wait(5)
+        second = writer.submit({'value': 2})
+        final = writer.submit({'value': 3})
+        assert second.cancelled()
+        assert not first.done() and not final.done()
+        release.set()
+        first.result(timeout=5)
+        final.result(timeout=5)
+        assert writes == [{'value': 1}, {'value': 3}]
+    finally:
+        release.set()
+        writer.close()
+
+
+def test_write_error_reaches_completion_and_writer_accepts_next_report(monkeypatch, tmp_path):
+    original = Path.write_text
+    monkeypatch.setattr(Path, 'write_text', lambda *a, **k: (_ for _ in ()).throw(OSError('disk error')))
+    writer = AsyncReportWriter(tmp_path / 'trace.json')
+    try:
+        with pytest.raises(OSError, match='disk error'):
+            writer.submit({'ok': False}).result(timeout=5)
+        monkeypatch.setattr(Path, 'write_text', original)
+        writer.submit({'ok': True}).result(timeout=5)
+        assert json.loads((tmp_path / 'trace.json').read_text()) == {'ok': True}
+    finally:
+        writer.close()
+    with pytest.raises(RuntimeError, match='closed'):
+        writer.submit({})

--- a/src/Tools/performance/test_roundtrip_invalid_flags.py
+++ b/src/Tools/performance/test_roundtrip_invalid_flags.py
@@ -1,0 +1,28 @@
+"""Test the probe's pure flag comparison without importing the GUI runtime."""
+import ast
+from pathlib import Path
+
+import pytest
+
+
+def check(expected, actual, allowed=()):
+    tree = ast.parse(Path(__file__).with_name('portable_roundtrip_probe.py').read_text())
+    function = next(node for node in tree.body
+                    if isinstance(node, ast.FunctionDef) and node.name == 'check_invalid_flags')
+    namespace = {}
+    exec(compile(ast.Module(body=[function], type_ignores=[]), '<probe>', 'exec'), namespace)
+    return namespace['check_invalid_flags'](expected, actual, allowed)
+
+
+def test_saved_invalid_flags_are_strict_by_default():
+    assert check(['assembly'], ['assembly']) == []
+    with pytest.raises(RuntimeError):
+        check(['assembly'], [])
+
+
+def test_only_explicitly_named_cleared_flags_are_admitted():
+    assert check(['assembly'], [], ['assembly']) == ['assembly']
+    with pytest.raises(RuntimeError):
+        check(['assembly', 'body'], [], ['assembly'])
+    with pytest.raises(RuntimeError):
+        check(['assembly'], ['new_failure'], ['assembly'])

--- a/src/Tools/performance/validate_boolean_document.py
+++ b/src/Tools/performance/validate_boolean_document.py
@@ -1,0 +1,30 @@
+"""Read-only geometry check of a generated workload after packaged GUI round-trip."""
+import json
+import math
+import os
+from pathlib import Path
+
+import FreeCAD as App
+import Part
+
+
+source = Path(os.environ['VIBECAD_VALIDATE_DOCUMENT']).resolve()
+expected = json.loads(Path(os.environ['VIBECAD_EXPECTED_GEOMETRY']).read_text(encoding='utf-8'))
+document = App.openDocument(str(source))
+try:
+    if len(document.Objects) != expected['objects']:
+        raise RuntimeError('Object count changed during round-trip')
+    for name, shape in expected['expected_results'].items():
+        obj = document.getObject(name)
+        if obj is None or obj.Shape.isNull() or len(obj.Shape.Solids) != 1:
+            raise RuntimeError(f'{name} did not retain one solid')
+        if not math.isclose(obj.Shape.Volume, shape['volume'], rel_tol=1e-8):
+            raise RuntimeError(f'{name} volume changed during round-trip')
+        if len(obj.Shape.Faces) != shape['faces']:
+            raise RuntimeError(f'{name} face count changed during round-trip')
+    print('VIBECAD_GEOMETRY_ROUNDTRIP ' + json.dumps({
+        'ok': True, 'objects': len(document.Objects),
+        'validated_solids': len(expected['expected_results']),
+    }), flush=True)
+finally:
+    App.closeDocument(document.Name)

--- a/src/Tools/performance/vibescript_edit_probe.py
+++ b/src/Tools/performance/vibescript_edit_probe.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+"""Run in a disposable GUI: real 50-output create/patch/input-edit/rollback probe.
+
+Set VIBECAD_TRACE_PROBE_RESULT to an ignored JSON output path. Uses the running
+build's modules and worker runtime. Creates and closes only its own document.
+"""
+
+import FreeCAD as App
+import FreeCADGui as Gui
+import json
+import os
+import sys
+import time
+import traceback
+import threading
+from pathlib import Path
+from PySide import QtCore
+
+# Reuse the native integration fixture; import production modules from the running build.
+fixture_root = Path(__file__).resolve().parents[2] / 'Mod/VibeCAD'
+# The integration fixture supports source-only tests by adding MODULE_ROOT.
+# Append it first so that helper does not put sources ahead of the packaged runtime.
+sys.path.append(str(fixture_root))
+sys.path.append(str(fixture_root / 'vibecad_tests'))
+from partdesign_vibescript_api_integration import _Service
+import VibeCADGui as gui
+from VibeCADSession import _run_domain_vibescript_tool
+
+class Probe:
+    def __init__(self):
+        self.root = Path(os.environ['VIBECAD_TRACE_PROBE_RESULT']).parent
+        home = Path(App.getHomePath()).resolve()
+        self.modules = {name: str(Path(sys.modules[name].__file__).resolve()) for name in
+                        ('VibeCADGui', 'VibeCADSession', 'VibeCADVibeScriptDomainRuntime',
+                         'VibeCADVibeScriptDomainPublication')}
+        if any(not Path(path).is_relative_to(home) for path in self.modules.values()):
+            raise RuntimeError('The probe must use the running build, not checkout modules: ' + str(self.modules))
+        self.doc = App.newDocument('ParallelPatchProbe')
+        self.doc.UndoMode = True
+        self.doc.commitTransaction()
+        self.service = _Service(self.doc, self.root / 'project')
+        self.events = []
+        self.result = None
+        self.heartbeats = []
+        self.last = time.monotonic()
+        self.phase = 'startup'
+        self.cancel = False
+        self.cancel_at_output = None
+        self.gaps = []
+        gui._ensure_document_thread_invoker()
+        self.timer = QtCore.QTimer()
+        self.timer.timeout.connect(self.tick)
+        self.timer.start(20)
+        self.thread = threading.Thread(target=self.run)
+        self.thread.start()
+
+    def progress(self, event):
+        self.events.append(event)
+        if (self.cancel_at_output is not None and event.get('phase') == 'publishing'
+                and event.get('completed', 0) >= self.cancel_at_output):
+            self.cancel = True
+
+    def call(self, operation, args, *, expect_success=True):
+        self.phase = operation
+        started = time.monotonic()
+        result = _run_domain_vibescript_tool(
+            self.service, 'vibescript.partdesign.' + operation, args,
+            document_thread_dispatch=gui._dispatch_to_document_thread,
+            cancellation_check=lambda: self.cancel,
+            progress_callback=self.progress)
+        (self.root / (operation + '.json')).write_text(json.dumps(result, indent=2, default=str))
+        print('PATCH_PIPELINE', operation, time.monotonic()-started, result.get('ok'), flush=True)
+        if expect_success and result.get('ok') is not True:
+            raise RuntimeError(str(result))
+        return result
+
+    def verify(self, result, width, height):
+        self.phase = 'test_geometry_verification'
+        def inspect():
+            outputs = result['live_outputs']
+            assert len(outputs) == 50, len(outputs)
+            names = []
+            for i in range(50):
+                obj = self.doc.getObject(outputs[f'Part{i}']['object_name'])
+                assert obj is not None
+                assert abs(obj.Shape.Volume - (width+i)*2*height) < 1e-7, (i, obj.Shape.Volume)
+                names.append(obj.Name)
+            return names
+        return gui._dispatch_to_document_thread(inspect)
+
+    def run(self):
+        try:
+            source = 'height = 3.0\nresult = {\n' + ''.join(
+                f"'Part{i}': api.body(api.box(inputs['width']+{i}, 2, height), label='Part{i}'),\n"
+                for i in range(50)) + '}\n'
+            result = self.call('create_program', {
+                'program_name':'Parallel patch probe', 'source':source,
+                'input_schema':{'type':'object','properties':{'width':{'type':'number','exclusiveMinimum':0}},
+                                'required':['width'],'additionalProperties':False},
+                'inputs':{'width':1},
+                'expected_outputs':[{'name':f'Part{i}','type':'solid'} for i in range(50)]})
+            names = self.verify(result, 1, 3)
+            def edit_args():
+                return {'program_id': result['program_id'], 'expected_revision':result['working_revision']}
+            result = self.call('apply_patch', dict(edit_args(), patch=
+                '*** Begin Patch\n*** Update File: source.py\n@@\n-height = 3.0\n+height = 4.0\n*** End Patch'))
+            assert self.verify(result, 1, 4) == names
+            result = self.call('set_inputs', dict(edit_args(), patch={'width':2}))
+            assert self.verify(result, 2, 4) == names
+            self.cancel_at_output = 10
+            cancelled = self.call('apply_patch', dict(edit_args(), patch=
+                '*** Begin Patch\n*** Update File: source.py\n@@\n-height = 4.0\n+height = 5.0\n*** End Patch'), expect_success=False)
+            assert self.cancel and cancelled.get('ok') is not True, cancelled
+            assert self.verify(result, 2, 4) == names
+            self.result = {'ok':True,'outputs':50,'operations':['create_program','apply_patch','set_inputs','cancelled_patch_rollback']}
+        except Exception:
+            self.result = {'ok':False,'error':traceback.format_exc()}
+
+    def tick(self):
+        now = time.monotonic()
+        if now-self.last > 0.1:
+            self.gaps.append({'seconds':now-self.last, 'phase':self.phase,
+                              'last_event':self.events[-1] if self.events else None})
+        self.heartbeats.append(now-self.last)
+        self.last = now
+        if self.result is None:
+            return
+        # Cancellation rolls the model back before the queued display updates
+        # finish. Wait for those owners before asking the diagnostic GUI to close.
+        if any(bool(getattr(self.doc, name, False)) for name in
+               ('Recomputing', 'RecomputePending', 'CooperativeMutationActive',
+                'PresentationUpdateActive')):
+            return
+        self.timer.stop()
+        self.thread.join()
+        self.result['heartbeat_max_seconds'] = max(self.heartbeats)
+        self.result['events'] = self.events
+        self.result['gaps'] = self.gaps
+        self.result['runtime_modules'] = self.modules
+        Path(os.environ['VIBECAD_TRACE_PROBE_RESULT']).write_text(json.dumps(self.result, indent=2, default=str))
+        print('PATCH_DONE', self.result['ok'], self.result.get('error',''), flush=True)
+        Gui.getDocument(self.doc.Name).Modified = False
+        App.closeDocument(self.doc.Name)
+        Gui.getMainWindow().close()
+
+probe = None
+def start():
+    global probe
+    probe = Probe()
+QtCore.QTimer.singleShot(1500, start)

--- a/src/Tools/performance/window_input_probe.py
+++ b/src/Tools/performance/window_input_probe.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Window-local Windows input latency for isolated GUI performance probes."""
+
+import ctypes
+from ctypes import wintypes
+import os
+from pathlib import Path
+import subprocess
+import uuid
+
+
+class WindowInputProbe:
+    """Measure Windows queue age without depending on the GUI's GIL or timers.
+
+    The existing sender posts an otherwise unused function key only to this
+    process's window. Its messages are consumed here; physical keyboard state
+    and desktop focus are never changed. Close signals the sender without
+    waiting on the GUI thread. The sender also exits if its parent disappears.
+    """
+
+    def __init__(self, window, on_input):
+        import FreeCAD as App
+        from PySide6 import QtCore, QtWidgets
+
+        self._closed = False
+        self._app = QtWidgets.QApplication.instance()
+        self._kernel = ctypes.WinDLL('kernel32', use_last_error=True)
+        self._kernel.CreateEventW.argtypes = (
+            ctypes.c_void_p, wintypes.BOOL, wintypes.BOOL, wintypes.LPCWSTR)
+        self._kernel.CreateEventW.restype = wintypes.HANDLE
+        self._kernel.SetEvent.argtypes = (wintypes.HANDLE,)
+        self._kernel.CloseHandle.argtypes = (wintypes.HANDLE,)
+        self._kernel.GetTickCount.restype = wintypes.DWORD
+        stop_name = f'Local\\VibeCADInputProbe-{os.getpid()}-{uuid.uuid4().hex}'
+        self._stop = self._kernel.CreateEventW(None, True, False, stop_name)
+        if not self._stop:
+            raise ctypes.WinError(ctypes.get_last_error())
+        kernel = self._kernel
+
+        class NativeFilter(QtCore.QAbstractNativeEventFilter):
+            def nativeEventFilter(self, event_type, message):
+                value = ctypes.cast(int(message), ctypes.POINTER(wintypes.MSG)).contents
+                if value.message == 0x0100 and value.wParam == 0x86:
+                    on_input((kernel.GetTickCount() - value.time) & 0xffffffff)
+                return False, 0
+
+        class KeyFilter(QtCore.QObject):
+            def eventFilter(self, watched, event):
+                return (event.type() in (QtCore.QEvent.KeyPress, QtCore.QEvent.KeyRelease)
+                        and event.key() == QtCore.Qt.Key_F23)
+
+        self._native_filter = NativeFilter()
+        self._key_filter = KeyFilter(window)
+        self._app.installNativeEventFilter(self._native_filter)
+        self._app.installEventFilter(self._key_filter)
+        python_bin = Path(os.environ.get(
+            'VIBECAD_TEST_PYTHON', str(Path(App.getHomePath()) / 'bin')))
+        try:
+            self._sender = subprocess.Popen([
+                str(python_bin / 'pythonw.exe'),
+                str(Path(__file__).with_name('native_input_sender.py')),
+                str(int(window.winId())), str(os.getpid()), stop_name,
+            ], creationflags=subprocess.CREATE_NO_WINDOW)
+        except BaseException:
+            self.close()
+            raise
+        self._app.aboutToQuit.connect(self.close)
+
+    def check(self):
+        if not self._closed and self._sender.poll() is not None:
+            raise RuntimeError('The independent Windows input sampler exited unexpectedly')
+
+    def close(self):
+        if self._closed:
+            return
+        self._closed = True
+        self._kernel.SetEvent(self._stop)
+        self._kernel.CloseHandle(self._stop)
+        self._app.removeNativeEventFilter(self._native_filter)
+        self._app.removeEventFilter(self._key_filter)

--- a/src/Tools/tests/test_linux_appimage_launcher.py
+++ b/src/Tools/tests/test_linux_appimage_launcher.py
@@ -12,6 +12,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[3]
 CREATE_BUNDLE = REPO_ROOT / "package" / "rattler-build" / "linux" / "create_bundle.sh"
 TRACKED_LAUNCHER = REPO_ROOT / "package" / "rattler-build" / "linux" / "AppDir" / "AppRun"
+EXCLUDE_HOST_GRAPHICS_LIBRARIES = (
+    REPO_ROOT
+    / "package"
+    / "rattler-build"
+    / "scripts"
+    / "exclude_appimage_host_graphics_libraries.sh"
+)
 
 
 def generated_launcher() -> str:
@@ -26,6 +33,31 @@ def generated_launcher() -> str:
 
 
 class TestLinuxAppImageLauncher(unittest.TestCase):
+    def test_bundled_libdrm_libraries_are_excluded(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            prefix = Path(temp_dir) / "usr"
+            library_dir = prefix / "lib"
+            library_dir.mkdir(parents=True)
+
+            (library_dir / "libdrm.so.2.125.0").touch()
+            (library_dir / "libdrm.so.99.999.0").touch()
+            (library_dir / "libdrm_futuregpu.so.42").touch()
+            (library_dir / "libdrm.so.2").symlink_to("libdrm.so.2.125.0")
+            (library_dir / "libdrm_amdgpu.so.1.125.0").touch()
+            (library_dir / "libdrm_amdgpu.so.1").symlink_to(
+                "libdrm_amdgpu.so.1.125.0"
+            )
+            preserved_library = library_dir / "libQt6Core.so.6.8.3"
+            preserved_library.touch()
+
+            subprocess.run(
+                [str(EXCLUDE_HOST_GRAPHICS_LIBRARIES), str(prefix)],
+                check=True,
+            )
+
+            self.assertEqual(list(library_dir.glob("libdrm*.so*")), [])
+            self.assertTrue(preserved_library.exists())
+
     def test_generated_launcher_matches_tracked_launcher(self) -> None:
         self.assertEqual(
             generated_launcher(),

--- a/tests/performance/gui_document_responsiveness.py
+++ b/tests/performance/gui_document_responsiveness.py
@@ -1,0 +1,132 @@
+"""Measure a real VibeCAD GUI document-open and presentation run.
+
+Launch this file through the complete VibeCAD executable, not FreeCADCmd:
+
+    VIBECAD_UI_PROBE_DOCUMENT=/absolute/model.FCStd \
+    VIBECAD_UI_PROBE_LOG=/absolute/result.log \
+    VibeCAD.exe /absolute/gui_document_responsiveness.py
+
+The GUI remains open after the measurement so the resulting document can be
+inspected interactively. The log records main-event-loop gaps together with the
+visible status/progress and process-lifetime worker occupancy.
+"""
+
+import os
+import time
+import traceback
+
+import FreeCAD as App
+import FreeCADGui as Gui
+from PySide6 import QtCore, QtGui, QtWidgets
+
+
+DOCUMENT = os.environ["VIBECAD_UI_PROBE_DOCUMENT"]
+LOG = os.environ["VIBECAD_UI_PROBE_LOG"]
+STARTED = time.perf_counter()
+last_tick = STARTED
+maximum_gap_ms = 0.0
+tick_count = 0
+open_returned = False
+open_requested = False
+stable_reported = False
+idle_ticks = 0
+
+
+def write(message):
+    elapsed = time.perf_counter() - STARTED
+    line = f"{elapsed:9.3f}s {message}\n"
+    with open(LOG, "a", encoding="utf-8") as stream:
+        stream.write(line)
+        stream.flush()
+    App.Console.PrintMessage("VIBECAD_REAL_UI " + line)
+
+
+def visible_progress():
+    main = Gui.getMainWindow()
+    values = []
+    for bar in main.findChildren(QtWidgets.QProgressBar):
+        if bar.isVisible():
+            values.append(f"{bar.value()}/{bar.maximum()} text={bar.text()!r}")
+    status = main.statusBar().currentMessage() if main.statusBar() else ""
+    return status, values
+
+
+def heartbeat():
+    global last_tick, maximum_gap_ms, tick_count, idle_ticks, stable_reported, open_returned
+    now = time.perf_counter()
+    gap_ms = (now - last_tick) * 1000.0
+    last_tick = now
+    tick_count += 1
+    maximum_gap_ms = max(maximum_gap_ms, gap_ms)
+    status, progress = visible_progress()
+    runtime = App.hostRuntimeStatus()
+
+    if open_requested and not open_returned and not App.isRestoring():
+        for document in App.listDocuments().values():
+            if os.path.normcase(os.path.abspath(document.FileName)) == os.path.normcase(
+                os.path.abspath(DOCUMENT)
+            ):
+                open_returned = True
+                write(
+                    f"OPEN_RESTORED name={document.Name!r} label={document.Label!r} "
+                    f"objects={len(document.Objects)}"
+                )
+                break
+
+    if gap_ms >= 50.0:
+        write(
+            f"EVENT_LOOP_GAP gap_ms={gap_ms:.1f} status={status!r} "
+            f"progress={progress!r} runtime={runtime!r}"
+        )
+    if tick_count % 60 == 0:
+        write(
+            f"HEARTBEAT max_gap_ms={maximum_gap_ms:.1f} "
+            f"open_returned={open_returned} status={status!r} "
+            f"progress={progress!r} runtime={runtime!r}"
+        )
+
+    if open_returned and not progress and not status:
+        idle_ticks += 1
+    else:
+        idle_ticks = 0
+    if not stable_reported and idle_ticks >= 120:
+        stable_reported = True
+        write(
+            f"DISPLAY_STABLE max_gap_ms={maximum_gap_ms:.1f} "
+            f"ticks={tick_count} runtime={runtime!r}"
+        )
+
+
+def open_document():
+    global open_requested
+    write(f"OPEN_BEGIN document={DOCUMENT!r}")
+    try:
+        if any(
+            os.path.normcase(os.path.abspath(document.FileName))
+            == os.path.normcase(os.path.abspath(DOCUMENT))
+            for document in App.listDocuments().values()
+        ):
+            raise RuntimeError("The probe document is already open; use a fresh test instance")
+        # Exercise the actual application file-open event, which selects the
+        # queued native GUI workflow. App.openDocument is a synchronous public
+        # scripting API and does not measure the interactive open path.
+        QtCore.QCoreApplication.postEvent(
+            QtWidgets.QApplication.instance(), QtGui.QFileOpenEvent(DOCUMENT)
+        )
+        open_requested = True
+        write("OPEN_QUEUED")
+    except Exception:
+        write("OPEN_FAILED\n" + traceback.format_exc())
+
+
+with open(LOG, "w", encoding="utf-8"):
+    pass
+
+timer = QtCore.QTimer(Gui.getMainWindow())
+timer.setTimerType(QtCore.Qt.TimerType.PreciseTimer)
+timer.setInterval(16)
+timer.timeout.connect(heartbeat)
+timer.start()
+
+write(f"PROBE_READY runtime={App.hostRuntimeStatus()!r}")
+QtCore.QTimer.singleShot(500, open_document)

--- a/tests/src/App/Application.cpp
+++ b/tests/src/App/Application.cpp
@@ -1,9 +1,22 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <condition_variable>
+#include <atomic>
+#include <chrono>
+#include <mutex>
+#include <set>
+#include <sstream>
+#include <thread>
+#include <vector>
+
 #include <gtest/gtest.h>
 #define FC_OS_MACOSX 1
 #include "App/ProgramOptionsUtilities.h"
 
+#include <App/HostRuntime.h>
+#include <App/private/CpuBudget.h>
+#include <Base/CancellationScope.h>
+#include <Base/Exception.h>
 #include <src/App/InitApplication.h>
 
 
@@ -57,3 +70,398 @@ TEST_F(ApplicationTest, fCustomSyntaxEmptyIn)
     Spr exp {"", ""};
     EXPECT_EQ(res, exp);
 };
+
+TEST_F(ApplicationTest, CpuAdmissionCancellationDoesNotNeedCapacityToBeReleased)
+{
+    using namespace std::chrono_literals;
+    App::detail::CpuBudget budget(2);
+    ASSERT_TRUE(budget.acquire(2, {}));
+    std::stop_source cancel;
+    std::promise<void> entering;
+    auto entered = entering.get_future();
+    auto waiting = std::async(std::launch::async, [&] {
+        entering.set_value();
+        return budget.acquire(2, cancel.get_token());
+    });
+    entered.get();
+    cancel.request_stop();
+    const auto cancelledWhileFull = waiting.wait_for(5s);
+    // Always release before any failing assertion, so a regression cannot
+    // strand the test's joining future. Cancellation must not need this release.
+    budget.release(2);
+    EXPECT_FALSE(waiting.get());
+    EXPECT_EQ(cancelledWhileFull, std::future_status::ready);
+    EXPECT_FALSE(budget.acquire(2, cancel.get_token()));
+    ASSERT_TRUE(budget.acquire(2, {}));
+    budget.release(2);
+}
+
+TEST_F(ApplicationTest, AsyncRuntimeCompletesSuccessfulFailedAndAbandonedWork)
+{
+    using namespace std::chrono_literals;
+    App::HostRuntime runtime(1);
+    std::promise<int> success;
+    auto succeeded = success.get_future();
+    runtime.submitWithCompletion(App::HostRuntime::Lane::Compute,
+        [](std::stop_token) { return 42; },
+        [&](std::future<int> result) {
+            EXPECT_EQ(result.wait_for(0ms), std::future_status::ready);
+            success.set_value(result.get());
+        });
+    EXPECT_EQ(succeeded.get(), 42);
+
+    std::promise<bool> failure;
+    auto failed = failure.get_future();
+    runtime.submitWithCompletion(App::HostRuntime::Lane::Compute,
+        [](std::stop_token) { throw std::runtime_error("prepare failed"); },
+        [&](std::future<void> result) {
+            try { result.get(); failure.set_value(false); }
+            catch (const std::runtime_error& error) {
+                failure.set_value(std::string(error.what()) == "prepare failed");
+            }
+        });
+    EXPECT_TRUE(failed.get());
+
+    std::promise<void> entered;
+    auto started = entered.get_future();
+    std::promise<void> release;
+    auto gate = release.get_future().share();
+    auto running = runtime.submit([&](std::stop_token) {
+        entered.set_value();
+        gate.wait();
+    });
+    started.get();
+    std::atomic<int> calls {0};
+    std::atomic<bool> executed {false};
+    std::promise<bool> abandoned;
+    auto cancelled = abandoned.get_future();
+    runtime.submitWithCompletion(App::HostRuntime::Lane::Compute,
+        [&](std::stop_token) { executed = true; },
+        [&](std::future<void> result) {
+            ++calls;
+            EXPECT_EQ(result.wait_for(0ms), std::future_status::ready);
+            // Completion must run outside the queue mutex.
+            (void)runtime.queuedTaskCount();
+            try { result.get(); abandoned.set_value(false); }
+            catch (const std::runtime_error&) { abandoned.set_value(true); }
+        });
+    auto stopping = std::async(std::launch::async, [&] { runtime.shutdown(); });
+    const auto observed = cancelled.wait_for(5s);
+    release.set_value();
+    running.get();
+    stopping.get();
+    ASSERT_EQ(observed, std::future_status::ready);
+    EXPECT_TRUE(cancelled.get());
+    EXPECT_FALSE(executed);
+    EXPECT_EQ(calls, 1);
+}
+
+TEST_F(ApplicationTest, ParallelWorkKeepsItsCapturesAliveDuringShutdown)
+{
+    using namespace std::chrono_literals;
+    App::HostRuntime runtime(56);
+    std::promise<void> entered;
+    auto firstWorker = entered.get_future();
+    std::promise<void> release;
+    auto released = release.get_future().share();
+    std::atomic_bool announced {false};
+    auto group = std::async(std::launch::async, [&] {
+        try {
+            runtime.parallelFor(500, [&](std::size_t) {
+                if (!announced.exchange(true)) {
+                    entered.set_value();
+                }
+                released.wait();
+            });
+        }
+        catch (const std::exception&) {
+            // Shutdown can reject admission or cancel queued work. Either
+            // outcome must still join every admitted, running callback.
+        }
+    });
+    firstWorker.wait();
+    auto stopping = std::async(std::launch::async, [&] { runtime.shutdown(); });
+    const auto stateWhileWorkerHeld = group.wait_for(20ms);
+    release.set_value();
+    group.get();
+    stopping.get();
+    EXPECT_EQ(stateWhileWorkerHeld, std::future_status::timeout);
+    EXPECT_FALSE(runtime.isAccepting());
+}
+
+TEST_F(ApplicationTest, RuntimeSubmissionsInheritOperationCancellation)
+{
+    App::HostRuntime runtime(1);
+    std::stop_source request;
+    std::promise<void> release;
+    auto gate = release.get_future().share();
+    std::future<void> direct;
+    std::promise<void> notified;
+    auto notification = notified.get_future();
+    {
+        Base::CancellationScope operation(request.get_token());
+        direct = runtime.submit([gate](std::stop_token) {
+            gate.wait();
+            Base::CancellationScope::check();
+        });
+        runtime.submitWithCompletion(App::HostRuntime::Lane::Io,
+            [gate](std::stop_token) {
+                gate.wait();
+                Base::CancellationScope::check();
+            },
+            [&](std::future<void> result) {
+                EXPECT_NO_THROW(Base::CancellationScope::check());
+                try { result.get(); notified.set_value(); }
+                catch (...) { notified.set_exception(std::current_exception()); }
+            });
+    }
+    // The caller's stack scope is already gone. Only owned stop tokens may
+    // travel to the workers; neither worker receives the token explicitly.
+    request.request_stop();
+    release.set_value();
+    EXPECT_THROW(direct.get(), Base::AbortException);
+    EXPECT_THROW(notification.get(), Base::AbortException);
+}
+
+TEST_F(ApplicationTest, HelpingAnotherJobDoesNotLeakTheWaitingJobsCancellation)
+{
+    App::HostRuntime runtime(1);
+    std::stop_source request;
+    std::promise<void> entered;
+    auto started = entered.get_future();
+    std::promise<void> queued;
+    auto ready = queued.get_future();
+    std::future<bool> unrelated;
+    auto parent = runtime.submit([&](std::stop_token) {
+        Base::CancellationScope operation(request.get_token());
+        request.request_stop();
+        entered.set_value();
+        ready.wait();
+        // With one worker, wait must execute the unrelated queued job here.
+        const bool result = runtime.wait(unrelated);
+        EXPECT_THROW(Base::CancellationScope::check(), Base::AbortException);
+        return result;
+    });
+    started.get();
+    unrelated = runtime.submit([](std::stop_token) {
+        Base::CancellationScope::check();
+        return true;
+    });
+    queued.set_value();
+    EXPECT_TRUE(parent.get());
+}
+
+TEST_F(ApplicationTest, ParallelWorkObservesOperationCancellationBetweenItems)
+{
+    App::HostRuntime runtime(1);
+    std::stop_source request;
+    Base::CancellationScope operation(request.get_token());
+    unsigned calls = 0;
+    EXPECT_THROW(runtime.parallelFor(500, [&](std::size_t) {
+        ++calls;
+        request.request_stop();
+    }), Base::AbortException);
+    EXPECT_EQ(calls, 1U);
+    EXPECT_TRUE(runtime.isAccepting());
+}
+
+TEST_F(ApplicationTest, ParallelWorkCannotReportSuccessForAnInterruptedChunk)
+{
+    using namespace std::chrono_literals;
+    App::HostRuntime runtime(1);
+    std::vector<std::size_t> values(500);
+    runtime.parallelFor(values.size(), [&](std::size_t index) { values[index] = index + 1; });
+    for (std::size_t index = 0; index < values.size(); ++index) {
+        ASSERT_EQ(values[index], index + 1);
+    }
+    std::promise<void> release;
+    auto gate = release.get_future().share();
+    std::promise<void> observing;
+    auto observerReady = observing.get_future();
+    std::promise<void> stopped;
+    auto stopSeen = stopped.get_future();
+    auto observer = runtime.submit(App::HostRuntime::Lane::Io, [&](std::stop_token stop) {
+        std::stop_callback notice(stop, [&] { stopped.set_value(); });
+        observing.set_value();
+        gate.wait();
+    });
+    observerReady.get();
+
+    std::promise<void> entered;
+    auto firstItem = entered.get_future();
+    std::atomic_size_t calls {0};
+    auto group = std::async(std::launch::async, [&] {
+        runtime.parallelFor(500, [&](std::size_t) {
+            if (calls.fetch_add(1) == 0) {
+                entered.set_value();
+                gate.wait();
+            }
+        });
+    });
+    firstItem.get();
+    // All compute work is admitted and running, so this exercises a stopped
+    // chunk, not the already-covered rejection/abandoned-future cases.
+    auto stopping = std::async(std::launch::async, [&] { runtime.shutdown(); });
+    const auto notified = stopSeen.wait_for(5s);
+    release.set_value();
+    EXPECT_THROW(group.get(), std::runtime_error);
+    observer.get();
+    stopping.get();
+    ASSERT_EQ(notified, std::future_status::ready);
+    EXPECT_EQ(calls.load(), std::size_t {1});
+}
+
+TEST_F(ApplicationTest, HostRuntimeWorkersAreEagerAndPersistent)
+{
+    auto& runtime = App::GetApplication().hostRuntime();
+    const auto expectedWorkers = App::HostRuntime::workerBudget(
+        std::thread::hardware_concurrency()
+    );
+    const auto expectedIoWorkers = App::HostRuntime::ioWorkerBudget(
+        std::thread::hardware_concurrency()
+    );
+    const auto expectedDocumentWorkers = App::HostRuntime::documentWorkerBudget(
+        std::thread::hardware_concurrency()
+    );
+    const auto expectedTotalWorkers =
+        expectedWorkers + expectedIoWorkers + expectedDocumentWorkers;
+
+    ASSERT_EQ(runtime.workerCount(), expectedWorkers);
+    ASSERT_EQ(runtime.workerCount(App::HostRuntime::Lane::Io), expectedIoWorkers);
+    ASSERT_EQ(
+        runtime.workerCount(App::HostRuntime::Lane::Document),
+        expectedDocumentWorkers
+    );
+    ASSERT_EQ(runtime.readyWorkerCount(), expectedWorkers);
+    ASSERT_EQ(runtime.readyWorkerCount(App::HostRuntime::Lane::Io), expectedIoWorkers);
+    ASSERT_EQ(
+        runtime.readyWorkerCount(App::HostRuntime::Lane::Document),
+        expectedDocumentWorkers
+    );
+    ASSERT_TRUE(runtime.isAccepting());
+
+    std::mutex mutex;
+    std::condition_variable allEntered;
+    std::condition_variable releaseWorkers;
+    std::condition_variable allCompleted;
+    std::set<std::thread::id> workerThreads;
+    std::size_t entered = 0;
+    std::size_t completed = 0;
+    bool release = false;
+    std::vector<std::future<void>> work;
+    work.reserve(expectedTotalWorkers);
+
+    const auto submitBlockingTask = [&](App::HostRuntime::Lane lane) {
+        work.emplace_back(runtime.submit(lane, [&](std::stop_token stopToken) {
+            std::unique_lock lock(mutex);
+            workerThreads.insert(std::this_thread::get_id());
+            ++entered;
+            allEntered.notify_one();
+            releaseWorkers.wait(lock, [&] { return release || stopToken.stop_requested(); });
+            ++completed;
+            allCompleted.notify_one();
+        }));
+    };
+    for (std::size_t index = 0; index < expectedWorkers; ++index) {
+        submitBlockingTask(App::HostRuntime::Lane::Compute);
+    }
+    for (std::size_t index = 0; index < expectedIoWorkers; ++index) {
+        submitBlockingTask(App::HostRuntime::Lane::Io);
+    }
+    for (std::size_t index = 0; index < expectedDocumentWorkers; ++index) {
+        submitBlockingTask(App::HostRuntime::Lane::Document);
+    }
+
+    {
+        std::unique_lock lock(mutex);
+        allEntered.wait(lock, [&] { return entered == expectedTotalWorkers; });
+        EXPECT_EQ(workerThreads.size(), expectedTotalWorkers);
+        release = true;
+    }
+    releaseWorkers.notify_all();
+
+    {
+        std::unique_lock lock(mutex);
+        allCompleted.wait(lock, [&] { return completed == expectedTotalWorkers; });
+    }
+    for (auto& result : work) {
+        EXPECT_NO_THROW(result.get());
+    }
+
+    EXPECT_EQ(runtime.readyWorkerCount(), expectedWorkers);
+    EXPECT_EQ(runtime.readyWorkerCount(App::HostRuntime::Lane::Io), expectedIoWorkers);
+    EXPECT_EQ(
+        runtime.readyWorkerCount(App::HostRuntime::Lane::Document),
+        expectedDocumentWorkers
+    );
+}
+
+TEST_F(ApplicationTest, HostRuntimeIsolationWorkersAreConcurrentPersistentAndRecoverable)
+{
+    using namespace std::chrono_literals;
+    auto& runtime = App::GetApplication().hostRuntime();
+    App::HostRuntime::IsolationConfiguration configuration;
+    configuration.executable = HOST_RUNTIME_ISOLATION_HELPER;
+    configuration.workerCount = 3;
+    runtime.startIsolationWorkers(std::move(configuration));
+
+    const auto readyDeadline = std::chrono::steady_clock::now() + 10s;
+    while (runtime.readyIsolationWorkerCount() != 3
+           && std::chrono::steady_clock::now() < readyDeadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+    ASSERT_EQ(runtime.isolationWorkerCount(), 3);
+    ASSERT_EQ(runtime.readyIsolationWorkerCount(), 3);
+
+    std::vector<App::HostRuntime::IsolationSubmission> firstWave;
+    for (int index = 0; index < 3; ++index) {
+        firstWave.push_back(runtime.submitIsolation("sleep:150"));
+    }
+    std::set<std::string> initialProcesses;
+    for (auto& submission : firstWave) {
+        const auto result = submission.completion.get();
+        ASSERT_EQ(result.status, App::HostRuntime::IsolationStatus::Completed)
+            << result.diagnostic;
+        initialProcesses.insert(result.response.substr(0, result.response.find(':')));
+    }
+    EXPECT_EQ(initialProcesses.size(), 3);
+
+    auto reused = runtime.submitIsolation("reused");
+    const auto reusedResult = reused.completion.get();
+    ASSERT_EQ(reusedResult.status, App::HostRuntime::IsolationStatus::Completed)
+        << reusedResult.diagnostic;
+    EXPECT_TRUE(initialProcesses.contains(
+        reusedResult.response.substr(0, reusedResult.response.find(':'))
+    ));
+
+    auto cancelled = runtime.submitIsolation("sleep:5000");
+    const auto activeDeadline = std::chrono::steady_clock::now() + 10s;
+    while (runtime.activeIsolationTaskCount() != 1
+           && std::chrono::steady_clock::now() < activeDeadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+    ASSERT_EQ(runtime.activeIsolationTaskCount(), 1);
+    ASSERT_TRUE(runtime.cancelIsolation(cancelled.id));
+    EXPECT_EQ(
+        cancelled.completion.get().status,
+        App::HostRuntime::IsolationStatus::Cancelled
+    );
+
+    auto afterCancellation = runtime.submitIsolation("after-cancellation");
+    const auto recovered = afterCancellation.completion.get();
+    ASSERT_EQ(recovered.status, App::HostRuntime::IsolationStatus::Completed)
+        << recovered.diagnostic;
+    EXPECT_NE(recovered.response.find(":after-cancellation"), std::string::npos);
+
+    auto memoryBound = runtime.submitIsolation("sleep:5000", 1);
+    const auto memoryResult = memoryBound.completion.get();
+    EXPECT_EQ(memoryResult.status, App::HostRuntime::IsolationStatus::Failed);
+    EXPECT_TRUE(memoryResult.memoryExceeded);
+    EXPECT_GT(memoryResult.observedMemoryBytes, 1);
+
+    auto afterMemoryLimit = runtime.submitIsolation("after-memory-limit");
+    const auto memoryRecovered = afterMemoryLimit.completion.get();
+    ASSERT_EQ(memoryRecovered.status, App::HostRuntime::IsolationStatus::Completed)
+        << memoryRecovered.diagnostic;
+    EXPECT_NE(memoryRecovered.response.find(":after-memory-limit"), std::string::npos);
+}

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -22,6 +22,10 @@
 #include <chrono>
 #include <future>
 #include <thread>
+#include <QAbstractEventDispatcher>
+#include <QCoreApplication>
+#include <QThread>
+#include <QTimer>
 
 #include <boost/scope_exit.hpp>
 #include <gtest/gtest.h>
@@ -29,9 +33,61 @@
 #include "App/Application.h"
 #include "App/Document.h"
 #include "App/FeatureTest.h"
+#include "App/HostRuntime.h"
+#include "App/HostWorkflow.h"
+#include "Base/Interpreter.h"
 #include <src/App/InitApplication.h>
 
 using namespace std::chrono_literals;
+
+namespace
+{
+App::HostWorkflow<int> orderedWorkerPhases(std::vector<std::thread::id>& threads)
+{
+    co_yield App::HostWorkflow<int>::Step {App::HostRuntime::Lane::Compute, [&](std::stop_token) {
+        threads.push_back(std::this_thread::get_id());
+    }};
+    try {
+        co_yield App::HostWorkflow<int>::Step {App::HostRuntime::Lane::Io, [&](std::stop_token) {
+            threads.push_back(std::this_thread::get_id());
+            throw std::runtime_error("phase failure");
+        }};
+    }
+    catch (const std::runtime_error&) {
+        co_return 7;
+    }
+    co_return 0;
+}
+}
+
+TEST(HostWorkflowTest, WorkerErrorsReturnToTheSuspendedPhase)
+{
+    App::HostRuntime runtime(4);
+    std::vector<std::thread::id> threads;
+    auto workflow = orderedWorkerPhases(threads);
+    while (workflow.advance()) {
+        auto step = workflow.step();
+        auto completion = runtime.submit(step.lane, std::move(step.work));
+        try {
+            completion.get();
+        }
+        catch (...) {
+            workflow.failStep(std::current_exception());
+        }
+    }
+    EXPECT_EQ(workflow.takeResult(), 7);
+    ASSERT_EQ(threads.size(), 2);
+    for (const auto thread : threads) {
+        EXPECT_NE(thread, std::this_thread::get_id());
+    }
+
+    // The existing synchronous API must run the same phase/exception logic,
+    // not a second implementation of document restoration.
+    threads.clear();
+    EXPECT_EQ(orderedWorkerPhases(threads).runSynchronously(), 7);
+    ASSERT_EQ(threads.size(), 2);
+    EXPECT_EQ(threads.front(), std::this_thread::get_id());
+}
 
 class AsyncRecomputeTest: public ::testing::Test
 {
@@ -58,12 +114,16 @@ protected:
     App::Document* _doc {};
 };
 
-TEST_F(AsyncRecomputeTest, CloseDocumentWaitsForInFlightAsyncRecompute)
+TEST_F(AsyncRecomputeTest, CloseDocumentCancelsWithoutBlockingCaller)
 {
     auto* object = dynamic_cast<App::FeatureTestAsyncBlocker*>(
         _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
     );
+    auto* queuedObject = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "QueuedFeature")
+    );
     ASSERT_NE(object, nullptr);
+    ASSERT_NE(queuedObject, nullptr);
 
     App::FeatureTestAsyncBlocker::resetBlocker();
     BOOST_SCOPE_EXIT_ALL(&)
@@ -72,23 +132,80 @@ TEST_F(AsyncRecomputeTest, CloseDocumentWaitsForInFlightAsyncRecompute)
     };
 
     object->touch();
+    queuedObject->touch();
 
-    App::GetApplication().queueRecomputeRequest(App::RecomputeRequest::fromDocumentObject(*object));
+    App::GetApplication().queueRecomputeRequest(App::RecomputeRequest::fromDocument(*_doc));
 
-    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2, 2s));
 
-    auto closeFuture = std::async(std::launch::async, [this] {
-        return App::GetApplication().closeDocument(_docName.c_str());
-    });
-
-    EXPECT_EQ(closeFuture.wait_for(50ms), std::future_status::timeout);
+    const auto closeStarted = std::chrono::steady_clock::now();
+    EXPECT_FALSE(App::GetApplication().closeDocument(_docName.c_str()));
+    EXPECT_LT(std::chrono::steady_clock::now() - closeStarted, 50ms);
 
     App::FeatureTestAsyncBlocker::releaseBlocker();
-
-    ASSERT_EQ(closeFuture.wait_for(2s), std::future_status::ready);
-    EXPECT_TRUE(closeFuture.get());
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (App::GetApplication().hasPendingRecomputeRequest(_docName)
+           && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+    ASSERT_FALSE(App::GetApplication().hasPendingRecomputeRequest(_docName));
+    EXPECT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2, 0ms));
+    EXPECT_TRUE(App::GetApplication().closeDocument(_docName.c_str()));
 
     _doc = nullptr;
+}
+
+TEST_F(AsyncRecomputeTest, SynchronousGuiCallerKeepsEventsAndMutationLeaseLive)
+{
+    int argc = 1;
+    char name[] = "recompute-gui-owner";
+    char* argv[] = {name, nullptr};
+    std::unique_ptr<QCoreApplication> application;
+    if (!QCoreApplication::instance()) {
+        application = std::make_unique<QCoreApplication>(argc, argv);
+    }
+    ASSERT_FALSE(App::MainThreadSignalConfig::hasHooks());
+    // App-only fixture: no GUI observers. The real packaged GUI gate exercises
+    // queued property notifications; this test isolates owner event liveness.
+    App::MainThreadSignalConfig::setHooks(
+        [] { return QThread::currentThread() == QCoreApplication::instance()->thread(); },
+        [](std::function<void()>&& work, bool) { work(); });
+    BOOST_SCOPE_EXIT_ALL(&) { App::MainThreadSignalConfig::setHooks(nullptr, nullptr); };
+
+    auto* object = _doc->addObject("App::FeatureTestAsyncBlocker", "OwnerWaitFeature");
+    ASSERT_NE(object, nullptr);
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    object->touch();
+    bool timerRan = false;
+    bool protectedDocument = false;
+    QObject timerOwner;
+    QTimer::singleShot(0, &timerOwner, [&] {
+        timerRan = true;
+        protectedDocument = _doc->isCooperativeMutationActive();
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    });
+    // Release the old blocked implementation so red is a failed assertion,
+    // not an indefinitely hung test process. This is a test watchdog only.
+    std::jthread watchdog([] {
+        App::FeatureTestAsyncBlocker::waitUntilStarted(1, 2s);
+        std::this_thread::sleep_for(100ms);
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    });
+    // A completed worker must interrupt the current dispatcher wait itself,
+    // not rely on subsequent mouse input or a timer to let recompute return.
+    bool neededWakeup = false;
+    QTimer completionWatchdog;
+    completionWatchdog.setSingleShot(true);
+    QObject::connect(&completionWatchdog, &QTimer::timeout, [&] {
+        neededWakeup = true;
+        QAbstractEventDispatcher::instance()->interrupt();
+    });
+    completionWatchdog.start(2000);
+    EXPECT_GE(_doc->recompute(), 1);
+    EXPECT_FALSE(neededWakeup);
+    EXPECT_TRUE(timerRan);
+    EXPECT_TRUE(protectedDocument);
+    EXPECT_FALSE(_doc->isCooperativeMutationActive());
 }
 
 TEST_F(AsyncRecomputeTest, WorkerSafetyIsCheckedFromRequest)
@@ -108,12 +225,12 @@ TEST_F(AsyncRecomputeTest, WorkerSafetyIsCheckedFromRequest)
             App::RecomputeRequest::fromDocumentObject(*safeObject)
         )
     );
-    EXPECT_FALSE(
+    EXPECT_TRUE(
         App::GetApplication().canRecomputeRequestOnWorker(
             App::RecomputeRequest::fromDocumentObject(*unsafeObject)
         )
     );
-    EXPECT_FALSE(
+    EXPECT_TRUE(
         App::GetApplication().canRecomputeRequestOnWorker(App::RecomputeRequest::fromDocument(*_doc))
     );
 
@@ -123,14 +240,14 @@ TEST_F(AsyncRecomputeTest, WorkerSafetyIsCheckedFromRequest)
             App::RecomputeRequest::fromDocumentObject(*safeObject, false)
         )
     );
-    EXPECT_FALSE(
+    EXPECT_TRUE(
         App::GetApplication().canRecomputeRequestOnWorker(
             App::RecomputeRequest::fromDocumentObject(*safeObject, true)
         )
     );
 }
 
-TEST_F(AsyncRecomputeTest, StrictBatchQueueRejectsAtomically)
+TEST_F(AsyncRecomputeTest, MixedPythonAndNativeBatchUsesBackgroundRuntime)
 {
     auto* safeObject = dynamic_cast<App::FeatureTestAsyncBlocker*>(
         _doc->addObject("App::FeatureTestAsyncBlocker", "SafeFeature")
@@ -153,9 +270,129 @@ TEST_F(AsyncRecomputeTest, StrictBatchQueueRejectsAtomically)
     requests.push_back(App::RecomputeRequest::fromDocumentObject(*safeObject));
     requests.push_back(App::RecomputeRequest::fromDocumentObject(*unsafeObject));
 
-    EXPECT_FALSE(App::GetApplication().tryQueueRecomputeRequests(std::move(requests)));
+    EXPECT_TRUE(App::GetApplication().tryQueueRecomputeRequests(std::move(requests)));
+    EXPECT_TRUE(App::GetApplication().hasPendingRecomputeRequest(_docName));
+    EXPECT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while (App::GetApplication().hasPendingRecomputeRequest(_docName)
+           && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(10ms);
+    }
     EXPECT_FALSE(App::GetApplication().hasPendingRecomputeRequest(_docName));
-    EXPECT_FALSE(App::FeatureTestAsyncBlocker::waitUntilStarted(50ms));
+    EXPECT_FALSE(App::FeatureTestAsyncBlocker::waitUntilStarted(2, 50ms));
+
+    // A public recompute invoked from Python enters App while holding the
+    // interpreter lock. Waiting for worker-side Python must release that lock.
+    Base::Interpreter().runString(
+        "import types; App.ActiveDocument.UnsafeFeature.Object = "
+        "types.SimpleNamespace(Name='worker-safe'); App.ActiveDocument.recompute()"
+    );
+    EXPECT_FALSE(unsafeObject->isTouched());
+    EXPECT_FALSE(unsafeObject->isError());
+}
+
+TEST_F(AsyncRecomputeTest, IndependentDocumentsRunConcurrently)
+{
+    const std::string secondName
+        = App::GetApplication().getUniqueDocumentName("async_recompute_parallel");
+    App::Document* second = App::GetApplication().newDocument(secondName.c_str(), "testUser");
+    ASSERT_NE(second, nullptr);
+
+    auto* firstObject = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "FirstBlockingFeature")
+    );
+    auto* secondObject = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        second->addObject("App::FeatureTestAsyncBlocker", "SecondBlockingFeature")
+    );
+    ASSERT_NE(firstObject, nullptr);
+    ASSERT_NE(secondObject, nullptr);
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+        if (App::GetApplication().getDocument(secondName.c_str())) {
+            App::GetApplication().closeDocument(secondName.c_str());
+        }
+    };
+
+    firstObject->touch();
+    secondObject->touch();
+    App::GetApplication().queueRecomputeRequest(
+        App::RecomputeRequest::fromDocumentObject(*firstObject)
+    );
+    App::GetApplication().queueRecomputeRequest(
+        App::RecomputeRequest::fromDocumentObject(*secondObject)
+    );
+
+    EXPECT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2, 2s));
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while ((App::GetApplication().hasPendingRecomputeRequest(_docName)
+            || App::GetApplication().hasPendingRecomputeRequest(secondName))
+           && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+    ASSERT_FALSE(App::GetApplication().hasPendingRecomputeRequest(_docName));
+    ASSERT_FALSE(App::GetApplication().hasPendingRecomputeRequest(secondName));
+    EXPECT_TRUE(App::GetApplication().closeDocument(secondName.c_str()));
+}
+
+TEST_F(AsyncRecomputeTest, IndependentObjectsInOneDocumentRunConcurrently)
+{
+    constexpr std::size_t objectCount = 50;
+    const auto parallelCount = std::min(
+        objectCount,
+        App::GetApplication().hostRuntime().workerCount(App::HostRuntime::Lane::Compute)
+    );
+    if (parallelCount < 2) {
+        GTEST_SKIP() << "At least two compute workers are required to prove parallel execution";
+    }
+
+    std::vector<App::FeatureTestAsyncBlocker*> objects;
+    objects.reserve(objectCount);
+    for (std::size_t index = 0; index < objectCount; ++index) {
+        const auto name = "IndependentFeature" + std::to_string(index);
+        auto* object = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+            _doc->addObject("App::FeatureTestAsyncBlocker", name.c_str())
+        );
+        ASSERT_NE(object, nullptr);
+        objects.push_back(object);
+    }
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    };
+
+    for (auto* object : objects) {
+        object->touch();
+    }
+    App::GetApplication().queueRecomputeRequest(App::RecomputeRequest::fromDocument(*_doc));
+
+    const bool saturatedComputeLane = App::FeatureTestAsyncBlocker::waitUntilStarted(
+        parallelCount,
+        2s
+    );
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+
+    const auto deadline = std::chrono::steady_clock::now() + 5s;
+    while (App::GetApplication().hasPendingRecomputeRequest(_docName)
+           && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+
+    EXPECT_TRUE(saturatedComputeLane);
+    EXPECT_FALSE(App::GetApplication().hasPendingRecomputeRequest(_docName));
+    EXPECT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(objectCount, 0ms));
+    for (const auto* object : objects) {
+        EXPECT_FALSE(object->isTouched());
+        EXPECT_FALSE(object->isError());
+        EXPECT_EQ(object->ExecutionCount.getValue(), 1);
+    }
 }
 
 TEST_F(AsyncRecomputeTest, PendingStateCoversQueuedAndInFlightWork)

--- a/tests/src/App/CMakeLists.txt
+++ b/tests/src/App/CMakeLists.txt
@@ -1,5 +1,9 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+add_executable(HostRuntimeIsolationHelper
+        HostRuntimeIsolationHelper.cpp
+)
+
 add_executable(App_tests_run
         AsyncRecompute.cpp
         Application.cpp
@@ -24,15 +28,20 @@ add_executable(App_tests_run
         Property.h
         Property.cpp
         PropertyExpressionEngine.cpp
+        SemanticDependencyOrder.cpp
         StringHasher.cpp
         VarSet.cpp
         VRMLObject.cpp
 )
 
-target_compile_definitions(App_tests_run PRIVATE DATADIR="${CMAKE_SOURCE_DIR}/data")
+add_dependencies(App_tests_run HostRuntimeIsolationHelper)
+
+target_compile_definitions(App_tests_run PRIVATE
+    DATADIR="${CMAKE_SOURCE_DIR}/data"
+    HOST_RUNTIME_ISOLATION_HELPER="$<TARGET_FILE:HostRuntimeIsolationHelper>"
+)
 
 target_link_libraries(App_tests_run PRIVATE
-    GTest::gtest_main
     GTest::gmock_main
     ${Python3_LIBRARIES}
     FreeCADApp

--- a/tests/src/App/Document.cpp
+++ b/tests/src/App/Document.cpp
@@ -4,11 +4,17 @@
 #include <gmock/gmock.h>
 
 #include <string_view>
+#include <atomic>
 #include <unordered_map>
+#include <future>
+#include <thread>
+#include <chrono>
+#include <boost/scope_exit.hpp>
 
 #include "App/Application.h"
 #include "App/Document.h"
 #include "App/DocumentTimeline.h"
+#include "App/HostRuntime.h"
 #include "App/Link.h"
 #include "App/PropertyLinks.h"
 #include "App/PropertyStandard.h"
@@ -58,6 +64,22 @@ private:
 
 PROPERTY_SOURCE(App::TimelineSuppressibleTestObject, App::DocumentObject)
 
+class TimelineDependencyCountingTestObject: public DocumentObject
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(App::TimelineDependencyCountingTestObject);
+
+public:
+    mutable size_t dependencyChecks {0};
+
+    bool isTimelineStructuralChild(const DocumentObject* object) const override
+    {
+        ++dependencyChecks;
+        return DocumentObject::isTimelineStructuralChild(object);
+    }
+};
+
+PROPERTY_SOURCE(App::TimelineDependencyCountingTestObject, App::DocumentObject)
+
 class RepeatedRestoreLabelTestObject: public DocumentObject
 {
     PROPERTY_HEADER_WITH_OVERRIDE(App::RepeatedRestoreLabelTestObject);
@@ -73,6 +95,45 @@ protected:
 };
 
 PROPERTY_SOURCE(App::RepeatedRestoreLabelTestObject, App::DocumentObject)
+
+class NativeRestoreFailureTestObject: public DocumentObject
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(App::NativeRestoreFailureTestObject);
+
+protected:
+    void onDocumentRestored() override
+    {
+        // Exercise native extension failures, not the Python proxy wrapper's
+        // separate exception handler. No Python thread state is held here.
+        throw 42;
+    }
+};
+
+PROPERTY_SOURCE(App::NativeRestoreFailureTestObject, App::DocumentObject)
+
+class RestoreAbortProperty: public PropertyString
+{
+public:
+    void afterRestore() override
+    {
+        throw Base::AbortException();
+    }
+};
+
+class PropertyRestoreCancellationTestObject: public DocumentObject
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(App::PropertyRestoreCancellationTestObject);
+
+public:
+    PropertyRestoreCancellationTestObject()
+    {
+        ADD_PROPERTY(CancelAtRestore, (""));
+    }
+
+    RestoreAbortProperty CancelAtRestore;
+};
+
+PROPERTY_SOURCE(App::PropertyRestoreCancellationTestObject, App::DocumentObject)
 
 }  // namespace App
 
@@ -94,7 +155,10 @@ protected:
         tests::initApplication();
         App::TimelineThrowingSetupTestObject::init();
         App::TimelineSuppressibleTestObject::init();
+        App::TimelineDependencyCountingTestObject::init();
         App::RepeatedRestoreLabelTestObject::init();
+        App::NativeRestoreFailureTestObject::init();
+        App::PropertyRestoreCancellationTestObject::init();
     }
 
     void SetUp() override
@@ -117,6 +181,112 @@ private:
     std::string _docName;
     App::Document* _doc {};
 };
+
+TEST_F(DocumentTest, closeAllReturnsWhenAWorkerStillOwnsADocument)
+{
+    auto& application = App::GetApplication();
+    const std::string busyName = doc()->getName();
+    auto* other = application.newDocument("ClosableAlongsideBusyDocument");
+    const std::string otherName = other->getName();
+    doc()->beginPresentationUpdate();
+
+    // This is the production owner-thread entry point. A refused close must
+    // return to the event loop, not retry until the worker's GUI adoption runs.
+    application.closeAllDocuments();
+    EXPECT_EQ(application.getDocument(busyName.c_str()), doc());
+    EXPECT_EQ(application.getDocument(otherName.c_str()), nullptr);
+    EXPECT_FALSE(application.isClosingAll());
+
+    doc()->endPresentationUpdate();
+    application.closeAllDocuments();
+    EXPECT_EQ(application.getDocument(busyName.c_str()), nullptr);
+}
+
+TEST_F(DocumentTest, closeObserversCannotRecursivelyDeleteTheSameDocument)
+{
+    auto& application = App::GetApplication();
+    const std::string name = doc()->getName();
+    int beforeCloseCalls = 0;
+    fastsignals::scoped_connection connection = application.signalBeforeCloseDocument.connect(
+        [&](const App::Document& closing) {
+            if (closing.getName() != name) {
+                return;
+            }
+            ++beforeCloseCalls;
+            EXPECT_FALSE(application.closeDocument(name.c_str()));
+            application.closeAllDocuments();
+        });
+    EXPECT_TRUE(application.closeDocument(name.c_str()));
+    EXPECT_EQ(beforeCloseCalls, 1);
+    EXPECT_EQ(application.getDocument(name.c_str()), nullptr);
+}
+
+TEST_F(DocumentTest, closeRechecksWorkAcquiredByBeforeCloseObservers)
+{
+    auto& application = App::GetApplication();
+    const std::string name = doc()->getName();
+    fastsignals::scoped_connection connection = application.signalBeforeCloseDocument.connect(
+        [&](const App::Document& closing) {
+            if (closing.getName() == name) {
+                closing.beginPresentationUpdate();
+            }
+        });
+    EXPECT_FALSE(application.closeDocument(name.c_str()));
+    ASSERT_EQ(application.getDocument(name.c_str()), doc());
+    connection.disconnect();
+    doc()->endPresentationUpdate();
+    EXPECT_TRUE(application.closeDocument(name.c_str()));
+}
+
+TEST_F(DocumentTest, closeAllDoesNotCloseANewDocumentReusingAnOldName)
+{
+    auto& application = App::GetApplication();
+    // Map order makes the first document's callback replace the later target.
+    auto* first = application.newDocument("A_CloseSnapshot");
+    auto* later = application.newDocument("Z_CloseSnapshot");
+    const std::string firstName = first->getName();
+    const std::string laterName = later->getName();
+    App::Document* replacement = nullptr;
+    fastsignals::scoped_connection connection = application.signalBeforeCloseDocument.connect(
+        [&](const App::Document& closing) {
+            if (closing.getName() == firstName) {
+                EXPECT_TRUE(application.closeDocument(laterName.c_str()));
+                replacement = application.newDocument(laterName.c_str());
+            }
+        });
+    application.closeAllDocuments();
+    ASSERT_NE(replacement, nullptr);
+    EXPECT_EQ(application.getDocument(laterName.c_str()), replacement);
+    connection.disconnect();
+    EXPECT_TRUE(application.closeDocument(laterName.c_str()));
+}
+
+TEST_F(DocumentTest, presentationCompletionMayCloseItsDocument)
+{
+    auto& application = App::GetApplication();
+    for (const bool throwAfterClose : {false, true}) {
+        auto* document = application.newDocument("CloseAtPresentationCompletion");
+        const std::string name = document->getName();
+        document->beginPresentationUpdate();
+        fastsignals::scoped_connection connection =
+            document->signalPresentationUpdateChanged.connect(
+                [&](const App::Document&, bool active) {
+                    if (!active) {
+                        EXPECT_TRUE(application.closeDocument(name.c_str()));
+                        if (throwAfterClose) {
+                            throw std::runtime_error("completion observer failed after close");
+                        }
+                    }
+                });
+        if (throwAfterClose) {
+            EXPECT_THROW(document->endPresentationUpdate(), std::runtime_error);
+        }
+        else {
+            EXPECT_NO_THROW(document->endPresentationUpdate());
+        }
+        EXPECT_EQ(application.getDocument(name.c_str()), nullptr);
+    }
+}
 
 namespace
 {
@@ -234,6 +404,44 @@ void expectTimelineTestState(const App::DocumentTimeline* timeline, const Timeli
 }  // namespace
 
 
+TEST_F(DocumentTest, objectGenerationInvalidatesCapturedStructureAndValues)
+{
+    auto generation = doc()->getObjectChangeGeneration();
+    auto* object = doc()->addObject("App::FeaturePython", "SnapshotSource");
+    EXPECT_GT(doc()->getObjectChangeGeneration(), generation);
+    generation = doc()->getObjectChangeGeneration();
+    object->Label.setValue("Changed source");
+    EXPECT_GT(doc()->getObjectChangeGeneration(), generation);
+    generation = doc()->getObjectChangeGeneration();
+    EXPECT_EQ(doc()->getObject("SnapshotSource"), object);
+    EXPECT_EQ(doc()->getObjectChangeGeneration(), generation);
+
+    object->addDynamicProperty("App::PropertyString", "SnapshotMetadata");
+    EXPECT_GT(doc()->getObjectChangeGeneration(), generation);
+    generation = doc()->getObjectChangeGeneration();
+    ASSERT_TRUE(object->removeDynamicProperty("SnapshotMetadata"));
+    EXPECT_GT(doc()->getObjectChangeGeneration(), generation);
+    generation = doc()->getObjectChangeGeneration();
+    doc()->removeObject("SnapshotSource");
+    EXPECT_GT(doc()->getObjectChangeGeneration(), generation);
+}
+
+TEST_F(DocumentTest, removalGenerationIgnoresAdditionsAndValuesButTracksRemovalAndClear)
+{
+    const auto initial = doc()->getObjectRemovalGeneration();
+    auto* object = doc()->addObject("App::FeaturePython", "IdentitySource");
+    object->Label.setValue("Updated label");
+    doc()->addObject("App::FeaturePython", "OtherSource");
+    EXPECT_EQ(doc()->getObjectRemovalGeneration(), initial);
+    doc()->removeObject("IdentitySource");
+    const auto removed = doc()->getObjectRemovalGeneration();
+    EXPECT_GT(removed, initial);
+    doc()->addObject("App::FeaturePython", "IdentitySource");
+    EXPECT_EQ(doc()->getObjectRemovalGeneration(), removed);
+    doc()->clearDocument();
+    EXPECT_GT(doc()->getObjectRemovalGeneration(), removed);
+}
+
 TEST_F(DocumentTest, addStringHasherIndicatesUnwrittenWhenNew)
 {
     // Arrange
@@ -245,6 +453,263 @@ TEST_F(DocumentTest, addStringHasherIndicatesUnwrittenWhenNew)
     // Assert
     EXPECT_TRUE(addResult.first);
     EXPECT_THAT(addResult.second, Ne(-1));
+}
+
+TEST_F(DocumentTest, restoreKeepsPresentationSuppressedUntilFinalState)
+{
+    auto* feature = doc()->addObject(
+        "App::FeaturePython",
+        "RestorePresentationFeature",
+        true,
+        "Gui::ViewProviderDocumentObject"
+    );
+    ASSERT_NE(feature, nullptr);
+    Base::FileInfo saved = timelineTestFile("restore-presentation-epoch");
+    ASSERT_TRUE(doc()->saveCopy(saved.filePath().c_str()));
+
+    bool startObserved = false;
+    bool finishObserved = false;
+    bool queuedRestoreProtected = false;
+    fastsignals::scoped_connection propertyConnection;
+    fastsignals::scoped_connection createdConnection =
+        App::GetApplication().signalNewDocument.connect([&](const App::Document& created, bool) {
+            auto* createdDocument = App::GetApplication().getDocument(created.getName());
+            propertyConnection = createdDocument->signalChanged.connect(
+                [&](const App::Document& changing, const App::Property& property) {
+                    if (&property != &changing.FileName || changing.FileName.getStrValue().empty()) {
+                        return;
+                    }
+                    queuedRestoreProtected = changing.isPresentationUpdateActive();
+                    EXPECT_TRUE(queuedRestoreProtected);
+                    if (queuedRestoreProtected) {
+                        EXPECT_FALSE(App::GetApplication().closeDocument(changing.getName()));
+                    }
+                });
+        });
+    fastsignals::scoped_connection startConnection =
+        App::GetApplication().signalStartRestoreDocument.connect([&](const App::Document& restoring) {
+            startObserved = true;
+            EXPECT_TRUE(restoring.isPresentationUpdateActive());
+        });
+    fastsignals::scoped_connection finishConnection =
+        App::GetApplication().signalFinishRestoreDocument.connect([&](const App::Document& restoring) {
+            finishObserved = true;
+            EXPECT_TRUE(restoring.isPresentationUpdateActive());
+        });
+
+    auto* reopened = App::GetApplication().openDocument(saved.filePath().c_str());
+    ASSERT_NE(reopened, nullptr);
+    EXPECT_TRUE(queuedRestoreProtected);
+    EXPECT_TRUE(startObserved);
+    EXPECT_TRUE(finishObserved);
+    EXPECT_FALSE(reopened->isPresentationUpdateActive());
+
+    const std::string reopenedName = reopened->getName();
+    EXPECT_TRUE(App::GetApplication().closeDocument(reopenedName.c_str()));
+    saved.deleteFile();
+}
+
+TEST_F(DocumentTest, overlappingRestoresKeepGlobalActivityUntilBothFinish)
+{
+    auto& application = App::GetApplication();
+    std::atomic<int> idleNotifications {0};
+    fastsignals::scoped_connection restoreIdle = application.signalRestoreActivityIdle.connect([&] {
+        EXPECT_FALSE(App::Document::isAnyRestoring());
+        ++idleNotifications;
+    });
+    App::HostRuntime runtime(8);  // two document workers even on single-core CI
+    Base::FileInfo saved = timelineTestFile("overlapping-restore");
+    ASSERT_TRUE(doc()->saveCopy(saved.filePath().c_str()));
+    auto* first = application.newDocument("restore_first", nullptr, {false, true});
+    auto* second = application.newDocument("restore_second", nullptr, {false, true});
+    std::promise<void> firstReached, secondReached, releaseFirst, releaseSecond;
+    auto firstReady = firstReached.get_future();
+    auto secondReady = secondReached.get_future();
+    auto firstGate = releaseFirst.get_future();
+    auto secondGate = releaseSecond.get_future();
+    std::future<void> firstWork, secondWork;
+    bool firstReleased = false, secondReleased = false;
+    BOOST_SCOPE_EXIT_ALL(&) {
+        if (!firstReleased) { releaseFirst.set_value(); }
+        if (!secondReleased) { releaseSecond.set_value(); }
+        if (firstWork.valid()) { firstWork.wait(); }
+        if (secondWork.valid()) { secondWork.wait(); }
+        for (auto* restored : {first, second}) {
+            if (restored->isPresentationUpdateActive()) {
+                restored->afterRestore(false);
+            }
+            application.closeDocument(restored->getName());
+        }
+        saved.deleteFile();
+    };
+    fastsignals::scoped_connection firstPause = first->signalRestoreDocument.connect(
+        [&](Base::XMLReader&) { firstReached.set_value(); firstGate.wait(); }
+    );
+    fastsignals::scoped_connection secondPause = second->signalRestoreDocument.connect(
+        [&](Base::XMLReader&) { secondReached.set_value(); secondGate.wait(); }
+    );
+    firstWork = runtime.submit(
+        App::HostRuntime::Lane::Document,
+        [&](std::stop_token) { first->restore(saved.filePath().c_str(), true, {}); }
+    );
+    ASSERT_EQ(firstReady.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    secondWork = runtime.submit(
+        App::HostRuntime::Lane::Document,
+        [&](std::stop_token) { second->restore(saved.filePath().c_str(), true, {}); }
+    );
+    ASSERT_EQ(secondReady.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    releaseFirst.set_value();
+    firstReleased = true;
+    firstWork.get();
+    EXPECT_TRUE(App::Document::isAnyRestoring());
+    EXPECT_EQ(idleNotifications.load(), 0);
+    releaseSecond.set_value();
+    secondReleased = true;
+    secondWork.get();
+    EXPECT_FALSE(App::Document::isAnyRestoring());
+    EXPECT_EQ(idleNotifications.load(), 1);
+}
+
+TEST_F(DocumentTest, partialReloadDoesNotDuplicateADocumentThatCannotClose)
+{
+    auto& application = App::GetApplication();
+    Base::FileInfo saved = timelineTestFile("blocked-partial-reload");
+    ASSERT_TRUE(doc()->saveCopy(saved.filePath().c_str()));
+    doc()->FileName.setValue(saved.filePath());
+    doc()->setStatus(App::Document::PartialDoc, true);
+    doc()->beginPresentationUpdate();
+    BOOST_SCOPE_EXIT_ALL(&) {
+        doc()->endPresentationUpdate();
+        doc()->setStatus(App::Document::PartialDoc, false);
+        saved.deleteFile();
+    };
+    const auto originalCount = application.getDocuments().size();
+    EXPECT_THROW(application.openDocument(saved.filePath().c_str()), Base::RuntimeError);
+    EXPECT_EQ(application.getDocuments().size(), originalCount);
+    EXPECT_EQ(application.getDocumentByPath(saved.filePath().c_str()), doc());
+}
+
+TEST_F(DocumentTest, dependencyReloadStopsWhenTheExistingDocumentCannotClose)
+{
+    auto& application = App::GetApplication();
+    Base::FileInfo dependency = timelineTestFile("blocked-dependency-reload");
+    Base::FileInfo mainFile = timelineTestFile("dependency-reload-owner");
+    ASSERT_TRUE(doc()->saveCopy(dependency.filePath().c_str()));
+    ASSERT_TRUE(doc()->saveCopy(mainFile.filePath().c_str()));
+    doc()->FileName.setValue(dependency.filePath());
+    doc()->setStatus(App::Document::PartialDoc, true);
+    doc()->lockTransaction();
+    BOOST_SCOPE_EXIT_ALL(&) {
+        doc()->unlockTransaction();
+        doc()->setStatus(App::Document::PartialDoc, false);
+        dependency.deleteFile();
+        mainFile.deleteFile();
+    };
+    const auto originalCount = application.getDocuments().size();
+    unsigned closeAttempts = 0;
+    fastsignals::scoped_connection closing = application.signalBeforeCloseDocument.connect(
+        [&](const App::Document& closingDocument) {
+            if (&closingDocument == doc() && ++closeAttempts > 1) {
+                // Bound the failing implementation without a timeout or a
+                // stranded worker: a second attempt is already the regression.
+                throw Base::RuntimeError("Dependency reload retried a refused close");
+            }
+        });
+    fastsignals::scoped_connection restoring = application.signalStartRestoreDocument.connect(
+        [&](const App::Document& restoringDocument) {
+            if (restoringDocument.FileName.getStrValue() == mainFile.filePath()) {
+                EXPECT_EQ(application.addPendingDocument(
+                    dependency.filePath().c_str(), "MissingDependencyObject", false), 1);
+            }
+        });
+
+    EXPECT_THROW(application.openDocument(mainFile.filePath().c_str()), Base::RuntimeError);
+    EXPECT_EQ(closeAttempts, 1);
+    EXPECT_EQ(application.getDocuments().size(), originalCount);
+    EXPECT_EQ(application.getDocumentByPath(dependency.filePath().c_str()), doc());
+    EXPECT_FALSE(application.isRestoring());
+}
+
+TEST_F(DocumentTest, propertyRestoreCancellationClosesOnlyTheIncompleteDocument)
+{
+    auto& application = App::GetApplication();
+    ASSERT_NE(doc()->addObject("App::PropertyRestoreCancellationTestObject", "CancelRestore"), nullptr);
+    Base::FileInfo saved = timelineTestFile("property-restore-cancellation");
+    ASSERT_TRUE(doc()->saveCopy(saved.filePath().c_str()));
+    const auto originalCount = application.getDocuments().size();
+    BOOST_SCOPE_EXIT_ALL(&) {
+        saved.deleteFile();
+    };
+
+    EXPECT_THROW(application.openDocument(saved.filePath().c_str()), Base::AbortException);
+    EXPECT_EQ(application.getDocuments().size(), originalCount);
+    EXPECT_NE(doc()->getObject("CancelRestore"), nullptr);
+    EXPECT_FALSE(App::Document::isAnyRestoring());
+}
+
+TEST_F(DocumentTest, workerRestoreReportsNativeFailureWithoutPythonThreadState)
+{
+    auto& application = App::GetApplication();
+    ASSERT_NE(doc()->addObject("App::NativeRestoreFailureTestObject", "BrokenRestore"), nullptr);
+    Base::FileInfo saved = timelineTestFile("native-restore-failure");
+    ASSERT_TRUE(doc()->saveCopy(saved.filePath().c_str()));
+    auto* restored = application.newDocument("native_restore_failure", nullptr, {false, true});
+    std::future<void> work;
+    BOOST_SCOPE_EXIT_ALL(&) {
+        if (work.valid()) { work.wait(); }
+        application.closeDocument(restored->getName());
+        saved.deleteFile();
+    };
+    work = application.hostRuntime().submit(App::HostRuntime::Lane::Document,
+        [&](std::stop_token) {
+            EXPECT_FALSE(PyGILState_Check());
+            restored->restore(saved.filePath().c_str(), false, {});
+        });
+    // This is a native worker-path test, not a GUI responsiveness measurement.
+    work.get();
+    auto* failed = restored->getObject("BrokenRestore");
+    ASSERT_NE(failed, nullptr);
+    EXPECT_STREQ(restored->getErrorDescription(failed), "Unknown exception on restore");
+    EXPECT_FALSE(restored->isPresentationUpdateActive());
+}
+
+TEST_F(DocumentTest, parallelDocumentRelabelDoesNotDiscardAnotherDocumentsUndo)
+{
+    auto& application = App::GetApplication();
+    auto* other = application.newDocument("relabel_independent");
+    auto* feature = other->addObject("App::FeaturePython", "Before");
+    other->setUndoMode(1);
+    std::promise<void> reached, release;
+    auto ready = reached.get_future();
+    auto gate = release.get_future();
+    std::future<void> work;
+    bool released = false;
+    BOOST_SCOPE_EXIT_ALL(&) {
+        if (!released) { release.set_value(); }
+        if (work.valid()) { work.wait(); }
+        application.closeDocument(other->getName());
+    };
+    fastsignals::scoped_connection pause = application.signalRelabelDocument.connect(
+        [&](const App::Document& changed) {
+            if (&changed == doc()) {
+                reached.set_value();
+                gate.wait();
+            }
+        }
+    );
+    other->openTransaction("Independent change");
+    work = application.hostRuntime().submit(App::HostRuntime::Lane::Document,
+        [&](std::stop_token) { doc()->Label.setValue("Renaming concurrently"); }
+    );
+    ASSERT_EQ(ready.wait_for(std::chrono::seconds(5)), std::future_status::ready);
+    feature->Label.setValue("After");
+    other->commitTransaction();
+    release.set_value();
+    released = true;
+    work.get();
+    ASSERT_EQ(other->getAvailableUndos(), 1);
+    other->undo();
+    EXPECT_STREQ(feature->Label.getValue(), "Before");
 }
 
 TEST_F(DocumentTest, addStringHasherIndicatesAlreadyWritten)
@@ -638,6 +1103,44 @@ TEST_F(DocumentTest, importedTimelineAdoptionValidatesAndOrdersProvisionalSemant
     EXPECT_TRUE(owner->testStatus(App::Property::Hidden));
 }
 
+TEST_F(DocumentTest, concurrentLinkedSubobjectResolutionPreservesTarget)
+{
+    auto* container = doc()->addObject("App::FeaturePython", "LinkedContainer");
+    auto* source = doc()->addObject("App::FeaturePython", "LongNamedLinkedSourceFeature");
+    auto* children = static_cast<App::PropertyLinkList*>(
+        container->addDynamicProperty("App::PropertyLinkList", "Children"));
+    children->setValues({source});
+    auto* link = dynamic_cast<App::Link*>(doc()->addObject("App::Link", "Occurrence"));
+    ASSERT_NE(link, nullptr);
+    const std::string subname = std::string(source->getNameInDocument()) + ".";
+    link->LinkedObject.setValue(container, subname.c_str());
+    // Warm ordinary dependency caches: this regression isolates concurrent
+    // reads of an unchanged link, not concurrent document mutation.
+    ASSERT_EQ(link->getLinkedObject(false), source);
+    auto* extension = link->getExtensionByType<App::LinkBaseExtension>();
+    std::atomic_bool start {false};
+    std::vector<std::future<size_t>> readers;
+    for (size_t worker = 0; worker < 4; ++worker) {
+        readers.push_back(std::async(std::launch::async, [&, worker] {
+            while (!start.load()) { std::this_thread::yield(); }
+            size_t failures = 0;
+            for (size_t i = 0; i < 20000; ++i) {
+                if (worker == 0) {
+                    // Display reads the public sub-element cache while the
+                    // recompute worker resolves the same linked source.
+                    extension->getSubElements();
+                }
+                else if (link->getLinkedObject(false) != source) {
+                    ++failures;
+                }
+            }
+            return failures;
+        }));
+    }
+    start.store(true);
+    for (auto& reader : readers) { EXPECT_EQ(reader.get(), 0); }
+}
+
 TEST_F(DocumentTest, timelineMetadataOnLinksIsOccurrenceLocalAndSurvivesReopen)
 {
     auto* timeline = App::DocumentTimeline::ensure(doc());
@@ -997,6 +1500,79 @@ TEST_F(DocumentTest, resourceFirstTimelinePublicationPreservesProvisionalEnrollm
     EXPECT_TRUE(App::DocumentTimeline::hasTimelineOperationRole(operation));
 }
 
+TEST_F(DocumentTest, semanticPublicationDoesNotRetraverseEveryTrackedDependencyChain)
+{
+    doc()->setUndoMode(1);
+    doc()->openTransaction("Create tracked dependency chain");
+    std::vector<App::TimelineDependencyCountingTestObject*> chain;
+    for (size_t index = 0; index < 50; ++index) {
+        auto* object = doc()->addObject<App::TimelineDependencyCountingTestObject>(
+            "Chain", true, "Gui::ViewProviderDocumentObject");
+        if (!chain.empty()) {
+            static_cast<App::PropertyLink*>(object->addDynamicProperty(
+                "App::PropertyLink", "Input"))->setValue(chain.back());
+        }
+        chain.push_back(object);
+    }
+    doc()->commitTransaction();
+    doc()->openTransaction("Publish one dependent operation");
+    auto* operation = addTimelineTestFeature(doc(), "DependentOperation");
+    static_cast<App::PropertyLink*>(operation->addDynamicProperty(
+        "App::PropertyLink", "Input"))->setValue(chain.back());
+    for (auto* object : chain) { object->dependencyChecks = 0; }
+
+    doc()->publishProvisionalTimelineOperationBlock(operation, {});
+
+    size_t checks = 0;
+    for (const auto* object : chain) { checks += object->dependencyChecks; }
+    // Every tracked operation is validated independently. Following its whole
+    // ancestry again for every descendant is quadratic, not extra validation.
+    EXPECT_LE(checks, chain.size() * 6);
+    doc()->abortTransaction();
+}
+
+TEST_F(DocumentTest, semanticPublicationStillChecksUntrackedDependencyBridges)
+{
+    doc()->setUndoMode(1);
+    doc()->openTransaction("Create ordered roots");
+    auto* earlier = addTimelineTestFeature(doc(), "Earlier");
+    auto* later = addTimelineTestFeature(doc(), "Later");
+    auto* bridge = doc()->addObject("App::DocumentObject", "UntrackedBridge");
+    static_cast<App::PropertyLink*>(bridge->addDynamicProperty(
+        "App::PropertyLink", "Input"))->setValue(later);
+    doc()->commitTransaction();
+    doc()->openTransaction("Reject hidden forward dependency");
+    static_cast<App::PropertyLink*>(earlier->addDynamicProperty(
+        "App::PropertyLink", "Input"))->setValue(bridge);
+    auto* operation = addTimelineTestFeature(doc(), "NewOperation");
+    EXPECT_THROW(doc()->publishProvisionalTimelineOperationBlock(operation, {}), Base::RuntimeError);
+    doc()->abortTransaction();
+}
+
+TEST_F(DocumentTest, semanticPublicationMembershipIsFreshAfterOwnershipChanges)
+{
+    doc()->setUndoMode(1);
+    doc()->openTransaction("Publish exact resource ownership");
+    auto* resource = addTimelineTestFeature(doc(), "Resource");
+    auto* first = addTimelineTestFeature(doc(), "FirstOperation");
+    doc()->publishProvisionalTimelineOperationBlock(first, {resource});
+    auto* timeline = App::DocumentTimeline::get(doc());
+    ASSERT_TRUE(timeline->isSemanticallyPublishedByCurrentTransaction(first));
+
+    auto* second = addTimelineTestFeature(doc(), "SecondOperation");
+    auto* owner = dynamic_cast<App::PropertyLinkHidden*>(
+        resource->getPropertyByName(App::DocumentTimeline::OwnerPropertyName));
+    ASSERT_NE(owner, nullptr);
+    owner->setValue(second);
+    // Pruning must observe ownership as it is now, not reuse the previous
+    // publication's census. This malformed block cannot be published.
+    EXPECT_THROW(doc()->publishProvisionalTimelineOperationBlock(second, {}), Base::RuntimeError);
+    owner->setValue(first);
+    // Restoring metadata cannot resurrect the discarded exact publication proof.
+    EXPECT_FALSE(timeline->isSemanticallyPublishedByCurrentTransaction(first));
+    doc()->abortTransaction();
+}
+
 TEST_F(DocumentTest, copiedObjectsRetainExactCreationProofForSemanticPublication)
 {
     doc()->setUndoMode(1);
@@ -1009,7 +1585,9 @@ TEST_F(DocumentTest, copiedObjectsRetainExactCreationProofForSemanticPublication
     const auto baseline = captureTimelineTestState(timeline);
 
     doc()->openTransaction("Publish copied semantic block");
-    const auto copied = doc()->copyObject({source}, false, false);
+    // Publication below owns adoption; the ordinary three-argument API
+    // already adopts copies into the timeline.
+    const auto copied = doc()->copyObject({source}, false, false, false);
     ASSERT_EQ(copied.size(), 1);
     auto* resource = copied.front();
     ASSERT_NE(resource, nullptr);
@@ -1043,7 +1621,7 @@ TEST_F(DocumentTest, adoptedCopyProofRebasesTheNextCreationGeneration)
     const auto baseline = captureTimelineTestState(timeline);
 
     doc()->openTransaction("Adopt copy then publish");
-    const auto copied = doc()->copyObject({source}, false, false);
+    const auto copied = doc()->copyObject({source}, false, false, false);
     ASSERT_EQ(copied.size(), 1);
     auto* adopted = copied.front();
     ASSERT_NE(adopted, nullptr);
@@ -1234,6 +1812,83 @@ TEST_F(DocumentTest, lockedDynamicPropertyCreationAbortsUndoesAndRedoesExactly)
     EXPECT_TRUE(restored->testStatus(App::Property::LockDynamic));
     EXPECT_FALSE(object->removeDynamicProperty("LockedMetadata"));
     EXPECT_EQ(object->getPropertyByName("LockedMetadata"), restored);
+}
+
+TEST_F(DocumentTest, linkMembershipIndexTracksEditsAndConcurrentReaders)
+{
+    auto* owner = addTimelineTestFeature(doc(), "IndexedLinkOwner");
+    auto* links = static_cast<App::PropertyLinkList*>(
+        owner->addDynamicProperty("App::PropertyLinkList", "Members"));
+    std::vector<App::DocumentObject*> members;
+    for (int index = 0; index < 50; ++index) {
+        members.push_back(addTimelineTestFeature(doc(), "Member"));
+    }
+    links->setValues(members);
+    for (int index = 0; index < 50; ++index) {
+        EXPECT_EQ(links->findObject(members[index]), index);
+    }
+    EXPECT_EQ(links->findObject(nullptr), -1);
+    EXPECT_EQ(links->findObject(owner), -1);
+
+    // Both notification phases may query membership. Neither may observe an
+    // index of the opposite property value, including a reentrant lazy lookup.
+    bool before = false;
+    bool after = false;
+    fastsignals::scoped_connection beforeChange = doc()->signalBeforeChangeObject.connect(
+        [&](const App::DocumentObject& object, const App::Property& property) {
+            if (&object == owner && &property == links) {
+                before = true;
+                EXPECT_EQ(links->findObject(members.front()), 0);
+            }
+        });
+    fastsignals::scoped_connection afterChange = doc()->signalChangedObject.connect(
+        [&](const App::DocumentObject& object, const App::Property& property) {
+            if (&object == owner && &property == links) {
+                after = true;
+                EXPECT_EQ(links->findObject(members.front()), -1);
+                EXPECT_EQ(links->findObject(members.back()), 0);
+            }
+        });
+    links->set1Value(0, members.back());
+    EXPECT_TRUE(before);
+    EXPECT_TRUE(after);
+    beforeChange.disconnect();
+    afterChange.disconnect();
+    links->setValues(members);
+
+    // Readers use the same persistent CPU executor as geometry preparation.
+    std::vector<std::future<bool>> readers;
+    for (int worker = 0; worker < 8; ++worker) {
+        readers.push_back(App::GetApplication().hostRuntime().submit(
+            App::HostRuntime::Lane::Compute, [links, members](std::stop_token) {
+                for (int repetition = 0; repetition < 100; ++repetition) {
+                    for (int index = 0; index < 50; ++index) {
+                        if (links->findObject(members[index]) != index) {
+                            return false;
+                        }
+                    }
+                }
+                return true;
+            }));
+    }
+    for (auto& reader : readers) {
+        EXPECT_TRUE(reader.get());
+    }
+    links->setValues({members.back(), members.front(), members.back()});
+    EXPECT_EQ(links->findObject(members.back()), 0); // First occurrence, not last.
+    links->setSize(1);
+    EXPECT_EQ(links->findObject(members.front()), -1);
+    links->setSize(3, members.front());
+    EXPECT_EQ(links->findObject(members.front()), 1);
+    std::unique_ptr<App::Property> copy(links->Copy());
+    EXPECT_EQ(static_cast<App::PropertyLinkList*>(copy.get())->findObject(members.front()), 1);
+    links->setValues({});
+    EXPECT_EQ(links->findObject(members.back()), -1);
+    links->Paste(*copy);
+    EXPECT_EQ(links->findObject(members.back()), 0);
+    links->setSize(1024, links->getValues()[0]);
+    EXPECT_EQ(links->getValues().back(), members.back());
+    EXPECT_EQ(links->findObject(members.back()), 0);
 }
 
 TEST_F(DocumentTest, frozenNewObjectRestoresLinksAcrossUndoAndRedo)
@@ -1978,6 +2633,40 @@ TEST_F(DocumentTest, atomicPublicationTracksFirstExcludedContainerAndNestedResou
     doc()->abortTransaction();
 }
 
+TEST_F(DocumentTest, visibilityDependenciesFollowOwnershipChangesDuringApplying)
+{
+    auto* timeline = App::DocumentTimeline::ensure(doc());
+    auto* resource = addTimelineTestFeature(doc(), "VisibilityResource");
+    auto* firstOwner = addTimelineTestFeature(doc(), "VisibilityOwnerA");
+    auto* secondOwner = addTimelineTestFeature(doc(), "VisibilityOwnerB");
+    timeline->beginApplying();
+    markTimelineTestOperation(firstOwner);
+    markTimelineTestOperation(secondOwner);
+    auto [role, ownerLink] = markTimelineTestResource(resource, firstOwner);
+    (void)role;
+    timeline->Operations.setValues({resource, firstOwner, secondOwner});
+    timeline->Position.setValue(3);
+    timeline->endApplying();
+    timeline->captureVisibility();
+
+    firstOwner->Visibility.setValue(false);
+    EXPECT_FALSE(resource->Visibility.getValue());
+    firstOwner->Visibility.setValue(true);
+    EXPECT_TRUE(resource->Visibility.getValue());
+
+    // Applying suppresses baseline capture but must not suppress invalidation
+    // of ownership metadata changed by a publication or transaction replay.
+    timeline->beginApplying();
+    ownerLink->setValue(secondOwner);
+    timeline->endApplying();
+    secondOwner->Visibility.setValue(false);
+    EXPECT_FALSE(resource->Visibility.getValue());
+    secondOwner->Visibility.setValue(true);
+    EXPECT_TRUE(resource->Visibility.getValue());
+    firstOwner->Visibility.setValue(false);
+    EXPECT_TRUE(resource->Visibility.getValue());
+}
+
 TEST_F(DocumentTest, atomicPublicationSupportsSequentialPendingBlocksAndBaselineRefresh)
 {
     auto* timeline = App::DocumentTimeline::ensure(doc());
@@ -2009,6 +2698,24 @@ TEST_F(DocumentTest, atomicPublicationSupportsSequentialPendingBlocksAndBaseline
     firstOperation->Visibility.setValue(false);
     timeline->captureVisibility();
     ASSERT_FALSE(timeline->VisibilityAtEnd.getValues().test(2));
+    EXPECT_FALSE(firstParent->Visibility.getValue());
+    EXPECT_FALSE(firstLeaf->Visibility.getValue());
+    EXPECT_TRUE(secondResource->Visibility.getValue());
+
+    // Repeated owner visibility changes must retain the resource's accepted
+    // visibility, including a resource nested under another resource.
+    firstOperation->Visibility.setValue(true);
+    EXPECT_TRUE(firstParent->Visibility.getValue());
+    EXPECT_TRUE(firstLeaf->Visibility.getValue());
+    firstParent->Visibility.setValue(false);
+    EXPECT_FALSE(firstLeaf->Visibility.getValue());
+    firstOperation->Visibility.setValue(false);
+    firstOperation->Visibility.setValue(true);
+    EXPECT_FALSE(firstParent->Visibility.getValue());
+    EXPECT_FALSE(firstLeaf->Visibility.getValue());
+    firstParent->Visibility.setValue(true);
+    EXPECT_TRUE(firstLeaf->Visibility.getValue());
+    firstOperation->Visibility.setValue(false);
 
     auto* thirdResource = addTimelineTestFeature(doc(), "ThirdGenerationResource");
     auto* thirdOperation = addTimelineTestFeature(doc(), "ThirdGenerationOperation");
@@ -3098,6 +3805,58 @@ TEST_F(DocumentTest, resourceReconciliationRejectsLaterRetirementRemovedByOwnerC
     EXPECT_NE(doc()->getObject("HostileRetirementFirst"), nullptr);
     EXPECT_NE(doc()->getObject("HostileRetirementLater"), nullptr);
     expectTimelineTestState(timeline, baseline);
+}
+
+TEST_F(DocumentTest, dependencyRebaseBatchesSharedDownstreamClosure)
+{
+    doc()->setUndoMode(1);
+    auto* timeline = App::DocumentTimeline::ensure(doc());
+    doc()->openTransaction("Create shared dependency graph");
+    auto* first = addTimelineTestFeature(doc(), "FirstJoint");
+    markTimelineTestOperation(first);
+    timeline->finalizeProvisionalOperationBlock(first, {first});
+    auto* second = addTimelineTestFeature(doc(), "SecondJoint");
+    markTimelineTestOperation(second);
+    timeline->finalizeProvisionalOperationBlock(second, {second});
+    auto* consumer = addTimelineTestFeature(doc(), "SharedSimulation");
+    markTimelineTestOperation(consumer);
+    auto* inputs = static_cast<App::PropertyLinkList*>(
+        consumer->addDynamicProperty("App::PropertyLinkList", "Inputs"));
+    inputs->setValues({first, second});
+    timeline->finalizeProvisionalOperationBlock(consumer, {consumer});
+    auto* unrelated = addTimelineTestFeature(doc(), "Unrelated");
+    markTimelineTestOperation(unrelated);
+    timeline->finalizeProvisionalOperationBlock(unrelated, {unrelated});
+    auto* source = addTimelineTestFeature(doc(), "NewTravelComponent");
+    markTimelineTestOperation(source);
+    timeline->finalizeProvisionalOperationBlock(source, {source});
+    doc()->commitTransaction();
+
+    doc()->openTransaction("Rebase both changed joints once");
+    for (auto* joint : {first, second}) {
+        auto* input = static_cast<App::PropertyLink*>(
+            joint->addDynamicProperty("App::PropertyLink", "NewInput"));
+        input->setValue(source);
+    }
+    EXPECT_TRUE(timeline->reorderOperationDependentClosuresAfter({first, second}, source));
+    EXPECT_THAT(timeline->Operations.getValues(),
+                ::testing::ElementsAre(unrelated, source, first, second, consumer));
+    EXPECT_FALSE(timeline->reorderOperationDependentClosuresAfter({first, second}, source));
+    EXPECT_THROW(timeline->reorderOperationDependentClosuresAfter({first, first}, source),
+                 Base::ValueError);
+    EXPECT_THROW(timeline->reorderOperationDependentClosuresAfter({source}, consumer),
+                 Base::RuntimeError);
+    auto* motion = addTimelineTestFeature(doc(), "NewMotionAfterRebase");
+    markTimelineTestOperation(motion);
+    auto* motionInput = static_cast<App::PropertyLink*>(
+        motion->addDynamicProperty("App::PropertyLink", "Joint"));
+    motionInput->setValue(first);
+    EXPECT_NO_THROW(timeline->finalizeProvisionalOperationBlock(motion, {motion}));
+    doc()->abortTransaction();
+    EXPECT_THAT(timeline->Operations.getValues(),
+                ::testing::ElementsAre(first, second, consumer, unrelated, source));
+    EXPECT_EQ(first->getPropertyByName("NewInput"), nullptr);
+    EXPECT_EQ(doc()->getObject("NewMotionAfterRebase"), nullptr);
 }
 
 TEST_F(DocumentTest, dependencyRebaseMovesCompleteDownstreamClosureAndPersists)

--- a/tests/src/App/DocumentObject.cpp
+++ b/tests/src/App/DocumentObject.cpp
@@ -2,6 +2,7 @@
 
 #include "gtest/gtest.h"
 #include <gmock/gmock.h>
+#include <chrono>
 
 #include <src/App/InitApplication.h>
 
@@ -10,11 +11,42 @@
 #include <App/DocumentObject.h>
 #include <App/DocumentObjectGroup.h>
 #include <App/GeoFeatureGroupExtension.h>
+#include <App/PropertyLinks.h>
 #include <Base/Interpreter.h>
 
 using namespace App;
 
 // NOLINTBEGIN(readability-magic-numbers,cppcoreguidelines-avoid-magic-numbers)
+
+namespace App
+{
+class CleanupCountingLink: public PropertyLink
+{
+public:
+    size_t cleanupCalls {0};
+    void breakLink(DocumentObject* object, bool clear) override
+    {
+        ++cleanupCalls;
+        PropertyLink::breakLink(object, clear);
+    }
+};
+
+class LinkCleanupTestObject: public DocumentObject
+{
+    PROPERTY_HEADER_WITH_OVERRIDE(App::LinkCleanupTestObject);
+
+public:
+    LinkCleanupTestObject()
+    {
+        ADD_PROPERTY(Link, (nullptr));
+        ADD_PROPERTY(HiddenLink, (nullptr));
+        HiddenLink.setScope(LinkScope::Hidden);
+    }
+    CleanupCountingLink Link;
+    CleanupCountingLink HiddenLink;
+};
+PROPERTY_SOURCE(App::LinkCleanupTestObject, App::DocumentObject)
+}
 
 class DocumentObjectTest: public ::testing::Test
 {
@@ -22,6 +54,7 @@ protected:
     static void SetUpTestSuite()
     {
         tests::initApplication();
+        App::LinkCleanupTestObject::init();
     }
 
     void SetUp() override
@@ -175,6 +208,119 @@ TEST_F(DocumentObjectTest, timelineStructuralChildrenDistinguishContainmentFromD
     EXPECT_TRUE(group->isTimelineStructuralChild(child));
     EXPECT_FALSE(group->isTimelineStructuralChild(dependency));
     EXPECT_FALSE(child->isTimelineStructuralChild(group));
+}
+
+TEST_F(DocumentObjectTest, linkCleanupSkipsObjectsWithoutTheDeletedTarget)
+{
+    auto* anchor = _doc->addObject<App::DocumentObject>("Anchor");
+    std::vector<App::LinkCleanupTestObject*> owners;
+    std::vector<std::string> targets;
+    for (size_t index = 0; index < 50; ++index) {
+        auto* target = _doc->addObject<App::DocumentObject>("Target");
+        targets.emplace_back(target->getNameInDocument());
+        auto* owner = _doc->addObject<App::LinkCleanupTestObject>("Owner");
+        owner->Link.setValue(anchor);
+        owner->HiddenLink.setValue(target);
+        owners.push_back(owner);
+    }
+    for (const auto& target : targets) {
+        _doc->removeObject(target.c_str());
+    }
+    size_t calls = 0;
+    for (const auto* owner : owners) {
+        EXPECT_EQ(owner->Link.getValue(), anchor);
+        EXPECT_EQ(owner->HiddenLink.getValue(), nullptr);
+        calls += owner->Link.cleanupCalls + owner->HiddenLink.cleanupCalls;
+    }
+    // Each deletion affects one owner, not all 50 owners' properties. This is
+    // an operation-count assertion, independent of host speed or a time budget.
+    EXPECT_LE(calls, owners.size() * 2);
+}
+
+TEST_F(DocumentObjectTest, linkCleanupTracksHiddenEditsUndoAndDynamicProperties)
+{
+    _doc->setUndoMode(1);
+    auto* first = _doc->addObject<App::DocumentObject>("First");
+    auto* second = _doc->addObject<App::DocumentObject>("Second");
+    auto* unrelated = _doc->addObject<App::DocumentObject>("Unrelated");
+    auto* owner = _doc->addObject<App::LinkCleanupTestObject>("Owner");
+    owner->HiddenLink.setValue(first);
+    // Populate cleanup queries without modifying the links.
+    PropertyLinkBase::breakLinks(unrelated, _doc->getObjects(), false);
+    _doc->openTransaction("Change hidden input");
+    owner->HiddenLink.setValue(second);
+    PropertyLinkBase::breakLinks(unrelated, _doc->getObjects(), false);
+    _doc->abortTransaction();
+    ASSERT_EQ(owner->HiddenLink.getValue(), first);
+    _doc->removeObject(first->getNameInDocument());
+    EXPECT_EQ(owner->HiddenLink.getValue(), nullptr);
+
+    auto* dynamic = static_cast<PropertyLink*>(owner->addDynamicProperty(
+        "App::PropertyLinkHidden", "LateLink"));
+    dynamic->setValue(second);
+    _doc->removeObject(second->getNameInDocument());
+    EXPECT_EQ(dynamic->getValue(), nullptr);
+    dynamic->setValue(unrelated);
+    auto* probe = _doc->addObject<App::DocumentObject>("Probe");
+    PropertyLinkBase::breakLinks(probe, _doc->getObjects(), false);
+    ASSERT_TRUE(owner->removeDynamicProperty("LateLink"));
+    owner->Link.cleanupCalls = owner->HiddenLink.cleanupCalls = 0;
+    _doc->removeObject(unrelated->getNameInDocument());
+    EXPECT_EQ(owner->Link.cleanupCalls + owner->HiddenLink.cleanupCalls, 0);
+
+    auto* last = _doc->addObject<App::DocumentObject>("Last");
+    owner->Link.setValue(last);
+    owner->HiddenLink.setValue(last);
+    // Removing an owner must clear its outgoing references even without a
+    // self-link. Exercise the same clear=true contract as document deletion.
+    PropertyLinkBase::breakLinks(owner, _doc->getObjects(), true);
+    EXPECT_EQ(owner->Link.getValue(), nullptr);
+    EXPECT_EQ(owner->HiddenLink.getValue(), nullptr);
+}
+
+TEST_F(DocumentObjectTest, membershipLookupDoesNotScanCreationOrder)
+{
+    auto* first = _doc->addObject<App::DocumentObject>("First");
+    App::DocumentObject* last = first;
+    for (size_t index = 1; index < 5000; ++index) {
+        last = _doc->addObject<App::DocumentObject>("Member");
+    }
+    const auto measure = [&](const App::DocumentObject* object) {
+        std::array<std::chrono::nanoseconds::rep, 3> samples;
+        for (auto& sample : samples) {
+            const auto start = std::chrono::steady_clock::now();
+            size_t found = 0;
+            for (size_t index = 0; index < 20000; ++index) {
+                found += _doc->containsObject(object);
+            }
+            sample = std::chrono::duration_cast<std::chrono::nanoseconds>(
+                std::chrono::steady_clock::now() - start).count();
+            EXPECT_EQ(found, 20000);
+        }
+        std::ranges::sort(samples);
+        return samples[1];
+    };
+    const auto firstCost = measure(first);
+    const auto lastCost = measure(last);
+    RecordProperty("first_lookup_ns", std::to_string(firstCost));
+    RecordProperty("last_lookup_ns", std::to_string(lastCost));
+    // Relative scaling, not an execution deadline: the last object must not
+    // require traversing all 5,000 predecessors for every identity check.
+    EXPECT_LE(lastCost, firstCost * 16);
+    EXPECT_FALSE(_doc->containsObject(nullptr));
+    EXPECT_FALSE(_doc->containsObject(reinterpret_cast<App::DocumentObject*>(1)));
+
+    _doc->setUndoMode(1);
+    _doc->openTransaction("Remove indexed member");
+    _doc->removeObject("First");
+    _doc->commitTransaction();
+    EXPECT_FALSE(_doc->containsObject(first));
+    _doc->undo();
+    EXPECT_TRUE(_doc->containsObject(_doc->getObject("First")));
+    _doc->redo();
+    EXPECT_FALSE(_doc->containsObject(first));
+    _doc->clearDocument();
+    EXPECT_FALSE(_doc->containsObject(last));
 }
 
 // NOLINTEND(readability-magic-numbers, cppcoreguidelines-avoid-magic-numbers)

--- a/tests/src/App/HostRuntimeIsolationHelper.cpp
+++ b/tests/src/App/HostRuntimeIsolationHelper.cpp
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#ifdef _WIN32
+# include <process.h>
+#else
+# include <unistd.h>
+#endif
+
+namespace
+{
+
+constexpr auto protocol = "VIBECAD-ISOLATION/1";
+
+long processId()
+{
+#ifdef _WIN32
+    return static_cast<long>(_getpid());
+#else
+    return static_cast<long>(getpid());
+#endif
+}
+
+}  // namespace
+
+int main()
+{
+    std::cout << protocol << " READY" << std::endl;
+    std::string line;
+    std::size_t sequence = 0;
+    while (std::getline(std::cin, line)) {
+        if (line == std::string(protocol) + " SHUTDOWN") {
+            return 0;
+        }
+        const std::string prefix = std::string(protocol) + " JOB ";
+        if (!line.starts_with(prefix)) {
+            continue;
+        }
+        const auto separator = line.find(' ', prefix.size());
+        if (separator == std::string::npos) {
+            continue;
+        }
+        const auto id = line.substr(prefix.size(), separator - prefix.size());
+        auto payload = line.substr(separator + 1);
+        const auto cpuSeparator = payload.find(' ');
+        if (cpuSeparator != std::string::npos
+            && !payload.substr(0, cpuSeparator).empty()
+            && std::ranges::all_of(
+                payload.substr(0, cpuSeparator),
+                [](unsigned char value) { return std::isdigit(value) != 0; }
+            )) {
+            payload = payload.substr(cpuSeparator + 1);
+        }
+        if (payload.starts_with("sleep:")) {
+            std::this_thread::sleep_for(
+                std::chrono::milliseconds(std::stoul(payload.substr(6)))
+            );
+        }
+        ++sequence;
+        std::cout << protocol << " RESULT " << id << ' ' << processId() << ':'
+                  << sequence << ':' << payload << std::endl;
+    }
+    return 0;
+}

--- a/tests/src/App/SemanticDependencyOrder.cpp
+++ b/tests/src/App/SemanticDependencyOrder.cpp
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include <gtest/gtest.h>
+#include <App/SemanticDependencyOrder.h>
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <set>
+
+namespace {
+using App::detail::SemanticDependencyGraph;
+using App::detail::stableSemanticDependencyOrder;
+
+std::vector<std::size_t> referenceOrder(const SemanticDependencyGraph& graph)
+{
+    std::vector<std::set<std::size_t>> dependencies(graph.members.size());
+    for (std::size_t block = 0; block < graph.members.size(); ++block) {
+        std::set<std::size_t> visited;
+        auto pending = graph.members[block];
+        while (!pending.empty()) {
+            const auto node = pending.back();
+            pending.pop_back();
+            if (!visited.insert(node).second) continue;
+            const auto owner = graph.block[node];
+            if (owner != SemanticDependencyGraph::untracked && owner != block)
+                dependencies[block].insert(owner);
+            pending.insert(pending.end(), graph.dependencies[node].begin(), graph.dependencies[node].end());
+        }
+    }
+    std::vector<std::size_t> result;
+    while (result.size() < dependencies.size()) {
+        std::size_t next = 0;
+        for (; next < dependencies.size(); ++next) {
+            if (dependencies[next].empty()
+                && std::find(result.begin(), result.end(), next) == result.end()) break;
+        }
+        if (next == dependencies.size()) throw std::runtime_error("cycle");
+        result.push_back(next);
+        for (auto& inputs : dependencies) inputs.erase(next);
+    }
+    return result;
+}
+}
+
+TEST(SemanticDependencyOrder, PreservesLexicographicOrderAgainstFullReachability)
+{
+    std::mt19937 random(914);
+    for (int trial = 0; trial < 100; ++trial) {
+        SemanticDependencyGraph graph;
+        graph.members.resize(12);
+        graph.dependencies.resize(30);
+        graph.block.assign(30, SemanticDependencyGraph::untracked);
+        for (std::size_t index = 0; index < 12; ++index) {
+            graph.members[index] = {index};
+            graph.block[index] = index;
+        }
+        // Include shared untracked nodes and non-topologically numbered roots.
+        std::vector<std::size_t> order(30);
+        std::iota(order.begin(), order.end(), 0);
+        std::shuffle(order.begin(), order.end(), random);
+        for (std::size_t index = 1; index < order.size(); ++index)
+            for (std::size_t prior = 0; prior < index; ++prior)
+                if (random() % 7 == 0) graph.dependencies[order[index]].push_back(order[prior]);
+        EXPECT_EQ(stableSemanticDependencyOrder(graph).order, referenceOrder(graph));
+    }
+}
+
+TEST(SemanticDependencyOrder, TraversesChainOncePerDirectSemanticDependency)
+{
+    SemanticDependencyGraph graph;
+    constexpr std::size_t count = 10000;
+    graph.members.resize(count);
+    graph.dependencies.resize(count);
+    graph.block.resize(count);
+    for (std::size_t index = 0; index < count; ++index) {
+        graph.members[index] = {index};
+        graph.block[index] = index;
+        if (index) graph.dependencies[index] = {index - 1};
+    }
+    const auto result = stableSemanticDependencyOrder(graph);
+    ASSERT_EQ(result.order.size(), count);
+    EXPECT_EQ(result.visitedEdges, count - 1);
+    for (std::size_t index = 0; index < count; ++index) EXPECT_EQ(result.order[index], index);
+}
+
+TEST(SemanticDependencyOrder, PreservesCyclesAndUntrackedResourceDependencies)
+{
+    SemanticDependencyGraph graph {{{0}, {1}}, {{2}, {}, {1}}, {0, 1, 1}};
+    // Node 2 belongs to block 1 but is not enrolled: its links still count.
+    EXPECT_EQ(stableSemanticDependencyOrder(graph).order, referenceOrder(graph));
+    graph.dependencies[1] = {0};
+    EXPECT_THROW(stableSemanticDependencyOrder(graph), std::runtime_error);
+    graph = {{{0, 1}}, {{1}, {0}}, {0, 0}};
+    EXPECT_EQ(stableSemanticDependencyOrder(graph).order, (std::vector<std::size_t>{0}));
+}
+
+TEST(SemanticDependencyOrder, CountsSharedPublicationMembershipInOnePass)
+{
+    std::vector<std::size_t> members(10000);
+    std::iota(members.begin(), members.end(), 0);
+    std::size_t resolutions = 0;
+    const auto counts = App::detail::countSemanticMembers(members, [&](std::size_t member) {
+        ++resolutions;
+        return member / 10;
+    });
+    ASSERT_EQ(counts.size(), 1000);
+    for (std::size_t publication = 0; publication < 1000; ++publication) {
+        EXPECT_EQ(counts.at(publication), 10);
+    }
+    EXPECT_EQ(resolutions, members.size());
+    // A fresh pass must see changed ownership and count duplicate entries,
+    // rather than caching a previous document state or hiding malformed input.
+    members.back() = 0;
+    const auto changed = App::detail::countSemanticMembers(members, [](std::size_t member) {
+        return member / 10;
+    });
+    EXPECT_EQ(changed.at(0), 11);
+    EXPECT_EQ(changed.at(999), 9);
+}

--- a/tests/src/App/StringHasher.cpp
+++ b/tests/src/App/StringHasher.cpp
@@ -9,6 +9,8 @@
 
 #include <QCryptographicHash>
 #include <array>
+#include <barrier>
+#include <thread>
 
 class StringIDTest: public ::testing::Test
 {
@@ -1116,6 +1118,40 @@ protected:
 private:
     Base::Reference<App::StringHasher> _hasher;
 };
+
+TEST_F(StringHasherTest, concurrentInterningPreservesTableAndReferences)  // NOLINT
+{
+    constexpr int workerCount = 8;
+    constexpr int stringsPerWorker = 1000;
+    auto hasher = Hasher();
+    std::barrier start(workerCount);
+    std::array<std::vector<App::StringIDRef>, workerCount> results;
+    std::vector<std::jthread> workers;
+    for (int worker = 0; worker < workerCount; ++worker) {
+        workers.emplace_back([&, worker] {
+            start.arrive_and_wait();
+            for (int index = 0; index < stringsPerWorker; ++index) {
+                // Both repeated and distinct names occur in independent feature recomputes.
+                const auto name = QByteArray::number(index) + ":" + QByteArray::number(worker % 2);
+                results[worker].push_back(hasher->getID(name));
+            }
+        });
+    }
+    workers.clear();
+    ASSERT_EQ(hasher->size(), 2 * stringsPerWorker);
+    for (int worker = 0; worker < workerCount; ++worker) {
+        for (int index = 0; index < stringsPerWorker; ++index) {
+            const auto& id = results[worker][index];
+            EXPECT_EQ(id, results[worker % 2][index]);
+            EXPECT_EQ(id, hasher->getID(id.value()));
+        }
+    }
+    hasher->clear();
+    EXPECT_EQ(hasher->size(), 0);
+    EXPECT_EQ(results[0][0].deref().data(), QByteArray("0:0"));
+    results = {};
+    EXPECT_EQ(hasher->getID("reused").deref().data(), QByteArray("reused"));
+}
 
 TEST_F(StringHasherTest, defaultConstructor)  // NOLINT
 {

--- a/tests/src/Base/Base64.cpp
+++ b/tests/src/Base/Base64.cpp
@@ -27,10 +27,24 @@ the tests into individual parts.
 */
 
 #include "Base/Base64.h"
+#include "Base/Base64Filter.h"
 
 #include <gtest/gtest.h>
+#include <sstream>
 
 using namespace Base;
+
+TEST(Base64, filterReportsConsumedBytesIncludingPendingTail)
+{
+    std::ostringstream encoded;
+    base64_encoder filter(0);
+    const std::string input = "abcdefg";
+    EXPECT_EQ(filter.write(encoded, input.data(), 1), 1);
+    EXPECT_EQ(filter.write(encoded, input.data() + 1, 2), 2);
+    EXPECT_EQ(filter.write(encoded, input.data() + 3, 4), 4);
+    filter.close(encoded);
+    EXPECT_EQ(base64_decode(encoded.str()), input);
+}
 
 // NOLINTBEGIN(cppcoreguidelines-pro-type-reinterpret-cast)
 

--- a/tests/src/Base/CMakeLists.txt
+++ b/tests/src/Base/CMakeLists.txt
@@ -46,7 +46,6 @@ add_executable(Base_tests_run
 setup_qt_test(InventorBuilder)
 
 target_link_libraries(Base_tests_run PRIVATE
-    GTest::gtest_main
     GTest::gmock_main
     FreeCADApp
     ${Python3_LIBRARIES}

--- a/tests/src/Base/Reader.cpp
+++ b/tests/src/Base/Reader.cpp
@@ -10,8 +10,10 @@
 #endif
 
 #include "Base/Exception.h"
+#include "Base/CancellationScope.h"
 #include "Base/Persistence.h"
 #include "Base/Reader.h"
+#include "Base/Writer.h"
 #include <array>
 #include <filesystem>
 #include <fstream>
@@ -92,6 +94,42 @@ protected:
     {}
 };
 
+TEST_F(ReaderTest, parserCallbackCancellationIsNotReportedAsCorruptXml)
+{
+    class CancellingReader: public Base::XMLReader
+    {
+    public:
+        using Base::XMLReader::XMLReader;
+
+    protected:
+        void startElement(const XMLCh* const, const XMLCh* const, const XMLCh* const,
+                          const XERCES_CPP_NAMESPACE::Attributes&) override
+        {
+            throw Base::AbortException();
+        }
+    };
+
+    std::istringstream input("<?xml version='1.0'?><document><item/></document>");
+    CancellingReader reader("cancelled-parser.xml", input);
+    EXPECT_THROW(reader.readElement("document"), Base::AbortException);
+}
+
+TEST_F(ReaderTest, cancellationStopsParsingAndDoesNotLeakToTheNextRequest)
+{
+    ReaderXML fixture;
+    fixture.givenDataAsXMLStream("<first/><second/>");
+    std::stop_source request;
+    {
+        Base::CancellationScope operation(request.get_token());
+        fixture.Reader()->readElement("first");
+        request.request_stop();
+        // An uncancelled nested scope must not hide its parent's cancellation.
+        Base::CancellationScope nested(std::stop_token {});
+        EXPECT_THROW(fixture.Reader()->readElement("second"), Base::AbortException);
+    }
+    EXPECT_NO_THROW(fixture.Reader()->readElement("second"));
+}
+
 TEST_F(ReaderTest, beginCharStreamNormal)
 {
     // Arrange
@@ -104,6 +142,30 @@ TEST_F(ReaderTest, beginCharStreamNormal)
 
     // Assert
     EXPECT_TRUE(result.good());
+}
+
+TEST_F(ReaderTest, characterStreamPreservesAllParserChunks)
+{
+    std::string input;
+    for (int i = 0; i < 20000; ++i) {
+        input.push_back(static_cast<char>('A' + i % 26));
+    }
+    for (const auto format : {Base::CharStreamFormat::Raw,
+                              Base::CharStreamFormat::Base64Encoded}) {
+        Base::StringWriter writer;
+        writer.Stream() << "<?xml version='1.0'?><document><data>";
+        writer.beginCharStream(format) << input;
+        writer.endCharStream() << "</data><after/></document>";
+        std::istringstream xml(writer.getString());
+        Base::XMLReader reader("character-chunks.xml", xml);
+        reader.readElement("data");
+        auto& stream = reader.beginCharStream(format);
+        const std::string result {std::istreambuf_iterator<char>(stream), {}};
+        ASSERT_EQ(result.size(), input.size());
+        EXPECT_TRUE(result == input);
+        reader.readEndElement("data");
+        EXPECT_NO_THROW(reader.readElement("after"));
+    }
 }
 
 TEST_F(ReaderTest, beginCharStreamOpenClose)

--- a/tests/src/Base/Writer.cpp
+++ b/tests/src/Base/Writer.cpp
@@ -3,7 +3,14 @@
 #include <gtest/gtest.h>
 
 #include "Base/Exception.h"
+#include "Base/Persistence.h"
 #include "Base/Writer.h"
+
+#include <thread>
+#ifdef _MSC_VER
+#include <zipios++/zipios-config.h>
+#endif
+#include <zipios++/zipinputstream.h>
 
 // Writer is designed to be a base class, so for testing we actually instantiate a StringWriter,
 // which is derived from it
@@ -128,4 +135,128 @@ TEST_F(WriterTest, charStreamBase64Encoded)
     // Assert
     // Conversion done using https://www.base64encode.org for testing purposes
     EXPECT_EQ(std::string("RnJlZUNBRCByb2NrcyEg8J+qqPCfqqjwn6qo\n"), _writer.getString());
+}
+
+TEST_F(WriterTest, ownerCaptureDoesNotWriteDestinationOnOwner)
+{
+    const auto caller = std::this_thread::get_id();
+    int dispatched = 0;
+    auto dispatch = [&](std::function<void()> capture) {
+        std::exception_ptr failure;
+        std::thread owner([&] {
+            ++dispatched;
+            EXPECT_NE(std::this_thread::get_id(), caller);
+            try {
+                capture();
+            }
+            catch (...) {
+                failure = std::current_exception();
+            }
+        });
+        owner.join();
+        if (failure) {
+            std::rethrow_exception(failure);
+        }
+    };
+    _writer.Stream() << "before:";
+    _writer.captureOnOwner(dispatch, [&] {
+        _writer.beginCharStream() << "captured";
+        _writer.endCharStream();
+        // No owner write may have reached the destination stream buffer.
+        EXPECT_EQ(_writer.getString(), "before:");
+    });
+    EXPECT_EQ(_writer.getString(), "before:<![CDATA[captured]]>");
+    EXPECT_EQ(dispatched, 1);
+
+    EXPECT_THROW(
+        _writer.captureOnOwner(
+            dispatch,
+            [&] {
+                _writer.Stream() << "discarded";
+                throw std::runtime_error("capture failed");
+            }
+        ),
+        std::runtime_error
+    );
+    _writer.Stream() << ":after";
+    EXPECT_EQ(_writer.getString(), "before:<![CDATA[captured]]>:after");
+}
+
+TEST_F(WriterTest, nestedBinaryFilesRetainCaptureOwner)
+{
+    struct Payload final: Base::Persistence
+    {
+        std::thread::id caller;
+        const Payload* child {nullptr};
+        mutable int writes {0};
+        unsigned int getMemSize() const override
+        {
+            return 0;
+        }
+        void Restore(Base::XMLReader&) override
+        {}
+        void Save(Base::Writer& writer) const override
+        {
+            writer.addFile("payload.bin", this);
+        }
+        void SaveDocFile(Base::Writer& writer) const override
+        {
+            EXPECT_NE(std::this_thread::get_id(), caller);
+            ++writes;
+            writer.Stream().write("a\0b", 3);
+            if (child) {
+                child->Save(writer);
+            }
+        }
+    };
+    Payload parent, child;
+    parent.caller = child.caller = std::this_thread::get_id();
+    parent.child = &child;
+    std::ostringstream archive;
+    {
+        Base::ZipWriter writer(archive);
+        writer.putNextEntry("root.xml");
+        writer.captureOnOwner(
+            [](std::function<void()> capture) {
+                std::exception_ptr failure;
+                std::thread owner([&] {
+                    try {
+                        capture();
+                    }
+                    catch (...) {
+                        failure = std::current_exception();
+                    }
+                });
+                owner.join();
+                if (failure) {
+                    std::rethrow_exception(failure);
+                }
+            },
+            [&] {
+                writer.Stream() << "root";
+                parent.Save(writer);
+            }
+        );
+        writer.writeFiles();
+    }
+    EXPECT_EQ(parent.writes, 1);
+    EXPECT_EQ(child.writes, 1);
+    std::istringstream input(archive.str());
+    zipios::ZipInputStream zip(input);
+    std::ostringstream root;
+    root << zip.rdbuf();
+    EXPECT_EQ(root.str(), "root");
+    std::vector<std::string> names;
+    // ZipInputStream reports the central directory with an exception rather
+    // than an EOF entry. Read the two registered payloads explicitly.
+    for (int index = 0; index < 2; ++index) {
+        auto entry = zip.getNextEntry();
+        ASSERT_TRUE(entry->isValid());
+        names.push_back(entry->getName());
+        std::ostringstream bytes;
+        bytes << zip.rdbuf();
+        EXPECT_EQ(bytes.str(), std::string("a\0b", 3));
+    }
+    ASSERT_EQ(names.size(), 2);
+    EXPECT_NE(names[0], names[1]);
 }

--- a/tests/src/Gui/AsyncImageExport.cpp
+++ b/tests/src/Gui/AsyncImageExport.cpp
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include <Gui/AsyncImageExport.h>
+#include <gtest/gtest.h>
+#include <QFile>
+#include <QTemporaryDir>
+#include <chrono>
+#include <thread>
+
+namespace
+{
+bool awaitImage(Gui::detail::AsyncImageExport& job)
+{
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (!job.finish() && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::yield();
+    }
+    return job.finish();
+}
+}
+
+TEST(AsyncImageExport, DetachedPixelsAreWrittenAndScaledOnRuntime)
+{
+    QTemporaryDir directory;
+    ASSERT_TRUE(directory.isValid());
+    App::HostRuntime runtime(4);
+    QImage source(40, 20, QImage::Format_ARGB32);
+    source.fill(Qt::red);
+    const auto path = directory.filePath("frame.png");
+    Gui::detail::AsyncImageExport job(runtime, source, path, 20, 10, false);
+    source.fill(Qt::blue);
+    ASSERT_TRUE(awaitImage(job));
+    EXPECT_TRUE(job.finish());
+    const QImage saved(path);
+    ASSERT_FALSE(saved.isNull());
+    EXPECT_EQ(saved.size(), QSize(20, 10));
+    EXPECT_EQ(saved.pixelColor(0, 0), QColor(Qt::red));
+}
+
+TEST(AsyncImageExport, CancellationBeforeAdmissionPreservesExistingDestination)
+{
+    QTemporaryDir directory;
+    App::HostRuntime runtime(1);
+    std::promise<void> release;
+    auto ready = release.get_future().share();
+    auto occupied = runtime.submit([ready](std::stop_token) { ready.wait(); });
+    const auto path = directory.filePath("frame.png");
+    QFile original(path);
+    ASSERT_TRUE(original.open(QIODevice::WriteOnly));
+    original.write("original");
+    original.close();
+    QImage source(40, 20, QImage::Format_ARGB32);
+    source.fill(Qt::red);
+    Gui::detail::AsyncImageExport job(runtime, source, path, 20, 10, false);
+    job.cancel();
+    EXPECT_FALSE(job.finish());
+    release.set_value();
+    occupied.get();
+    EXPECT_THROW(awaitImage(job), std::runtime_error);
+    ASSERT_TRUE(original.open(QIODevice::ReadOnly));
+    EXPECT_EQ(original.readAll(), QByteArray("original"));
+}
+
+TEST(AsyncImageExport, InvalidDestinationIsReportedInsteadOfPublishingSuccess)
+{
+    QTemporaryDir directory;
+    App::HostRuntime runtime(2);
+    QImage source(2, 2, QImage::Format_ARGB32);
+    source.fill(Qt::red);
+    Gui::detail::AsyncImageExport job(runtime, source,
+        directory.filePath("missing/frame.png"), 2, 2, false);
+    EXPECT_THROW(awaitImage(job), std::runtime_error);
+    EXPECT_THROW(job.finish(), std::runtime_error);
+}

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -5,6 +5,7 @@ add_subdirectory(propertyeditor)
 
 # Standard C++ GTest tests
 add_executable(Gui_tests_run
+        AsyncImageExport.cpp
         Assistant.cpp
         Camera.cpp
         DocumentProjection.cpp
@@ -23,8 +24,11 @@ add_executable(Gui_tests_run
 
 # Qt tests
 setup_qt_test(DockLayoutState)
+setup_qt_test(DocumentBulkMutation)
 setup_qt_test(MacroTaskAcceptance)
 setup_qt_test(QuantitySpinBox)
+set(RenderMeshController_LIBS PartGui Part)
+setup_qt_test(RenderMeshController)
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main

--- a/tests/src/Gui/DocumentBulkMutation.cpp
+++ b/tests/src/Gui/DocumentBulkMutation.cpp
@@ -1,0 +1,1813 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <algorithm>
+#include <atomic>
+#include <future>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+#include <QCoreApplication>
+#include <QCloseEvent>
+#include <QElapsedTimer>
+#include <QMouseEvent>
+#include <QMessageBox>
+#include <QAbstractButton>
+#include <QListWidget>
+#include <QTest>
+#include <QThread>
+#include <QTimer>
+#include <QTemporaryDir>
+#include <QFile>
+#include <QScopeGuard>
+#include <QTreeWidget>
+#include <QTreeWidgetItemIterator>
+
+#include <src/App/InitApplication.h>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/DocumentObject.h>
+#include <App/DocumentObserverPython.h>
+#include <App/DocumentTimeline.h>
+#include <App/HostRuntime.h>
+#include <App/HostWorkflow.h>
+#include <App/GroupExtension.h>
+#include <App/Link.h>
+#include <App/PropertyLinks.h>
+#include <App/PropertyStandard.h>
+#include <Base/Interpreter.h>
+#include <Base/ConsoleObserver.h>
+#include <Base/Reader.h>
+#include <Base/Sequencer.h>
+#include <Base/Writer.h>
+#include <CXX/Objects.hxx>
+#include <Gui/Application.h>
+#include <Gui/Command.h>
+#include <Gui/Document.h>
+#include <Gui/FrameBudget.h>
+#include <Gui/FrameSequence.h>
+#include <Gui/ModelTreeBrowser.h>
+#include <Gui/MainWindow.h>
+#include <Gui/MDIView.h>
+#include <Gui/ProgressBar.h>
+#include <Gui/Selection/Selection.h>
+#include <Gui/ViewProviderDocumentObject.h>
+
+#ifdef _MSC_VER
+#include <Windows.h>
+#include <DbgHelp.h>
+#include <zipios++/zipios-config.h>
+#endif
+#include <zipios++/zipinputstream.h>
+
+namespace
+{
+
+#ifdef _MSC_VER
+LONG CALLBACK captureAccessViolation(EXCEPTION_POINTERS* exception)
+{
+    if (exception->ExceptionRecord->ExceptionCode != EXCEPTION_ACCESS_VIOLATION) {
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+    static std::atomic_flag captured;
+    const auto path = qEnvironmentVariable("VIBECAD_TEST_ACCESS_VIOLATION_DUMP");
+    if (path.isEmpty() || captured.test_and_set()) {
+        return EXCEPTION_CONTINUE_SEARCH;
+    }
+    // Capture first-chance corruption without attaching a debugger, whose
+    // exception-event overhead changes the timing of asynchronous restore.
+    HMODULE library = LoadLibraryW(L"dbghelp.dll");
+    auto writeDump = library ? reinterpret_cast<decltype(&MiniDumpWriteDump)>(
+        GetProcAddress(library, "MiniDumpWriteDump")) : nullptr;
+    HANDLE file = CreateFileW(reinterpret_cast<LPCWSTR>(path.utf16()), GENERIC_WRITE,
+        0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
+    if (writeDump && file != INVALID_HANDLE_VALUE) {
+        MINIDUMP_EXCEPTION_INFORMATION information {GetCurrentThreadId(), exception, FALSE};
+        writeDump(GetCurrentProcess(), GetCurrentProcessId(), file, MiniDumpWithFullMemory,
+            &information, nullptr, nullptr);
+    }
+    if (file != INVALID_HANDLE_VALUE) { CloseHandle(file); }
+    if (library) { FreeLibrary(library); }
+    return EXCEPTION_CONTINUE_SEARCH;
+}
+#endif
+
+App::HostWorkflow<bool> restoreGuiArchive(Gui::Document* document, std::string data)
+{
+    co_yield App::HostWorkflowStep {App::HostRuntime::Lane::Document, [&](std::stop_token) {
+        if (QThread::currentThread() == qApp->thread()) {
+            throw std::runtime_error("Archive preparation ran on the GUI owner");
+        }
+        Base::PyGILStateLocker python;
+        std::istringstream input(data);
+        zipios::ZipInputStream zip(input);
+        Base::Reader reader(zip, "GuiDocument.xml", 1);
+        document->RestoreDocFile(reader);
+        auto properties = reader.getLocalReader();
+        if (!properties || properties->FileList.empty()) {
+            throw std::runtime_error("GUI archive did not register binary properties");
+        }
+        properties->readFiles(zip);
+        for (const auto& file : properties->FileList) {
+            if (properties->hasReadFailed(file.FileName)) {
+                throw std::runtime_error("Embedded GUI property failed to restore");
+            }
+        }
+    }};
+    co_return QThread::currentThread() == qApp->thread();
+}
+
+App::HostWorkflow<std::string> saveGuiArchive(Gui::Document* document)
+{
+    std::ostringstream archive;
+    co_yield App::HostWorkflowStep {App::HostRuntime::Lane::Document, [&](std::stop_token) {
+                                        Base::PyGILStateLocker python;
+                                        Base::ZipWriter writer(archive);
+                                        writer.putNextEntry("GuiDocument.xml");
+                                        document->SaveDocFile(writer);
+                                        writer.writeFiles();
+                                    }};
+    co_return archive.str();
+}
+
+App::HostWorkflow<bool> saveDocumentCopy(App::Document* document, std::string filename)
+{
+    bool saved = false;
+    co_yield App::HostWorkflowStep {App::HostRuntime::Lane::Document, [&](std::stop_token) {
+        Base::PyGILStateLocker python;
+        saved = document->saveCopy(filename.c_str());
+    }};
+    co_return saved;
+}
+
+class MousePressProbe final: public QWidget
+{
+public:
+    bool receivedMousePress {false};
+
+protected:
+    void mousePressEvent(QMouseEvent* event) override
+    {
+        receivedMousePress = true;
+        QWidget::mousePressEvent(event);
+    }
+};
+
+class PostedEventProbe final: public QObject
+{
+public:
+    explicit PostedEventProbe(QEvent::Type eventType)
+        : eventType(eventType)
+    {}
+
+    int received {0};
+
+protected:
+    bool event(QEvent* event) override
+    {
+        if (event->type() == eventType) {
+            ++received;
+            return true;
+        }
+        return QObject::event(event);
+    }
+
+private:
+    QEvent::Type eventType;
+};
+
+class CloseRequestProbe final: public QObject
+{
+public:
+    int requests {0};
+
+protected:
+    bool eventFilter(QObject*, QEvent* event) override
+    {
+        if (event->type() != QEvent::Close) {
+            return false;
+        }
+        ++requests;
+        event->ignore();
+        return true; // Observe application shutdown without quitting the test runner.
+    }
+};
+
+}  // namespace
+
+class DocumentBulkMutationTest: public QObject
+{
+    Q_OBJECT
+
+    std::unique_ptr<Gui::Application> application;
+    std::unique_ptr<Gui::MainWindow> window;
+    std::unique_ptr<Base::ConsoleObserverStd> console;
+#ifdef _MSC_VER
+    void* exceptionHandler {nullptr};
+#endif
+
+private Q_SLOTS:
+    void closeRemainsRejectedWhenAnObserverStartsFinalization()
+    {
+        auto& guiApplication = *application;
+        auto& mainWindow = *window;
+        auto& application = App::GetApplication();
+        auto* document = application.newDocument("close_observer_finalization");
+        const std::string name = document->getName();
+        guiApplication.getDocument(document)->setModified(false);
+        fastsignals::scoped_connection connection = application.signalBeforeCloseDocument.connect(
+            [&](const App::Document& closing) {
+                if (closing.getName() == name) {
+                    closing.beginPresentationUpdate();
+                }
+            });
+
+        QVERIFY(!mainWindow.closeAllDocuments(true));
+        QCOMPARE(application.getDocument(name.c_str()), document);
+        document->endPresentationUpdate();
+
+        QCloseEvent close;
+        guiApplication.tryClose(&close);
+        QVERIFY(!close.isAccepted());
+        QVERIFY(!guiApplication.isClosing());
+        QCOMPARE(application.getDocument(name.c_str()), document);
+        QTRY_VERIFY_WITH_TIMEOUT(document->isPresentationUpdateActive(), 5000);
+        connection.disconnect();
+        document->endPresentationUpdate();
+        QVERIFY(application.closeDocument(name.c_str()));
+    }
+
+    void sharesPreparedProjectionAndWakesAfterMutation()
+    {
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("SharedProjectionCache");
+        for (int index = 0; index < 50; ++index) {
+            document->addObject("App::FeaturePython", "Source");
+        }
+        Gui::ModelTreeBrowserCache cache(document);
+        QObject firstReceiver;
+        QObject secondReceiver;
+        std::shared_ptr<const Gui::ModelTreeBrowserProjection> first;
+        std::shared_ptr<const Gui::ModelTreeBrowserProjection> second;
+        std::string error;
+        document->beginCooperativeMutation();
+        cache.request(&firstReceiver, [&](auto result, std::string failure) {
+            first = std::move(result);
+            error = std::move(failure);
+        });
+        cache.request(&secondReceiver, [&](auto result, std::string failure) {
+            second = std::move(result);
+            error = std::move(failure);
+        });
+        QCoreApplication::processEvents();
+        QVERIFY(!first && !second);
+        document->endCooperativeMutation();
+        QTRY_VERIFY_WITH_TIMEOUT(first && second, 10000);
+        QVERIFY(error.empty());
+        QCOMPARE(first.get(), second.get());
+        auto offOwnerRequest = std::async(std::launch::async, [&] {
+            try {
+                cache.request(&firstReceiver, [](auto, std::string) {});
+            }
+            catch (const std::exception&) {
+                return true;
+            }
+            return false;
+        });
+        QVERIFY(offOwnerRequest.get());
+        int invalidations = 0;
+        cache.observeInvalidation(&firstReceiver, [&] { ++invalidations; });
+        second.reset();
+        cache.request(&secondReceiver, [&](auto result, std::string) { second = std::move(result); });
+        QTRY_VERIFY(second);
+        QCOMPARE(first.get(), second.get());
+        document->beginCooperativeMutation();
+        for (auto* object : document->getObjects()) {
+            object->Label.setValue("Changed source");
+        }
+        document->endCooperativeMutation();
+        QCoreApplication::processEvents();
+        QCOMPARE(invalidations, 0); // Local property-specific handlers own refresh policy.
+        auto* added = document->addObject("App::FeaturePython", "NewSource");
+        second.reset();
+        cache.request(&secondReceiver, [&](auto result, std::string) { second = std::move(result); });
+        QTRY_VERIFY_WITH_TIMEOUT(second, 10000);
+        QVERIFY(second.get() != first.get());
+        QVERIFY(second->find(added));
+        QCOMPARE(invalidations, 0);
+        auto* linkedDocument = app.newDocument("ProjectionLinkedSource");
+        auto* linkedOwner = linkedDocument->addObject("App::FeaturePython", "LinkedOwner");
+        // Timeline ownership is document-local. Exercise a supported external
+        // reference instead: its incoming relationship is part of the capture.
+        auto* externalReference = static_cast<App::PropertyLink*>(
+            linkedOwner->addDynamicProperty("App::PropertyLink", "ReferencedSource"));
+        externalReference->setAllowExternal(true);
+        externalReference->setValue(added);
+        second.reset();
+        cache.request(&secondReceiver, [&](auto result, std::string) { second = std::move(result); });
+        QTRY_VERIFY_WITH_TIMEOUT(second, 10000);
+        const auto sources = second->sourceDocuments();
+        QVERIFY(std::ranges::find(sources, linkedDocument) != sources.end());
+        const auto beforeLinkedChange = invalidations;
+        for (int index = 0; index < 50; ++index) {
+            linkedOwner->Label.setValue(("Linked source " + std::to_string(index)).c_str());
+        }
+        QTRY_COMPARE(invalidations, beforeLinkedChange + 1);
+        QVERIFY(!second->isCurrent());
+        app.closeDocument(document->getName());
+        app.closeDocument(linkedDocument->getName());
+    }
+
+    void projectionSchemaChangesInvalidateWithoutValueChanges()
+    {
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("ProjectionSchemaChanges");
+        auto* object = document->addObject("App::FeaturePython", "Source");
+        Gui::ModelTreeBrowserCache cache(document);
+        QObject receiver;
+        Gui::ModelTreeBrowserCache::Result snapshot;
+        int invalidations = 0;
+        cache.observeInvalidation(&receiver, [&] { ++invalidations; });
+        const auto refresh = [&] {
+            snapshot.reset();
+            cache.request(&receiver, [&](auto result, std::string) { snapshot = std::move(result); });
+        };
+        refresh();
+        QTRY_VERIFY_WITH_TIMEOUT(snapshot, 10000);
+
+        // No property value is set: schema edits themselves must wake the
+        // consumer, including removal where the old property no longer exists.
+        auto* property = object->addDynamicProperty("App::PropertyString", "Metadata");
+        QVERIFY(property);
+        QTRY_COMPARE(invalidations, 1);
+        QVERIFY(!snapshot->isCurrent());
+        refresh();
+        QTRY_VERIFY_WITH_TIMEOUT(snapshot, 10000);
+        QVERIFY(object->renameDynamicProperty(property, "RenamedMetadata"));
+        QTRY_COMPARE(invalidations, 2);
+        QVERIFY(!snapshot->isCurrent());
+        refresh();
+        QTRY_VERIFY_WITH_TIMEOUT(snapshot, 10000);
+        QVERIFY(object->removeDynamicProperty("RenamedMetadata"));
+        QTRY_COMPARE(invalidations, 3);
+        QVERIFY(!snapshot->isCurrent());
+        refresh();
+        QTRY_VERIFY_WITH_TIMEOUT(snapshot, 10000);
+
+        // Use the same exported type factory as document restore and Python
+        // addExtension; the template's type methods are not exported on Windows.
+        auto* extension = static_cast<App::Extension*>(
+            Base::Type::fromName("App::GroupExtensionPython").createInstance());
+        QVERIFY(extension);
+        extension->initExtension(object); // Container owns Python extensions.
+        QTRY_COMPARE(invalidations, 4);
+        QVERIFY(!snapshot->isCurrent());
+        refresh();
+        QTRY_VERIFY_WITH_TIMEOUT(snapshot, 10000);
+        app.closeDocument(document->getName());
+    }
+
+    void initTestCase()
+    {
+        tests::initApplication();
+#ifdef _MSC_VER
+        if (qEnvironmentVariableIsSet("VIBECAD_TEST_ACCESS_VIOLATION_DUMP")) {
+            exceptionHandler = AddVectoredExceptionHandler(1, captureAccessViolation);
+        }
+#endif
+        if (qEnvironmentVariableIsSet("VIBECAD_RESTORE_DETAIL_TRACE")) {
+            console = std::make_unique<Base::ConsoleObserverStd>();
+            Base::Console().attachObserver(console.get());
+        }
+        Gui::Application::initApplication();
+        Gui::Application::initOpenInventor();
+        application = std::make_unique<Gui::Application>(true);
+        window = std::make_unique<Gui::MainWindow>();
+        // Native GUI commands use the application's normal console aliases.
+        Base::Interpreter().runString("import FreeCAD as App\nimport FreeCADGui as Gui\n");
+    }
+
+    void cleanupTestCase()
+    {
+        App::GetApplication().closeAllDocuments();
+        window.reset();
+        application.reset();
+        if (console) { Base::Console().detachObserver(console.get()); }
+#ifdef _MSC_VER
+        if (exceptionHandler) { RemoveVectoredExceptionHandler(exceptionHandler); }
+#endif
+    }
+
+    void visibilityBurstUpdatesFolderWithoutReplacingHierarchy()
+    {
+        auto& guiApplication = *application;
+        auto& mainWindow = *window;
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("FolderVisibilityBurst");
+        std::vector<App::DocumentObject*> objects;
+        for (int index = 0; index < 50; ++index) {
+            objects.push_back(document->addObject("App::FeaturePython", "VisibilitySource"));
+            objects.back()->Visibility.setValue(true);
+        }
+        QTreeWidget* tree = nullptr;
+        for (auto* candidate : mainWindow.findChildren<QTreeWidget*>()) {
+            if (candidate->inherits("Gui::TreeWidget")) { tree = candidate; break; }
+        }
+        QVERIFY(tree);
+        const auto folderWithTip = [&](const QString& tip) -> QTreeWidgetItem* {
+            for (QTreeWidgetItemIterator it(tree); *it; ++it) {
+                if ((*it)->toolTip(0) == tip) { return *it; }
+            }
+            return nullptr;
+        };
+        QTRY_VERIFY_WITH_TIMEOUT(folderWithTip(QStringLiteral("50 of 50 items visible")), 10000);
+        auto* folder = folderWithTip(QStringLiteral("50 of 50 items visible"));
+        constexpr int marker = Qt::UserRole + 123;
+        folder->setData(0, marker, QStringLiteral("retained hierarchy"));
+        for (auto* object : objects) { object->Visibility.setValue(false); }
+        QTRY_VERIFY_WITH_TIMEOUT(folderWithTip(QStringLiteral("0 of 50 items visible")), 10000);
+        auto* hiddenFolder = folderWithTip(QStringLiteral("0 of 50 items visible"));
+        QCOMPARE(hiddenFolder->data(0, marker).toString(), QStringLiteral("retained hierarchy"));
+        for (int index = 0; index < 25; ++index) { objects[index]->Visibility.setValue(true); }
+        QTRY_VERIFY_WITH_TIMEOUT(folderWithTip(QStringLiteral("25 of 50 items visible")), 10000);
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+
+        auto* retained = folderWithTip(QStringLiteral("25 of 50 items visible"));
+        retained->setExpanded(true);
+        QVERIFY(retained->childCount() > 0);
+        auto* selectedItem = retained->child(0);
+        const auto selectedName = selectedItem->text(2);
+        selectedItem->setSelected(true);
+        int insertedRows = 0;
+        int removedRows = 0;
+        bool transferredPopulatedSubtree = false;
+        const auto inspectRows = [&](const QModelIndex& parent, int first, int last) {
+            for (int row = first; row <= last; ++row) {
+                transferredPopulatedSubtree |= tree->model()->rowCount(
+                    tree->model()->index(row, 0, parent)) != 0;
+            }
+        };
+        const auto inserted = QObject::connect(tree->model(), &QAbstractItemModel::rowsInserted,
+            tree, [&](const QModelIndex& parent, int first, int last) {
+                insertedRows += last - first + 1;
+                inspectRows(parent, first, last);
+            });
+        const auto removed = QObject::connect(tree->model(), &QAbstractItemModel::rowsAboutToBeRemoved,
+            tree, [&](const QModelIndex& parent, int first, int last) {
+                removedRows += last - first + 1;
+                inspectRows(parent, first, last);
+            });
+        // A schema-only change requests a replacement hierarchy. Qt does not
+        // retain expansion/visibility set on detached staging items.
+        objects.front()->addDynamicProperty("App::PropertyString", "RebuildBrowser");
+        QTRY_VERIFY_WITH_TIMEOUT(
+            folderWithTip(QStringLiteral("25 of 50 items visible"))
+                && folderWithTip(QStringLiteral("25 of 50 items visible"))->data(0, marker).isNull(),
+            10000);
+        auto* replacement = folderWithTip(QStringLiteral("25 of 50 items visible"));
+        QVERIFY(replacement->isExpanded());
+        bool selectionRetained = false;
+        for (int index = 0; index < replacement->childCount(); ++index) {
+            const auto* child = replacement->child(index);
+            if (child->text(2) == selectedName) { selectionRetained = child->isSelected(); }
+        }
+        QVERIFY(selectionRetained);
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        QObject::disconnect(inserted);
+        QObject::disconnect(removed);
+        QVERIFY(insertedRows >= 50);
+        QVERIFY(removedRows >= 50);
+        QVERIFY(!transferredPopulatedSubtree);
+        app.closeDocument(document->getName());
+    }
+
+    void transientLinkPlacementsDoNotScheduleTreeRefresh()
+    {
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("TransientLinkPlacement");
+        auto* link = dynamic_cast<App::Link*>(
+            document->addObject("App::Link", "AnimatedLink"));
+        QVERIFY(link);
+
+        QTreeWidget* tree = nullptr;
+        for (auto* candidate : window->findChildren<QTreeWidget*>()) {
+            if (candidate->inherits("Gui::TreeWidget")) {
+                tree = candidate;
+                break;
+            }
+        }
+        QVERIFY(tree);
+        QTRY_VERIFY_WITH_TIMEOUT(
+            !tree->findItems(
+                     QStringLiteral("AnimatedLink"),
+                     Qt::MatchStartsWith | Qt::MatchRecursive)
+                 .empty(),
+            5000
+        );
+
+        const auto activeTreeTimers = [tree] {
+            const auto timers =
+                tree->findChildren<QTimer*>(QString(), Qt::FindDirectChildrenOnly);
+            return std::count_if(
+                timers.cbegin(),
+                timers.cend(),
+                [](const QTimer* timer) { return timer->isActive(); }
+            );
+        };
+        QTRY_COMPARE_WITH_TIMEOUT(activeTreeTimers(), 0, 5000);
+
+        link->setStatus(App::ObjectStatus::NoTouch, true);
+        link->LinkPlacement.setValue(
+            Base::Placement(Base::Vector3d(1, 2, 3), Base::Rotation()));
+        QCOMPARE(activeTreeTimers(), 0);
+        link->setStatus(App::ObjectStatus::NoTouch, false);
+
+        QVERIFY(app.closeDocument(document->getName()));
+    }
+
+    void restoresGuiArchivePropertiesFromDocumentWorker()
+    {
+        auto& guiApplication = *application;
+        auto& mainWindow = *window;
+        auto& application = App::GetApplication();
+        auto* document = application.newDocument("worker_gui_restore");
+        auto* guiDocument = guiApplication.getDocument(document);
+        QVERIFY(guiDocument);
+        std::vector<Gui::ViewProviderDocumentObject*> providers;
+        for (int index = 0; index < 50; ++index) {
+            auto* object = document->addObject("App::FeaturePython", "RestoredFeature");
+            auto* provider = dynamic_cast<Gui::ViewProviderDocumentObject*>(
+                guiDocument->getViewProvider(object)
+            );
+            QVERIFY(provider);
+            provider->Visibility.setValue(false);
+            provider->setTreeRank(index);
+            auto* colours = dynamic_cast<App::PropertyColorList*>(provider->addDynamicProperty(
+                "App::PropertyColorList", "RestoreColours"
+            ));
+            QVERIFY(colours);
+            colours->setValues({Base::Color(1, 0, 0, 0.5F), Base::Color(0, 1, 0, 0.5F)});
+            providers.push_back(provider);
+        }
+
+        bool saved = false;
+        auto archive = saveGuiArchive(guiDocument).runAsync(
+            application.hostRuntime(), [](std::function<void()> resume) {
+                if (!Gui::dispatchToGuiFrame(std::move(resume))) {
+                    throw std::runtime_error("Owner dispatch failed");
+                }
+            }, [&] { saved = true; });
+        QTRY_VERIFY_WITH_TIMEOUT(saved, 10000);
+        std::string archiveData;
+        try {
+            archiveData = archive.get();
+        }
+        catch (const std::exception& error) {
+            QFAIL(error.what());
+        }
+        for (auto* provider : providers) {
+            provider->Visibility.setValue(true);
+            provider->setTreeRank(-1);
+            static_cast<App::PropertyColorList*>(provider->getPropertyByName("RestoreColours"))
+                ->setValues({});
+        }
+
+        // Exercise real XML and embedded binary restoration, including the
+        // Python-owned caller case. Neither GUI adoption nor its callbacks may
+        // run on the document worker or deadlock waiting for its GIL.
+        std::atomic<int> wrongThread {0};
+        std::atomic<int> notifications {0};
+        fastsignals::scoped_connection connection = guiApplication.signalChangedObject.connect(
+            [&](const Gui::ViewProvider&, const App::Property&) {
+                if (QThread::currentThread() != qApp->thread()) {
+                    ++wrongThread;
+                }
+                Base::PyGILStateLocker python;
+                ++notifications;
+            }
+        );
+        bool completionNotified = false;
+        std::future<bool> restored;
+        restored = restoreGuiArchive(guiDocument, std::move(archiveData)).runAsync(
+            application.hostRuntime(), [](std::function<void()> resume) {
+                if (!Gui::dispatchToGuiFrame(std::move(resume))) {
+                    throw std::runtime_error("Owner dispatch failed");
+                }
+            }, [&] {
+                QCOMPARE(QThread::currentThread(), qApp->thread());
+                QVERIFY(restored.valid());
+                QVERIFY(restored.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready);
+                completionNotified = true;
+            }
+        );
+        QTRY_VERIFY_WITH_TIMEOUT(completionNotified, 10000);
+        try {
+            QVERIFY(restored.get());
+        }
+        catch (const std::exception& error) {
+            QFAIL(error.what());
+        }
+        QCOMPARE(wrongThread.load(), 0);
+        QVERIFY(notifications.load() >= static_cast<int>(providers.size()));
+        for (std::size_t index = 0; index < providers.size(); ++index) {
+            auto* provider = providers[index];
+            QVERIFY(!provider->Visibility.getValue());
+            QCOMPARE(provider->getTreeRank(), static_cast<int>(index));
+            const auto& colours = static_cast<App::PropertyColorList*>(
+                provider->getPropertyByName("RestoreColours")
+            )->getValues();
+            QCOMPARE(colours.size(), std::size_t(2));
+            QCOMPARE(colours[0].r, 1.0F);
+            QCOMPARE(colours[1].g, 1.0F);
+        }
+        connection.disconnect();
+        application.closeDocument(document->getName());
+    }
+
+    void queuesNativeDocumentOpenWithoutBlockingInput()
+    {
+        auto& guiApplication = *application;
+        auto& mainWindow = *window;
+        QTemporaryDir files;
+        QVERIFY(files.isValid());
+        const auto filename = files.filePath(QStringLiteral("queued-restore.FCStd")).toStdString();
+        auto& application = App::GetApplication();
+        auto* original = application.newDocument("queued_restore_fixture");
+        for (int index = 0; index < 50; ++index) {
+            original->addObject("App::FeaturePython", "RestoredFeature");
+        }
+        bool saveCompleted = false;
+        auto saved = saveDocumentCopy(original, filename).runAsync(
+            application.hostRuntime(), [](std::function<void()> resume) {
+                if (!Gui::dispatchToGuiFrame(std::move(resume))) {
+                    throw std::runtime_error("Owner dispatch failed");
+                }
+            }, [&] { saveCompleted = true; });
+        QTRY_VERIFY_WITH_TIMEOUT(saveCompleted, 10000);
+        try { QVERIFY(saved.get()); }
+        catch (const std::exception& error) { QFAIL(error.what()); }
+        QVERIFY(application.closeDocument(original->getName()));
+        const auto cancelledFile = files.filePath(QStringLiteral("cancelled.FCStd"));
+        QVERIFY(QFile::copy(QString::fromStdString(filename), cancelledFile));
+        const auto followingFile = files.filePath(QStringLiteral("after-cancellation.FCStd"));
+        QVERIFY(QFile::copy(QString::fromStdString(filename), followingFile));
+
+        MousePressProbe input;
+        input.show();
+        int completed = 0;
+        std::string openedName;
+        std::string cancelledName;
+        std::string followingName;
+        std::stop_source cancellation;
+        fastsignals::scoped_connection cancelDuringFinalization;
+        fastsignals::scoped_connection opening = application.signalStartRestoreDocument.connect(
+            [&](const App::Document& restoring) {
+                if (restoring.FileName.getStrValue().find("cancelled.FCStd") != std::string::npos) {
+                    cancelledName = restoring.getName();
+                    cancelDuringFinalization = application.getDocument(restoring.getName())
+                        ->signalFinishRestoreObject.connect(
+                        [&](const App::DocumentObject&) { cancellation.request_stop(); });
+                }
+                QCoreApplication::postEvent(&input, new QMouseEvent(
+                    QEvent::MouseButtonPress, QPointF(1, 1), QPointF(1, 1),
+                    Qt::LeftButton, Qt::LeftButton, Qt::NoModifier));
+            });
+        App::OpenDocumentsRequest first;
+        first.filenames = {filename};
+        first.callback = [&](App::OpenDocumentsResult result) {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            if (result.failure) {
+                try { std::rethrow_exception(result.failure); }
+                catch (const Base::Exception& error) { QFAIL(error.what()); }
+                catch (const std::exception& error) { QFAIL(error.what()); }
+                catch (...) { QFAIL("Unknown open failure"); }
+            }
+            QCOMPARE(result.documents.size(), std::size_t(1));
+            QVERIFY(result.documents.front());
+            QVERIFY(result.errors.front().empty());
+            QVERIFY(result.documents.front()->getObject("RestoredFeature049"));
+            openedName = result.documents.front()->getName();
+            QVERIFY(input.receivedMousePress);
+            QCOMPARE(completed++, 0);
+        };
+        App::OpenDocumentsRequest missing;
+        missing.filenames = {files.filePath(QStringLiteral("missing.FCStd")).toStdString()};
+        missing.callback = [&](App::OpenDocumentsResult result) {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            QVERIFY(!result.failure);
+            QCOMPARE(result.documents.size(), std::size_t(1));
+            QVERIFY(!result.documents.front());
+            QVERIFY(!result.errors.front().empty());
+            QCOMPARE(completed++, 1);
+        };
+        App::OpenDocumentsRequest cancelled;
+        cancelled.filenames = {cancelledFile.toStdString()};
+        cancelled.cancellation = cancellation;
+        cancelled.callback = [&](App::OpenDocumentsResult result) {
+            cancelDuringFinalization.disconnect();
+            bool aborted = false;
+            if (result.failure) {
+                try {
+                    std::rethrow_exception(result.failure);
+                }
+                catch (const Base::AbortException&) {
+                    aborted = true;
+                }
+                catch (...) {}
+            }
+            QVERIFY(aborted);
+            QVERIFY(!cancelledName.empty());
+            QVERIFY(!application.getDocument(cancelledName.c_str()));
+            QCOMPARE(completed++, 2);
+        };
+        App::OpenDocumentsRequest following;
+        following.filenames = {followingFile.toStdString()};
+        following.inputFlags = {{.createView = false}};
+        following.callback = [&](App::OpenDocumentsResult result) {
+            QVERIFY(!result.failure);
+            QCOMPARE(result.documents.size(), std::size_t(1));
+            QVERIFY(result.documents.front());
+            QVERIFY(result.errors.front().empty());
+            QVERIFY(result.documents.front()->getObject("RestoredFeature049"));
+            auto* guiDocument = guiApplication.getDocument(result.documents.front());
+            QVERIFY(guiDocument);
+            QVERIFY(guiDocument->getMDIViews().empty());
+            followingName = result.documents.front()->getName();
+            QCOMPARE(completed++, 3);
+        };
+        guiApplication.openNativeDocumentAsync(filename.c_str(), false, std::move(first.callback));
+        application.openDocumentsAsync(std::move(missing));
+        application.openDocumentsAsync(std::move(cancelled));
+        application.openDocumentsAsync(std::move(following));
+        QCOMPARE(completed, 0);
+        QVERIFY(application.hasPendingDocumentOpens());
+        QTRY_COMPARE_WITH_TIMEOUT(completed, 4, 10000);
+        QVERIFY(!application.hasPendingDocumentOpens());
+        // Open completion precedes the independently tracked display adoption.
+        // Wait for the actual close barrier, not just the file-open callback.
+        QTRY_VERIFY_WITH_TIMEOUT(application.getDocument(openedName.c_str())->isClosable(), 5000);
+        QTRY_VERIFY_WITH_TIMEOUT(application.getDocument(followingName.c_str())->isClosable(), 5000);
+        QVERIFY(application.closeDocument(openedName.c_str()));
+        QVERIFY(application.closeDocument(followingName.c_str()));
+
+        // Cancelling the final open does not mean a previous document's
+        // asynchronous display adoption is finished. Resume close only after
+        // that authoritative lease ends, not merely when the open queue empties.
+        auto* displaying = application.newDocument("close_waits_for_display");
+        const std::string displayingName = displaying->getName();
+        displaying->beginPresentationUpdate();
+        auto displayWaiter = application.hostRuntime().submit(
+            App::HostRuntime::Lane::Document, [displaying](std::stop_token) {
+                displaying->waitForPresentationReady();
+            });
+        CloseRequestProbe closeProbe;
+        mainWindow.installEventFilter(&closeProbe);
+        bool cancelledOpenFinished = false;
+        App::OpenDocumentsRequest closingRequest;
+        closingRequest.filenames = {filename};
+        closingRequest.callback = [&](App::OpenDocumentsResult) { cancelledOpenFinished = true; };
+        application.openDocumentsAsync(std::move(closingRequest));
+        QCloseEvent close;
+        guiApplication.tryClose(&close);
+        QVERIFY(!close.isAccepted());
+        QTRY_VERIFY_WITH_TIMEOUT(cancelledOpenFinished, 10000);
+        QCoreApplication::sendPostedEvents(&mainWindow, QEvent::MetaCall);
+        QCOMPARE(closeProbe.requests, 0);
+        displaying->endPresentationUpdate();
+        QTRY_VERIFY_WITH_TIMEOUT(
+            displayWaiter.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready, 5000);
+        displayWaiter.get();
+        QTRY_COMPARE_WITH_TIMEOUT(closeProbe.requests, 1, 5000);
+        QVERIFY(application.closeDocument(displayingName.c_str()));
+    }
+
+    void repeatedVisibilityAdoptionDoesNotDirtySavedDocument()
+    {
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("visibility_adoption");
+        auto* object = document->addObject("App::FeaturePython", "Result");
+        auto* gui = application->getDocument(document);
+        auto* provider = dynamic_cast<Gui::ViewProviderDocumentObject*>(gui->getViewProvider(object));
+        QVERIFY(provider);
+        provider->setStatus(Gui::ViewStatus::TouchDocument, true);
+        provider->hide();
+        gui->setModified(false);
+        provider->hide();
+        QVERIFY(!gui->isModified());
+        QVERIFY(!provider->Visibility.getValue());
+        provider->show();
+        QVERIFY(gui->isModified());
+        gui->setModified(false);
+        provider->show();
+        QVERIFY(!gui->isModified());
+        QVERIFY(provider->Visibility.getValue());
+        QVERIFY(app.closeDocument(document->getName()));
+    }
+
+    void queuesInteractiveSaveAndKeepsDocumentLeasedUntilCompletion()
+    {
+        auto& app = App::GetApplication();
+        QTemporaryDir files;
+        QVERIFY(files.isValid());
+        auto* document = app.newDocument("queued_save");
+        auto* guiDocument = application->getDocument(document);
+        for (int index = 0; index < 50; ++index) {
+            document->addObject("App::FeaturePython", "SavedFeature");
+        }
+        const auto filename = files.filePath("saved.FCStd").toStdString();
+        QVERIFY(document->saveAs(filename.c_str()));
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        std::vector<std::string> expectedObjects;
+        for (const auto* object : document->getObjects()) {
+            expectedObjects.emplace_back(object->getNameInDocument());
+        }
+        std::sort(expectedObjects.begin(), expectedObjects.end());
+        document->Comment.setValue("queued save preserves this edit");
+        guiDocument->setModified(true);
+        bool finished = false;
+        bool success = false;
+        QVERIFY(guiDocument->saveAsync([&](bool saved) {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            success = saved;
+            finished = true;
+        }));
+        QVERIFY(!finished);
+        QVERIFY(document->isCooperativeMutationActive());
+        QVERIFY(guiDocument->isModified());
+        QVERIFY(!app.closeDocument(document->getName()));
+        QTRY_VERIFY_WITH_TIMEOUT(finished, 10000);
+        QVERIFY(success);
+        QVERIFY(!document->isCooperativeMutationActive());
+        QVERIFY(!guiDocument->isModified());
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+
+        // A filesystem failure must complete the request and release the lease,
+        // without claiming the user's edits were saved.
+        QFile blocker(files.filePath("not-a-directory"));
+        QVERIFY(blocker.open(QIODevice::WriteOnly));
+        blocker.close();
+        document->FileName.setValue((blocker.fileName() + "/cannot-save.FCStd").toStdString());
+        document->Comment.setValue("must remain modified after save failure");
+        guiDocument->setModified(true);
+        finished = false;
+        success = true;
+        QVERIFY(guiDocument->saveAsync([&](bool saved) {
+            success = saved;
+            finished = true;
+        }));
+        QTRY_VERIFY_WITH_TIMEOUT(finished, 10000);
+        QVERIFY(!success);
+        QVERIFY(!document->isCooperativeMutationActive());
+        QVERIFY(guiDocument->isModified());
+        QVERIFY(app.closeDocument(document->getName()));
+        auto* restored = app.openDocument(filename.c_str());
+        QVERIFY(restored);
+        std::vector<std::string> restoredObjects;
+        for (const auto* object : restored->getObjects()) {
+            restoredObjects.emplace_back(object->getNameInDocument());
+        }
+        std::sort(restoredObjects.begin(), restoredObjects.end());
+        QVERIFY(restoredObjects == expectedObjects);
+        QCOMPARE(restored->Comment.getStrValue(), std::string("queued save preserves this edit"));
+        QTRY_VERIFY_WITH_TIMEOUT(!restored->isPresentationUpdateActive(), 10000);
+        QVERIFY(app.closeDocument(restored->getName()));
+    }
+
+    void versionWarningReturnsBeforeAnswerAndReportsCancellation()
+    {
+        auto& app = App::GetApplication();
+        QTemporaryDir files;
+        QVERIFY(files.isValid());
+        auto* document = app.newDocument("version_warning");
+        auto* gui = application->getDocument(document);
+        const auto filename = files.filePath("version.FCStd").toStdString();
+        QVERIFY(document->saveAs(filename.c_str()));
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        document->Comment.setValue("unsaved edit");
+        gui->setModified(true);
+        auto preferences = app.GetParameterGroupByPath("User parameter:BaseApp/Preferences/Document");
+        const bool disabled = preferences->GetBool("DisableVersionCheckOnSave", false);
+        auto& config = App::Application::Config();
+        const auto major = config["BuildVersionMajor"];
+        const auto restore = qScopeGuard([&] {
+            preferences->SetBool("DisableVersionCheckOnSave", disabled);
+            config["BuildVersionMajor"] = major;
+        });
+        preferences->SetBool("DisableVersionCheckOnSave", false);
+        config["BuildVersionMajor"] = "999";
+        bool returned = false;
+        bool returnedBeforeAnswer = false;
+        bool answered = false;
+        int callbacks = 0;
+        bool saved = true;
+        // Exercise the real warning and cancel it even on the old nested-exec
+        // implementation, so a regression fails instead of hanging the suite.
+        QTimer::singleShot(0, window.get(), [&] {
+            auto* prompt = qobject_cast<QMessageBox*>(QApplication::activeModalWidget());
+            if (!prompt) { return; }
+            returnedBeforeAnswer = returned;
+            answered = true;
+            prompt->button(QMessageBox::Cancel)->click();
+        });
+        const bool accepted = gui->saveAsync([&](bool success) {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            ++callbacks;
+            saved = success;
+        });
+        returned = true;
+        QTRY_VERIFY_WITH_TIMEOUT(answered, 5000);
+        QVERIFY(returnedBeforeAnswer);
+        QVERIFY(accepted);
+        QTRY_COMPARE_WITH_TIMEOUT(callbacks, 1, 5000);
+        QVERIFY(!saved);
+        QVERIFY(gui->isModified());
+        QVERIFY(!document->isCooperativeMutationActive());
+        QVERIFY(app.closeDocument(document->getName()));
+        auto* reopened = app.openDocument(filename.c_str());
+        QVERIFY(reopened);
+        QVERIFY(reopened->Comment.getStrValue() != "unsaved edit");
+        QTRY_VERIFY_WITH_TIMEOUT(!reopened->isPresentationUpdateActive(), 10000);
+        gui = application->getDocument(reopened);
+        reopened->Comment.setValue("approved upgrade");
+        gui->setModified(true);
+        callbacks = 0;
+        QVERIFY(gui->saveAsync([&](bool success) { ++callbacks; saved = success; }));
+        auto* prompt = window->findChild<QMessageBox*>("confirmVersionUpgrade");
+        QVERIFY(prompt);
+        for (auto* button : prompt->buttons()) {
+            if (prompt->buttonRole(button) == QMessageBox::AcceptRole) {
+                button->click();
+                break;
+            }
+        }
+        QCOMPARE(callbacks, 0);
+        QTRY_COMPARE_WITH_TIMEOUT(callbacks, 1, 10000);
+        QVERIFY(saved);
+        QVERIFY(!gui->isModified());
+        QTRY_VERIFY_WITH_TIMEOUT(!reopened->isPresentationUpdateActive(), 10000);
+        QVERIFY(app.closeDocument(reopened->getName()));
+        reopened = app.openDocument(filename.c_str());
+        QCOMPARE(reopened->Comment.getStrValue(), std::string("approved upgrade"));
+        QTRY_VERIFY_WITH_TIMEOUT(!reopened->isPresentationUpdateActive(), 10000);
+        QVERIFY(app.closeDocument(reopened->getName()));
+    }
+
+    void refusesQueuedSaveDuringAnEditingTransaction()
+    {
+        auto& app = App::GetApplication();
+        QTemporaryDir files;
+        QVERIFY(files.isValid());
+        auto* document = app.newDocument("save_edit_conflict");
+        auto* guiDocument = application->getDocument(document);
+        QVERIFY(document->saveAs(files.filePath("editing.FCStd").toStdString().c_str()));
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        document->openTransaction("Feature edit");
+        bool finished = false;
+        const bool accepted = guiDocument->saveAsync([&](bool) { finished = true; });
+        if (accepted) {
+            QTRY_VERIFY_WITH_TIMEOUT(finished, 10000);
+        }
+        document->abortTransaction();
+        QVERIFY(app.closeDocument(document->getName()));
+        QVERIFY(!accepted);
+        QVERIFY(!finished);
+    }
+
+    void archiveSaveRejectsConflictingGuiMutation()
+    {
+        auto& app = App::GetApplication();
+        QTemporaryDir files;
+        QVERIFY(files.isValid());
+        auto* document = app.newDocument("save_mutation_conflict");
+        auto* other = app.newDocument("other_save_document");
+        auto* object = document->addObject("App::FeaturePython", "SavedFeature");
+        auto* guiDocument = application->getDocument(document);
+        QVERIFY(document->saveAs(files.filePath("snapshot.FCStd").toStdString().c_str()));
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        const std::string comment = document->Comment.getStrValue();
+        const std::string label = object->Label.getStrValue();
+        bool attempted = false;
+        int rejected = 0;
+        auto connection = document->signalSaveDocument.connect([&](Base::Writer&) {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            attempted = true;
+            const auto attempt = [&](auto mutation) {
+                try { mutation(); }
+                catch (const Base::RuntimeError&) { ++rejected; }
+            };
+            attempt([&] { document->Comment.setValue("racing document edit"); });
+            attempt([&] { object->Label.setValue("racing object edit"); });
+            attempt([&] { document->addObject("App::FeaturePython", "RacingFeature"); });
+            // The other document is independent of the archive being written.
+            other->Comment.setValue("independent edit is allowed");
+        });
+        bool finished = false;
+        bool success = false;
+        QVERIFY(guiDocument->saveAsync([&](bool saved) {
+            success = saved;
+            finished = true;
+        }));
+        QTRY_VERIFY_WITH_TIMEOUT(finished, 10000);
+        connection.disconnect();
+        QVERIFY(attempted);
+        QVERIFY(success);
+        const bool intact = document->Comment.getStrValue() == comment
+            && object->Label.getStrValue() == label && !document->getObject("RacingFeature");
+        QCOMPARE(other->Comment.getStrValue(), std::string("independent edit is allowed"));
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        QVERIFY(app.closeDocument(document->getName()));
+        QVERIFY(app.closeDocument(other->getName()));
+        QCOMPARE(rejected, 3);
+        QVERIFY(intact);
+    }
+
+    void queuedSavePreservesEditsMadeByCompletionObservers()
+    {
+        auto& app = App::GetApplication();
+        QTemporaryDir files;
+        QVERIFY(files.isValid());
+        auto* document = app.newDocument("save_completion_edit");
+        auto* object = document->addObject("App::FeaturePython", "SavedFeature");
+        auto* guiDocument = application->getDocument(document);
+        const auto filename = files.filePath("completion.FCStd").toStdString();
+        QVERIFY(document->saveAs(filename.c_str()));
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        object->Label.setValue("saved label");
+        guiDocument->setModified(true);
+        auto connection = document->signalFinishSave.connect([&](const App::Document&, const std::string&) {
+            object->Label.setValue("new edit after capture");
+        });
+        bool finished = false;
+        bool success = false;
+        QVERIFY(guiDocument->saveAsync([&](bool saved) {
+            success = saved;
+            finished = true;
+        }));
+        QTRY_VERIFY_WITH_TIMEOUT(finished, 10000);
+        connection.disconnect();
+        QVERIFY(success);
+        const bool stillModified = guiDocument->isModified();
+        QCOMPARE(object->Label.getStrValue(), std::string("new edit after capture"));
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        QVERIFY(app.closeDocument(document->getName()));
+        auto* restored = app.openDocument(filename.c_str());
+        QVERIFY(restored);
+        QCOMPARE(restored->getObject("SavedFeature")->Label.getStrValue(), std::string("saved label"));
+        QTRY_VERIFY_WITH_TIMEOUT(!restored->isPresentationUpdateActive(), 10000);
+        QVERIFY(app.closeDocument(restored->getName()));
+        QVERIFY(stillModified);
+    }
+
+    void queuedSaveRecomputesWorkDirtiedAfterAdmission()
+    {
+        auto& app = App::GetApplication();
+        QTemporaryDir files;
+        QVERIFY(files.isValid());
+        auto* document = app.newDocument("save_recompute_order");
+        auto* object = document->addObject("App::FeaturePython", "SavedFeature");
+        auto* guiDocument = application->getDocument(document);
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        document->recompute();
+        QVERIFY(!document->mustExecute());
+        QVERIFY(document->saveAs(files.filePath("ordered.FCStd").toStdString().c_str()));
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        bool recomputed = false;
+        bool injected = false;
+        fastsignals::scoped_connection dirtied = document->signalCooperativeMutationChanged.connect(
+            [&](const App::Document&, bool active) {
+                // Introduce one dependency change at admission, not another
+                // edit when the final presentation takes over the lease.
+                if (active && !injected) {
+                    injected = true;
+                    object->touch();
+                }
+            });
+        fastsignals::scoped_connection recompute = document->signalBeforeRecompute.connect(
+            [&](const App::Document&) { recomputed = true; });
+        bool finished = false;
+        bool success = false;
+        QVERIFY(guiDocument->saveAsync([&](bool saved) {
+            success = saved;
+            finished = true;
+        }));
+        QTRY_VERIFY_WITH_TIMEOUT(finished, 10000);
+        QVERIFY(success);
+        const bool clean = !document->mustExecute();
+        if (!clean) {
+            for (const auto* item : document->getObjects()) {
+                if (item->isTouched()) {
+                    qWarning("Still touched after queued save: %s", item->getNameInDocument());
+                }
+            }
+        }
+        dirtied.disconnect();
+        recompute.disconnect();
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        QVERIFY(app.closeDocument(document->getName()));
+        QVERIFY(recomputed);
+        QVERIFY(clean);
+    }
+
+    void preparesCloseThroughTheQueuedSaveAndPresentationBoundary()
+    {
+        auto& app = App::GetApplication();
+        QTemporaryDir files;
+        QVERIFY(files.isValid());
+        auto* document = app.newDocument("queued_close_save");
+        auto* guiDocument = application->getDocument(document);
+        for (int index = 0; index < 50; ++index) {
+            document->addObject("App::FeaturePython", "CloseFeature");
+        }
+        const auto filename = files.filePath("close.FCStd").toStdString();
+        QVERIFY(document->saveAs(filename.c_str()));
+        QTRY_VERIFY_WITH_TIMEOUT(!document->isPresentationUpdateActive(), 10000);
+        document->Comment.setValue("saved before closing");
+        guiDocument->setModified(true);
+        bool finished = false;
+        bool approved = false;
+        Gui::Document::prepareCloseAsync({guiDocument}, [&](bool ready) {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            approved = ready;
+            finished = true;
+        });
+        QVERIFY(!finished);
+        QTRY_VERIFY_WITH_TIMEOUT(window->findChild<QMessageBox*>("confirmSave"), 5000);
+        auto* prompt = window->findChild<QMessageBox*>("confirmSave");
+        QVERIFY(prompt->isVisible());
+        QTest::mouseClick(prompt->button(QMessageBox::Save), Qt::LeftButton);
+        QTRY_VERIFY_WITH_TIMEOUT(finished, 10000);
+        QVERIFY(approved);
+        QVERIFY(!guiDocument->isModified());
+        QVERIFY(document->isClosable());
+        QVERIFY(app.closeDocument(document->getName()));
+        auto* restored = app.openDocument(filename.c_str());
+        QVERIFY(restored);
+        QCOMPARE(restored->Comment.getStrValue(), std::string("saved before closing"));
+        QTRY_VERIFY_WITH_TIMEOUT(!restored->isPresentationUpdateActive(), 10000);
+        QVERIFY(app.closeDocument(restored->getName()));
+    }
+
+    void documentDestructionRemovesItsLastView()
+    {
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("terminal_view_close");
+        auto* guiDocument = application->getDocument(document);
+        const std::string name = document->getName();
+        auto views = guiDocument->getMDIViews();
+        if (views.empty()) {
+            auto* view = new Gui::MDIView(guiDocument, window.get());
+            window->addWindow(view);
+            views = guiDocument->getMDIViews();
+        }
+        QCOMPARE(views.size(), std::size_t(1));
+        QPointer<Gui::MDIView> view = views.front();
+        QVERIFY(window->windows().contains(view.data()));
+        QTRY_VERIFY_WITH_TIMEOUT(document->isClosable(), 5000);
+        QVERIFY(app.closeDocument(name.c_str()));
+        QVERIFY(!app.getDocument(name.c_str()));
+        QTRY_VERIFY_WITH_TIMEOUT(view.isNull(), 5000);
+        QVERIFY(!window->findChild<QMessageBox*>("confirmSave"));
+    }
+
+    void queuedCloseAllPreservesDocumentsCreatedWhilePrompting()
+    {
+        auto& app = App::GetApplication();
+        auto* original = app.newDocument("close_all_original");
+        const std::string name = original->getName();
+        application->getDocument(original)->setModified(true);
+        bool finished = false;
+        bool closed = true;
+        window->closeAllDocumentsAsync([&](bool success) {
+            closed = success;
+            finished = true;
+        });
+        QVERIFY(!finished);
+        QTRY_VERIFY_WITH_TIMEOUT(window->findChild<QMessageBox*>("confirmSave"), 5000);
+        auto* prompt = window->findChild<QMessageBox*>("confirmSave");
+        auto* added = app.newDocument("created_during_close");
+        const std::string addedName = added->getName();
+        QTest::mouseClick(prompt->button(QMessageBox::Discard), Qt::LeftButton);
+        QTRY_VERIFY_WITH_TIMEOUT(finished, 5000);
+        QVERIFY(!closed);
+        QVERIFY(!app.getDocument(name.c_str()));
+        QCOMPARE(app.getDocument(addedName.c_str()), added);
+        QTRY_VERIFY_WITH_TIMEOUT(added->isClosable(), 5000);
+        QVERIFY(app.closeDocument(addedName.c_str()));
+    }
+
+    void unorganizedTreeFinishesPresentation()
+    {
+        auto& app = App::GetApplication();
+        auto preferences = app.GetParameterGroupByPath("User parameter:BaseApp/Preferences/TreeView");
+        const bool organized = preferences->GetBool("OrganizeModelByType", true);
+        const auto restorePreference = qScopeGuard([&] {
+            preferences->SetBool("OrganizeModelByType", organized);
+        });
+        preferences->SetBool("OrganizeModelByType", false);
+        auto* document = app.newDocument("UnorganizedTree");
+        const std::string name = document->getName();
+        document->beginCooperativeMutation();
+        for (int index = 0; index < 50; ++index) {
+            document->addObject("App::FeaturePython", "UnorganizedFeature");
+        }
+        document->endCooperativeMutation();
+        QTRY_VERIFY_WITH_TIMEOUT(document->isClosable(), 5000);
+        QVERIFY(app.closeDocument(name.c_str()));
+    }
+
+    void pythonPresentationCallPreservesResultAndExceptionAcrossWorkerHandoff()
+    {
+        auto& guiApplication = *application;
+        auto& mainWindow = *window;
+        auto& application = App::GetApplication();
+        auto* document = application.newDocument("python_presentation_handoff");
+        const std::string name = document->getName();
+        auto work = application.hostRuntime().submit(App::HostRuntime::Lane::Document,
+            [name](std::stop_token) {
+                Base::PyGILStateLocker python;
+                Py::Module gui(PyImport_ImportModule("FreeCADGui"), true);
+                Py::Dict globals;
+                globals.setItem("__builtins__", Py::Object(PyEval_GetBuiltins()));
+                globals.setItem("Gui", gui);
+                Py::Object lookup(PyRun_String(
+                    "lambda name: Gui.getDocument(name).Document.Name",
+                    Py_eval_input, globals.ptr(), globals.ptr()), true);
+                Py::Tuple args(2);
+                args.setItem(0, lookup);
+                args.setItem(1, Py::String(name));
+                Py::Object dispatcher = gui.getAttr("runOnMainThread");
+                PyObject* result = PyObject_CallObject(dispatcher.ptr(), args.ptr());
+                if (!result) {
+                    PyErr_Print();
+                    throw std::runtime_error("GUI presentation call failed from worker");
+                }
+                const bool correct = PyUnicode_Check(result)
+                    && name == PyUnicode_AsUTF8(result);
+                Py_DECREF(result);
+                if (!correct) {
+                    throw std::runtime_error("GUI presentation call lost its return value");
+                }
+                args.setItem(1, Py::String("missing_presentation_document"));
+                result = PyObject_CallObject(dispatcher.ptr(), args.ptr());
+                const bool preservedError = !result && PyErr_ExceptionMatches(PyExc_NameError);
+                Py_XDECREF(result);
+                PyErr_Clear();
+                if (!preservedError) {
+                    throw std::runtime_error("GUI presentation call lost its Python exception type");
+                }
+
+                // A document's Python proxy module can register commands when
+                // imported on its restore worker. Registration belongs to the
+                // owner even though module loading and caller-stack metadata do not.
+                Py::Object command(PyRun_String(
+                    "type('RestoreCommand', (), {'GetResources': lambda self: "
+                    "{'MenuText': 'Restore handoff test'}})()",
+                    Py_eval_input, globals.ptr(), globals.ptr()), true);
+                Py::Tuple registration(2);
+                registration.setItem(0, Py::String("Test_WorkerRestoreCommand"));
+                registration.setItem(1, command);
+                Py::Callable addCommand(gui.getAttr("addCommand"));
+                addCommand.apply(registration);
+            });
+        QTRY_VERIFY_WITH_TIMEOUT(
+            work.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready, 10000);
+        try {
+            work.get();
+        }
+        catch (const std::exception& error) {
+            QFAIL(error.what());
+        }
+        auto* command = guiApplication.commandManager().getCommandByName("Test_WorkerRestoreCommand");
+        QVERIFY(command);
+        guiApplication.commandManager().removeCommand(command);
+        QVERIFY(application.closeDocument(name.c_str()));
+    }
+
+    void defersViewProviderAttachmentUntilDocumentIsStable()
+    {
+        auto& guiApplication = *application;
+        auto& mainWindow = *window;
+
+        const auto documentName =
+            App::GetApplication().getUniqueDocumentName("bulk_view_providers");
+        auto* document = App::GetApplication().newDocument(documentName.c_str());
+        QVERIFY(document);
+        auto* guiDocument = guiApplication.getDocument(document);
+        QVERIFY(guiDocument);
+        guiApplication.setActiveDocument(guiDocument);
+        Base::PyGILStateLocker python;
+        Py::Dict globals;
+        globals.setItem("__builtins__", Py::Object(PyEval_GetBuiltins()));
+        Py::List epochs;
+        globals.setItem("epochs", epochs);
+        Py::Object observerInstance(PyRun_String(
+            "type('EpochObserver', (), {'slotCooperativeMutationChanged': "
+            "lambda self, doc, active: epochs.append((doc.Name, active))})()",
+            Py_eval_input, globals.ptr(), globals.ptr()), true);
+        App::DocumentObserverPython observer(observerInstance);
+        int publishedViewProviders = 0;
+        fastsignals::scoped_connection publishedConnection = guiDocument->signalNewObject.connect(
+            [&publishedViewProviders](const Gui::ViewProviderDocumentObject&) {
+                ++publishedViewProviders;
+            }
+        );
+
+        document->beginCooperativeMutation();
+        document->beginCooperativeMutation();
+        document->endCooperativeMutation();
+        QCOMPARE(epochs.length(), Py_ssize_t(1));
+        const Py::Tuple entered(epochs[0]);
+        QCOMPARE(Py::String(entered[0]).as_std_string(), documentName);
+        QVERIFY(entered[1].isTrue());
+        std::vector<App::DocumentObject*> objects;
+        objects.reserve(50);
+        for (int index = 0; index < 50; ++index) {
+            auto* object = document->addObject(
+                "App::FeaturePython",
+                ("BulkFeature" + std::to_string(index)).c_str()
+            );
+            QVERIFY(object);
+            objects.push_back(object);
+            auto* provider = dynamic_cast<Gui::ViewProviderDocumentObject*>(
+                guiDocument->getViewProvider(object)
+            );
+            QVERIFY(provider);
+            QCOMPARE(provider->getObject(), object);
+            QCOMPARE(publishedViewProviders, 0);
+        }
+
+        document->endCooperativeMutation();
+        // GUI adoption acquires its own lease before the original end returns.
+        // Its completion is asynchronous; providers must remain protected.
+        QCOMPARE(epochs.length(), Py_ssize_t(3));
+        const Py::Tuple left(epochs[1]);
+        QCOMPARE(Py::String(left[0]).as_std_string(), documentName);
+        QVERIFY(!left[1].isTrue());
+        const Py::Tuple adopting(epochs[2]);
+        QCOMPARE(Py::String(adopting[0]).as_std_string(), documentName);
+        QVERIFY(adopting[1].isTrue());
+        QVERIFY(document->isCooperativeMutationActive());
+        Base::PyGILStateRelease release;
+        QTRY_COMPARE_WITH_TIMEOUT(publishedViewProviders, 50, 5000);
+        QTRY_VERIFY_WITH_TIMEOUT(
+            std::ranges::all_of(objects, [guiDocument](const auto* object) {
+                auto* provider = dynamic_cast<Gui::ViewProviderDocumentObject*>(
+                    guiDocument->getViewProvider(object)
+                );
+                return provider && provider->getObject() == object;
+            }),
+            5000
+        );
+
+        // A large stable document must never make one tree projection callback
+        // monopolize the GUI thread. Queue the exact signal path used by normal
+        // object creation, then require the first drain to return within one
+        // human-visible frame while the remaining work continues cooperatively.
+        constexpr int projectionObjectCount = 1000;
+        std::vector<App::DocumentObject*> projectionObjects;
+        projectionObjects.reserve(projectionObjectCount);
+        for (int index = 0; index < projectionObjectCount; ++index) {
+            auto* object = document->addObject(
+                "App::FeaturePython",
+                ("ProjectionLoad" + std::to_string(index)).c_str()
+            );
+            QVERIFY(object);
+            auto* role = static_cast<App::PropertyString*>(object->addDynamicProperty(
+                "App::PropertyString",
+                App::DocumentTimeline::RolePropertyName
+            ));
+            QVERIFY(role);
+            role->setValue(App::DocumentTimeline::OperationRole);
+            role->setStatus(App::Property::Hidden, true);
+            role->setStatus(App::Property::NoRecompute, true);
+            projectionObjects.push_back(object);
+        }
+        QTreeWidget* modelTree = nullptr;
+        for (auto* candidate : mainWindow.findChildren<QTreeWidget*>()) {
+            if (candidate->inherits("Gui::TreeWidget")) {
+                modelTree = candidate;
+                break;
+            }
+        }
+        QVERIFY(modelTree);
+        QElapsedTimer heartbeatInterval;
+        heartbeatInterval.start();
+        qint64 maximumHeartbeatGap = 0;
+        QTimer heartbeat;
+        heartbeat.setInterval(0);
+        connect(&heartbeat, &QTimer::timeout, [&]() {
+            maximumHeartbeatGap = std::max(maximumHeartbeatGap, heartbeatInterval.restart());
+        });
+        heartbeat.start();
+
+        QElapsedTimer projectionSlice;
+        projectionSlice.start();
+        QVERIFY(QMetaObject::invokeMethod(modelTree, "onUpdateStatus", Qt::DirectConnection));
+        QVERIFY2(
+            projectionSlice.elapsed() < 16,
+            qPrintable(
+                QStringLiteral("Tree projection blocked the GUI thread for %1 ms")
+                    .arg(projectionSlice.elapsed())
+            )
+        );
+        QTRY_VERIFY_WITH_TIMEOUT(
+            modelTree->findItems(
+                        QStringLiteral("ProjectionLoad"),
+                        Qt::MatchStartsWith | Qt::MatchRecursive
+                    )
+                    .size()
+                >= projectionObjectCount * 2,
+            10000
+        );
+        heartbeat.stop();
+        QVERIFY2(
+            maximumHeartbeatGap < 100,
+            qPrintable(
+                QStringLiteral("Tree projection starved the event loop for %1 ms")
+                    .arg(maximumHeartbeatGap)
+            )
+        );
+
+        auto* history = App::DocumentTimeline::ensure(document);
+        QVERIFY(history);
+        history->Operations.setValues(projectionObjects);
+        history->Position.setValue(projectionObjectCount);
+        auto* featureTimeline = mainWindow.findChild<QListWidget*>(
+            QStringLiteral("VibeCADFeatureTimelineItems")
+        );
+        QVERIFY(featureTimeline);
+        QTRY_COMPARE_WITH_TIMEOUT(featureTimeline->count(), projectionObjectCount + 1, 10000);
+
+        Gui::Selection().clearSelection();
+        QTRY_COMPARE(featureTimeline->selectedItems().size(), 0);
+
+        // Resources belonging to the same root cannot straddle an unrelated
+        // operation: History must refuse that ambiguous navigation boundary.
+        auto* owned = projectionObjects.at(2);
+        auto* role = dynamic_cast<App::PropertyString*>(
+            owned->getPropertyByName(App::DocumentTimeline::RolePropertyName));
+        if (!role) {
+            role = static_cast<App::PropertyString*>(owned->addDynamicProperty(
+                "App::PropertyString", App::DocumentTimeline::RolePropertyName));
+        }
+        auto* owner = dynamic_cast<App::PropertyLink*>(
+            owned->getPropertyByName(App::DocumentTimeline::OwnerPropertyName));
+        if (!owner) {
+            owner = static_cast<App::PropertyLinkHidden*>(owned->addDynamicProperty(
+                "App::PropertyLinkHidden", App::DocumentTimeline::OwnerPropertyName));
+        }
+        QVERIFY(role);
+        QVERIFY(owner);
+        const std::string previousRole = role->getValue();
+        auto* previousOwner = owner->getValue();
+        owner->setValue(projectionObjects.front());
+        role->setValue(App::DocumentTimeline::ResourceRole);
+        history->Operations.setValues(projectionObjects);
+        QTRY_VERIFY(!featureTimeline->isEnabled());
+        role->setValue(previousRole);
+        owner->setValue(previousOwner);
+        history->Operations.setValues(projectionObjects);
+        QTRY_VERIFY(featureTimeline->isEnabled());
+        QTRY_COMPARE(featureTimeline->count(), projectionObjectCount + 1);
+        Gui::Selection().addSelection(document->getName(), projectionObjects.front()->getNameInDocument());
+        Gui::Selection().addSelection(document->getName(), projectionObjects.back()->getNameInDocument());
+        // Selection observers must enqueue one aggregate update, not scan and
+        // mutate every history row inline for each selected object.
+        QCOMPARE(featureTimeline->selectedItems().size(), 0);
+        QTRY_COMPARE(featureTimeline->selectedItems().size(), 2);
+        Gui::Selection().rmvSelection(document->getName(), projectionObjects.front()->getNameInDocument());
+        QTRY_COMPARE(featureTimeline->selectedItems().size(), 1);
+        Gui::Selection().clearSelection();
+        QTRY_COMPARE(featureTimeline->selectedItems().size(), 0);
+
+        // A stable bulk epoch must project only identities that changed. A
+        // one-object recompute in a large document previously rebuilt both
+        // the complete Tree and the complete History timeline before releasing
+        // the presentation barrier.
+        QTRY_VERIFY_WITH_TIMEOUT(document->isClosable(), 5000);
+        QElapsedTimer targetedProjection;
+        targetedProjection.start();
+        document->beginCooperativeMutation();
+        projectionObjects.front()->touch();
+        document->endCooperativeMutation();
+        QTRY_VERIFY_WITH_TIMEOUT(document->isClosable(), 5000);
+        QVERIFY2(
+            targetedProjection.elapsed() < 100,
+            qPrintable(
+                QStringLiteral(
+                    "One dirty identity caused a whole-document projection taking %1 ms"
+                ).arg(targetedProjection.elapsed())
+            )
+        );
+
+        // Progress reported by a worker must remain cancellable without
+        // turning the application's global progress filter into a modal input
+        // blocker. This is the path used by async document recompute and every
+        // workbench operation that reports through Base::SequencerLauncher.
+        Gui::SequencerBar::instance()->getProgressBar(&mainWindow);
+        std::promise<void> progressStarted;
+        std::promise<void> releaseProgress;
+        const auto releaseSignal = releaseProgress.get_future().share();
+        std::thread progressWorker([&] {
+            Base::SequencerLauncher progress("Background document work", 10);
+            progressStarted.set_value();
+            releaseSignal.wait();
+        });
+        progressStarted.get_future().wait();
+        QCoreApplication::processEvents();
+
+        MousePressProbe inputProbe;
+        QMouseEvent mousePress(
+            QEvent::MouseButtonPress,
+            QPointF(1.0, 1.0),
+            QPointF(1.0, 1.0),
+            Qt::LeftButton,
+            Qt::LeftButton,
+            Qt::NoModifier
+        );
+        QCoreApplication::sendEvent(&inputProbe, &mousePress);
+        const bool inputReachedApplication = inputProbe.receivedMousePress;
+        releaseProgress.set_value();
+        progressWorker.join();
+        QCoreApplication::processEvents();
+        QVERIFY2(
+            inputReachedApplication,
+            "Background progress consumed normal GUI input as if it were modal work"
+        );
+
+        // Progress percentage is presentation, not event-loop scheduling. A
+        // large operation can advance thousands of times between visible
+        // percentage changes; those advances must still provide bounded GUI
+        // heartbeats so paint, status, and timers remain live.
+        qint64 maximumProgressHeartbeatGap = 0;
+        QElapsedTimer progressHeartbeatInterval;
+        progressHeartbeatInterval.start();
+        QTimer progressHeartbeat;
+        progressHeartbeat.setTimerType(Qt::PreciseTimer);
+        progressHeartbeat.setInterval(1);
+        connect(&progressHeartbeat, &QTimer::timeout, [&] {
+            maximumProgressHeartbeatGap =
+                std::max(maximumProgressHeartbeatGap, progressHeartbeatInterval.restart());
+        });
+        progressHeartbeat.start();
+        {
+            Base::SequencerLauncher outerProgress("Opening a large document", 1);
+            Base::SequencerLauncher progress("Restoring nested document presentation", 10000);
+            for (int step = 0; step < 300; ++step) {
+                QThread::msleep(1);
+                progress.next();
+            }
+        }
+        QCoreApplication::processEvents();
+        progressHeartbeat.stop();
+        QVERIFY(maximumProgressHeartbeatGap > 0);
+        QVERIFY2(
+            maximumProgressHeartbeatGap < 50,
+            qPrintable(
+                QStringLiteral("Progress scheduling starved the GUI event loop for %1 ms")
+                    .arg(maximumProgressHeartbeatGap)
+            )
+        );
+
+        // A single human action can change hundreds of Visibility properties
+        // (for example, Assembly hides every joint at drag start). Folder
+        // aggregates are a document projection and must be coalesced rather
+        // than recursively traversing the complete model once per object.
+        constexpr int visibilityBurstCount = 300;
+        QElapsedTimer visibilityBurst;
+        visibilityBurst.start();
+        for (int index = 0; index < visibilityBurstCount; ++index) {
+            projectionObjects[index]->Visibility.setValue(false);
+        }
+        QVERIFY2(
+            visibilityBurst.elapsed() < 100,
+            qPrintable(
+                QStringLiteral("Bulk visibility synchronously blocked the GUI thread for %1 ms")
+                    .arg(visibilityBurst.elapsed())
+            )
+        );
+
+        // Presentation work may finish asynchronously after the document view
+        // exists. Keep that document's canvas quiet until the outermost update
+        // completes, including views attached while the update is active.
+        {
+            Gui::MDIView existingView(guiDocument, &mainWindow);
+            QVERIFY(existingView.updatesEnabled());
+
+            document->beginPresentationUpdate();
+            QVERIFY(!existingView.updatesEnabled());
+
+            Gui::MDIView attachedDuringUpdate(guiDocument, &mainWindow);
+            QVERIFY(!attachedDuringUpdate.updatesEnabled());
+
+            document->beginPresentationUpdate();
+            document->endPresentationUpdate();
+            QVERIFY(!existingView.updatesEnabled());
+            QVERIFY(!attachedDuringUpdate.updatesEnabled());
+
+            document->endPresentationUpdate();
+            QVERIFY(existingView.updatesEnabled());
+            QVERIFY(attachedDuringUpdate.updatesEnabled());
+        }
+
+        QVERIFY(App::GetApplication().closeDocument(documentName.c_str()));
+    }
+
+    void sharedGuiAdoptionQueueYieldsBetweenReadyResults()
+    {
+        auto& guiApplication = *application;
+        constexpr int resultCount = 20;
+        int completed = 0;
+        int completedAtHeartbeat = -1;
+
+        for (int index = 0; index < resultCount; ++index) {
+            // Exercise the App-to-Gui gateway used by asynchronous document
+            // notifications, not only the dispatcher's direct entry point.
+            App::MainThreadSignalConfig::invoke([&completed] {
+                QThread::msleep(2);
+                ++completed;
+            }, false);
+        }
+        QTimer::singleShot(0, [&] { completedAtHeartbeat = completed; });
+
+        QTRY_COMPARE_WITH_TIMEOUT(completed, resultCount, 5000);
+        QVERIFY2(
+            completedAtHeartbeat >= 0 && completedAtHeartbeat < resultCount,
+            qPrintable(
+                QStringLiteral("GUI adoption queue failed to yield; heartbeat observed at %1/%2")
+                    .arg(completedAtHeartbeat)
+                    .arg(resultCount)
+            )
+        );
+    }
+
+    void nestedPresentationSequenceResumesOnOwnerAndUnwinds()
+    {
+        std::vector<int> steps;
+        int liveScopes = 0;
+        const auto child = [&](int value) -> Gui::FrameSequence<int> {
+            struct Scope {
+                int& count;
+                explicit Scope(int& count) : count(count) { ++count; }
+                ~Scope() { --count; }
+            } scope(liveScopes);
+            steps.push_back(value);
+            co_await std::suspend_always {};
+            if (value == 2) { throw std::runtime_error("presentation failed"); }
+            co_return value;
+        };
+        const auto parent = [&]() -> Gui::FrameSequence<> {
+            if (co_await child(1) != 1) { throw std::runtime_error("wrong child result"); }
+            try { co_await child(2); }
+            catch (const std::runtime_error& error) {
+                steps.push_back(std::string(error.what()) == "presentation failed" ? 3 : -1);
+            }
+        };
+        auto sequence = parent();
+        QVERIFY(sequence.advance());
+        QCOMPARE(steps, std::vector<int> {1});
+        QCOMPARE(liveScopes, 1);
+        QVERIFY(sequence.advance());
+        QCOMPARE(steps, (std::vector<int> {1, 2}));
+        QCOMPARE(liveScopes, 1);
+        QVERIFY(!sequence.advance());
+        sequence.takeResult();
+        QCOMPARE(steps, (std::vector<int> {1, 2, 3}));
+        QCOMPARE(liveScopes, 0);
+        {
+            auto cancelled = parent();
+            QVERIFY(cancelled.advance());
+            QCOMPARE(liveScopes, 1);
+        }
+        QCOMPARE(liveScopes, 0); // Destroying the root unwinds its suspended child.
+    }
+
+    void workerConsoleRefreshDoesNotRunANestedGuiEventLoop()
+    {
+        Base::Console().enableRefresh(true);
+        QCoreApplication::sendPostedEvents();
+
+        const auto eventType = static_cast<QEvent::Type>(QEvent::registerEventType());
+        PostedEventProbe probe(eventType);
+
+        std::thread worker([] { Base::Console().refresh(); });
+        worker.join();
+
+        for (int index = 0; index < 32; ++index) {
+            QCoreApplication::postEvent(&probe, new QEvent(eventType));
+        }
+
+        // Deliver only callbacks addressed to the application. A worker-side
+        // console refresh must not recursively drain unrelated GUI work.
+        QCoreApplication::sendPostedEvents(qApp, QEvent::MetaCall);
+        QCOMPARE(probe.received, 0);
+        QCoreApplication::removePostedEvents(&probe, eventType);
+    }
+
+    void blockingWorkerNotificationsShareTheGuiFrameBudget()
+    {
+        constexpr int notificationCount = 24;
+        std::atomic<int> completed {0};
+        std::atomic<int> failures {0};
+        std::promise<void> start;
+        const auto startSignal = start.get_future().share();
+        std::vector<std::future<void>> workers;
+        workers.reserve(notificationCount);
+
+        for (int index = 0; index < notificationCount; ++index) {
+            workers.push_back(std::async(std::launch::async, [&, startSignal] {
+                startSignal.wait();
+                const bool accepted = Gui::dispatchToGuiFrameAndWait([&] {
+                    if (QThread::currentThread() != qApp->thread()) {
+                        ++failures;
+                    }
+                    QThread::msleep(2);
+                    ++completed;
+                });
+                if (!accepted) {
+                    ++failures;
+                }
+            }));
+        }
+
+        start.set_value();
+        QThread::msleep(20);
+        int completedAtHeartbeat = -1;
+        QTimer::singleShot(0, [&] { completedAtHeartbeat = completed.load(); });
+
+        QTRY_COMPARE_WITH_TIMEOUT(completed.load(), notificationCount, 5000);
+        for (auto& worker : workers) {
+            worker.get();
+        }
+        QCOMPARE(failures.load(), 0);
+        QVERIFY2(
+            completedAtHeartbeat >= 0 && completedAtHeartbeat < notificationCount,
+            qPrintable(
+                QStringLiteral("Blocking worker notifications monopolized the GUI queue; "
+                               "heartbeat observed at %1/%2")
+                    .arg(completedAtHeartbeat)
+                    .arg(notificationCount)
+            )
+        );
+    }
+    // Retire the real Tree after tests which need it, without exporting an
+    // internal widget constructor solely for this Windows test executable.
+    void destroysTreeWhileItsDocumentRemainsOpen()
+    {
+        QTreeWidget* tree = nullptr;
+        for (auto* candidate : window->findChildren<QTreeWidget*>()) {
+            if (candidate->inherits("Gui::TreeWidget")) { tree = candidate; break; }
+        }
+        QVERIFY(tree);
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("TreeWindowLifetime");
+        const std::string name = document->getName();
+        for (int index = 0; index < 50; ++index) {
+            document->addObject("App::FeaturePython", "TeardownFeature");
+        }
+        QTRY_VERIFY_WITH_TIMEOUT(
+            tree->findItems(QStringLiteral("TeardownFeature"),
+                            Qt::MatchStartsWith | Qt::MatchRecursive).size() >= 50, 10000);
+        delete tree;
+        QCOMPARE(app.getDocument(name.c_str()), document);
+        QTRY_VERIFY_WITH_TIMEOUT(document->isClosable(), 5000);
+        QVERIFY(app.closeDocument(name.c_str()));
+    }
+
+    // Keep last: this exercises the application's actual terminal Qt signal,
+    // not a resettable test-only dispatcher or a second event loop.
+    void shutdownReleasesQueuedAdoptionAndItsWaiter()
+    {
+        bool executed = false;
+        bool releasedOnOwner = false;
+        bool acceptedDuringRelease = true;
+        struct OwnerCapture {
+            std::function<void()> release;
+            ~OwnerCapture() { release(); }
+        };
+        auto capture = std::make_shared<OwnerCapture>();
+        capture->release = [&] {
+            releasedOnOwner = QThread::currentThread() == qApp->thread();
+            acceptedDuringRelease = Gui::dispatchToGuiFrame([] {});
+        };
+        auto completion = std::make_shared<std::promise<void>>();
+        auto waiting = completion->get_future();
+        QVERIFY(Gui::dispatchToGuiFrame(
+            [capture = std::move(capture), completion = std::move(completion), &executed] {
+                executed = true;
+                completion->set_value();
+            }));
+        QVERIFY(QMetaObject::invokeMethod(qApp, "aboutToQuit", Qt::DirectConnection));
+        QCOMPARE(waiting.wait_for(std::chrono::milliseconds(0)), std::future_status::ready);
+        QVERIFY_EXCEPTION_THROWN(waiting.get(), std::future_error);
+        QVERIFY(releasedOnOwner);
+        QVERIFY(!executed);
+        QVERIFY(!acceptedDuringRelease);
+        QVERIFY(!Gui::dispatchToGuiFrame([] {}));
+    }
+};
+
+QTEST_MAIN(DocumentBulkMutationTest)
+
+#include "DocumentBulkMutation.moc"

--- a/tests/src/Gui/DocumentProjection.cpp
+++ b/tests/src/Gui/DocumentProjection.cpp
@@ -2,8 +2,20 @@
 
 #include <gtest/gtest.h>
 
+#include <chrono>
+#include <future>
+
 #include "App/Application.h"
 #include "App/Document.h"
+#include "App/DocumentTimeline.h"
+#include "App/PropertyLinks.h"
+#include "App/PropertyStandard.h"
+#include "App/GroupExtension.h"
+#include "App/OriginGroupExtension.h"
+#include "App/Origin.h"
+#include "App/HostRuntime.h"
+#include "App/GeoFeature.h"
+#include "Gui/ModelTreeBrowser.h"
 #include "Gui/Document.h"
 #include <src/App/InitApplication.h>
 
@@ -45,6 +57,118 @@ TEST_F(DocumentProjectionTest, NormalTransactionKeepsIncrementalProjectionLive)
     _document->commitTransaction();
     EXPECT_FALSE(Gui::Document::projectionRefreshBlocked(_document));
     EXPECT_FALSE(Gui::Document::historyMutationBlocked(_document));
+}
+
+TEST_F(DocumentProjectionTest, BrowserGraphSurvivesDisplayChangesButRejectsStructuralEdits)
+{
+    auto* object = static_cast<App::GeoFeature*>(
+        _document->addObject("App::GeoFeature", "MovingPart"));
+    const Gui::ModelTreeBrowserProjection snapshot(_document);
+    const auto fullRevision = _document->getObjectChangeGeneration();
+    for (int index = 0; index < 50; ++index) {
+        object->Visibility.setValue(index % 2 == 0);
+        object->Placement.setValue(Base::Placement(
+            Base::Vector3d(index, 0, 0), Base::Rotation()));
+        EXPECT_TRUE(snapshot.isCurrent());
+    }
+    EXPECT_GT(_document->getObjectChangeGeneration(), fullRevision);
+
+    auto* metadata = static_cast<App::PropertyString*>(
+        object->addDynamicProperty("App::PropertyString", "VibeCADTreeRole"));
+    EXPECT_FALSE(snapshot.isCurrent());
+    const Gui::ModelTreeBrowserProjection withProperty(_document);
+    metadata->setValue("meshes");
+    EXPECT_FALSE(withProperty.isCurrent());
+
+    auto* group = _document->addObject("App::DocumentObjectGroup", "Group");
+    const Gui::ModelTreeBrowserProjection beforeLink(_document);
+    group->getExtensionByType<App::GroupExtension>()->addObject(object);
+    EXPECT_FALSE(beforeLink.isCurrent());
+    const Gui::ModelTreeBrowserProjection beforeDelete(_document);
+    _document->removeObject(object->getNameInDocument());
+    EXPECT_FALSE(beforeDelete.isCurrent());
+}
+
+TEST_F(DocumentProjectionTest, BrowserPreparationDoesNotReadLiveObjectsOnWorker)
+{
+    auto* group = _document->addObject("App::DocumentObjectGroup", "Group");
+    auto* member = _document->addObject("App::FeaturePython", "Member");
+    group->getExtensionByType<App::GroupExtension>()->addObject(member);
+    auto* role = dynamic_cast<App::PropertyString*>(
+        member->getPropertyByName(App::DocumentTimeline::RolePropertyName));
+    if (!role) {
+        role = static_cast<App::PropertyString*>(member->addDynamicProperty(
+            "App::PropertyString", App::DocumentTimeline::RolePropertyName));
+    }
+    auto* owner = dynamic_cast<App::PropertyLink*>(
+        member->getPropertyByName(App::DocumentTimeline::OwnerPropertyName));
+    if (!owner) {
+        owner = static_cast<App::PropertyLink*>(member->addDynamicProperty(
+            "App::PropertyLinkHidden", App::DocumentTimeline::OwnerPropertyName));
+    }
+    ASSERT_NE(role, nullptr);
+    ASSERT_NE(owner, nullptr);
+    role->setValue(App::DocumentTimeline::ResourceRole);
+    owner->setValue(group);
+    Gui::ModelTreeBrowserProjection::Preparation preparation(_document);
+    while (!preparation.captureNext()) {}
+    EXPECT_TRUE(preparation.isCurrent());
+
+    // Invalidate the source after capture. Preparation must use its immutable
+    // graph, not consult the live Group property during worker classification.
+    group->getExtensionByType<App::GroupExtension>()->removeObject(member);
+    owner->setValue(nullptr);
+    EXPECT_FALSE(preparation.isCurrent());
+    auto& runtime = App::GetApplication().hostRuntime();
+    auto computed = runtime.submit(
+        [preparation = std::move(preparation), &runtime](std::stop_token) mutable {
+            return std::move(preparation).finish(&runtime);
+        });
+    const auto snapshot = runtime.wait(computed);
+    EXPECT_FALSE(snapshot.isCurrent());
+    ASSERT_NE(snapshot.find(member), nullptr);
+    EXPECT_EQ(snapshot.find(member)->group, group);
+    EXPECT_EQ(snapshot.find(member)->logicalParent, group);
+    EXPECT_EQ(snapshot.timelineRoots().at(member), group);
+    const Gui::ModelTreeBrowserProjection current(_document);
+    EXPECT_TRUE(current.isCurrent());
+    ASSERT_NE(current.find(member), nullptr);
+    EXPECT_EQ(current.find(member)->group, nullptr);
+    EXPECT_EQ(current.timelineRoots().at(member), nullptr);
+}
+
+TEST_F(DocumentProjectionTest, CapturedParentGraphPreservesPartGroupAndOriginOwnership)
+{
+    auto* part = _document->addObject("App::Part", "Component");
+    auto* group = _document->addObject("App::DocumentObjectGroup", "Organization");
+    auto* member = _document->addObject("App::GeoFeature", "Member");
+    auto* component = part->getExtensionByType<App::OriginGroupExtension>();
+    component->addObject(group);
+    group->getExtensionByType<App::GroupExtension>()->addObject(member);
+    ASSERT_EQ(App::GeoFeatureGroupExtension::getGroupOfObject(group), part);
+    auto* origin = component->getOrigin();
+    ASSERT_FALSE(origin->OriginFeatures.getValues().empty());
+    auto* datum = origin->OriginFeatures.getValues().front();
+    ASSERT_NE(datum, nullptr);
+
+    Gui::ModelTreeBrowserProjection::Preparation preparation(_document);
+    while (!preparation.captureNext()) {}
+    // Change the live relationships after capture. Worker parent resolution
+    // must retain the captured graph, not call the live extension methods.
+    group->getExtensionByType<App::GroupExtension>()->removeObject(member);
+    auto& runtime = App::GetApplication().hostRuntime();
+    auto ready = runtime.submit([input = std::move(preparation), &runtime](std::stop_token) mutable {
+        return std::move(input).finish(&runtime);
+    });
+    const auto projection = runtime.wait(ready);
+    ASSERT_NE(projection.find(member), nullptr);
+    EXPECT_EQ(projection.find(member)->group, group);
+    EXPECT_EQ(projection.find(member)->component, part);
+    ASSERT_NE(projection.find(origin), nullptr);
+    EXPECT_EQ(projection.find(origin)->component, part);
+    ASSERT_NE(projection.find(datum), nullptr);
+    EXPECT_EQ(projection.find(datum)->logicalParent, origin);
+    EXPECT_EQ(projection.find(datum)->role, Gui::ModelTreeBrowserProjection::Role::OriginFeature);
 }
 
 TEST_F(DocumentProjectionTest, NormalEditLockKeepsIncrementalProjectionLive)
@@ -121,4 +245,30 @@ TEST_F(DocumentProjectionTest, CooperativeMutationRefusesUndoUntilPublicationEnd
     _document->endCooperativeMutation();
     EXPECT_TRUE(_document->undo());
     EXPECT_EQ(_document->getObject("ProtectedObject"), nullptr);
+}
+
+TEST_F(DocumentProjectionTest, PresentationCompletionIncludesStableObserverWork)
+{
+    using namespace std::chrono_literals;
+
+    ASSERT_NE(_document, nullptr);
+    auto connection = _document->signalBecameStable.connect(
+        [this](const App::Document&) { _document->beginPresentationUpdate(); }
+    );
+
+    _document->beginCooperativeMutation();
+    _document->endCooperativeMutation();
+
+    EXPECT_TRUE(_document->isPresentationUpdateActive());
+    EXPECT_FALSE(_document->isClosable());
+    auto completion = std::async(std::launch::async, [this] {
+        _document->waitForPresentationReady();
+    });
+    EXPECT_EQ(completion.wait_for(20ms), std::future_status::timeout);
+
+    _document->endPresentationUpdate();
+    EXPECT_EQ(completion.wait_for(1s), std::future_status::ready);
+    completion.get();
+    EXPECT_FALSE(_document->isPresentationUpdateActive());
+    EXPECT_TRUE(_document->isClosable());
 }

--- a/tests/src/Gui/RenderMeshController.cpp
+++ b/tests/src/Gui/RenderMeshController.cpp
@@ -1,0 +1,428 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <QThread>
+#include <QTest>
+#include <QElapsedTimer>
+
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRepPrimAPI_MakeCylinder.hxx>
+#include <Inventor/nodes/SoMaterial.h>
+#include <Inventor/nodes/SoSeparator.h>
+
+#include <src/App/InitApplication.h>
+
+#include <App/Application.h>
+#include <App/Document.h>
+#include <App/GeoFeature.h>
+#include <App/HostRuntime.h>
+#include <Gui/Application.h>
+#include <Gui/Document.h>
+#include <Gui/FrameBudget.h>
+#include <Gui/MainWindow.h>
+#include <Gui/Inventor/SoFCBoundingBox.h>
+#include <Gui/ViewProviderGeometryObject.h>
+#include <Mod/Part/App/PropertyTopoShape.h>
+#include <Mod/Part/Gui/RenderMeshController.h>
+#include <Mod/Part/Gui/SoBrepEdgeSet.h>
+#include <Mod/Part/Gui/SoBrepFaceSet.h>
+#include <Mod/Part/Gui/SoBrepPointSet.h>
+#include <Mod/Part/Gui/ViewProviderExt.h>
+
+namespace
+{
+struct ReleaseCallback
+{
+    std::function<void()> callback;
+    ~ReleaseCallback() { callback(); }
+};
+
+class InspectablePartView: public PartGui::ViewProviderPartExt
+{
+public:
+    SoMaterial* edgeMaterial() const { return pcLineMaterial; }
+    SoMaterial* pointMaterial() const { return pcPointMaterial; }
+    SoMaterial* faceMaterial() const { return pcShapeMaterial; }
+    void setFaceCount(int count) { faceset->partIndex.setNum(count); }
+    void clearLineGeometry() { lineset->coordIndex.setNum(0); }
+    mutable unsigned shapeReads {0};
+    Part::TopoShape getRenderedShape() const override { ++shapeReads; return {}; }
+    void refreshUnchangedGeometry() { VisualTouched = false; updateVisual(); }
+};
+
+class CountedShape: public Part::PropertyPartShape
+{
+public:
+    struct Reads
+    {
+        std::atomic<unsigned> count {0};
+        std::atomic<bool> usedGui {false};
+    };
+    std::shared_ptr<Reads> reads = std::make_shared<Reads>();
+    App::Property* Copy() const override
+    {
+        auto copy = new CountedShape;
+        copy->setValue(getValue());
+        copy->reads = reads;
+        return copy;
+    }
+    Base::BoundBox3d getBoundingBox() const override
+    {
+        ++reads->count;
+        if (QThread::currentThread() == qApp->thread()) { reads->usedGui = true; }
+        return Part::PropertyPartShape::getBoundingBox();
+    }
+};
+
+class BoundsFeature: public App::GeoFeature
+{
+public:
+    CountedShape shape;
+    const App::PropertyComplexGeoData* getPropertyOfGeometry() const override { return &shape; }
+};
+
+class BoundsView: public Gui::ViewProviderGeometryObject
+{
+public:
+    SbVec3f minimum() const { return pcBoundingBox->minBounds.getValue(); }
+    SbVec3f maximum() const { return pcBoundingBox->maxBounds.getValue(); }
+};
+}
+
+class RenderMeshControllerTest: public QObject
+{
+    Q_OBJECT
+
+    std::unique_ptr<Gui::Application> application;
+    std::unique_ptr<Gui::MainWindow> window;
+
+private Q_SLOTS:
+    void initTestCase()
+    {
+        tests::initApplication();
+        Gui::Application::initApplication();
+        Gui::Application::initOpenInventor();
+        application = std::make_unique<Gui::Application>(true);
+        window = std::make_unique<Gui::MainWindow>();
+    }
+
+    void cleanupTestCase()
+    {
+        App::GetApplication().closeAllDocuments();
+        window.reset();
+        application.reset();
+    }
+
+    void preparesLatestShapeOffTheGuiThread()
+    {
+        PartGui::RenderMeshController controller;
+        int target = 0;
+        int completions = 0;
+        std::shared_ptr<const Part::RenderMesh> result;
+
+        controller.request(
+            &target,
+            BRepPrimAPI_MakeCylinder(10.0, 20.0).Shape(),
+            0.1,
+            28.5,
+            false,
+            [&](PartGui::RenderMeshResult prepared) {
+                ++completions;
+                result = std::move(prepared.mesh);
+            }
+        );
+        controller.request(
+            &target,
+            BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape(),
+            0.1,
+            28.5,
+            false,
+            [&](PartGui::RenderMeshResult prepared) {
+                QCOMPARE(QThread::currentThread(), qApp->thread());
+                QVERIFY2(prepared.error.empty(), prepared.error.c_str());
+                ++completions;
+                result = std::move(prepared.mesh);
+            }
+        );
+
+        QTRY_COMPARE_WITH_TIMEOUT(completions, 1, 5000);
+        QVERIFY(result);
+        QCOMPARE(result->faceTriangleCounts.size(), std::size_t {6});
+    }
+
+    void boundingOverlayDoesNotInspectGeometryUntilShown()
+    {
+        if (Part::PropertyPartShape::getClassTypeId().isBad()) {
+            Part::PropertyPartShape::init();
+        }
+        BoundsFeature feature;
+        BoundsView view;
+        feature.shape.setValue(BRepPrimAPI_MakeBox(10, 20, 30).Shape());
+        view.attach(&feature);
+        view.addDisplayMaskMode(new SoSeparator, "Test");
+        view.setDisplayMaskMode("Test");
+        view.show();
+        QVERIFY(view.isShow());
+        for (int i = 0; i < 50; ++i) {
+            view.updateData(&feature.shape);
+            view.updateData(&feature.Placement);
+        }
+        QCOMPARE(feature.shape.reads->count.load(), 0U);
+
+        view.BoundingBox.setValue(true);
+        QCOMPARE(feature.shape.reads->count.load(), 0U);
+        QTRY_VERIFY((view.maximum() - SbVec3f(10, 20, 30)).length() < 0.001F);
+        QVERIFY(!feature.shape.reads->usedGui.load());
+        view.show();
+        QCOMPARE(feature.shape.reads->count.load(), 1U);
+
+        view.hide();
+        feature.shape.setValue(BRepPrimAPI_MakeBox(gp_Pnt(4, 5, 6), 7, 8, 9).Shape());
+        view.updateData(&feature.shape);
+        QCOMPARE(feature.shape.reads->count.load(), 1U);
+        view.show();
+        QTRY_VERIFY((view.minimum() - SbVec3f(4, 5, 6)).length() < 0.001F);
+        QCOMPARE(feature.shape.reads->count.load(), 2U);
+        QVERIFY((view.maximum() - SbVec3f(11, 13, 15)).length() < 0.001F);
+
+        view.BoundingBox.setValue(false);
+        view.updateData(&feature.shape);
+        QCOMPARE(feature.shape.reads->count.load(), 2U);
+        // The public method is also used independently of the property.
+        view.showBoundingBox(true);
+        QTRY_COMPARE(feature.shape.reads->count.load(), 3U);
+        view.updateData(&feature.shape);
+        QTRY_COMPARE(feature.shape.reads->count.load(), 4U);
+        QVERIFY(!feature.shape.reads->usedGui.load());
+
+        // A burst is captured once at the next owner dispatch, not once per
+        // property notification. Only the newest immutable value is adopted.
+        const auto beforeBurst = feature.shape.reads->count.load();
+        for (int i = 1; i <= 50; ++i) {
+            feature.shape.setValue(BRepPrimAPI_MakeBox(i, 20, 30).Shape());
+            view.updateData(&feature.shape);
+        }
+        QTRY_VERIFY((view.maximum() - SbVec3f(50, 20, 30)).length() < 0.001F);
+        QCOMPARE(feature.shape.reads->count.load(), beforeBurst + 1);
+        QVERIFY(!feature.shape.reads->usedGui.load());
+
+        auto reads = feature.shape.reads;
+        {
+            BoundsView discarded;
+            discarded.attach(&feature);
+            discarded.addDisplayMaskMode(new SoSeparator, "Test");
+            discarded.setDisplayMaskMode("Test");
+            discarded.show();
+            discarded.BoundingBox.setValue(true);
+        }
+        bool ownerDrained = false;
+        QVERIFY(Gui::dispatchToGuiFrame([&] { ownerDrained = true; }));
+        QTRY_VERIFY(ownerDrained);
+        QCOMPARE(reads->count.load(), beforeBurst + 1);
+    }
+
+    void deferredRestoreDoesNotTargetAReplacementDocument()
+    {
+        if (PartGui::SoBrepFaceSet::getClassTypeId().isBad()) {
+            PartGui::SoBrepFaceSet::initClass();
+            PartGui::SoBrepEdgeSet::initClass();
+            PartGui::SoBrepPointSet::initClass();
+        }
+        if (PartGui::ViewProviderPartExt::getClassTypeId().isBad()) {
+            PartGui::ViewProviderPartExt::init();
+        }
+        auto& guiApplication = *application;
+        auto& app = App::GetApplication();
+        const auto addView = [&](App::Document* document) {
+            auto* object = document->addObject("App::DocumentObject", "RestoredShape");
+            auto* view = new InspectablePartView;
+            view->attach(object);
+            guiApplication.getDocument(document)->addViewProvider(view);
+            view->Visibility.setValue(true);
+            return view;
+        };
+        auto* original = app.newDocument("DeferredRestoreIdentity");
+        auto* originalView = addView(original);
+        originalView->startRestoring();
+        originalView->finishRestoring();
+        // No Qt events have run: the old restore request is still queued.
+        // Removing its target cancels presentation before closing the document.
+        original->removeObject("RestoredShape");
+        QVERIFY(app.closeDocument("DeferredRestoreIdentity"));
+        auto* replacement = app.newDocument("DeferredRestoreIdentity");
+        auto* replacementView = addView(replacement);
+        replacementView->shapeReads = 0;
+        bool dispatched = false;
+        QVERIFY(Gui::dispatchToGuiFrame([&] { dispatched = true; }));
+        QTRY_VERIFY_WITH_TIMEOUT(dispatched, 5000);
+        // A queued restore must not inspect/render a different document just
+        // because its name and its first object's name/ID were reused.
+        QCOMPARE(replacementView->shapeReads, 0U);
+        QVERIFY(app.closeDocument("DeferredRestoreIdentity"));
+    }
+
+    void cancelledCompletionCannotAdoptIntoReusedTarget()
+    {
+        PartGui::RenderMeshController controller;
+        auto& runtime = App::GetApplication().hostRuntime();
+        int target = 0;
+        int obsoleteCompletions = 0;
+        int currentCompletions = 0;
+        std::shared_ptr<const Part::RenderMesh> result;
+        controller.request(
+            &target, BRepPrimAPI_MakeCylinder(10.0, 20.0).Shape(), 0.1, 28.5, false,
+            [&](PartGui::RenderMeshResult) { ++obsoleteCompletions; }
+        );
+
+        // Let the real worker enqueue its completion without dispatching GUI
+        // events. Reusing the target then deterministically tests a late result
+        // from before cancelAll(), rather than depending on worker timing.
+        QElapsedTimer deadline;
+        deadline.start();
+        while ((runtime.queuedTaskCount() || runtime.activeTaskCount())
+               && deadline.elapsed() < 5000) {
+            QThread::msleep(1);
+        }
+        QCOMPARE(runtime.queuedTaskCount(), std::size_t {0});
+        QCOMPARE(runtime.activeTaskCount(), std::size_t {0});
+        controller.cancelAll();
+        controller.request(
+            &target, BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape(), 0.1, 28.5, false,
+            [&](PartGui::RenderMeshResult prepared) {
+                ++currentCompletions;
+                result = std::move(prepared.mesh);
+            }
+        );
+
+        QTRY_COMPARE_WITH_TIMEOUT(currentCompletions, 1, 5000);
+        QCOMPARE(obsoleteCompletions, 0);
+        QVERIFY(result);
+        QCOMPARE(result->faceTriangleCounts.size(), std::size_t {6});
+    }
+
+    void cancellationReleasesOwnerCapturesBeforeWorkerDelivery()
+    {
+        PartGui::RenderMeshController controller;
+        int target = 0;
+        bool released = false;
+        bool delivered = false;
+        auto lease = std::make_shared<ReleaseCallback>();
+        lease->callback = [&] {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            released = true;
+        };
+        controller.request(&target, BRepPrimAPI_MakeBox(10, 20, 30).Shape(), 0.1, 28.5, false,
+            [lease, &delivered](PartGui::RenderMeshResult) { delivered = true; });
+        lease.reset();
+        controller.cancel(&target);
+        // No GUI event processing: cancellation must not retain a document's
+        // presentation lease until the obsolete worker delivers its result.
+        QVERIFY(released);
+        QVERIFY(!delivered);
+    }
+
+    void pendingCaptureReleaseMayReenterController()
+    {
+        PartGui::RenderMeshController controller;
+        int target = 0;
+        int obsoleteCompletions = 0;
+        int currentCompletions = 0;
+        bool released = false;
+        controller.request(&target, BRepPrimAPI_MakeCylinder(10, 20).Shape(), 0.1, 28.5, false,
+            [&](PartGui::RenderMeshResult) { ++obsoleteCompletions; });
+        auto lease = std::make_shared<ReleaseCallback>();
+        lease->callback = [&] {
+            QCOMPARE(QThread::currentThread(), qApp->thread());
+            released = true;
+            controller.cancelAll();
+            controller.request(&target, BRepPrimAPI_MakeBox(10, 20, 30).Shape(), 0.1, 28.5, false,
+                [&](PartGui::RenderMeshResult result) {
+                    QVERIFY2(result.error.empty(), result.error.c_str());
+                    QVERIFY(result.mesh);
+                    QCOMPARE(result.mesh->faceTriangleCounts.size(), std::size_t {6});
+                    ++currentCompletions;
+                });
+        };
+        controller.request(&target, BRepPrimAPI_MakeCylinder(12, 20).Shape(), 0.1, 28.5, false,
+            [lease, &obsoleteCompletions](PartGui::RenderMeshResult) { ++obsoleteCompletions; });
+        lease.reset();
+        // Replacing the pending request releases the old capture. Its callback
+        // clears/reuses the same target before this outer request returns.
+        controller.request(&target, BRepPrimAPI_MakeCylinder(14, 20).Shape(), 0.1, 28.5, false,
+            [&](PartGui::RenderMeshResult) { ++obsoleteCompletions; });
+        QVERIFY(released);
+        QTRY_COMPARE_WITH_TIMEOUT(currentCompletions, 1, 5000);
+        QCOMPARE(obsoleteCompletions, 0);
+    }
+
+    void edgeColoursAreCompleteBeforeMeshAdoption()
+    {
+        if (PartGui::SoBrepFaceSet::getClassTypeId().isBad()) {
+            PartGui::SoBrepFaceSet::initClass();
+            PartGui::SoBrepEdgeSet::initClass();
+            PartGui::SoBrepPointSet::initClass();
+        }
+        if (PartGui::ViewProviderPartExt::getClassTypeId().isBad()) {
+            PartGui::ViewProviderPartExt::init();
+        }
+        InspectablePartView provider;
+        provider.clearLineGeometry();
+        std::vector<Base::Color> colours;
+        for (int index = 0; index < 50; ++index) {
+            colours.emplace_back(0.1F + index * 0.01F, 0.3F, 0.7F);
+        }
+        // Exercise the actual property callback, not a conversion substitute.
+        // Restore can supply materials while geometry is still on a worker.
+        provider.LineColorArray.setValues(colours);
+        const auto& actual = provider.edgeMaterial()->diffuseColor;
+        QCOMPARE(actual.getNum(), static_cast<int>(colours.size()));
+        for (int index = 0; index < actual.getNum(); ++index) {
+            QCOMPARE(actual[index][0], colours[index].r);
+            QCOMPARE(actual[index][1], colours[index].g);
+            QCOMPARE(actual[index][2], colours[index].b);
+        }
+
+        provider.PointColorArray.setValues(colours);
+        provider.setFaceCount(static_cast<int>(colours.size()));
+        std::vector<App::Material> materials(colours.size());
+        for (std::size_t index = 0; index < colours.size(); ++index) {
+            materials[index].diffuseColor = colours[index];
+        }
+        provider.ShapeAppearance.setValues(materials);
+        provider.refreshUnchangedGeometry();
+        const auto edgeStamp = provider.edgeMaterial()->getNodeId();
+        const auto pointStamp = provider.pointMaterial()->getNodeId();
+        const auto faceStamp = provider.faceMaterial()->getNodeId();
+        for (int index = 0; index < 50; ++index) {
+            provider.refreshUnchangedGeometry();
+        }
+        QCOMPARE(provider.edgeMaterial()->getNodeId(), edgeStamp);
+        QCOMPARE(provider.pointMaterial()->getNodeId(), pointStamp);
+        QCOMPARE(provider.faceMaterial()->getNodeId(), faceStamp);
+
+        provider.setHighlightedEdges({Base::Color(1.0F, 0.0F, 0.0F)});
+        provider.refreshUnchangedGeometry();
+        QCOMPARE(actual.getNum(), static_cast<int>(colours.size()));
+        QCOMPARE(actual[0][0], colours[0].r);
+        // Derived providers can also change Coin fields directly. A cache
+        // cannot assume that only property notifications alter appearance.
+        provider.pointMaterial()->diffuseColor.setValue(1.0F, 0.0F, 0.0F);
+        provider.refreshUnchangedGeometry();
+        QCOMPARE(provider.pointMaterial()->diffuseColor.getNum(), static_cast<int>(colours.size()));
+        QCOMPARE(provider.pointMaterial()->diffuseColor[0][0], colours[0].r);
+
+        provider.setHighlightedFaces(std::vector<App::Material> {App::Material()});
+        provider.refreshUnchangedGeometry();
+        QCOMPARE(provider.faceMaterial()->diffuseColor.getNum(), static_cast<int>(colours.size()));
+        QCOMPARE(provider.faceMaterial()->diffuseColor[0][0], colours[0].r);
+
+        colours[0] = Base::Color(0.2F, 0.5F, 0.8F);
+        provider.LineColorArray.setValues(colours);
+        QCOMPARE(actual[0][0], colours[0].r);
+        QCOMPARE(actual[0][1], colours[0].g);
+        QCOMPARE(actual[0][2], colours[0].b);
+    }
+};
+
+QTEST_MAIN(RenderMeshControllerTest)
+
+#include "RenderMeshController.moc"

--- a/tests/src/Mod/Assembly/App/AssemblyObject.cpp
+++ b/tests/src/Mod/Assembly/App/AssemblyObject.cpp
@@ -4,12 +4,19 @@
 
 #include <FCConfig.h>
 
+#include <algorithm>
 #include <App/Application.h>
 #include <App/Document.h>
 #include <App/Expression.h>
 #include <App/ObjectIdentifier.h>
+#include <App/GeoFeature.h>
+#include <App/PropertyStandard.h>
+#include <App/PropertyLinks.h>
+#include <chrono>
+#include <thread>
 #include <Mod/Assembly/App/AssemblyObject.h>
 #include <Mod/Assembly/App/JointGroup.h>
+#include <OndselSolver/ASMTPart.h>
 #include <src/App/InitApplication.h>
 
 class AssemblyObjectTest: public ::testing::Test
@@ -52,4 +59,276 @@ TEST_F(AssemblyObjectTest, createAssemblyObject)  // NOLINT
     // Act
 
     // Assert
+}
+
+TEST_F(AssemblyObjectTest, SolverStatusRefreshIsCoalescedDuringPublicationAndRollback)
+{
+    auto* assembly = getObject();
+    auto* document = assembly->getDocument();
+    auto* grounded = assembly->addObject<App::GeoFeature>("Grounded");
+    grounded->Placement.setStatus(App::Property::ReadOnly, true);
+    ASSERT_EQ(assembly->solve(), 0);
+    const auto originalGroup = assembly->Group.getValues();
+    const auto originalDoF = assembly->getLastDoF();
+    document->setUndoMode(1);
+
+    size_t updates = 0;
+    bool updatedDuringReplay = false;
+    fastsignals::scoped_connection connection = assembly->signalSolverUpdate.connect([&] {
+        ++updates;
+        updatedDuringReplay |= document->isPerformingTransaction();
+    });
+    document->openTransaction("Create components to roll back");
+    for (size_t index = 0; index < 50; ++index) {
+        assembly->addObject<App::GeoFeature>("TemporaryComponent");
+    }
+    updates = 0;
+    document->abortTransaction();
+    EXPECT_FALSE(updatedDuringReplay);
+    EXPECT_EQ(updates, 1);
+    EXPECT_EQ(assembly->Group.getValues(), originalGroup);
+    EXPECT_EQ(assembly->getLastDoF(), originalDoF);
+
+    updates = 0;
+    document->beginCooperativeMutation();
+    document->openTransaction("Publish component batch");
+    for (size_t index = 0; index < 50; ++index) {
+        assembly->addObject<App::GeoFeature>("PublishedComponent");
+    }
+    EXPECT_EQ(updates, 0);
+    document->commitTransaction();
+    EXPECT_EQ(updates, 0);
+    document->endCooperativeMutation();
+    EXPECT_EQ(updates, 1);
+    EXPECT_EQ(assembly->getLastDoF(), originalDoF + 50 * 6);
+
+    updates = 0;
+    assembly->addObject<App::GeoFeature>("NormalComponent");
+    EXPECT_EQ(updates, 1);  // Ordinary edits retain immediate status updates.
+}
+
+TEST_F(AssemblyObjectTest, DeferredStatusRefreshDoesNotStartAnImplicitSolve)
+{
+    auto* document = getObject()->getDocument();
+    document->beginCooperativeMutation();
+    auto* assembly = document->addObject<Assembly::AssemblyObject>("NewAssembly");
+    auto* component = assembly->addObject<App::GeoFeature>("UngroundedComponent");
+    ASSERT_EQ(assembly->getLastSolverStatus(), 0);
+    document->endCooperativeMutation();
+    // A status refresh after loading/publication is not a request to solve.
+    // In particular it must not auto-ground a component as a solver side effect.
+    EXPECT_EQ(assembly->getLastSolverStatus(), 0);
+    EXPECT_TRUE(assembly->getLastSolverMessage().empty());
+    EXPECT_FALSE(component->Placement.testStatus(App::Property::ReadOnly));
+    EXPECT_EQ(assembly->getLastDoF(), 12);
+}
+
+TEST_F(AssemblyObjectTest, SimulationFramePlacementsSuppressTransientTouchState)
+{
+    auto* assembly = getObject();
+    auto* component = assembly->addObject<App::GeoFeature>("AnimatedComponent");
+    component->Placement.setStatus(App::Property::ReadOnly, true);
+    auto* simulation = assembly->addObject<App::DocumentObject>("Simulation");
+    const auto addFloat = [simulation](const char* name, double value) {
+        static_cast<App::PropertyFloat*>(simulation->addDynamicProperty("App::PropertyFloat", name))
+            ->setValue(value);
+    };
+    addFloat("aTimeStart", 0);
+    addFloat("bTimeEnd", 0.1);
+    addFloat("cTimeStepOutput", 0.1);
+    addFloat("fGlobalErrorTolerance", 1e-6);
+    addFloat("jFramesPerSecond", 30);
+    const auto waitReady = [](const auto& poll) {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        while (!poll()) {
+            if (std::chrono::steady_clock::now() >= deadline) { return false; }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return true;
+    };
+    const auto solve = assembly->startSimulation(simulation);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulation(solve); }));
+
+    const bool wasApplying = assembly->setSimulationPresentation(true);
+    component->Placement.setValue(
+        Base::Placement(Base::Vector3d(17, 0, 0), Base::Rotation()));
+    component->purgeTouched();
+    assembly->setSimulationPresentation(wasApplying);
+
+    const auto documentPlacement = component->Placement.getValue();
+    const auto immediateFrame = assembly->getSimulationFrame(1);
+    EXPECT_NE(
+        std::ranges::find_if(immediateFrame, [&](const auto& item) {
+            return item.first == component->getNameInDocument();
+        }),
+        immediateFrame.end()
+    );
+    EXPECT_TRUE(component->Placement.getValue().isSame(documentPlacement));
+
+    const auto presentationRequest = assembly->requestSimulationFrame(1);
+    std::optional<std::vector<std::pair<std::string, Base::Placement>>> presentationFrame;
+    ASSERT_TRUE(waitReady([&] {
+        presentationFrame = assembly->takeSimulationFrame(presentationRequest);
+        return presentationFrame.has_value();
+    }));
+    EXPECT_NE(
+        std::ranges::find_if(*presentationFrame, [&](const auto& item) {
+            return item.first == component->getNameInDocument();
+        }),
+        presentationFrame->end()
+    );
+    EXPECT_TRUE(component->Placement.getValue().isSame(documentPlacement));
+
+    size_t placementNotifications = 0;
+    bool noTouchDuringNotification = true;
+    fastsignals::scoped_connection connection =
+        assembly->getDocument()->signalChangedObject.connect(
+            [&](const App::DocumentObject& changed, const App::Property& property) {
+                if (&changed != component || &property != changed.getPlacementProperty()) { return; }
+                ++placementNotifications;
+                noTouchDuringNotification &= changed.testStatus(App::ObjectStatus::NoTouch);
+            });
+    const auto frame = assembly->requestSimulationFrame(1);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulationFrame(frame); }));
+    EXPECT_GT(placementNotifications, 0);
+    EXPECT_TRUE(noTouchDuringNotification);
+    EXPECT_FALSE(component->testStatus(App::ObjectStatus::NoTouch));
+}
+
+TEST_F(AssemblyObjectTest, DetachedSimulationAndFrameLifecycle)
+{
+    auto* assembly = getObject();
+    std::vector<App::GeoFeature*> components;
+    for (size_t index = 0; index < 50; ++index) {
+        auto* component = assembly->addObject<App::GeoFeature>("Component");
+        component->Placement.setValue(Base::Placement(
+            Base::Vector3d(double(index) * 2, 0, 0), Base::Rotation()));
+        component->Placement.setStatus(App::Property::ReadOnly, true);
+        components.push_back(component);
+    }
+    const auto sourceDocumentName = App::GetApplication().getUniqueDocumentName("SimulationSource");
+    auto* sourceDocument = App::GetApplication().newDocument(sourceDocumentName.c_str());
+    const auto closeSource = [](App::Document* document) {
+        App::GetApplication().closeDocument(document->getName());
+    };
+    std::unique_ptr<App::Document, decltype(closeSource)> sourceLifetime(sourceDocument, closeSource);
+    auto* linkedSource = sourceDocument->addObject<App::GeoFeature>("Source");
+    auto* sourceLink = static_cast<App::PropertyLink*>(components[0]->addDynamicProperty(
+        "App::PropertyLinkGlobal", "SimulationSource"));
+    sourceLink->setAllowExternal(true);
+    sourceLink->setValue(linkedSource);
+    auto* simulation = assembly->addObject<App::DocumentObject>("Simulation");
+    const auto addFloat = [simulation](const char* name, double value) {
+        static_cast<App::PropertyFloat*>(simulation->addDynamicProperty("App::PropertyFloat", name))->setValue(value);
+    };
+    addFloat("aTimeStart", 0);
+    addFloat("bTimeEnd", 0.2);
+    addFloat("cTimeStepOutput", 0.1);
+    addFloat("fGlobalErrorTolerance", 1e-6);
+    addFloat("jFramesPerSecond", 30);
+    const auto waitReady = [](const auto& poll) {
+        const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(30);
+        while (!poll()) {
+            if (std::chrono::steady_clock::now() >= deadline) { return false; }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        return true;
+    };
+    const auto oldSolve = assembly->startSimulation(simulation);
+    const auto solve = assembly->startSimulation(simulation);
+    assembly->cancelSimulation(oldSolve);
+    EXPECT_THROW(assembly->finishSimulation(oldSolve), std::runtime_error);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulation(solve); }));
+    ASSERT_GE(assembly->numberOfFrames(), 3);
+    // Discard in-memory reuse without changing the accepted input. Persisted
+    // playback must retain the existing full solver rather than installing a
+    // fake pose-only ASMT engine, and still support exact frame application.
+    const auto solvedPart = assembly->getMbDPart(components[0]);
+    const auto baseline = components[0]->Placement.getValue();
+    components[0]->Placement.setValue(Base::Placement(Base::Vector3d(77, 0, 0), Base::Rotation()));
+    components[0]->Placement.setValue(baseline);
+    const auto playback = assembly->startSimulationPlayback(simulation);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulation(playback); }));
+    EXPECT_EQ(assembly->getMbDPart(components[0]), solvedPart);
+    ASSERT_GE(assembly->numberOfFrames(), 3);
+    ASSERT_EQ(assembly->updateForFrame(1), 0);
+    const auto staleCachedFrame = assembly->requestSimulationFrame(2);
+    simulation->getPropertyByName<App::PropertyFloat>("bTimeEnd")->setValue(0.3);
+    EXPECT_THROW(assembly->finishSimulationFrame(staleCachedFrame), std::runtime_error);
+    const auto changedPlayback = assembly->startSimulationPlayback(simulation);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulation(changedPlayback); }));
+    EXPECT_NE(assembly->getMbDPart(components[0]), solvedPart);
+    EXPECT_GE(assembly->numberOfFrames(), 4);
+    simulation->getPropertyByName<App::PropertyFloat>("bTimeEnd")->setValue(0.2);
+    // A caller requesting full state after cached playback still receives a
+    // complete fresh engine, not the presentation cache as a purported solve.
+    const auto fullAgain = assembly->startSimulation(simulation);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulation(fullAgain); }));
+    EXPECT_NE(assembly->getMbDPart(components[0]), solvedPart);
+    EXPECT_EQ(assembly->getMbDPart(components[0])->xs->size(), assembly->numberOfFrames());
+    // An unrelated document object is not a simulation input. Creating,
+    // changing, or deleting it must not discard the already solved frames.
+    auto* unrelated = assembly->getDocument()->addObject<App::GeoFeature>("Unrelated");
+    unrelated->Placement.setValue(Base::Placement(Base::Vector3d(7, 8, 9), Base::Rotation()));
+    const auto unchangedFrame = assembly->requestSimulationFrame(1);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulationFrame(unchangedFrame); }));
+    assembly->getDocument()->removeObject(unrelated->getNameInDocument());
+    const auto frameAfterUnrelatedDeletion = assembly->requestSimulationFrame(1);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulationFrame(frameAfterUnrelatedDeletion); }));
+    // Visibility propagates a derived _GroupTouched notification to the parent.
+    // Neither notification changes any input used by the kinematic solve.
+    for (const bool visible : {false, true}) {
+        components[0]->Visibility.setValue(visible);
+        auto* groupTouched = assembly->getJointGroup()->getPropertyByName("_GroupTouched");
+        ASSERT_NE(groupTouched, nullptr);
+        groupTouched->touch();
+        const auto frameAfterVisibility = assembly->requestSimulationFrame(1);
+        ASSERT_TRUE(waitReady([&] { return assembly->finishSimulationFrame(frameAfterVisibility); }));
+    }
+    // Display cadence is not a solver input. Editing it must not throw away
+    // solved channels, unlike a time-step or component-placement change.
+    simulation->getPropertyByName<App::PropertyFloat>("jFramesPerSecond")->setValue(60);
+    // Unchanged solved inputs must be reusable without scheduling another solve.
+    const auto cachedSolve = assembly->startSimulation(simulation);
+    ASSERT_TRUE(assembly->finishSimulation(cachedSolve));
+    const auto cancelledReuse = assembly->startSimulation(simulation);
+    assembly->cancelSimulation(cancelledReuse);
+    EXPECT_THROW(assembly->finishSimulation(cancelledReuse), std::runtime_error);
+    const auto savedFrame = assembly->requestSimulationFrame(1);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulationFrame(savedFrame); }));
+    // Restoring a presentation pose during save is not a model edit; nested
+    // owner scopes must restore their prior state exactly.
+    const bool outer = assembly->setSimulationPresentation(true);
+    const bool inner = assembly->setSimulationPresentation(true);
+    EXPECT_FALSE(outer);
+    EXPECT_TRUE(inner);
+    components[0]->Placement.setValue(Base::Placement(Base::Vector3d(2, 3, 4), Base::Rotation()));
+    assembly->setSimulationPresentation(inner);
+    components[0]->Placement.setValue(Base::Placement());
+    assembly->setSimulationPresentation(outer);
+    ASSERT_EQ(assembly->updateForFrame(1), 0);
+    std::vector<Base::Placement> expected;
+    for (const auto* component : components) { expected.push_back(component->Placement.getValue()); }
+    const auto oldFrame = assembly->requestSimulationFrame(2);
+    const auto frame = assembly->requestSimulationFrame(1);
+    assembly->cancelSimulationFrame(oldFrame);
+    EXPECT_THROW(assembly->finishSimulationFrame(oldFrame), std::runtime_error);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulationFrame(frame); }));
+    for (size_t index = 0; index < components.size(); ++index) {
+        EXPECT_TRUE(components[index]->Placement.getValue().isSame(expected[index], 1e-10));
+    }
+    const auto cancelled = assembly->requestSimulationFrame(2);
+    assembly->cancelSimulationFrame(cancelled);
+    EXPECT_THROW(assembly->finishSimulationFrame(cancelled), std::runtime_error);
+    const auto invalidated = assembly->requestSimulationFrame(2);
+    components[0]->Placement.setValue(Base::Placement(Base::Vector3d(100, 0, 0), Base::Rotation()));
+    EXPECT_THROW(assembly->finishSimulationFrame(invalidated), std::runtime_error);
+    EXPECT_DOUBLE_EQ(components[0]->Placement.getValue().getPosition().x, 100);
+    const auto solveWithSource = assembly->startSimulation(simulation);
+    ASSERT_TRUE(waitReady([&] { return assembly->finishSimulation(solveWithSource); }));
+    const auto frameWithSource = assembly->requestSimulationFrame(1);
+    linkedSource->Placement.setValue(Base::Placement(Base::Vector3d(3, 4, 5), Base::Rotation()));
+    EXPECT_THROW(assembly->finishSimulationFrame(frameWithSource), std::runtime_error);
+    // Closing the owner while generation is active must not join the worker.
+    assembly->startSimulation(simulation);
 }

--- a/tests/src/Mod/Assembly/App/CMakeLists.txt
+++ b/tests/src/Mod/Assembly/App/CMakeLists.txt
@@ -2,4 +2,9 @@
 
 add_executable(Assembly_tests_run
         AssemblyObject.cpp
+        SimulationFrameSnapshot.cpp
+        SimulationPlaybackCache.cpp
 )
+
+# Ondsel's public matrix templates use the standard MSVC math constants.
+target_compile_definitions(Assembly_tests_run PRIVATE _USE_MATH_DEFINES)

--- a/tests/src/Mod/Assembly/App/SimulationFrameSnapshot.cpp
+++ b/tests/src/Mod/Assembly/App/SimulationFrameSnapshot.cpp
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include <gtest/gtest.h>
+#include <Mod/Assembly/App/SimulationFrameSnapshot.h>
+#include <App/HostRuntime.h>
+#include <OndselSolver/ASMTPart.h>
+
+TEST(SimulationFrameSnapshot, MatchesSolverAndOwnsItsSamples)
+{
+    MbD::ASMTPart part;
+    part.xs = std::make_shared<MbD::FullRow<double>>(std::initializer_list<double>{1, 2, 3});
+    part.ys = part.xs->copy();
+    part.zs = part.xs->copy();
+    part.bryxs = std::make_shared<MbD::FullRow<double>>(std::initializer_list<double>{0.3, -0.7, 1.1});
+    part.bryys = std::make_shared<MbD::FullRow<double>>(std::initializer_list<double>{-0.1, 0.4, -0.9});
+    part.bryzs = std::make_shared<MbD::FullRow<double>>(std::initializer_list<double>{2.1, 1.5, -2.7});
+    Base::Placement offset(Base::Vector3d(3, 4, 5), Base::Rotation(0.2, 0.3, 0.4, 0.5));
+    const auto track = Assembly::detail::SimulationFrameTrack::capture(part, offset, 3);
+    for (size_t frame = 0; frame < 3; ++frame) {
+        part.setPosition3D(part.getPosition3D(frame));
+        part.setRotationMatrix(part.getRotationMatrix(frame));
+        double x, y, z, w, qx, qy, qz;
+        part.getPosition3D(x, y, z);
+        part.getQuarternions(w, qx, qy, qz);
+        const auto expected = Base::Placement(Base::Vector3d(x, y, z), Base::Rotation(qx, qy, qz, w)) * offset;
+        EXPECT_TRUE(track.placementAt(frame).isSame(expected, 1e-12));
+    }
+    const auto expected = track.placementAt(1);
+    part.xs->at(1) = 100;
+    part.bryxs->at(1) = 100;
+    EXPECT_TRUE(track.placementAt(1).isSame(expected, 1e-12));
+    EXPECT_THROW(track.placementAt(3), std::out_of_range);
+    part.ys->clear();
+    EXPECT_THROW(Assembly::detail::SimulationFrameTrack::capture(part, offset, 3), std::runtime_error);
+}
+
+TEST(SimulationFrameSnapshot, IndependentComponentsUseTheSharedExecutor)
+{
+    MbD::ASMTPart part;
+    part.xs = part.ys = part.zs = part.bryxs = part.bryys = part.bryzs =
+        std::make_shared<MbD::FullRow<double>>(std::initializer_list<double>{0.1, 0.2});
+    const auto track = Assembly::detail::SimulationFrameTrack::capture(part, {}, 2);
+    App::HostRuntime runtime(4);
+    std::vector<Base::Placement> results(500);
+    auto completion = runtime.submit([&](std::stop_token) {
+        runtime.parallelFor(results.size(), [&](size_t index) {
+            results[index] = track.placementAt(index % 2);
+        });
+    });
+    runtime.wait(completion);
+    for (size_t index = 0; index < results.size(); ++index) {
+        EXPECT_TRUE(results[index].isSame(track.placementAt(index % 2), 1e-12));
+    }
+}

--- a/tests/src/Mod/Assembly/App/SimulationPlaybackCache.cpp
+++ b/tests/src/Mod/Assembly/App/SimulationPlaybackCache.cpp
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+#include <gtest/gtest.h>
+#include <QFile>
+#include <QTemporaryDir>
+#include <Mod/Assembly/App/SimulationPlaybackCache.h>
+#include <OndselSolver/ASMTPart.h>
+#include <OndselSolver/ASMTAssembly.h>
+
+TEST(SimulationPlaybackCache, AuthenticatesCompleteTracksAndRejectsCorruption)
+{
+    QTemporaryDir directory;
+    ASSERT_TRUE(directory.isValid());
+    Assembly::detail::SimulationPlaybackCache cache(directory.path().toStdString());
+    MbD::ASMTPart part;
+    part.xs = part.ys = part.zs = part.bryxs = part.bryys = part.bryzs =
+        std::make_shared<MbD::FullRow<double>>(std::initializer_list<double>{0.1, 0.2, 0.3});
+    const Base::Placement offset(Base::Vector3d(2, 3, 4), Base::Rotation());
+    const auto track = Assembly::detail::SimulationFrameTrack::capture(part, offset, 3);
+    const std::string key(64, 'a');
+    EXPECT_FALSE(cache.load(key, {offset}));
+    cache.store(key, {track});
+    const auto loaded = cache.load(key, {offset});
+    ASSERT_TRUE(loaded);
+    ASSERT_EQ(loaded->size(), 1);
+    for (size_t frame = 0; frame < 3; ++frame) {
+        EXPECT_TRUE(loaded->front().placementAt(frame).isSame(track.placementAt(frame), 1e-12));
+    }
+    EXPECT_FALSE(cache.load(std::string(64, 'b'), {offset}));
+    EXPECT_FALSE(cache.load(key, {offset, offset}));
+    QFile file(directory.filePath(QString::fromStdString(key) + ".frames"));
+    ASSERT_TRUE(file.open(QIODevice::ReadWrite));
+    ASSERT_TRUE(file.seek(file.size() - 1));
+    const auto last = file.read(1);
+    ASSERT_TRUE(file.seek(file.size() - 1));
+    ASSERT_EQ(file.write(QByteArray(1, last.front() ^ 1)), 1);
+    file.close();
+    EXPECT_FALSE(cache.load(key, {offset}));
+    // A valid completed replacement remains reusable after a bad cache entry.
+    cache.store(key, {track});
+    ASSERT_TRUE(cache.load(key, {offset}));
+}
+
+TEST(SimulationPlaybackCache, RejectsTruncatedAndMisidentifiedData)
+{
+    QTemporaryDir directory;
+    Assembly::detail::SimulationPlaybackCache cache(directory.path().toStdString());
+    MbD::ASMTPart part;
+    part.xs = part.ys = part.zs = part.bryxs = part.bryys = part.bryzs =
+        std::make_shared<MbD::FullRow<double>>(std::initializer_list<double>{0, 1});
+    const auto track = Assembly::detail::SimulationFrameTrack::capture(part, {}, 2);
+    const std::string key(64, 'c');
+    cache.store(key, {track});
+    QFile file(directory.filePath(QString::fromStdString(key) + ".frames"));
+    ASSERT_TRUE(file.open(QIODevice::ReadWrite));
+    ASSERT_TRUE(file.resize(file.size() - 1));
+    file.close();
+    EXPECT_FALSE(cache.load(key, {{}}));
+    EXPECT_THROW(cache.load("../invalid", {{}}), std::invalid_argument);
+}
+
+TEST(SimulationPlaybackCache, InputKeyIsExactAndIndependentOfContainerOrder)
+{
+    auto assembly = MbD::ASMTAssembly::With();
+    auto first = MbD::ASMTPart::With();
+    auto second = MbD::ASMTPart::With();
+    first->setName("first");
+    second->setName("second");
+    assembly->addPart(first);
+    assembly->addPart(second);
+    using Cache = Assembly::detail::SimulationPlaybackCache;
+    const std::vector<Cache::Binding> bindings {{"first", {}}, {"second", {}}};
+    const auto original = Cache::inputKey(*assembly, bindings, "producer-1");
+    std::reverse(assembly->parts->begin(), assembly->parts->end());
+    EXPECT_EQ(original, Cache::inputKey(*assembly, bindings, "producer-1"));
+    EXPECT_NE(original, Cache::inputKey(*assembly, bindings, "producer-2"));
+    auto changed = bindings;
+    changed[0].second.setPosition(Base::Vector3d(0, 0, 1e-14));
+    EXPECT_NE(original, Cache::inputKey(*assembly, changed, "producer-1"));
+    first->setPosition3D(0, 0, 1e-14);
+    EXPECT_NE(original, Cache::inputKey(*assembly, bindings, "producer-1"));
+}

--- a/tests/src/Mod/Mesh/App/Mesh.cpp
+++ b/tests/src/Mod/Mesh/App/Mesh.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 #include <Mod/Mesh/App/Mesh.h>
 #include <Mod/Mesh/App/Core/Grid.h>
+#include <Mod/Mesh/App/MeshProperties.h>
 
 #include <src/App/InitApplication.h>
 
@@ -27,6 +28,73 @@ TEST_F(MeshTest, TestDefault)
     EXPECT_EQ(kernel.CountPoints(), 3);
     EXPECT_EQ(kernel.CountEdges(), 3);
     EXPECT_EQ(kernel.CountFacets(), 1);
+}
+
+TEST_F(MeshTest, MoveTransfersGeometryBuffersAndSegmentOwnership)
+{
+    MeshCore::MeshKernel kernel;
+    kernel.AddFacet(MeshCore::MeshGeomFacet(
+        Base::Vector3f {0, 0, 0}, Base::Vector3f {0, 0, 1}, Base::Vector3f {0, 1, 0}));
+    const auto* kernelPoints = kernel.GetPoints().data();
+    const auto* kernelFacets = kernel.GetFacets().data();
+    MeshCore::MeshKernel transferred(std::move(kernel));
+    EXPECT_EQ(transferred.GetPoints().data(), kernelPoints);
+    EXPECT_EQ(transferred.GetFacets().data(), kernelFacets);
+
+    Mesh::MeshObject source(transferred);
+    source.addSegment(std::vector<Mesh::FacetIndex> {0});
+    source.getSegment(0).setName("surface");
+    Base::Matrix4D placement;
+    placement.move(Base::Vector3d {10, 20, 30});
+    source.setTransform(placement);
+    const auto* points = source.getKernel().GetPoints().data();
+    const auto* facets = source.getKernel().GetFacets().data();
+    const auto* indices = source.getSegment(0).getIndices().data();
+    const auto bounds = source.getBoundBox();
+
+    Mesh::MeshObject constructed(std::move(source));
+    EXPECT_EQ(constructed.getKernel().GetPoints().data(), points);
+    EXPECT_EQ(constructed.getKernel().GetFacets().data(), facets);
+    EXPECT_EQ(constructed.getSegment(0).getIndices().data(), indices);
+
+    Base::Reference<Mesh::MeshObject> assigned(new Mesh::MeshObject(transferred));
+    assigned->addSegment(std::vector<Mesh::FacetIndex> {0});
+    *assigned = std::move(constructed);
+    EXPECT_EQ(assigned->getKernel().GetPoints().data(), points);
+    EXPECT_EQ(assigned->getKernel().GetFacets().data(), facets);
+    EXPECT_EQ(assigned->getSegment(0).getIndices().data(), indices);
+    EXPECT_EQ(assigned->getSegment(0).getName(), "surface");
+    EXPECT_DOUBLE_EQ(assigned->getBoundBox().MinX, bounds.MinX);
+    EXPECT_DOUBLE_EQ(assigned->getBoundBox().MaxZ, bounds.MaxZ);
+    // Segment iterators must address the new owner, not either moved-from mesh.
+    EXPECT_DOUBLE_EQ(assigned->getSegment(0).facets_begin()->_aclPoints[0].x, 10.0);
+    *assigned = std::move(*assigned);
+    EXPECT_EQ(assigned->countFacets(), 1);
+}
+
+TEST_F(MeshTest, PropertySnapshotsRemainIndependentAndPastePreservesMeshIdentity)
+{
+    MeshCore::MeshKernel kernel;
+    kernel.AddFacet(MeshCore::MeshGeomFacet(
+        Base::Vector3f {0, 0, 0}, Base::Vector3f {0, 0, 1}, Base::Vector3f {0, 1, 0}));
+    Mesh::PropertyMeshKernel source;
+    source.setValue(kernel);
+    std::unique_ptr<App::Property> copy(source.Copy());
+    const auto& snapshot = dynamic_cast<const Mesh::PropertyMeshKernel&>(*copy);
+    EXPECT_NE(source.getValue().getKernel().GetPoints().data(),
+              snapshot.getValue().getKernel().GetPoints().data());
+    Mesh::PropertyMeshKernel destination;
+    const auto* identity = destination.getValuePtr();
+    destination.Paste(snapshot);
+    EXPECT_EQ(destination.getValuePtr(), identity);
+    EXPECT_NE(destination.getValue().getKernel().GetPoints().data(),
+              snapshot.getValue().getKernel().GetPoints().data());
+    source.setValue(MeshCore::MeshKernel {});
+    EXPECT_EQ(snapshot.getValue().countFacets(), 1);
+    EXPECT_EQ(destination.getValue().countFacets(), 1);
+    destination.Paste(destination);
+    EXPECT_EQ(destination.getValuePtr(), identity);
+    EXPECT_EQ(destination.getValue().countFacets(), 1);
 }
 
 TEST_F(MeshTest, TestGrid1OfPlanarMesh)

--- a/tests/src/Mod/Part/App/BRepMesh.cpp
+++ b/tests/src/Mod/Part/App/BRepMesh.cpp
@@ -1,12 +1,30 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <algorithm>
+#include <stdexcept>
+#include <numbers>
+
 #include <gtest/gtest.h>
+#include <BRepPrimAPI_MakeBox.hxx>
+#include <BRep_Builder.hxx>
+#include <TopoDS_Compound.hxx>
+#include <App/Application.h>
+#include <App/HostRuntime.h>
+#include <src/App/InitApplication.h>
 #include "Mod/Part/App/BRepMesh.h"
+#include "Mod/Part/App/RenderMesh.h"
+#include "Mod/Part/App/ProgressIndicator.h"
+#include <Message_ProgressScope.hxx>
 
 // NOLINTBEGIN
 class BRepMeshTest: public ::testing::Test
 {
 protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+
     void SetUp() override
     {}
 
@@ -172,5 +190,153 @@ TEST_F(BRepMeshTest, testUnconnectedDomains)
 
     EXPECT_EQ(points.size(), 6);
     EXPECT_EQ(faces.size(), 4);
+}
+
+TEST_F(BRepMeshTest, preparesCompleteRenderArraysWithoutCoinNodes)
+{
+    const TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape();
+
+    const Part::RenderMesh mesh = Part::prepareRenderMesh(box, 0.5, 28.5, true);
+
+    EXPECT_FALSE(mesh.vertices.empty());
+    EXPECT_EQ(mesh.normalCount(), mesh.vertexStart);
+    EXPECT_EQ(mesh.triangleIndices.size() % 4, 0);
+    EXPECT_EQ(mesh.faceTriangleCounts.size(), 6);
+    EXPECT_FALSE(mesh.lineIndices.empty());
+    EXPECT_EQ(
+        mesh.lineMaterialIndices.size(),
+        static_cast<std::size_t>(std::count(mesh.lineIndices.begin(), mesh.lineIndices.end(), -1))
+            + 1
+    );
+    EXPECT_TRUE(std::all_of(
+        mesh.lineMaterialIndices.begin(),
+        mesh.lineMaterialIndices.end(),
+        [](std::int32_t material) {
+            return material == 0;
+        }
+    ));
+    EXPECT_EQ(mesh.vertexStart + 8, mesh.vertexCount());
+}
+
+TEST_F(BRepMeshTest, preparesFiftyLocatedInstancesOnTheSharedRuntime)
+{
+    BRep_Builder builder;
+    TopoDS_Compound assembly;
+    builder.MakeCompound(assembly);
+    const TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape();
+    for (int index = 0; index < 50; ++index) {
+        gp_Trsf placement;
+        placement.SetRotation(gp_Ax1(gp_Pnt(), gp_Dir(0, 0, 1)),
+                              index % 2 ? std::numbers::pi / 2 : 0);
+        placement.SetTranslationPart(gp_Vec(index * 40.0, 0.0, 0.0));
+        builder.Add(assembly, box.Located(TopLoc_Location(placement)));
+    }
+    auto& runtime = App::GetApplication().hostRuntime();
+    std::vector<std::future<Part::RenderMesh>> jobs;
+    for (const bool useUV : {false, true}) {
+        jobs.push_back(runtime.submit([assembly, useUV](std::stop_token stop) {
+            return Part::prepareRenderMesh(assembly, 0.5, 28.5, useUV, stop);
+        }));
+    }
+    for (auto& job : jobs) {
+        const auto mesh = job.get();
+        EXPECT_EQ(mesh.faceTriangleCounts.size(), 300);
+        EXPECT_EQ(mesh.triangleIndices.size(), 50 * 12 * 4);
+        EXPECT_EQ(std::count(mesh.lineIndices.begin(), mesh.lineIndices.end(), -1), 600);
+        EXPECT_EQ(mesh.lineMaterialIndices.size(), 601);
+        EXPECT_EQ(mesh.vertexStart + 400, mesh.vertexCount());
+        for (const auto index : mesh.triangleIndices) {
+            EXPECT_TRUE(index == -1 || (index >= 0 && index < mesh.vertexStart));
+        }
+        for (const auto index : mesh.lineIndices) {
+            EXPECT_TRUE(index == -1 || (index >= 0 && index < mesh.vertexCount()));
+        }
+        for (std::size_t offset = 0; offset < mesh.triangleIndices.size(); offset += 4) {
+            const auto point = [&](int vertex) {
+                return Base::Vector3f(mesh.vertices[vertex * 3],
+                                      mesh.vertices[vertex * 3 + 1],
+                                      mesh.vertices[vertex * 3 + 2]);
+            };
+            const int first = mesh.triangleIndices[offset];
+            auto geometric = (point(mesh.triangleIndices[offset + 1]) - point(first))
+                % (point(mesh.triangleIndices[offset + 2]) - point(first));
+            geometric.Normalize();
+            const Base::Vector3f normal(mesh.normals[first * 3],
+                                        mesh.normals[first * 3 + 1],
+                                        mesh.normals[first * 3 + 2]);
+            EXPECT_GT(geometric * normal, 0.99f);
+        }
+        for (std::size_t offset = 0; offset < mesh.normals.size(); offset += 3) {
+            const auto x = mesh.normals[offset];
+            const auto y = mesh.normals[offset + 1];
+            const auto z = mesh.normals[offset + 2];
+            EXPECT_NEAR(x * x + y * y + z * z, 1.0, 1e-5);
+        }
+        float maximumX = 0;
+        for (std::size_t offset = 0; offset < mesh.vertices.size(); offset += 3) {
+            maximumX = std::max(maximumX, mesh.vertices[offset]);
+        }
+        EXPECT_FLOAT_EQ(maximumX, 49 * 40.0f);
+    }
+}
+
+TEST_F(BRepMeshTest, renderCoordinatesExcludeOnlyTheRootPlacement)
+{
+    BRep_Builder builder;
+    TopoDS_Compound compound;
+    builder.MakeCompound(compound);
+    gp_Trsf childPlacement;
+    childPlacement.SetTranslation(gp_Vec(40, 10, 5));
+    const auto child = BRepPrimAPI_MakeBox(10, 20, 30).Shape()
+        .Located(TopLoc_Location(childPlacement));
+    builder.Add(compound, child);
+    gp_Trsf placement;
+    placement.SetRotation(gp_Ax1(gp_Pnt(), gp_Dir(0, 0, 1)), std::numbers::pi / 2);
+    placement.SetTranslationPart(gp_Vec(100, 200, 300));
+    const auto located = compound.Located(TopLoc_Location(placement));
+    const auto originalRootLocation = located.Location();
+    const auto originalChildLocation = child.Location();
+    const auto localMesh = Part::prepareRenderMesh(compound, 0.5, 28.5, true);
+    const auto placedMesh = Part::prepareRenderMesh(located, 0.5, 28.5, true);
+    // The scene graph applies the root Placement exactly once; nested compound
+    // placements remain baked into the private render coordinates.
+    EXPECT_EQ(placedMesh.vertices, localMesh.vertices);
+    EXPECT_EQ(placedMesh.normals, localMesh.normals);
+    EXPECT_EQ(placedMesh.triangleIndices, localMesh.triangleIndices);
+    EXPECT_EQ(placedMesh.lineIndices, localMesh.lineIndices);
+    ASSERT_FALSE(localMesh.vertices.empty());
+    EXPECT_FLOAT_EQ(localMesh.vertices[0], 40);
+    EXPECT_TRUE(located.Location().IsEqual(originalRootLocation));
+    EXPECT_TRUE(child.Location().IsEqual(originalChildLocation));
+    EXPECT_TRUE(compound.Location().IsIdentity());
+}
+
+TEST_F(BRepMeshTest, kernelProgressObservesWorkerCancellation)
+{
+    std::stop_source cancellation;
+    Handle(Part::ProgressIndicator) indicator =
+        new Part::ProgressIndicator(cancellation.get_token());
+    Message_ProgressScope scope(indicator->Start(), "Meshing", 50);
+    EXPECT_FALSE(scope.UserBreak());
+    {
+        Message_ProgressScope face(scope.Next(), "Face", 3);
+        EXPECT_FALSE(face.UserBreak());
+        cancellation.request_stop();
+        EXPECT_TRUE(face.UserBreak());
+    }
+    EXPECT_TRUE(scope.UserBreak());
+}
+
+TEST_F(BRepMeshTest, cancelledRenderCannotReturnAPartialArtifact)
+{
+    std::stop_source cancellation;
+    cancellation.request_stop();
+    const TopoDS_Shape box = BRepPrimAPI_MakeBox(10.0, 20.0, 30.0).Shape();
+    EXPECT_THROW(
+        Part::prepareRenderMesh(box, 0.5, 28.5, true, cancellation.get_token()),
+        std::runtime_error);
+    EXPECT_THROW(
+        Part::prepareRenderMesh(TopoDS_Shape(), 0.5, 28.5, true, cancellation.get_token()),
+        std::runtime_error);
 }
 // NOLINTEND

--- a/tests/src/Mod/Part/App/PropertyTopoShape.cpp
+++ b/tests/src/Mod/Part/App/PropertyTopoShape.cpp
@@ -1,6 +1,11 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
 #include <gtest/gtest.h>
+#include <sstream>
+
+#include <Base/Reader.h>
+#include <Base/Writer.h>
+#include <Base/Base64Filter.h>
 
 #include <BRepFilletAPI_MakeFillet.hxx>
 #include "Mod/Part/App/FeaturePartCommon.h"
@@ -119,6 +124,77 @@ TEST_F(PropertyTopoShapeTest, testPropertyPartShapeTopoShape)
     EXPECT_TRUE(topoDsShapeOut.IsSame(topoDsShapeIn));
     EXPECT_EQ(getVolume(topoDsShapeOut), 3);
     EXPECT_EQ(topoShapeOut.getElementMapSize(), 26);
+}
+
+TEST_F(PropertyTopoShapeTest, geometryValuePreservesStructureRevisionButSchemaDoesNot)
+{
+    auto* object = _doc->addObject<App::DocumentObject>();
+    auto* shape = static_cast<Part::PropertyPartShape*>(
+        object->addDynamicProperty("Part::PropertyPartShape", "Shape"));
+    ASSERT_NE(shape, nullptr);
+    const auto structure = _doc->getObjectStructureGeneration();
+    const auto values = _doc->getObjectChangeGeneration();
+    shape->setValue(_common->Shape.getValue());
+    EXPECT_EQ(_doc->getObjectStructureGeneration(), structure);
+    EXPECT_GT(_doc->getObjectChangeGeneration(), values);
+    EXPECT_TRUE(object->removeDynamicProperty("Shape"));
+    EXPECT_GT(_doc->getObjectStructureGeneration(), structure);
+}
+
+TEST_F(PropertyTopoShapeTest, inlineShapeRoundTripPreservesGeometry)
+{
+    Part::PropertyPartShape original;
+    original.setValue(_common->Shape.getValue());
+    for (const bool binary : {false, true}) {
+        SCOPED_TRACE(binary ? "inline binary BREP" : "inline text BREP");
+        Base::StringWriter writer;
+        writer.setForceXML(true);
+        if (binary) {
+            writer.setMode("BinaryBrep");
+        }
+        writer.Stream() << "<?xml version='1.0'?><Document>";
+        original.Save(writer);
+        writer.Stream() << "</Document>";
+
+        if (binary) {
+            std::ostringstream expected;
+            original.getShape().exportBinary(expected);
+            const auto saved = writer.getString();
+            const auto contentStart = saved.find('>', saved.find("<Part ")) + 1;
+            std::istringstream encoded(saved.substr(contentStart,
+                                                    saved.find("</Part>") - contentStart));
+            auto decoder = Base::create_base64_decoder(encoded);
+            const std::string written {std::istreambuf_iterator<char>(*decoder), {}};
+            ASSERT_EQ(written.size(), expected.str().size()) << "binary writer";
+            ASSERT_TRUE(written == expected.str()) << "binary writer";
+            std::istringstream xml(writer.getString());
+            Base::XMLReader decodedReader("binary-shape.xml", xml);
+            decodedReader.readElement("Part");
+            auto& decodedStream = decodedReader.beginCharStream(Base::CharStreamFormat::Base64Encoded);
+            const std::string decoded {std::istreambuf_iterator<char>(decodedStream), {}};
+            ASSERT_EQ(decoded.size(), expected.str().size());
+            ASSERT_TRUE(decoded == expected.str());
+        }
+
+        std::istringstream stream(writer.getString());
+        Base::XMLReader reader("inline-shape.xml", stream);
+        Part::PropertyPartShape restored;
+        try {
+            restored.Restore(reader);
+        }
+        catch (const Base::Exception& error) {
+            FAIL() << error.what();
+        }
+        catch (const Standard_Failure& error) {
+            FAIL() << error.GetMessageString();
+        }
+        ASSERT_FALSE(restored.getValue().IsNull());
+        EXPECT_DOUBLE_EQ(getVolume(restored.getValue()), getVolume(original.getValue()));
+        EXPECT_EQ(restored.getShape().countSubShapes(TopAbs_FACE),
+                  original.getShape().countSubShapes(TopAbs_FACE));
+        EXPECT_EQ(restored.getShape().countSubShapes(TopAbs_SOLID),
+                  original.getShape().countSubShapes(TopAbs_SOLID));
+    }
 }
 
 TEST_F(PropertyTopoShapeTest, testPropertyPartShapeTopoDSShape)

--- a/tests/src/Mod/TechDraw/App/CMakeLists.txt
+++ b/tests/src/Mod/TechDraw/App/CMakeLists.txt
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
 add_executable(TechDraw_tests_run
+        DrawViewThreading.cpp
         LineFormat.cpp
 )

--- a/tests/src/Mod/TechDraw/App/DrawViewThreading.cpp
+++ b/tests/src/Mod/TechDraw/App/DrawViewThreading.cpp
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <atomic>
+#include <functional>
+#include <thread>
+
+#include <boost/scope_exit.hpp>
+#include <gtest/gtest.h>
+
+#include <App/MainThreadSignal.h>
+#include <Mod/TechDraw/App/DrawPage.h>
+#include <Mod/TechDraw/App/DrawView.h>
+#include <src/App/InitApplication.h>
+
+namespace
+{
+std::atomic_bool ownerDispatchUsed {false};
+std::atomic_bool blockingDispatchUsed {false};
+
+bool reportWorkerThread()
+{
+    return false;
+}
+
+void invokeOwner(std::function<void()>&& function, bool blocking)
+{
+    ownerDispatchUsed.store(true, std::memory_order_release);
+    blockingDispatchUsed.store(blocking, std::memory_order_release);
+    function();
+}
+}  // namespace
+
+class DrawViewThreadingTest: public ::testing::Test
+{
+protected:
+    static void SetUpTestSuite()
+    {
+        tests::initApplication();
+    }
+};
+
+TEST_F(DrawViewThreadingTest, PaintNotificationUsesOwnerDispatchFromNativeWorker)
+{
+    ownerDispatchUsed.store(false, std::memory_order_release);
+    blockingDispatchUsed.store(false, std::memory_order_release);
+    App::MainThreadSignalConfig::setHooks(&reportWorkerThread, &invokeOwner);
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::MainThreadSignalConfig::setHooks(nullptr, nullptr);
+    };
+
+    TechDraw::DrawView view;
+    std::atomic_bool slotCalled {false};
+    auto connection = view.signalGuiPaint.connect([&](const TechDraw::DrawView* source) {
+        EXPECT_EQ(source, &view);
+        slotCalled.store(true, std::memory_order_release);
+    });
+
+    std::thread worker([&] { view.signalGuiPaint(&view); });
+    worker.join();
+
+    EXPECT_TRUE(ownerDispatchUsed.load(std::memory_order_acquire));
+    EXPECT_TRUE(blockingDispatchUsed.load(std::memory_order_acquire));
+    EXPECT_TRUE(slotCalled.load(std::memory_order_acquire));
+    EXPECT_TRUE(connection.connected());
+}
+
+TEST_F(DrawViewThreadingTest, PagePaintNotificationUsesOwnerDispatchFromNativeWorker)
+{
+    ownerDispatchUsed.store(false, std::memory_order_release);
+    blockingDispatchUsed.store(false, std::memory_order_release);
+    App::MainThreadSignalConfig::setHooks(&reportWorkerThread, &invokeOwner);
+    BOOST_SCOPE_EXIT_ALL(&)
+    {
+        App::MainThreadSignalConfig::setHooks(nullptr, nullptr);
+    };
+
+    TechDraw::DrawPage page;
+    std::atomic_bool slotCalled {false};
+    auto connection = page.signalGuiPaint.connect([&](const TechDraw::DrawPage* source) {
+        EXPECT_EQ(source, &page);
+        slotCalled.store(true, std::memory_order_release);
+    });
+
+    std::thread worker([&] { page.signalGuiPaint(&page); });
+    worker.join();
+
+    EXPECT_TRUE(ownerDispatchUsed.load(std::memory_order_acquire));
+    EXPECT_TRUE(blockingDispatchUsed.load(std::memory_order_acquire));
+    EXPECT_TRUE(slotCalled.load(std::memory_order_acquire));
+    EXPECT_TRUE(connection.connected());
+}

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC6",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 1,
+  "build_version": 2,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
## Summary

Collect the complete `performance/authoritative-runtime` work: **109 VibeCAD commits consolidated into one commit, `de050853`**, including the original shared-core performance work, the subsequent publication/simulation fixes, and Linux AppImage graphics compatibility. This is not a simulation-only PR. The owner explicitly requested the squash. Historical revision labels in the evidence documents identify the original test checkpoints.

Substantial improvements are implemented and exercised. The original application-wide performance goal is not presented as universally complete; final Windows archive acceptance, macOS acceptance, and the measured residual latency work remain listed below.

## User-visible improvements and implementation

- Start an application-owned runtime with shared compute/I/O admission and persistent isolated workers. Route recompute dependency waves, detached geometry preparation, rendering preparation and existing VibeScript domains through shared infrastructure. Independent work can overlap; live document ownership and Qt presentation remain coordinated, not arbitrary concurrent mutation.
- Improve document open/restore, queued save and close, progress reporting, and bounded Tree/History/render adoption. Reuse dirty-object projections, preserve restored presentation state, and avoid redundant visibility changes and repeated whole-document scans.
- Control numerical-library thread/scratch-memory allocation under the shared CPU/memory budget; avoid redundant mesh-buffer copies and preserve resource-lifecycle diagnostics.
- Accelerate publication through indexed live-object membership, call-local History ownership data, batched dependency rebasing, isolated result validation, and reduced observer bookkeeping during rollback. Preserve identities, revision validation, cancellation and rollback.
- Improve native assembly solving, async human/AI playback, changed-input invalidation, frame preparation and animation export. Persist authenticated native playback channels for reuse after reopen, while keeping full solver APIs separate. Correct root-local rendering transforms and avoid blocking camera animation during setup.
- Present cached simulation poses directly through existing ViewProvider scene-graph transforms during interactive playback. This avoids per-frame document placement writes, document notifications, recompute work and Tree refresh scheduling while preserving the document-backed path for presentation/export behavior. Playback advances sequentially without wall-clock catch-up bursts.
- Exclude every bundled `libdrm*.so*` library from the Linux AppImage staging tree so Mesa resolves the host-matched DRM stack. The wildcard covers current and future libdrm ABI filenames and keeps the existing AMD host-library launcher fallback.
- Fix concurrent linked-source resolution and shared topology-string interning; keep GUI access on its owner thread while background computation proceeds.
- Remove the reported arbitrary model/component/output-size and automatic source-operation ceilings while preserving validation, cancellation and resource/overflow checks. Page source discovery for bounded AI context instead of imposing model-size limits.
- Bundle Codex 0.153.4 with its required companion executables. Retain opt-in production tracing and reusable native-input, GUI lifecycle, publication, simulation, capacity and memory probes.
- Advance the canonical release identity to `v26.3.1-RC6-build2`, the next unused build number, so merged artifacts publish as a new immutable release rather than replacing build 1.

The engineering-brief work is not included. The unrelated working-tree `package/rattler-build/pixi.lock` edit is not committed or included. No local model fixtures or private machine paths are included.

## Solver dependency

The OndselSolver submodule advances from `bd0b5dc` to `f649801`: independent static-solve work, preservation of the host executor during kinematics, and host cancellation handling. These changes are merged into the `10-X-eng/OndselSolver` fork's `main` by [OndselSolver PR #1](https://github.com/10-X-eng/OndselSolver/pull/1); clean checkout does not depend on an unpublished commit or feature branch.

## Verification already performed

Fresh Linux red/green tests and a complete local AppImage build were run for the final playback and packaging changes. Earlier detailed history, commands, failures and measurements remain in [the results ledger](src/Tools/performance/PUBLICATION_SIMULATION_RESULTS.md) and [the benchmark documentation](src/Tools/performance/README.md).

The new focused tests failed before implementation: the playback regression observed document-placement use instead of direct graphics transforms, the Tree regression observed one active refresh timer instead of zero, and the packaging regression had no wildcard DRM exclusion helper. After implementation:

```text
cmake --build build/release --target Assembly_tests_run -j4
cmake --build build/release --target FreeCADGui DocumentBulkMutation_Tests_run -j4
  PASS: all touched native targets rebuilt.
ctest --test-dir build/release -R '^AssemblyObjectTest\.SimulationFramePlacementsSuppressTransientTouchState$' --output-on-failure
  PASS: 1/1.

xvfb-run -a build/release/tests/DocumentBulkMutation_Tests_run transientLinkPlacementsDoNotScheduleTreeRefresh
  PASS: 3 passed, 0 failed with Qt 6.11.1.

python3 -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py
  PASS: 54 passed.

python3 -m unittest src.Tools.tests.test_linux_appimage_launcher
  PASS: 3 passed.

CREATE_BUNDLE_PHASE=appdir ./create_bundle.sh
CREATE_BUNDLE_PHASE=appimage ./create_bundle.sh
  PASS: built VibeCAD-26.3.1-RC6-build1-Linux-x86_64.AppImage; SHA-256 verified.

APPIMAGE_EXTRACT_AND_RUN=1 ./VibeCAD-26.3.1-RC6-build1-Linux-x86_64.AppImage freecadcmd --safe-mode --version
  PASS: VibeCAD 26.3.1-RC6 (Build 1).
```

Release metadata validation after the build-number bump:

```text
python3 src/Tools/sync_version.py --check
python3 -m unittest src.Tools.tests.test_sync_version src.Tools.tests.test_release_artifact_name src.Tools.tests.test_windows_installer_version src.Tools.tests.test_generate_update_manifest src.Tools.tests.test_release_workflow src.Tools.tests.test_vibecad_update
  PASS: 117 tests, 5 skipped; build 2 tag and GitHub release identity confirmed unused.
```

A packaged 60-frame jet-engine playback probe reported consecutive frames, zero document-property changes, Tree updates continuously enabled and zero active Tree refresh timers. The owner confirmed that simulation playback works much better and that the rebuilt AppImage launches successfully on the real Linux display.

Earlier relevant commands and recorded Windows results:

```text
build/authoritative-runtime-build.cmd all
  PASS: full native rebuild, exit 0.

build/authoritative-runtime-build.cmd Assembly_tests_run
build/authoritative-runtime-native/bin/Assembly_tests_run.exe
  PASS: 9 native tests, 1.853 seconds, with matching native dependency environment.

.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_animation_export.py src/Mod/VibeCAD/vibecad_tests/test_async_simulation_service.py src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py src/Mod/VibeCAD/vibecad_tests/test_native_assembly_playback.py src/Tools/performance/test_async_report_writer.py -q
  PASS: 73 tests, 6.78 seconds.

.pixi/envs/default/python.exe -m pytest src/Mod/VibeCAD/vibecad_tests/test_native_state.py src/Mod/VibeCAD/vibecad_tests/test_vibescript_timeline_publication.py src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py -q
  PASS: 108 tests, 1.87 seconds.
```

The commands under `build/` refer to retained local build wrappers, not clean-checkout tooling. Reproducible probe entry points are committed under `src/Tools/performance`; their setup is documented there. The full Windows portable build using the Rattler packaging flow was started separately; its completion and final extracted-archive acceptance are **not claimed here**.

Representative real-GUI evidence, with rebuilt modules (not final-archive certification):

- Large-model publication: cancel after 900 objects restores the exact 3,022-object inventory; retry publishes all 1,159 items, reaching 3,253 objects. Profiled retry: 42.750 seconds. Cancellation callback reduced from 1.187 to 0.453 seconds.
- Simulation: fresh preparation/display 47.648 seconds; after document reopen, matching cached preparation/display 0.571 seconds, excluding document-open time. All 337 tracked component poses matched at three frames; 672 joint-marker poses checked.
- Animation export: successful 22-frame retry in 11.340 seconds, with visible motion; cancellation and close restore the selected frame/original poses.
- Concurrent link regression: unfixed code produced 12,663 incorrect results in 60,000 lookups; corrected code completed 1.5 million concurrent lookups without errors.
- Owner testing reports substantially smoother opening/rendering, responsive normal operation, restored Tree expansion state and roughly 1 GiB memory on the large model. These are observed checkpoints, not universal guarantees.

For the latest playback changes, native missing-API/header tests and a Python playback-selection regression failed before implementation, then passed. Rollback-observer changes similarly had seven failing cases before their fix. These focused red/green results do not substitute for a fresh entire-branch suite.

## Remaining work / risk

- Validate the final complete extracted Windows archive without source overlays: publication cancel/rollback/retry, independent multi-output create/patch/input edits, playback/cache invalidation, export and document lifecycle.
- Attribute the measured 1.219-second combined cleanup/close/reopen callback. Residual oversized owner callbacks remain; do not describe the entire interface as never blocking or publication as entirely parallel.
- Reconcile the original whole-application acceptance inventory; Analyze, Drawing, Manufacturing and other workbenches are not all newly certified by the simulation results.
- This is a large cross-cutting native/Python change (278 files), with concurrency, persistence, rendering and packaging risk. Windows has direct local evidence. Linux now has a complete local AppImage build, packaged simulation probe and owner launch/playback acceptance; macOS acceptance is not established here.

The user-facing outcomes, implementation summary, measurements and outstanding acceptance work are consolidated in [PERFORMANCE.md](PERFORMANCE.md). Related: #188 and #191; no automatic issue closure is requested while acceptance remains outstanding.

## Compatibility / verification checklist

- [ ] Entire-branch public API compatibility audit complete.
- [ ] No unapproved preference/tool/schema renames or removals across the full branch.
- [ ] Entire-branch defaults/behavior changes fully audited; performance scheduling and capacity changes are intentional owner-requested changes.
- [ ] Deprecation and breaking-change inventory complete, with any required owner approvals recorded.
- [x] Latest fixes include recorded red/green regression results; exact commands and outcomes are listed above and in the ledger.
- [x] Final Linux AppImage built, checksum verified, launched and exercised with packaged simulation playback.
- [ ] Final Windows portable archive and whole-application acceptance complete.

No screenshots or customer documents are attached; committed benchmarks and evidence are the verification record.




