### PR TITLE
Keep document workflow cleanup on its owner and reject stale recompute notifications

### DIFF
--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -3840,12 +3840,21 @@ void Application::drainRecomputeDocument(
         _recomputeGeneration.erase(current);
     }
 
-    if (Document* document = getDocument(documentName.c_str());
-        document && document->isCooperativeMutationActive()) {
-        document->endCooperativeMutation();
+    std::string documentUid;
+    if (Document* document = getDocument(documentName.c_str()); document) {
+        documentUid = document->Uid.getValueStr();
+        if (document->isCooperativeMutationActive()) {
+            document->endCooperativeMutation();
+        }
     }
 
-    auto notifyFinished = [this, documentName]() {
+    auto notifyFinished = [this, documentName, documentUid]() {
+        Document* document = getDocument(documentName.c_str());
+        if (documentUid.empty()
+            || !document
+            || document->Uid.getValueStr() != documentUid) {
+            return;
+        }
         signalRecomputeRequestFinished(documentName);
     };
     if (App::MainThreadSignalConfig::hasHooks()

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -219,6 +219,12 @@ std::atomic<App::MainThreadSignalConfig::IsMainThreadFn>& mainThreadCheckHook()
     return hook;
 }
 
+std::atomic<App::MainThreadSignalConfig::CleanupFn>& mainThreadCleanupHook()
+{
+    static std::atomic<App::MainThreadSignalConfig::CleanupFn> hook {nullptr};
+    return hook;
+}
+
 std::atomic<App::MainThreadSignalConfig::InvokeFn>& mainThreadInvokeHook()
 {
     static std::atomic<App::MainThreadSignalConfig::InvokeFn> hook {nullptr};
@@ -369,6 +375,25 @@ bool App::MainThreadSignalConfig::hasHooks()
 {
     return mainThreadCheckHook().load(std::memory_order_acquire)
         && mainThreadInvokeHook().load(std::memory_order_acquire);
+}
+
+void App::MainThreadSignalConfig::setCleanupHook(CleanupFn cleanup)
+{
+    mainThreadCleanupHook().store(cleanup, std::memory_order_release);
+}
+
+bool App::MainThreadSignalConfig::hasCleanupHook()
+{
+    return mainThreadCleanupHook().load(std::memory_order_acquire) != nullptr;
+}
+
+void App::MainThreadSignalConfig::invokeCleanup(std::function<void()>&& fn)
+{
+    const auto hook = mainThreadCleanupHook().load(std::memory_order_acquire);
+    if (!hook) {
+        throw std::runtime_error("Owner cleanup dispatcher is not installed");
+    }
+    hook(std::move(fn));
 }
 
 void App::MainThreadSignalConfig::invoke(std::function<void()>&& fn, bool blocking)
@@ -1334,14 +1359,27 @@ void Application::startNextDocumentOpen()
         if (request.prepare) {
             request.prepare(request);
         }
-        task->work = openDocumentsWorkflow(
+        auto workflow = openDocumentsWorkflow(
             request.filenames,
             request.paths.empty() ? nullptr : &request.paths,
             request.labels.empty() ? nullptr : &request.labels,
             &task->result.errors, request.initFlags, &request.inputFlags
-        ).runAsync(hostRuntime(), [](std::function<void()> resume) {
+        );
+        auto dispatch = [](std::function<void()> resume) {
             MainThreadSignalConfig::invoke(std::move(resume), false);
-        }, [this, task] { finishDocumentOpen(task); }, request.cancellation.get_token());
+        };
+        auto finished = [this, task] { finishDocumentOpen(task); };
+        if (MainThreadSignalConfig::hasCleanupHook()) {
+            task->work = std::move(workflow).runAsyncWithCleanup(
+                hostRuntime(), dispatch,
+                [](std::function<void()> cleanup) {
+                    MainThreadSignalConfig::invokeCleanup(std::move(cleanup));
+                }, finished, request.cancellation.get_token());
+        }
+        else {
+            task->work = std::move(workflow).runAsync(
+                hostRuntime(), dispatch, finished, request.cancellation.get_token());
+        }
     }
     catch (...) {
         task->result.failure = std::current_exception();

--- a/src/App/HostWorkflow.h
+++ b/src/App/HostWorkflow.h
@@ -118,6 +118,8 @@ public:
      * finished runs once on the owner after the frame is destroyed and the
      * future is ready (success or failure); it must not throw. Dispatch must
      * enqueue, never invoke inline, including the initial coordinator step.
+     * If dispatchOwner throws, the future is completed with that error and
+     * finished still runs once; the coordinator is not resumed on the caller.
      */
     std::future<Result> runAsync(
         HostRuntime& runtime,
@@ -142,6 +144,22 @@ public:
                   dispatchOwner(std::move(dispatchOwner)), finished(std::move(finished)),
                   cancellation(std::move(cancellation))
             {}
+
+            void completeFromDispatchFailure(std::exception_ptr error)
+            {
+                // HostRuntime swallows completion exceptions to keep the lane
+                // alive. Complete this future here so callers cannot hang, and
+                // do not resume the coordinator on the failing thread.
+                try {
+                    workflow.reset();
+                    completion.set_exception(std::move(error));
+                }
+                catch (...) {
+                }
+                if (auto notify = std::move(finished)) {
+                    notify();
+                }
+            }
 
             void resume(std::exception_ptr failure = {})
             {
@@ -178,14 +196,26 @@ public:
                             std::exception_ptr failure;
                             try { result.get(); }
                             catch (...) { failure = std::current_exception(); }
-                            self->dispatchOwner([self, failure] { self->resume(failure); });
+                            try {
+                                self->dispatchOwner(
+                                    [self, failure] { self->resume(failure); });
+                            }
+                            catch (...) {
+                                self->completeFromDispatchFailure(
+                                    std::current_exception());
+                            }
                         });
                 }
                 catch (...) {
                     // Let the coroutine run its own cleanup/recovery at the
                     // failed yield, on a later owner dispatch (no recursion).
                     auto failure = std::current_exception();
-                    dispatchOwner([self, failure] { self->resume(failure); });
+                    try {
+                        dispatchOwner([self, failure] { self->resume(failure); });
+                    }
+                    catch (...) {
+                        completeFromDispatchFailure(std::current_exception());
+                    }
                 }
             }
         };
@@ -193,7 +223,12 @@ public:
                                               std::move(dispatchOwner), std::move(finished),
                                               std::move(cancellation));
         auto result = driver->completion.get_future();
-        driver->dispatchOwner([driver] { driver->resume(); });
+        try {
+            driver->dispatchOwner([driver] { driver->resume(); });
+        }
+        catch (...) {
+            driver->completeFromDispatchFailure(std::current_exception());
+        }
         return result;
     }
 

--- a/src/App/HostWorkflow.h
+++ b/src/App/HostWorkflow.h
@@ -6,6 +6,7 @@
 #include <exception>
 #include <optional>
 #include <stdexcept>
+#include <thread>
 #include <utility>
 
 #include "HostRuntime.h"
@@ -136,6 +137,7 @@ public:
             std::promise<Result> completion;
             std::function<void()> finished;
             std::stop_token cancellation;
+            std::thread::id ownerThread;
 
             Driver(HostWorkflow&& workflow, HostRuntime& runtime,
                    std::function<void(std::function<void()>)> dispatchOwner,
@@ -162,8 +164,47 @@ public:
                 }
             }
 
+            std::function<void()> continuation(std::exception_ptr failure)
+            {
+                struct Delivery
+                {
+                    std::shared_ptr<Driver> driver;
+                    std::exception_ptr failure;
+                    bool invoked {false};
+
+                    Delivery(std::shared_ptr<Driver> driver, std::exception_ptr failure)
+                        : driver(std::move(driver)), failure(std::move(failure))
+                    {}
+
+                    ~Delivery()
+                    {
+                        // An accepted callback can be discarded by its owner
+                        // during shutdown while the worker still holds Driver.
+                        // Release the suspended frame here, before that worker
+                        // drops the last reference. Rejection on the submitting
+                        // thread is handled separately by the dispatch catch.
+                        if (!invoked && std::this_thread::get_id() == driver->ownerThread) {
+                            try {
+                                driver->completeFromDispatchFailure(std::make_exception_ptr(
+                                    std::runtime_error("Owner discarded workflow completion")));
+                            }
+                            catch (...) {
+                                // A completion notification must not throw from
+                                // destruction of a cancelled queue entry.
+                            }
+                        }
+                    }
+                };
+                return [delivery = std::make_shared<Delivery>(
+                            this->shared_from_this(), std::move(failure))] {
+                    delivery->invoked = true;
+                    delivery->driver->resume(delivery->failure);
+                };
+            }
+
             void resume(std::exception_ptr failure = {})
             {
+                ownerThread = std::this_thread::get_id();
                 workflow->failStep(std::move(failure));
                 if (!workflow->advance()) {
                     try {
@@ -201,8 +242,7 @@ public:
                             try { result.get(); }
                             catch (...) { failure = std::current_exception(); }
                             try {
-                                self->dispatchOwner(
-                                    [self, failure] { self->resume(failure); });
+                                self->dispatchOwner(self->continuation(failure));
                             }
                             catch (...) {
                                 self->completeFromDispatchFailure(

--- a/src/App/HostWorkflow.h
+++ b/src/App/HostWorkflow.h
@@ -118,8 +118,9 @@ public:
      * finished runs once on the owner after the frame is destroyed and the
      * future is ready (success or failure); it must not throw. Dispatch must
      * enqueue, never invoke inline, including the initial coordinator step.
-     * If dispatchOwner throws, the future is completed with that error and
-     * finished still runs once; the coordinator is not resumed on the caller.
+     * Initial dispatch failure propagates to the caller without invoking
+     * finished. For a later dispatch failure the future receives that error;
+     * the coordinator is not resumed on the failing thread.
      */
     std::future<Result> runAsync(
         HostRuntime& runtime,
@@ -226,12 +227,10 @@ public:
                                               std::move(dispatchOwner), std::move(finished),
                                               std::move(cancellation));
         auto result = driver->completion.get_future();
-        try {
-            driver->dispatchOwner([driver] { driver->resume(); });
-        }
-        catch (...) {
-            driver->completeFromDispatchFailure(std::current_exception());
-        }
+        // Preserve initial admission failure as an exception to the caller.
+        // Its finished callback may read the returned future, which cannot be
+        // stored until this function returns. Never notify it inline here.
+        driver->dispatchOwner([driver] { driver->resume(); });
         return result;
     }
 

--- a/src/App/HostWorkflow.h
+++ b/src/App/HostWorkflow.h
@@ -119,6 +119,8 @@ public:
      * finished runs once on the owner after the frame is destroyed and the
      * future is ready (success or failure); it must not throw. Dispatch must
      * enqueue, never invoke inline, including the initial coordinator step.
+     * After initial admission, dispatchOwner must remain available until the
+     * workflow finishes. Use runAsyncWithCleanup when that queue can stop first.
      * Initial dispatch failure propagates to the caller without invoking
      * finished. For a later dispatch failure the future receives that error;
      * the coordinator is not resumed on the failing thread.

--- a/src/App/HostWorkflow.h
+++ b/src/App/HostWorkflow.h
@@ -204,7 +204,9 @@ private:
 
             void dispatchFailure(std::exception_ptr error)
             {
-                if (dispatchCleanup && std::this_thread::get_id() != ownerThread) {
+                if (dispatchCleanup) {
+                    // Owner-side queued cancellation can occur inside worker
+                    // joining, with the GIL released. Cleanup must wait too.
                     auto self = this->shared_from_this();
                     dispatchCleanup([self, error] { self->completeFromDispatchFailure(error); });
                     return;

--- a/src/App/HostWorkflow.h
+++ b/src/App/HostWorkflow.h
@@ -184,13 +184,16 @@ public:
 
                 auto self = this->shared_from_this();
                 try {
-                    const auto next = workflow->step();
+                    const auto& next = workflow->step();
+                    // The suspended frame owns the callable until completion
+                    // returns to the owner. A worker-side copy could outlive
+                    // owner cleanup and release its captures on the worker.
                     runtime.submitWithCompletion(next.lane,
-                        [self, work = next.work](std::stop_token stop) {
+                        [self, work = &next.work](std::stop_token stop) {
                             Base::CancellationScope shutdown(stop);
                             Base::CancellationScope operation(self->cancellation);
                             Base::CancellationScope::check();
-                            work(stop);
+                            (*work)(stop);
                         },
                         [self](std::future<void> result) {
                             std::exception_ptr failure;

--- a/src/App/HostWorkflow.h
+++ b/src/App/HostWorkflow.h
@@ -129,11 +129,45 @@ public:
         std::function<void()> finished = {},
         std::stop_token cancellation = {}) &&
     {
+        return std::move(*this).runAsyncImpl(runtime, std::move(dispatchOwner), {},
+                                             std::move(finished), cancellation);
+    }
+
+    /** Use an independent owner queue for failure cleanup.
+     * dispatchCleanup must accept and execute cleanup on the same owner even
+     * after normal dispatch stops. It must not throw or discard accepted work.
+     * Its lifetime must cover worker completion and cleanup during shutdown.
+     * Normal work continues to use dispatchOwner and its existing frame budget.
+     */
+    std::future<Result> runAsyncWithCleanup(
+        HostRuntime& runtime,
+        std::function<void(std::function<void()>)> dispatchOwner,
+        std::function<void(std::function<void()>)> dispatchCleanup,
+        std::function<void()> finished = {},
+        std::stop_token cancellation = {}) &&
+    {
+        if (!dispatchCleanup) {
+            throw std::invalid_argument("Workflow cleanup dispatcher is required");
+        }
+        return std::move(*this).runAsyncImpl(runtime, std::move(dispatchOwner),
+                                             std::move(dispatchCleanup),
+                                             std::move(finished), cancellation);
+    }
+
+private:
+    std::future<Result> runAsyncImpl(
+        HostRuntime& runtime,
+        std::function<void(std::function<void()>)> dispatchOwner,
+        std::function<void(std::function<void()>)> dispatchCleanup,
+        std::function<void()> finished,
+        std::stop_token cancellation) &&
+    {
         struct Driver: std::enable_shared_from_this<Driver>
         {
             std::optional<HostWorkflow> workflow;
             HostRuntime& runtime;
             std::function<void(std::function<void()>)> dispatchOwner;
+            std::function<void(std::function<void()>)> dispatchCleanup;
             std::promise<Result> completion;
             std::function<void()> finished;
             std::stop_token cancellation;
@@ -141,10 +175,12 @@ public:
 
             Driver(HostWorkflow&& workflow, HostRuntime& runtime,
                    std::function<void(std::function<void()>)> dispatchOwner,
+                   std::function<void(std::function<void()>)> dispatchCleanup,
                    std::function<void()> finished,
                    std::stop_token cancellation)
                 : workflow(std::move(workflow)), runtime(runtime),
-                  dispatchOwner(std::move(dispatchOwner)), finished(std::move(finished)),
+                  dispatchOwner(std::move(dispatchOwner)),
+                  dispatchCleanup(std::move(dispatchCleanup)), finished(std::move(finished)),
                   cancellation(std::move(cancellation))
             {}
 
@@ -162,6 +198,16 @@ public:
                 if (auto notify = std::move(finished)) {
                     notify();
                 }
+            }
+
+            void dispatchFailure(std::exception_ptr error)
+            {
+                if (dispatchCleanup && std::this_thread::get_id() != ownerThread) {
+                    auto self = this->shared_from_this();
+                    dispatchCleanup([self, error] { self->completeFromDispatchFailure(error); });
+                    return;
+                }
+                completeFromDispatchFailure(std::move(error));
             }
 
             std::function<void()> continuation(std::exception_ptr failure)
@@ -245,8 +291,7 @@ public:
                                 self->dispatchOwner(self->continuation(failure));
                             }
                             catch (...) {
-                                self->completeFromDispatchFailure(
-                                    std::current_exception());
+                                self->dispatchFailure(std::current_exception());
                             }
                         });
                 }
@@ -258,14 +303,14 @@ public:
                         dispatchOwner([self, failure] { self->resume(failure); });
                     }
                     catch (...) {
-                        completeFromDispatchFailure(std::current_exception());
+                        dispatchFailure(std::current_exception());
                     }
                 }
             }
         };
         auto driver = std::make_shared<Driver>(std::move(*this), runtime,
-                                              std::move(dispatchOwner), std::move(finished),
-                                              std::move(cancellation));
+                                              std::move(dispatchOwner), std::move(dispatchCleanup),
+                                              std::move(finished), std::move(cancellation));
         auto result = driver->completion.get_future();
         // Preserve initial admission failure as an exception to the caller.
         // Its finished callback may read the returned future, which cannot be

--- a/src/App/MainThreadSignal.h
+++ b/src/App/MainThreadSignal.h
@@ -49,12 +49,18 @@ class AppExport MainThreadSignalConfig
 public:
     using IsMainThreadFn = bool (*)();  // true iff currently on GUI/main thread
     using InvokeFn = void (*)(std::function<void()>&& fn, bool blocking);
+    using CleanupFn = void (*)(std::function<void()>&& fn);
 
     // Implemented by FreeCADApp rather than inline so Windows DLLs and PYDs
     // all observe the same process-wide hook pair.
     static void setHooks(IsMainThreadFn isMainThread, InvokeFn invoke);
     static bool isMainThread();
     static bool hasHooks();
+    // Independent cleanup delivery, kept alive until document workers join.
+    // No inline fallback: an absent hook is an error, never worker-side cleanup.
+    static void setCleanupHook(CleanupFn cleanup);
+    static bool hasCleanupHook();
+    static void invokeCleanup(std::function<void()>&& fn);
     static void invoke(std::function<void()>&& fn, bool blocking);
 };
 

--- a/src/Gui/Application.cpp
+++ b/src/Gui/Application.cpp
@@ -59,6 +59,7 @@
 #include <App/DocumentObserver.h>
 #include <App/DocumentObjectPy.h>
 #include <App/MainThreadSignal.h>
+#include <App/HostRuntime.h>
 #include <Base/Console.h>
 #include <Base/Interpreter.h>
 #include <Base/Exception.h>
@@ -505,6 +506,14 @@ bool qtIsMainThread()
     return !qApp || (QThread::currentThread() == qApp->thread());
 }
 
+// Cleanup delivery remains available until document workers have joined.
+void qtInvokeCleanup(std::function<void()>&& fn)
+{
+    if (!dispatchToGuiCleanup(std::move(fn))) {
+        throw Base::RuntimeError("Owner cleanup requested after runtime shutdown");
+    }
+}
+
 // Hook: invoke a functor on the GUI thread, either blocking or queued.
 void qtInvokeOnMain(std::function<void()>&& fn, bool blocking)
 {
@@ -611,7 +620,8 @@ Application::Application(bool GUIenabled)
 {
     // App::GetApplication().Attach(this);
     if (GUIenabled) {
-        initializeGuiFrameDispatcher();
+        initializeGuiFrameDispatcher([] { App::GetApplication().hostRuntime().shutdown(); });
+        App::MainThreadSignalConfig::setCleanupHook(&qtInvokeCleanup);
         App::MainThreadSignalConfig::setHooks(&qtIsMainThread, &qtInvokeOnMain);
 
         // NOLINTBEGIN

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -2796,11 +2796,16 @@ bool queueDocumentSave(std::vector<SaveTarget> targets, Document::SaveCallback f
             target.document->beginCooperativeMutation();
         }
         getMainWindow()->showMessage(QObject::tr("Saving document…"));
-        pending->result = saveDocuments(pending).runAsync(
+        pending->result = saveDocuments(pending).runAsyncWithCleanup(
             App::GetApplication().hostRuntime(),
             [](std::function<void()> resume) {
                 if (!dispatchToGuiFrame(std::move(resume))) {
                     throw Base::RuntimeError("Unable to dispatch document save completion");
+                }
+            },
+            [](std::function<void()> cleanup) {
+                if (!dispatchToGuiCleanup(std::move(cleanup))) {
+                    throw Base::RuntimeError("Document save cleanup requested after runtime shutdown");
                 }
             },
             [pending, finished = std::move(finished)] {

--- a/src/Gui/FrameBudget.cpp
+++ b/src/Gui/FrameBudget.cpp
@@ -121,6 +121,12 @@ private:
         // Release queued synchronous handoffs before joining their workers.
         cancelled.clear();
         if (auto finish = std::move(finishWorkers)) {
+            // A Python-triggered close can hold the GIL while a worker needs
+            // it to finish. Restore it before draining owner cleanup below.
+            std::unique_ptr<Base::PyGILStateRelease> release;
+            if (Py_IsInitialized() && PyGILState_Check()) {
+                release = std::make_unique<Base::PyGILStateRelease>();
+            }
             finish();
         }
         // Workers are now joined, so no workflow can arrive after this seal.

--- a/src/Gui/FrameBudget.cpp
+++ b/src/Gui/FrameBudget.cpp
@@ -66,6 +66,37 @@ public:
         return true;
     }
 
+    void setWorkerShutdown(std::function<void()> finish)
+    {
+        if (stopped || finishWorkers || !finish) {
+            throw std::logic_error("Invalid GUI worker shutdown registration");
+        }
+        finishWorkers = std::move(finish);
+    }
+
+    bool enqueueCleanup(std::function<void()> task)
+    {
+        if (!task || !qApp) {
+            return false;
+        }
+        bool schedule = false;
+        {
+            std::lock_guard lock(mutex);
+            if (cleanupStopped) {
+                return false;
+            }
+            cleanupQueue.push_back(std::move(task));
+            if (!stopped && !scheduled) {
+                scheduled = true;
+                schedule = true;
+            }
+        }
+        if (schedule) {
+            scheduleDrain();
+        }
+        return true;
+    }
+
 private:
     FrameDispatcher() = default;
     ~FrameDispatcher() override = default;
@@ -80,9 +111,32 @@ private:
         std::deque<std::function<void()>> cancelled;
         {
             std::lock_guard lock(mutex);
+            if (stopped) {
+                return;
+            }
             stopped = true;
             scheduled = false;
             cancelled.swap(queue);
+        }
+        // Release queued synchronous handoffs before joining their workers.
+        cancelled.clear();
+        if (auto finish = std::move(finishWorkers)) {
+            finish();
+        }
+        // Workers are now joined, so no workflow can arrive after this seal.
+        // Cleanup may enqueue more cleanup; run it outside the queue mutex.
+        for (;;) {
+            std::function<void()> task;
+            {
+                std::lock_guard lock(mutex);
+                if (cleanupQueue.empty()) {
+                    cleanupStopped = true;
+                    break;
+                }
+                task = std::move(cleanupQueue.front());
+                cleanupQueue.pop_front();
+            }
+            execute(task);
         }
     }
 
@@ -123,29 +177,16 @@ private:
             std::function<void()> task;
             {
                 std::lock_guard lock(mutex);
-                if (queue.empty()) {
+                if (queue.empty() && cleanupQueue.empty()) {
                     scheduled = false;
                     return;
                 }
-                task = std::move(queue.front());
-                queue.pop_front();
+                auto& ready = cleanupQueue.empty() ? queue : cleanupQueue;
+                task = std::move(ready.front());
+                ready.pop_front();
             }
 
-            try {
-                task();
-            }
-            catch (const Base::Exception& exception) {
-                exception.reportException();
-            }
-            catch (const std::exception& exception) {
-                Base::Console().error(
-                    "GUI frame adoption failed: %s\n",
-                    exception.what()
-                );
-            }
-            catch (...) {
-                Base::Console().error("GUI frame adoption failed with an unknown exception\n");
-            }
+            execute(task);
         } while (!budget.exhausted());
 
         // Posting another event while Qt is draining posted events can let the
@@ -156,8 +197,30 @@ private:
         QTimer::singleShot(0, this, [this] { scheduleDrain(); });
     }
 
+    static void execute(const std::function<void()>& task)
+    {
+        try {
+            task();
+        }
+        catch (const Base::Exception& exception) {
+            exception.reportException();
+        }
+        catch (const std::exception& exception) {
+            Base::Console().error(
+                "GUI frame adoption failed: %s\n",
+                exception.what()
+            );
+        }
+        catch (...) {
+            Base::Console().error("GUI frame adoption failed with an unknown exception\n");
+        }
+    }
+
     std::mutex mutex;
     std::deque<std::function<void()>> queue;
+    std::deque<std::function<void()>> cleanupQueue;
+    std::function<void()> finishWorkers;
+    bool cleanupStopped {false};
     bool scheduled {false};
     bool stopped {false};
 };
@@ -189,6 +252,20 @@ void initializeGuiFrameDispatcher()
         throw std::logic_error("GUI frame dispatcher initialization requires the Qt owner");
     }
     FrameDispatcher::instance();
+}
+
+void initializeGuiFrameDispatcher(std::function<void()> finishWorkers)
+{
+    initializeGuiFrameDispatcher();
+    FrameDispatcher::instance()->setWorkerShutdown(std::move(finishWorkers));
+}
+
+bool dispatchToGuiCleanup(std::function<void()> task)
+{
+    if (!task || !qApp) {
+        return false;
+    }
+    return FrameDispatcher::instance()->enqueueCleanup(std::move(task));
 }
 
 bool dispatchToGuiFrame(std::function<void()> task)

--- a/src/Gui/FrameBudget.h
+++ b/src/Gui/FrameBudget.h
@@ -65,6 +65,12 @@ private:
 // Install the application-lifetime shutdown hook on the Qt owner before any
 // document worker can submit GUI notifications.
 GuiExport void initializeGuiFrameDispatcher();
+// Register owner-side shutdown that joins every worker using the cleanup queue.
+// Called once during owner initialization, before starting document workflows.
+GuiExport void initializeGuiFrameDispatcher(std::function<void()> finishWorkers);
+// Cleanup remains admitted while finishWorkers joins the runtime. It is drained
+// on the owner before shutdown returns, then permanently closed.
+GuiExport bool dispatchToGuiCleanup(std::function<void()> task);
 // Returns false once Qt shutdown begins. Accepted, unexecuted callbacks are
 // released on the owner at shutdown; a waiting promise then reports cancellation
 // through std::future_error instead of retaining its worker indefinitely.

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -198,6 +198,42 @@ std::deque<std::function<void()>> takeQueuedOwnerWork()
 }
 }
 
+TEST(MainThreadCleanupTest, MissingHookNeverRunsCleanupInline)
+{
+    ASSERT_FALSE(App::MainThreadSignalConfig::hasCleanupHook());
+    bool invoked = false;
+    EXPECT_THROW(App::MainThreadSignalConfig::invokeCleanup([&] { invoked = true; }),
+                 std::runtime_error);
+    EXPECT_FALSE(invoked);
+}
+
+TEST(MainThreadCleanupTest, CleanupHasAnIndependentOwnerHook)
+{
+    queuedOwnerId = std::this_thread::get_id();
+    takeQueuedOwnerWork();
+    App::MainThreadSignalConfig::setCleanupHook([](std::function<void()>&& cleanup) {
+        std::lock_guard lock(queuedOwnerMutex);
+        queuedOwnerWork.push_back(std::move(cleanup));
+    });
+    BOOST_SCOPE_EXIT_ALL(&) {
+        App::MainThreadSignalConfig::setCleanupHook(nullptr);
+        takeQueuedOwnerWork();
+    };
+    ASSERT_TRUE(App::MainThreadSignalConfig::hasCleanupHook());
+    std::thread::id cleanedOn;
+    std::thread worker([&] {
+        App::MainThreadSignalConfig::invokeCleanup([&] {
+            cleanedOn = std::this_thread::get_id();
+        });
+    });
+    worker.join();
+    EXPECT_EQ(cleanedOn, std::thread::id {});
+    auto cleanup = takeQueuedOwnerWork();
+    ASSERT_EQ(cleanup.size(), 1);
+    cleanup.front()();
+    EXPECT_EQ(cleanedOn, queuedOwnerId);
+}
+
 TEST(HostWorkflowTest, WorkerErrorsReturnToTheSuspendedPhase)
 {
     App::HostRuntime runtime(4);
@@ -281,7 +317,7 @@ TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
     std::atomic<int> dispatches {0};
     std::promise<std::thread::id> finishedOn;
     std::atomic<int> finishedCalls {0};
-    auto future = singleComputePhase(worker, resumed).runAsync(
+    auto future = singleComputePhase(worker, resumed).runAsyncWithCleanup(
         runtime,
         [&](std::function<void()> resume) {
             if (dispatches.fetch_add(1) >= 1) {
@@ -289,6 +325,7 @@ TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
             }
             owner.dispatch(std::move(resume));
         },
+        [&](std::function<void()> cleanup) { owner.dispatch(std::move(cleanup)); },
         [&] { ++finishedCalls; finishedOn.set_value(std::this_thread::get_id()); }
     );
     ASSERT_EQ(future.wait_for(2s), std::future_status::ready)
@@ -299,6 +336,30 @@ TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
     EXPECT_NE(worker, std::thread::id {});
     EXPECT_EQ(finishedOn.get_future().get(), owner.id());
     EXPECT_EQ(finishedCalls.load(), 1);
+}
+
+TEST(HostWorkflowTest, DispatchFailureDestroysSuspendedFrameOnOwner)
+{
+    App::HostRuntime runtime(1);
+    QueuedOwner owner;
+    std::promise<std::thread::id> destroyedOn;
+    auto destroyed = destroyedOn.get_future();
+    std::atomic<int> dispatches {0};
+    auto future = phaseWithOwnerCleanup(destroyedOn).runAsyncWithCleanup(
+        runtime,
+        [&](std::function<void()> resume) {
+            if (dispatches.fetch_add(1) != 0) {
+                throw std::runtime_error("owner dispatch failed");
+            }
+            owner.dispatch(std::move(resume));
+        },
+        [&](std::function<void()> cleanup) { owner.dispatch(std::move(cleanup)); }
+    );
+    ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
+    EXPECT_THROW(future.get(), std::runtime_error);
+    ASSERT_EQ(destroyed.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(destroyed.get(), owner.id())
+        << "Suspended document resources must be released by their owner";
 }
 
 TEST(HostWorkflowTest, RejectedDispatchUsesIndependentOwnerCleanup)

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -362,6 +362,25 @@ TEST(HostWorkflowTest, QueuedPhaseCancellationReleasesCapturesOnOwner)
     EXPECT_EQ(destroyed.get(), owner.id());
 }
 
+TEST(HostWorkflowTest, InitialDispatchFailurePropagatesWithoutInlineCompletion)
+{
+    App::HostRuntime runtime(1);
+    std::thread::id worker, resumed;
+    bool finished = false;
+    EXPECT_THROW(
+        singleComputePhase(worker, resumed).runAsync(
+            runtime,
+            [](std::function<void()>) { throw std::runtime_error("initial dispatch failed"); },
+            [&] { finished = true; }
+        ),
+        std::runtime_error
+    );
+    EXPECT_FALSE(finished)
+        << "The caller has not received or stored the workflow future yet";
+    EXPECT_EQ(worker, std::thread::id {});
+    EXPECT_EQ(resumed, std::thread::id {});
+}
+
 class AsyncRecomputeTest: public ::testing::Test
 {
 protected:

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -74,6 +74,22 @@ App::HostWorkflow<int> singleComputePhase(std::thread::id& worker, std::thread::
     co_return 11;
 }
 
+App::HostWorkflow<int> phaseWithCapturedOwnerResource(std::promise<std::thread::id>& destroyedOn)
+{
+    struct OwnerResource
+    {
+        std::promise<std::thread::id>& destroyedOn;
+        explicit OwnerResource(std::promise<std::thread::id>& result) : destroyedOn(result) {}
+        ~OwnerResource() { destroyedOn.set_value(std::this_thread::get_id()); }
+    };
+    auto resource = std::make_shared<OwnerResource>(destroyedOn);
+    App::HostWorkflow<int>::Step phase {
+        App::HostRuntime::Lane::Compute, [resource](std::stop_token) {}
+    };
+    co_yield std::move(phase);
+    co_return 1;
+}
+
 class QueuedOwner
 {
 public:
@@ -270,6 +286,35 @@ TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
     EXPECT_NE(worker, std::thread::id {});
     EXPECT_EQ(finishedOn.get_future().get(), owner.id());
     EXPECT_EQ(finishedCalls.load(), 1);
+}
+
+TEST(HostWorkflowTest, WorkerDoesNotRetainPhaseCapturesAfterOwnerCompletion)
+{
+    App::HostRuntime runtime(1);
+    QueuedOwner owner;
+    std::promise<std::thread::id> destroyedOn;
+    auto destroyed = destroyedOn.get_future();
+    std::promise<void> finished;
+    auto finishedFuture = finished.get_future().share();
+    std::atomic<int> dispatches {0};
+    auto future = phaseWithCapturedOwnerResource(destroyedOn).runAsync(
+        runtime,
+        [&](std::function<void()> resume) {
+            const bool completion = dispatches.fetch_add(1) != 0;
+            owner.dispatch(std::move(resume));
+            if (completion) {
+                // Hold the worker completion on this side of dispatch until
+                // the owner has destroyed its frame and notified the caller.
+                EXPECT_EQ(finishedFuture.wait_for(2s), std::future_status::ready);
+            }
+        },
+        [&] { finished.set_value(); }
+    );
+    ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(future.get(), 1);
+    runtime.shutdown();
+    ASSERT_EQ(destroyed.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(destroyed.get(), owner.id());
 }
 
 class AsyncRecomputeTest: public ::testing::Test

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -362,6 +362,36 @@ TEST(HostWorkflowTest, DispatchFailureDestroysSuspendedFrameOnOwner)
         << "Suspended document resources must be released by their owner";
 }
 
+TEST(HostWorkflowTest, OwnerSubmissionFailureUsesCleanupQueue)
+{
+    App::HostRuntime runtime(1);
+    runtime.shutdown();
+    QueuedOwner owner;
+    std::promise<std::thread::id> destroyedOn;
+    auto destroyed = destroyedOn.get_future();
+    std::atomic<int> dispatches {0};
+    std::atomic<int> cleanupDispatches {0};
+    auto future = phaseWithOwnerCleanup(destroyedOn).runAsyncWithCleanup(
+        runtime,
+        [&](std::function<void()> resume) {
+            if (dispatches.fetch_add(1) != 0) {
+                throw std::runtime_error("normal queue stopped");
+            }
+            owner.dispatch(std::move(resume));
+        },
+        [&](std::function<void()> cleanup) {
+            ++cleanupDispatches;
+            owner.dispatch(std::move(cleanup));
+        }
+    );
+    ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
+    EXPECT_THROW(future.get(), std::runtime_error);
+    ASSERT_EQ(destroyed.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(destroyed.get(), owner.id());
+    EXPECT_EQ(cleanupDispatches.load(), 1)
+        << "Owner-side cancellation must also defer cleanup until after worker joining";
+}
+
 TEST(HostWorkflowTest, RejectedDispatchUsesIndependentOwnerCleanup)
 {
     App::HostRuntime runtime(1);

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -74,6 +74,19 @@ App::HostWorkflow<int> singleComputePhase(std::thread::id& worker, std::thread::
     co_return 11;
 }
 
+App::HostWorkflow<int> phaseWithOwnerCleanup(std::promise<std::thread::id>& destroyedOn)
+{
+    struct OwnerResource
+    {
+        std::promise<std::thread::id>& destroyedOn;
+        ~OwnerResource() { destroyedOn.set_value(std::this_thread::get_id()); }
+    } resource {destroyedOn};
+    co_yield App::HostWorkflow<int>::Step {
+        App::HostRuntime::Lane::Compute, [](std::stop_token) {}
+    };
+    co_return 1;
+}
+
 App::HostWorkflow<int> phaseWithCapturedOwnerResource(std::promise<std::thread::id>& destroyedOn)
 {
     struct OwnerResource
@@ -285,6 +298,42 @@ TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
     EXPECT_EQ(resumed, std::thread::id {});
     EXPECT_NE(worker, std::thread::id {});
     EXPECT_EQ(finishedOn.get_future().get(), owner.id());
+    EXPECT_EQ(finishedCalls.load(), 1);
+}
+
+TEST(HostWorkflowTest, DroppedOwnerDispatchStillCleansUpOnOwner)
+{
+    App::HostRuntime runtime(1);
+    QueuedOwner owner;
+    std::promise<std::thread::id> destroyedOn;
+    auto destroyed = destroyedOn.get_future();
+    std::promise<void> discarded;
+    auto discardedOnOwner = discarded.get_future();
+    std::atomic<int> dispatches {0};
+    std::atomic<int> finishedCalls {0};
+    auto future = phaseWithOwnerCleanup(destroyedOn).runAsync(
+        runtime,
+        [&](std::function<void()> resume) {
+            if (dispatches.fetch_add(1) == 0) {
+                owner.dispatch(std::move(resume));
+                return;
+            }
+            // Model a GUI queue accepting a completion and then discarding it
+            // on shutdown while the submitting worker still owns its driver.
+            owner.dispatch([resume = std::move(resume), &discarded]() mutable {
+                resume = {};
+                discarded.set_value();
+            });
+            discardedOnOwner.wait();
+        },
+        [&] { ++finishedCalls; }
+    );
+    ASSERT_EQ(discardedOnOwner.wait_for(2s), std::future_status::ready);
+    runtime.shutdown();
+    ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
+    EXPECT_ANY_THROW(future.get());
+    ASSERT_EQ(destroyed.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(destroyed.get(), owner.id());
     EXPECT_EQ(finishedCalls.load(), 1);
 }
 

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -78,8 +78,8 @@ class QueuedOwner
 {
 public:
     QueuedOwner()
-        : thread([this] { run(); })
     {
+        thread = std::thread([this] { run(); });
         started.get_future().wait();
     }
 
@@ -205,16 +205,16 @@ TEST(HostWorkflowTest, RunAsyncResumesOnTheOwnerAndRunsWorkOffIt)
     QueuedOwner owner;
     std::thread::id worker;
     std::thread::id resumed;
-    std::thread::id finishedOn;
+    std::promise<std::thread::id> finishedOn;
     auto future = singleComputePhase(worker, resumed).runAsync(
         runtime,
         [&](std::function<void()> resume) { owner.dispatch(std::move(resume)); },
-        [&] { finishedOn = std::this_thread::get_id(); }
+        [&] { finishedOn.set_value(std::this_thread::get_id()); }
     );
     ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
     EXPECT_EQ(future.get(), 11);
     EXPECT_EQ(resumed, owner.id());
-    EXPECT_EQ(finishedOn, owner.id());
+    EXPECT_EQ(finishedOn.get_future().get(), owner.id());
     EXPECT_NE(worker, std::thread::id {});
     EXPECT_NE(worker, owner.id());
     EXPECT_NE(worker, std::this_thread::get_id());
@@ -226,11 +226,11 @@ TEST(HostWorkflowTest, RunAsyncWorkerErrorsReturnToTheOwner)
     App::HostRuntime runtime(2);
     QueuedOwner owner;
     std::vector<std::thread::id> threads;
-    std::thread::id finishedOn;
+    std::promise<std::thread::id> finishedOn;
     auto future = orderedWorkerPhases(threads).runAsync(
         runtime,
         [&](std::function<void()> resume) { owner.dispatch(std::move(resume)); },
-        [&] { finishedOn = std::this_thread::get_id(); }
+        [&] { finishedOn.set_value(std::this_thread::get_id()); }
     );
     ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
     EXPECT_EQ(future.get(), 7);
@@ -239,7 +239,7 @@ TEST(HostWorkflowTest, RunAsyncWorkerErrorsReturnToTheOwner)
         EXPECT_NE(thread, owner.id());
         EXPECT_NE(thread, std::this_thread::get_id());
     }
-    EXPECT_EQ(finishedOn, owner.id());
+    EXPECT_EQ(finishedOn.get_future().get(), owner.id());
 }
 
 TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
@@ -250,6 +250,7 @@ TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
     std::thread::id worker;
     std::thread::id resumed;
     std::atomic<int> dispatches {0};
+    std::promise<std::thread::id> finishedOn;
     std::atomic<int> finishedCalls {0};
     auto future = singleComputePhase(worker, resumed).runAsync(
         runtime,
@@ -259,7 +260,7 @@ TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
             }
             owner.dispatch(std::move(resume));
         },
-        [&] { ++finishedCalls; }
+        [&] { ++finishedCalls; finishedOn.set_value(std::this_thread::get_id()); }
     );
     ASSERT_EQ(future.wait_for(2s), std::future_status::ready)
         << "Owner dispatch failure must complete the workflow future; HostRuntime "
@@ -267,6 +268,7 @@ TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
     EXPECT_THROW(future.get(), std::runtime_error);
     EXPECT_EQ(resumed, std::thread::id {});
     EXPECT_NE(worker, std::thread::id {});
+    EXPECT_EQ(finishedOn.get_future().get(), owner.id());
     EXPECT_EQ(finishedCalls.load(), 1);
 }
 

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -301,6 +301,38 @@ TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
     EXPECT_EQ(finishedCalls.load(), 1);
 }
 
+TEST(HostWorkflowTest, RejectedDispatchUsesIndependentOwnerCleanup)
+{
+    App::HostRuntime runtime(1);
+    QueuedOwner owner;
+    std::promise<std::thread::id> destroyedOn;
+    auto destroyed = destroyedOn.get_future();
+    std::promise<std::thread::id> finishedOn;
+    std::atomic<int> dispatches {0};
+    std::atomic<int> cleanupDispatches {0};
+    auto future = phaseWithOwnerCleanup(destroyedOn).runAsyncWithCleanup(
+        runtime,
+        [&](std::function<void()> resume) {
+            if (dispatches.fetch_add(1) != 0) {
+                throw std::runtime_error("normal queue stopped");
+            }
+            owner.dispatch(std::move(resume));
+        },
+        [&](std::function<void()> cleanup) {
+            ++cleanupDispatches;
+            owner.dispatch(std::move(cleanup));
+        },
+        [&] { finishedOn.set_value(std::this_thread::get_id()); }
+    );
+    ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
+    EXPECT_THROW(future.get(), std::runtime_error);
+    ASSERT_EQ(destroyed.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(destroyed.get(), owner.id());
+    EXPECT_EQ(finishedOn.get_future().get(), owner.id());
+    EXPECT_EQ(dispatches.load(), 2);
+    EXPECT_EQ(cleanupDispatches.load(), 1);
+}
+
 TEST(HostWorkflowTest, DroppedOwnerDispatchStillCleansUpOnOwner)
 {
     App::HostRuntime runtime(1);

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -19,8 +19,14 @@
  *                                                                            *
  ******************************************************************************/
 
+#include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <deque>
+#include <functional>
 #include <future>
+#include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <QAbstractEventDispatcher>
 #include <QCoreApplication>
@@ -58,6 +64,109 @@ App::HostWorkflow<int> orderedWorkerPhases(std::vector<std::thread::id>& threads
     }
     co_return 0;
 }
+
+App::HostWorkflow<int> singleComputePhase(std::thread::id& worker, std::thread::id& owner)
+{
+    co_yield App::HostWorkflow<int>::Step {App::HostRuntime::Lane::Compute, [&](std::stop_token) {
+        worker = std::this_thread::get_id();
+    }};
+    owner = std::this_thread::get_id();
+    co_return 11;
+}
+
+class QueuedOwner
+{
+public:
+    QueuedOwner()
+        : thread([this] { run(); })
+    {
+        started.get_future().wait();
+    }
+
+    QueuedOwner(const QueuedOwner&) = delete;
+    QueuedOwner& operator=(const QueuedOwner&) = delete;
+
+    ~QueuedOwner()
+    {
+        {
+            std::lock_guard lock(mutex);
+            stop = true;
+        }
+        cv.notify_one();
+        thread.join();
+    }
+
+    std::thread::id id() const
+    {
+        return ownerId;
+    }
+
+    void dispatch(std::function<void()> work)
+    {
+        {
+            std::lock_guard lock(mutex);
+            queue.push_back(std::move(work));
+        }
+        cv.notify_one();
+    }
+
+private:
+    void run()
+    {
+        ownerId = std::this_thread::get_id();
+        started.set_value();
+        std::unique_lock lock(mutex);
+        while (true) {
+            cv.wait(lock, [&] { return stop || !queue.empty(); });
+            if (queue.empty()) {
+                if (stop) {
+                    break;
+                }
+                continue;
+            }
+            auto work = std::move(queue.front());
+            queue.pop_front();
+            lock.unlock();
+            work();
+            lock.lock();
+        }
+    }
+
+    std::mutex mutex;
+    std::condition_variable cv;
+    std::deque<std::function<void()>> queue;
+    std::thread thread;
+    std::thread::id ownerId;
+    std::promise<void> started;
+    bool stop {false};
+};
+
+std::thread::id queuedOwnerId;
+std::mutex queuedOwnerMutex;
+std::deque<std::function<void()>> queuedOwnerWork;
+
+bool queuedOwnerIsMainThread()
+{
+    return std::this_thread::get_id() == queuedOwnerId;
+}
+
+void queuedOwnerInvoke(std::function<void()>&& work, bool blocking)
+{
+    if (blocking || std::this_thread::get_id() == queuedOwnerId) {
+        work();
+        return;
+    }
+    std::lock_guard lock(queuedOwnerMutex);
+    queuedOwnerWork.push_back(std::move(work));
+}
+
+std::deque<std::function<void()>> takeQueuedOwnerWork()
+{
+    std::lock_guard lock(queuedOwnerMutex);
+    std::deque<std::function<void()>> pending;
+    pending.swap(queuedOwnerWork);
+    return pending;
+}
 }
 
 TEST(HostWorkflowTest, WorkerErrorsReturnToTheSuspendedPhase)
@@ -87,6 +196,78 @@ TEST(HostWorkflowTest, WorkerErrorsReturnToTheSuspendedPhase)
     EXPECT_EQ(orderedWorkerPhases(threads).runSynchronously(), 7);
     ASSERT_EQ(threads.size(), 2);
     EXPECT_EQ(threads.front(), std::this_thread::get_id());
+}
+
+TEST(HostWorkflowTest, RunAsyncResumesOnTheOwnerAndRunsWorkOffIt)
+{
+    using namespace std::chrono_literals;
+    App::HostRuntime runtime(2);
+    QueuedOwner owner;
+    std::thread::id worker;
+    std::thread::id resumed;
+    std::thread::id finishedOn;
+    auto future = singleComputePhase(worker, resumed).runAsync(
+        runtime,
+        [&](std::function<void()> resume) { owner.dispatch(std::move(resume)); },
+        [&] { finishedOn = std::this_thread::get_id(); }
+    );
+    ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(future.get(), 11);
+    EXPECT_EQ(resumed, owner.id());
+    EXPECT_EQ(finishedOn, owner.id());
+    EXPECT_NE(worker, std::thread::id {});
+    EXPECT_NE(worker, owner.id());
+    EXPECT_NE(worker, std::this_thread::get_id());
+}
+
+TEST(HostWorkflowTest, RunAsyncWorkerErrorsReturnToTheOwner)
+{
+    using namespace std::chrono_literals;
+    App::HostRuntime runtime(2);
+    QueuedOwner owner;
+    std::vector<std::thread::id> threads;
+    std::thread::id finishedOn;
+    auto future = orderedWorkerPhases(threads).runAsync(
+        runtime,
+        [&](std::function<void()> resume) { owner.dispatch(std::move(resume)); },
+        [&] { finishedOn = std::this_thread::get_id(); }
+    );
+    ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(future.get(), 7);
+    ASSERT_EQ(threads.size(), 2);
+    for (const auto thread : threads) {
+        EXPECT_NE(thread, owner.id());
+        EXPECT_NE(thread, std::this_thread::get_id());
+    }
+    EXPECT_EQ(finishedOn, owner.id());
+}
+
+TEST(HostWorkflowTest, RunAsyncOwnerDispatchFailureCompletesTheFuture)
+{
+    using namespace std::chrono_literals;
+    App::HostRuntime runtime(1);
+    QueuedOwner owner;
+    std::thread::id worker;
+    std::thread::id resumed;
+    std::atomic<int> dispatches {0};
+    std::atomic<int> finishedCalls {0};
+    auto future = singleComputePhase(worker, resumed).runAsync(
+        runtime,
+        [&](std::function<void()> resume) {
+            if (dispatches.fetch_add(1) >= 1) {
+                throw std::runtime_error("owner dispatch failed");
+            }
+            owner.dispatch(std::move(resume));
+        },
+        [&] { ++finishedCalls; }
+    );
+    ASSERT_EQ(future.wait_for(2s), std::future_status::ready)
+        << "Owner dispatch failure must complete the workflow future; HostRuntime "
+           "swallows the completion exception and the coordinator currently hangs";
+    EXPECT_THROW(future.get(), std::runtime_error);
+    EXPECT_EQ(resumed, std::thread::id {});
+    EXPECT_NE(worker, std::thread::id {});
+    EXPECT_EQ(finishedCalls.load(), 1);
 }
 
 class AsyncRecomputeTest: public ::testing::Test
@@ -425,4 +606,68 @@ TEST_F(AsyncRecomputeTest, PendingStateCoversQueuedAndInFlightWork)
         std::this_thread::sleep_for(10ms);
     }
     EXPECT_FALSE(App::GetApplication().hasPendingRecomputeRequest(_docName));
+}
+
+TEST_F(AsyncRecomputeTest, FinishedSignalDoesNotAdoptAReplacementDocument)
+{
+    using namespace std::chrono_literals;
+    auto& application = App::GetApplication();
+    queuedOwnerId = std::this_thread::get_id();
+    takeQueuedOwnerWork();
+    App::MainThreadSignalConfig::setHooks(&queuedOwnerIsMainThread, &queuedOwnerInvoke);
+    BOOST_SCOPE_EXIT_ALL(&) {
+        App::MainThreadSignalConfig::setHooks(nullptr, nullptr);
+        takeQueuedOwnerWork();
+    };
+
+    auto* object = dynamic_cast<App::FeatureTestAsyncBlocker*>(
+        _doc->addObject("App::FeatureTestAsyncBlocker", "BlockingFeature")
+    );
+    ASSERT_NE(object, nullptr);
+    const std::string originalUid = _doc->Uid.getValueStr();
+
+    std::atomic<int> finishedAfterReplacement {0};
+    fastsignals::scoped_connection finished =
+        application.signalRecomputeRequestFinished.connect([&](const std::string& name) {
+            if (name != _docName) {
+                return;
+            }
+            auto* current = application.getDocument(name.c_str());
+            if (current && current->Uid.getValueStr() != originalUid) {
+                ++finishedAfterReplacement;
+            }
+        });
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&) {
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    };
+
+    object->touch();
+    application.queueRecomputeRequest(App::RecomputeRequest::fromDocumentObject(*object));
+    ASSERT_TRUE(App::FeatureTestAsyncBlocker::waitUntilStarted(2s));
+    App::FeatureTestAsyncBlocker::releaseBlocker();
+
+    const auto deadline = std::chrono::steady_clock::now() + 2s;
+    while ((application.hasPendingRecomputeRequest(_docName)
+            || _doc->isCooperativeMutationActive()
+            || _doc->isPresentationUpdateActive())
+           && std::chrono::steady_clock::now() < deadline) {
+        std::this_thread::sleep_for(10ms);
+    }
+    ASSERT_FALSE(application.hasPendingRecomputeRequest(_docName));
+    ASSERT_FALSE(_doc->isCooperativeMutationActive());
+    ASSERT_TRUE(application.closeDocument(_docName.c_str()));
+    _doc = nullptr;
+    auto* replacement = application.newDocument(_docName.c_str(), "testUser");
+    ASSERT_NE(replacement, nullptr);
+    EXPECT_NE(replacement->Uid.getValueStr(), originalUid);
+
+    for (auto& work : takeQueuedOwnerWork()) {
+        work();
+    }
+
+    EXPECT_EQ(finishedAfterReplacement.load(), 0)
+        << "A queued recompute-finished notification must not adopt a replacement "
+           "document that reused the cancelled document's name";
 }

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -317,6 +317,51 @@ TEST(HostWorkflowTest, WorkerDoesNotRetainPhaseCapturesAfterOwnerCompletion)
     EXPECT_EQ(destroyed.get(), owner.id());
 }
 
+TEST(HostWorkflowTest, QueuedPhaseCancellationReleasesCapturesOnOwner)
+{
+    QueuedOwner owner;
+    App::HostRuntime runtime(1);
+    std::promise<void> blockerStarted;
+    auto started = blockerStarted.get_future();
+    auto blocker = runtime.submit(App::HostRuntime::Lane::Compute, [&](std::stop_token stop) {
+        std::promise<void> released;
+        auto release = released.get_future();
+        std::stop_callback cancelled(stop, [&] { released.set_value(); });
+        blockerStarted.set_value();
+        release.get();
+    });
+    ASSERT_EQ(started.wait_for(2s), std::future_status::ready);
+    std::promise<std::thread::id> destroyedOn;
+    auto destroyed = destroyedOn.get_future();
+    std::promise<void> phaseQueued;
+    auto queued = phaseQueued.get_future();
+    std::promise<void> finished;
+    auto finish = finished.get_future().share();
+    std::atomic<int> dispatches {0};
+    auto future = phaseWithCapturedOwnerResource(destroyedOn).runAsync(
+        runtime,
+        [&](std::function<void()> resume) {
+            const bool initial = dispatches.fetch_add(1) == 0;
+            owner.dispatch([&, initial, resume = std::move(resume)] {
+                resume();
+                if (initial) { phaseQueued.set_value(); }
+            });
+            if (!initial) {
+                EXPECT_EQ(finish.wait_for(2s), std::future_status::ready);
+            }
+        },
+        [&] { finished.set_value(); }
+    );
+    ASSERT_EQ(queued.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(runtime.queuedTaskCount(App::HostRuntime::Lane::Compute), 1);
+    runtime.shutdown();
+    blocker.get();
+    ASSERT_EQ(future.wait_for(2s), std::future_status::ready);
+    EXPECT_THROW(future.get(), std::runtime_error);
+    ASSERT_EQ(destroyed.wait_for(2s), std::future_status::ready);
+    EXPECT_EQ(destroyed.get(), owner.id());
+}
+
 class AsyncRecomputeTest: public ::testing::Test
 {
 protected:

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(Gui_tests_run
 # Qt tests
 setup_qt_test(DockLayoutState)
 setup_qt_test(DocumentBulkMutation)
+setup_qt_test(FrameBudget)
 setup_qt_test(MacroTaskAcceptance)
 setup_qt_test(QuantitySpinBox)
 set(RenderMeshController_LIBS PartGui Part)

--- a/tests/src/Gui/FrameBudget.cpp
+++ b/tests/src/Gui/FrameBudget.cpp
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: LGPL-2.1-or-later
+
+#include <condition_variable>
+#include <future>
+#include <mutex>
+#include <QApplication>
+#include <QThread>
+#include <QtTest/QtTest>
+#include <App/HostRuntime.h>
+#include <Gui/FrameBudget.h>
+
+class FrameBudgetTest: public QObject
+{
+    Q_OBJECT
+
+private Q_SLOTS:
+    void shutdownDrainsWorkerCleanupOnOwner()
+    {
+        App::HostRuntime runtime(1);
+        Gui::initializeGuiFrameDispatcher([&] { runtime.shutdown(); });
+        bool normalCleanup = false;
+        QVERIFY(Gui::dispatchToGuiCleanup([&] { normalCleanup = true; }));
+        QTRY_VERIFY(normalCleanup);
+
+        bool cleanedOnOwner = false;
+        bool cleanupAccepted = false;
+        bool ordinaryAccepted = true;
+        std::promise<void> started;
+        auto ready = started.get_future();
+        auto worker = runtime.submit(App::HostRuntime::Lane::Compute,
+            [&](std::stop_token stop) {
+                std::mutex mutex;
+                std::unique_lock lock(mutex);
+                std::condition_variable_any wake;
+                started.set_value();
+                wake.wait(lock, stop, [] { return false; });
+                ordinaryAccepted = Gui::dispatchToGuiFrame([] {});
+                cleanupAccepted = Gui::dispatchToGuiCleanup([&] {
+                    cleanedOnOwner = QThread::currentThread() == qApp->thread();
+                });
+            });
+        ready.get();
+        QVERIFY(QMetaObject::invokeMethod(qApp, "aboutToQuit", Qt::DirectConnection));
+        worker.get();
+        QVERIFY(!ordinaryAccepted);
+        QVERIFY(cleanupAccepted);
+        QVERIFY(cleanedOnOwner);
+        QVERIFY(!runtime.isAccepting());
+        QVERIFY(!Gui::dispatchToGuiCleanup([] {}));
+    }
+};
+
+QTEST_MAIN(FrameBudgetTest)
+#include "FrameBudget.moc"

--- a/tests/src/Gui/FrameBudget.cpp
+++ b/tests/src/Gui/FrameBudget.cpp
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <Python.h>
 #include <condition_variable>
 #include <future>
 #include <mutex>
@@ -38,8 +39,15 @@ class FrameBudgetTest: public QObject
 private Q_SLOTS:
     void shutdownDrainsWorkerCleanupOnOwner()
     {
+        Py_Initialize();
+        QVERIFY(PyGILState_Check());
+        bool joinedWithoutGil = false;
+        bool cleanupHasGil = false;
         App::HostRuntime runtime(1);
-        Gui::initializeGuiFrameDispatcher([&] { runtime.shutdown(); });
+        Gui::initializeGuiFrameDispatcher([&] {
+            joinedWithoutGil = !PyGILState_Check();
+            runtime.shutdown();
+        });
         bool normalCleanup = false;
         QVERIFY(Gui::dispatchToGuiCleanup([&] { normalCleanup = true; }));
         QTRY_VERIFY(normalCleanup);
@@ -78,6 +86,7 @@ private Q_SLOTS:
                 ordinaryAccepted = Gui::dispatchToGuiFrame([] {});
                 cleanupAccepted = Gui::dispatchToGuiCleanup([&] {
                     cleanedOnOwner = QThread::currentThread() == qApp->thread();
+                    cleanupHasGil = PyGILState_Check();
                 });
             });
         ready.get();
@@ -90,6 +99,9 @@ private Q_SLOTS:
         QVERIFY(!ordinaryAccepted);
         QVERIFY(cleanupAccepted);
         QVERIFY(cleanedOnOwner);
+        QVERIFY(joinedWithoutGil);
+        QVERIFY(cleanupHasGil);
+        QVERIFY(PyGILState_Check());
         QVERIFY(!runtime.isAccepting());
         QVERIFY(!Gui::dispatchToGuiCleanup([] {}));
     }

--- a/tests/src/Gui/FrameBudget.cpp
+++ b/tests/src/Gui/FrameBudget.cpp
@@ -7,7 +7,29 @@
 #include <QThread>
 #include <QtTest/QtTest>
 #include <App/HostRuntime.h>
+#include <App/HostWorkflow.h>
 #include <Gui/FrameBudget.h>
+
+namespace
+{
+App::HostWorkflow<int> cancellableWorkflow(std::promise<void>& started,
+                                         std::thread::id& destroyedOn)
+{
+    struct OwnerResource
+    {
+        std::thread::id& destroyedOn;
+        ~OwnerResource() { destroyedOn = std::this_thread::get_id(); }
+    } resource {destroyedOn};
+    co_yield App::HostWorkflowStep {App::HostRuntime::Lane::Io, [&](std::stop_token stop) {
+        std::mutex mutex;
+        std::unique_lock lock(mutex);
+        std::condition_variable_any wake;
+        started.set_value();
+        wake.wait(lock, stop, [] { return false; });
+    }};
+    co_return 1;
+}
+}
 
 class FrameBudgetTest: public QObject
 {
@@ -21,6 +43,25 @@ private Q_SLOTS:
         bool normalCleanup = false;
         QVERIFY(Gui::dispatchToGuiCleanup([&] { normalCleanup = true; }));
         QTRY_VERIFY(normalCleanup);
+
+        std::promise<void> workflowStarted;
+        auto workflowReady = workflowStarted.get_future();
+        std::thread::id frameDestroyedOn, finishedOn;
+        auto workflow = cancellableWorkflow(workflowStarted, frameDestroyedOn).runAsyncWithCleanup(
+            runtime,
+            [](std::function<void()> resume) {
+                if (!Gui::dispatchToGuiFrame(std::move(resume))) {
+                    throw std::runtime_error("normal queue stopped");
+                }
+            },
+            [](std::function<void()> cleanup) {
+                if (!Gui::dispatchToGuiCleanup(std::move(cleanup))) {
+                    throw std::runtime_error("cleanup queue stopped too early");
+                }
+            },
+            [&] { finishedOn = std::this_thread::get_id(); });
+        QTRY_VERIFY(workflowReady.wait_for(std::chrono::milliseconds(0))
+                    == std::future_status::ready);
 
         bool cleanedOnOwner = false;
         bool cleanupAccepted = false;
@@ -42,6 +83,10 @@ private Q_SLOTS:
         ready.get();
         QVERIFY(QMetaObject::invokeMethod(qApp, "aboutToQuit", Qt::DirectConnection));
         worker.get();
+        QVERIFY(workflow.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready);
+        QVERIFY_EXCEPTION_THROWN(workflow.get(), std::runtime_error);
+        QCOMPARE(frameDestroyedOn, std::this_thread::get_id());
+        QCOMPARE(finishedOn, std::this_thread::get_id());
         QVERIFY(!ordinaryAccepted);
         QVERIFY(cleanupAccepted);
         QVERIFY(cleanedOnOwner);


### PR DESCRIPTION
Document open/save completion must release document resources on the GUI thread, including when normal dispatch stops during shutdown. A delayed recompute notification must also ignore a replacement document that reused the original name.

This keeps the existing asynchronous worker phases and frame-budgeted adoption. It fixes ownership and shutdown delivery without moving document work back onto the UI thread.

### Changes

- Preserve coroutine ownership of worker-phase callback captures, so the last captured resource is released on the owner even when the submitting worker still holds its completion callback.
- Clean up an accepted completion discarded by the GUI queue on its owner, rather than leaving destruction to the worker's final reference.
- Add `HostWorkflow::runAsyncWithCleanup` and a separate GUI cleanup queue. Open/save use this route. At shutdown, ordinary queued handoffs are released before workers join; cleanup stays admitted until those workers finish and is then drained on the owner.
- Keep `runAsync` available for callers whose owner queue remains available through completion. A permanently rejecting dispatcher alone cannot deliver owner cleanup; the new entry point explicitly supplies the independent route.
- Release a caller-held Python GIL while joining workers, restore it before owner cleanup, and defer owner-side cancellation cleanup through the independent queue as well.
- Preserve initial dispatch failure as an exception to the caller, before any completion notification can read an unassigned future.
- Check document UID before delivering queued recompute-finished notification, rejecting a replacement with the same name.
- Correct the native test fixture's thread initialization and completion synchronization so ownership regressions are deterministic.

### Validation

The complete Linux Release build passed with 12 jobs and all sanitizers disabled. Tests then ran against that complete build, with private profiles and Xvfb for GUI tests.

- 16 App tests passed: workflow ownership/cleanup hooks and asynchronous recompute, including document UID replacement.
- Six production GUI regressions passed: responsive native document opening, save leases, completion-observer edits, recompute after save admission, queued-save close, and shutdown release of queued handoffs (Qt reports 8 including fixture setup/cleanup).
- The Qt shutdown regression passed, verifying worker cancellation and owner cleanup after ordinary dispatch stops, with a caller-held Python GIL (Qt reports 3 including fixture setup/cleanup).

Exact final build and validation commands:

```sh
cmake --build build/release --parallel 12
python /tmp/vibecad-run-full-runtime-tests.py
```

Both exited 0. The validation harness checks the Release/sanitizer settings, verifies the linked App/GUI libraries come from this build, and executes `App_tests_run`, `DocumentBulkMutation_Tests_run`, and `FrameBudget_Tests_run` in isolated processes. It does not interact with an existing application instance. Earlier isolated object builds also passed the same ownership regressions; the final results above supersede those preliminary checks.

Red/green evidence: the original phase-capture and discarded-completion tests observed destruction on a worker; the initial-dispatch test observed inline completion before future assignment; the UID test observed one notification on the replacement document. Additional red tests showed worker joining retained the GIL and owner-side failure skipped the cleanup queue; both now pass. The new cleanup entry point, hook, and Qt queue tests were added before their implementations and initially failed to compile because those APIs were absent. Rejection tests retain their owner-thread assertions and now exercise the explicit cleanup route used by production.

### Compatibility and remaining risk

- [x] Existing public APIs remain present; the cleanup entry point and hooks are additive.
- [x] No preference keys, tool names, or schemas renamed or removed.
- [x] Normal rendering/adoption keeps the existing frame budget and worker execution.
- [x] Initial admission semantics match main; no published history was rewritten.
- [x] Full Linux Release build and final integrated checks completed.

Shutdown now joins the runtime while the cleanup queue remains available. Validation here is Linux; a native macOS or Windows run has not been performed. This does not establish a fix for the separately investigated malloc corruption.

Related to #194's runtime work. No automatic issue closure.
