### PR TITLE
Fix macOS packaging environment with the upgraded compiler

### DIFF
--- a/package/rattler-build/build.sh
+++ b/package/rattler-build/build.sh
@@ -10,8 +10,10 @@ if [[ -n "${CCACHE_DIR:-}" ]] && command -v ccache >/dev/null 2>&1; then
     ccache -z >/dev/null 2>&1 || true
 fi
 
-if [[ ${HOST} =~ .*linux.*  ]]; then
-    CMAKE_PRESET=conda-linux-release
+VIBECAD_BUILD_PLATFORM="${VIBECAD_TARGET_PLATFORM:-${HOST:-}}"
+CMAKE_PRESET="$(bash scripts/select_cmake_preset.sh "${VIBECAD_BUILD_PLATFORM}")"
+
+if [[ ${CMAKE_PRESET} == conda-linux-release ]]; then
 
     # The Linux conda preset builds with Clang, but conda compiler activation
     # can still provide GCC-only flags.
@@ -22,9 +24,7 @@ if [[ ${HOST} =~ .*linux.*  ]]; then
     done
 fi
 
-if [[ ${HOST} =~ .*darwin.* ]]; then
-    CMAKE_PRESET=conda-macos-release
-
+if [[ ${CMAKE_PRESET} == conda-macos-release ]]; then
     # add hacks for osx here!
     echo "adding hacks for osx"
 

--- a/package/rattler-build/build.sh
+++ b/package/rattler-build/build.sh
@@ -39,7 +39,9 @@ if [[ ${CMAKE_PRESET} == conda-macos-release ]]; then
     CMAKE_PLATFORM_FLAGS+=(-DFREECAD_USE_3DCONNEXION:BOOL=ON)
     CMAKE_PLATFORM_FLAGS+=(-D3DCONNEXIONCLIENT_FRAMEWORK:FILEPATH="/Library/Frameworks/3DconnexionClient.framework")
 
-    CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
+    # We bundle conda's libc++, whose symbols are newer than the system libc++.
+    # Export explicitly: newer compiler environments may not export CXXFLAGS.
+    export CXXFLAGS="${CXXFLAGS:-} -D_LIBCPP_DISABLE_AVAILABILITY"
 
     # Use MACOS_DEPLOYMENT_TARGET from environment, default to 11.0 for backwards compat.
     # Note that CI sets this per target: 10.13 (Intel), 11.0 (ARM legacy), 15.0 (ARM modern)

--- a/package/rattler-build/build.sh
+++ b/package/rattler-build/build.sh
@@ -11,7 +11,8 @@ if [[ -n "${CCACHE_DIR:-}" ]] && command -v ccache >/dev/null 2>&1; then
 fi
 
 VIBECAD_BUILD_PLATFORM="${VIBECAD_TARGET_PLATFORM:-${HOST:-}}"
-CMAKE_PRESET="$(bash scripts/select_cmake_preset.sh "${VIBECAD_BUILD_PLATFORM}")"
+# Rattler executes this script from the source root.
+CMAKE_PRESET="$(bash package/rattler-build/scripts/select_cmake_preset.sh "${VIBECAD_BUILD_PLATFORM}")"
 
 if [[ ${CMAKE_PRESET} == conda-linux-release ]]; then
 

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -23,6 +23,9 @@ build:
       # Hash compiler *content* rather than mtime so cached objects survive the
       # fresh conda extraction on each CI run (where compiler mtimes change).
       CCACHE_COMPILERCHECK: ${{ env.get("CCACHE_COMPILERCHECK", default="content") }}
+      # Compiler activation does not consistently define HOST. Forward the
+      # rattler target explicitly so build.sh always selects the right preset.
+      VIBECAD_TARGET_PLATFORM: ${{ target_platform }}
 
 requirements:
   build:

--- a/package/rattler-build/scripts/select_cmake_preset.sh
+++ b/package/rattler-build/scripts/select_cmake_preset.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+set -euo pipefail
+
+platform="${1:-}"
+if [[ -z "${platform}" ]]; then
+    platform="$(uname -s)"
+fi
+
+case "${platform}" in
+    linux-*|*linux*|Linux)
+        echo "conda-linux-release"
+        ;;
+    osx-*|*darwin*|Darwin)
+        echo "conda-macos-release"
+        ;;
+    *)
+        echo "Unsupported build platform: ${platform}" >&2
+        exit 2
+        ;;
+esac

--- a/src/Tools/tests/test_macos_build_toolchain.py
+++ b/src/Tools/tests/test_macos_build_toolchain.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import os
 import subprocess
 import unittest
 from pathlib import Path
@@ -18,6 +19,33 @@ PRESET_SELECTOR = (
 
 
 class TestMacOSBuildToolchain(unittest.TestCase):
+    def test_build_setup_from_rattler_source_directory(self) -> None:
+        # Rattler runs the recipe script from the copied source root, not
+        # from the recipe directory. Execute setup before platform side effects
+        # (driver installation, dependency patching, and compilation).
+        setup = BUILD_SCRIPT.read_text(encoding="utf-8").split(
+            "\nif [[ ${CMAKE_PRESET}", maxsplit=1
+        )[0]
+        for platform, preset in (
+            ("osx-arm64", "conda-macos-release"),
+            ("osx-64", "conda-macos-release"),
+            ("linux-64", "conda-linux-release"),
+        ):
+            with self.subTest(platform=platform):
+                env = os.environ.copy()
+                env.pop("HOST", None)
+                env["CCACHE_DIR"] = ""
+                env["VIBECAD_TARGET_PLATFORM"] = platform
+                result = subprocess.run(
+                    ["bash", "-e", "-c", setup + '\nprintf "%s" "$CMAKE_PRESET"'],
+                    cwd=REPO_ROOT,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, preset)
+
     def test_macos_uses_libcxx_with_standard_cxx20_stop_token(self) -> None:
         recipe = RECIPE.read_text(encoding="utf-8")
 

--- a/src/Tools/tests/test_macos_build_toolchain.py
+++ b/src/Tools/tests/test_macos_build_toolchain.py
@@ -1,11 +1,20 @@
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
+import subprocess
 import unittest
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 RECIPE = REPO_ROOT / "package" / "rattler-build" / "recipe.yaml"
+BUILD_SCRIPT = REPO_ROOT / "package" / "rattler-build" / "build.sh"
+PRESET_SELECTOR = (
+    REPO_ROOT
+    / "package"
+    / "rattler-build"
+    / "scripts"
+    / "select_cmake_preset.sh"
+)
 
 
 class TestMacOSBuildToolchain(unittest.TestCase):
@@ -31,6 +40,26 @@ class TestMacOSBuildToolchain(unittest.TestCase):
             "        - libcxx>=21,<22",
             host_requirements,
         )
+
+    def test_rattler_target_platform_selects_macos_preset(self) -> None:
+        recipe = RECIPE.read_text(encoding="utf-8")
+        build_script = BUILD_SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "VIBECAD_TARGET_PLATFORM: ${{ target_platform }}",
+            recipe,
+        )
+        self.assertIn("VIBECAD_TARGET_PLATFORM:-${HOST:-}", build_script)
+
+        for platform in ("osx-arm64", "osx-64", "arm64-apple-darwin20.0.0"):
+            with self.subTest(platform=platform):
+                result = subprocess.run(
+                    ["bash", str(PRESET_SELECTOR), platform],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                )
+                self.assertEqual(result.stdout.strip(), "conda-macos-release")
 
 
 if __name__ == "__main__":

--- a/src/Tools/tests/test_macos_build_toolchain.py
+++ b/src/Tools/tests/test_macos_build_toolchain.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -19,6 +20,52 @@ PRESET_SELECTOR = (
 
 
 class TestMacOSBuildToolchain(unittest.TestCase):
+    def test_macos_build_exports_flags_to_cmake(self) -> None:
+        # Execute the complete recipe script, replacing external build/install
+        # commands with stubs. CMake's stub starts a child shell so a shell-only
+        # CXXFLAGS assignment cannot accidentally satisfy the assertion.
+        stubs = r'''
+function /usr/bin/curl() { :; }
+hdiutil() { :; }
+sudo() { :; }
+diskutil() { :; }
+mv() { :; }
+cmake() { bash -c 'printf "CMAKE_FLAGS=%s\n" "${CXXFLAGS:-}"'; }
+source "$1"
+'''
+        for platform in ("osx-arm64", "osx-64"):
+            for initial_flags in (None, "-DEXISTING_FLAG"):
+                with self.subTest(platform=platform, initial_flags=initial_flags):
+                    with tempfile.TemporaryDirectory() as prefix:
+                        env = os.environ.copy()
+                        env.pop("HOST", None)
+                        env.pop("CXXFLAGS", None)
+                        if initial_flags is not None:
+                            env["CXXFLAGS"] = initial_flags
+                        env.update(
+                            VIBECAD_TARGET_PLATFORM=platform,
+                            CCACHE_DIR="",
+                            PREFIX=prefix,
+                        )
+                        result = subprocess.run(
+                            ["bash", "-e", "-c", stubs, "test-build", str(BUILD_SCRIPT)],
+                            cwd=REPO_ROOT,
+                            env=env,
+                            capture_output=True,
+                            text=True,
+                        )
+                        self.assertEqual(result.returncode, 0, result.stderr)
+                        flags = [
+                            line.split("=", 1)[1].split()
+                            for line in result.stdout.splitlines()
+                            if line.startswith("CMAKE_FLAGS=")
+                        ]
+                        self.assertEqual(len(flags), 3)
+                        for child_flags in flags:
+                            self.assertIn("-D_LIBCPP_DISABLE_AVAILABILITY", child_flags)
+                            if initial_flags:
+                                self.assertIn(initial_flags, child_flags)
+
     def test_build_setup_from_rattler_source_directory(self) -> None:
         # Rattler runs the recipe script from the copied source root, not
         # from the recipe directory. Execute setup before platform side effects


### PR DESCRIPTION
The upgraded macOS compiler environment no longer supplies the exported `HOST` and `CXXFLAGS` variables that the packaging script implicitly relied on. This caused an empty CMake preset, then missing libc++ compatibility flags during compilation of `Document.cpp`.

Forward rattler's target platform explicitly, resolve the preset helper from the source working directory, and explicitly export the existing libc++ flags to CMake. Preserve legacy `HOST` fallback and existing caller flags. Application code and minimum supported macOS versions are unchanged.

The libc++ flag is appropriate for the bundled modern conda runtime, as described in [conda-forge's documentation](https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk).

## Verification

- [x] Red/green TDD: `python -m unittest src.Tools.tests.test_macos_build_toolchain` first failed for missing target forwarding; the working-directory regression then reproduced the missing helper on all three targets. The full-script regression reproduced missing exported flags for both macOS targets with `CXXFLAGS` initially unset. After fixes, all 4 tests pass.
- [x] The full-script regression stubs external build/install commands, checks child-process environment visibility, and verifies preservation of existing flags.
- [x] `python -m unittest discover -s src/Tools/tests -p 'test_*.py'`: 124 tests run, PASS, 5 skipped.
- [x] `bash -n package/rattler-build/build.sh package/rattler-build/scripts/select_cmake_preset.sh`: PASS.
- [x] `git diff --check`: PASS.
- [x] `pixi lock --no-install`: passed after target forwarding without changing the lock file.
- [ ] Both native macOS packages build and pass bundle validation. `gh workflow run 'VibeCAD macOS Build' --ref fix/macos-target-detection -f source_ref=fix/macos-target-detection -f architecture=both` started [run 34397606366](https://github.com/10-X-eng/vibecad/actions/runs/34397606366) for `e06bea19`. Results pending.

Local script tests establish the environment handoff; they do not establish successful macOS compilation, linking, or DMG execution. Keep this PR draft until both architectures pass. The previous run reached Clang 21 compilation but failed on libc++ availability checks because the flag did not reach compiler commands.

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields are renamed or removed.
- [x] Existing `HOST` compiler triples and existing CXXFLAGS remain supported.
- [x] No breaking changes or deprecations are introduced.
