### PR TITLE
Fix strict release builds across Linux, macOS, and Windows

### DIFF
--- a/src/Gui/NaviCube.cpp
+++ b/src/Gui/NaviCube.cpp
@@ -763,7 +763,11 @@ void NaviCubeImplementation::createCubeFaceTextures()
 
         // Coin backend: store as a Coin-managed texture (SoTexture2).
         // Mirror to match the OpenGL texture coordinate origin (bottom-left).
+#if QT_VERSION < QT_VERSION_CHECK(6, 9, 0)
         const QImage rgba = image.mirrored().convertToFormat(QImage::Format_RGBA8888);
+#else
+        const QImage rgba = image.flipped(Qt::Vertical).convertToFormat(QImage::Format_RGBA8888);
+#endif
         const int w = rgba.width();
         const int h = rgba.height();
         std::vector<unsigned char> pixels(static_cast<size_t>(w) * static_cast<size_t>(h) * 4U);

--- a/src/Mod/Part/App/GizmoHelper.cpp
+++ b/src/Mod/Part/App/GizmoHelper.cpp
@@ -136,7 +136,9 @@ std::pair<TopoDS_Face, TopoDS_Face> getAdjacentFacesFromEdge(
     assert(faces.Extent() >= 2 && "This is probably a bug so please report it to the issue tracker");
 
     TopoDS_Face face1 = TopoDS::Face(faces.First());
-    TopoDS_Face face2 = TopoDS::Face(*(++faces.begin()));
+    TopTools_ListOfShape::Iterator faceIterator(faces);
+    faceIterator.Next();
+    TopoDS_Face face2 = TopoDS::Face(faceIterator.Value());
 
     return {face1, face2};
 }

--- a/src/Mod/Part/App/SectionGeometry.cpp
+++ b/src/Mod/Part/App/SectionGeometry.cpp
@@ -22,6 +22,8 @@
 #include <TopoDS_Wire.hxx>
 #include <gp.hxx>
 
+// MSVC instantiates the exported FaceDriller destructor at the class definition.
+#include "WireJoiner.h"
 #include "FaceMakerBullseye.h"
 #include "TopoShape.h"
 #include "RenderMesh.h"

--- a/src/Mod/Part/Gui/AppPartGui.cpp
+++ b/src/Mod/Part/Gui/AppPartGui.cpp
@@ -350,7 +350,8 @@ private:
             }
             instances.push_back({
                 static_cast<Part::TopoShapePy*>(shape.ptr())->getTopoShapePtr()->getShape(),
-                *static_cast<Base::MatrixPy*>(matrix.ptr())->getMatrixPtr()
+                *static_cast<Base::MatrixPy*>(matrix.ptr())->getMatrixPtr(),
+                {}
             });
         }
         struct OwnerCallback

--- a/src/Tools/tests/check_section_compilation.py
+++ b/src/Tools/tests/check_section_compilation.py
@@ -28,7 +28,8 @@ def main():
     failures = 0
     with tempfile.TemporaryDirectory(prefix="section-compile-") as temporary:
         for module, target, filename in (("Gui", "PartGui", "AppPartGui.cpp"),
-                                         ("App", "Part", "SectionGeometry.cpp")):
+                                         ("App", "Part", "SectionGeometry.cpp"),
+                                         ("App", "Part", "GizmoHelper.cpp")):
             obj = f"src/Mod/Part/{module}/CMakeFiles/{target}.dir/{filename}.o"
             commands = subprocess.check_output(
                 ["ninja", "-C", str(build), "-t", "commands", obj], text=True)

--- a/src/Tools/tests/check_section_compilation.py
+++ b/src/Tools/tests/check_section_compilation.py
@@ -27,10 +27,13 @@ def main():
                       if line.startswith("CMAKE_HOME_DIRECTORY:INTERNAL="))
     failures = 0
     with tempfile.TemporaryDirectory(prefix="section-compile-") as temporary:
-        for module, target, filename in (("Gui", "PartGui", "AppPartGui.cpp"),
-                                         ("App", "Part", "SectionGeometry.cpp"),
-                                         ("App", "Part", "GizmoHelper.cpp")):
-            obj = f"src/Mod/Part/{module}/CMakeFiles/{target}.dir/{filename}.o"
+        for directory, target, filename in (
+            ("src/Mod/Part/Gui", "PartGui", "AppPartGui.cpp"),
+            ("src/Mod/Part/App", "Part", "SectionGeometry.cpp"),
+            ("src/Mod/Part/App", "Part", "GizmoHelper.cpp"),
+            ("src/Gui", "FreeCADGui", "NaviCube.cpp"),
+        ):
+            obj = f"{directory}/CMakeFiles/{target}.dir/{filename}.o"
             commands = subprocess.check_output(
                 ["ninja", "-C", str(build), "-t", "commands", obj], text=True)
             command = shlex.split(commands.splitlines()[-1])
@@ -49,7 +52,7 @@ def main():
                     if flag.startswith("-I" + old_source + "/src"):
                         cleaned.append(flag.replace(old_source, str(source), 1))
                     cleaned.append(flag)
-            production = source / "src/Mod/Part" / module / filename
+            production = source / directory / filename
             probe = Path(temporary) / filename
             probe.write_text(f'#include "{production.as_posix()}"\n' + (
                 "// MSVC eagerly instantiates this exported nested destructor.\n"

--- a/src/Tools/tests/check_section_compilation.py
+++ b/src/Tools/tests/check_section_compilation.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: LGPL-2.1-or-later
+"""Compile section-view regression probes with an existing Ninja build's flags.
+
+Usage: python src/Tools/tests/check_section_compilation.py BUILD_DIR --compiler clang++
+Outputs go into a temporary directory; the supplied build is never modified.
+The build must be configured from this checkout with dependencies/generated headers
+available. --source-dir can instead check another checkout of the same baseline.
+"""
+
+import argparse
+from pathlib import Path
+import shlex
+import subprocess
+import tempfile
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("build_dir", type=Path)
+    parser.add_argument("--compiler", default="clang++")
+    parser.add_argument("--source-dir", type=Path, default=Path(__file__).resolve().parents[3])
+    args = parser.parse_args()
+    build = args.build_dir.resolve()
+    source = args.source_dir.resolve()
+    cache = (build / "CMakeCache.txt").read_text()
+    old_source = next(line.split("=", 1)[1] for line in cache.splitlines()
+                      if line.startswith("CMAKE_HOME_DIRECTORY:INTERNAL="))
+    failures = 0
+    with tempfile.TemporaryDirectory(prefix="section-compile-") as temporary:
+        for module, target, filename in (("Gui", "PartGui", "AppPartGui.cpp"),
+                                         ("App", "Part", "SectionGeometry.cpp")):
+            obj = f"src/Mod/Part/{module}/CMakeFiles/{target}.dir/{filename}.o"
+            commands = subprocess.check_output(
+                ["ninja", "-C", str(build), "-t", "commands", obj], text=True)
+            command = shlex.split(commands.splitlines()[-1])
+            # Ninja may prefix the compiler with ccache.
+            flags = command[2:] if Path(command[0]).name == "ccache" else command[1:]
+            cleaned = []
+            iterator = iter(flags)
+            for flag in iterator:
+                if flag in ("-o", "-MF", "-MT", "-MQ"):
+                    next(iterator)
+                elif flag in ("-c", "-MD", "-MMD") or flag.endswith("/" + filename):
+                    continue
+                else:
+                    # Keep generated headers in the existing build. Prefer the
+                    # checked source, retaining original dependency include paths.
+                    if flag.startswith("-I" + old_source + "/src"):
+                        cleaned.append(flag.replace(old_source, str(source), 1))
+                    cleaned.append(flag)
+            production = source / "src/Mod/Part" / module / filename
+            probe = Path(temporary) / filename
+            probe.write_text(f'#include "{production.as_posix()}"\n' + (
+                "// MSVC eagerly instantiates this exported nested destructor.\n"
+                "// Force the same completeness requirement on other compilers.\n"
+                "struct SectionFaceDrillerProbe : Part::FaceMakerBullseye {\n"
+                "    static void destroy(FaceDriller* value) { delete value; }\n"
+                "};\n"
+                if filename == "SectionGeometry.cpp" else ""))
+            # The inline body above is enough to instantiate the destructor.
+            result = subprocess.run(
+                [args.compiler, *cleaned, "-Werror",
+                 "-c", str(probe), "-o", str(Path(temporary) / (filename + ".o"))],
+                cwd=build)
+            print(f"{filename}: {'PASS' if result.returncode == 0 else 'FAIL'}", flush=True)
+            failures += result.returncode != 0
+    return bool(failures)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/src/Gui/CMakeLists.txt
+++ b/tests/src/Gui/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(UnitSettings_Tests_run PRIVATE
 
 target_link_libraries(Gui_tests_run PRIVATE
     GTest::gmock_main
+    ${Python3_LIBRARIES}
     FreeCADApp
     FreeCADGui
 )


### PR DESCRIPTION
The RC6 Build 2 release failed after #192: Clang rejected an omitted mesh initializer, and MSVC could not instantiate an exported destructor with an incomplete type. A full strict local build also exposed compatibility warnings with older OpenCASCADE and newer Qt.

This PR keeps the release compilation fixes together:

- Explicitly initialize the exact-shape section instance's mesh pointer to empty.
- Include the complete `WireJoiner` definition before `FaceMakerBullseye` in section geometry.
- Use OpenCASCADE's native iterator for the second adjacent gizmo face, avoiding the deprecated STL adapter in OCCT 7.6.
- Use `QImage::flipped(Qt::Vertical)` for navigation-cube textures on Qt 6.9+, retaining `mirrored()` on older Qt with identical orientation.
- Explicitly link `Gui_tests_run` to Python, matching the other native test targets. With packaged `BUILD_DYNAMIC_LINK_PYTHON=OFF`, its existing document-projection tests otherwise fail to link four Python symbols. The failed full build reproduced this missing dependency before the CMake-only fix; the complete build and those tests now pass.

No API, document, simulation, section performance, or dependency changes. No warning suppression. The only visual code change preserves the existing texture orientation.

## Verification

- [x] Red/green compile probes: the added `src/Tools/tests/check_section_compilation.py` reproduced each original compiler diagnostic before its corresponding source fix.
- [x] `python src/Tools/tests/check_section_compilation.py build/strict-release --compiler clang++`: **4 translation units passed with warnings as errors**, using system Clang 18, Qt 6.11.1 and OCCT 7.6.3.
- [x] `bash /tmp/vibecad-strict-tests/with-release-env.sh python src/Tools/tests/check_section_compilation.py build/strict-package-release --compiler clang++`: **4 translation units passed with warnings as errors**, using Clang 21, Qt 6.8.3 and OCCT 7.8.1 from the existing local Pixi dependency environment.
- [x] Original two section fixes also passed the compile probes with GCC 13 and `-Werror`.
- [x] `PYTHONPATH=src/Mod/VibeCAD /tmp/vibecad-pr-review-env/bin/python -m pytest -q src/Mod/VibeCAD/vibecad_tests/test_section_view.py`: **80 passed**.
- [x] `git diff --check`: passed.
- [x] Full strict local build with packaged dependencies: **exit 0**, including all application modules and native test executables. Repeated the full default build after the final commit to refresh metadata: **exit 0**, build stamp matches `b0bcea12671cbbf971a6b9dad385b161ab492c42`.
- [x] `python /tmp/vibecad-strict-tests/run-final-section-native.py`: **21 passed**, exit 0.
- [x] `python /tmp/vibecad-strict-tests/run-final-section-gui.py`: **17 passed**, exit 0.
- [x] `python /tmp/vibecad-strict-tests/run-final-runtime-tests.py`: **9 document-projection tests, 16 App runtime tests, 6 open/save/shutdown tests, and 1 frame-budget shutdown test passed** (plus Qt setup/cleanup fixtures), exit 0.
- [x] Both PR contract checks passed on the final commit.

Native and GUI tests used this completed build, isolated profiles, private temporary/socket directories and Xvfb. No user instance was automated or modified.
Platform packaging builds will run after this PR is merged. Local full-build and runtime validation remain required before merge.

Local full-build commands (the wrapper activates the existing Pixi compiler environment, prepends its bin/lib directories, and removes the same GCC-only flag as the Linux packaging script):

```sh
bash /tmp/vibecad-strict-tests/with-release-env.sh cmake --preset conda-linux-release -S . -B build/strict-package-release -DFREECAD_WARN_ERROR=ON -DFREECAD_USE_CCACHE=ON -DENABLE_DEVELOPER_TESTS=ON -DPython3_EXECUTABLE=/home/robit/vibecad/.pixi/envs/default/bin/python -DBUILD_DYNAMIC_LINK_PYTHON=OFF -DCMAKE_INSTALL_PREFIX=/tmp/vibecad-section-release-fix/build/strict-package-install
bash /tmp/vibecad-strict-tests/with-release-env.sh cmake --build build/strict-package-release --parallel 12 -- -k 0
```

The initial full system-library build used Clang 18 and `FREECAD_WARN_ERROR=ON`. Besides the fixed OCCT/Qt diagnostics, it encountered old VTK 9.1's deprecated `std::iterator` adapter and a GNU-linker/Clang-LTO mismatch. The definitive full local build uses packaged VTK 9.3.1 (which removes that adapter) and the packaging preset's mold linker. No system headers were patched and no warnings were downgraded. The full build and focused runtime validation have now passed using the packaged dependencies. Actual macOS/Windows packaging remains a post-merge check; these platforms were not claimed to be built locally.

## Compatibility

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields renamed or removed.
- [x] Existing defaults and performance paths preserved.
- [x] No deprecations or breaking changes introduced.
