### PR TITLE
Keep human CAD workflows correct during async recompute

### DIFF
--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -1,7 +1,7 @@
 # VibeCAD performance work
 
 Status: active
-Last updated: 2026-09-09
+Last updated: 2026-09-11
 
 ## What this work delivers
 
@@ -129,6 +129,14 @@ round trips. Detailed measurements and red/green history are retained in
 These are concrete checkpoints from the tested documents and machines, not
 universal performance guarantees:
 
+- The PR #205 Windows package passes clean startup and real GUI acceptance for
+  Part Design task accept/cancel, every additive and subtractive primitive,
+  Assembly simulation playback, Drawing redraw and section views, Analyze/FEM,
+  and Manufacturing/CAM. A disposable 2,685-object robot document opened,
+  saved, reopened, and compared equal by exact object type, link, and state
+  inventory. Its first display settled in 176.4 seconds and save completed in
+  9.4 seconds, with no access violation, Qt thread-affinity, invalid-extension,
+  lost-link, or nested-recompute diagnostic.
 - A saved robot simulation prepared and displayed in 47.648 seconds from a
   fresh solve and 0.571 seconds after reopen from matching authenticated native
   results. All 337 component poses were checked at three frames, along with 672
@@ -205,15 +213,16 @@ The current Linux AppImage has direct build and owner acceptance evidence.
 Remaining work is focused on final acceptance rather than another architecture
 rewrite:
 
-- Build and exercise one final ABI-consistent Windows portable archive without
-  source overlays. Repeat publication cancel/rollback/retry, independent
-  multi-output create/patch/input edits, playback invalidation, export, and
-  document lifecycle checks.
-- Attribute and reduce the measured 1.219-second combined cleanup,
-  close, and reopen callback while preserving safe document shutdown.
-- Complete the application-wide acceptance inventory for Analyze, Drawing,
-  Manufacturing, Mesh, import/export, multi-document, memory-pressure, and
-  shutdown scenarios.
+- Repeat packaged publication cancel/rollback/retry, independent multi-output
+  create/patch/input edits, playback invalidation, and export measurements on
+  future publication changes. The current ABI-consistent Windows archive and
+  document lifecycle acceptance are complete.
+- Reduce the remaining large-document first-load and teardown event spans. The
+  final PR #205 package preserves exact state and stays operational, but the
+  independent input probe still records isolated 0.12-0.38 second open spans
+  and a 0.75 second document-close span against the research-grade 100 ms gate.
+- Complete the remaining application-wide acceptance inventory for Mesh,
+  import/export, multi-document, memory-pressure, and shutdown scenarios.
 - Run equivalent packaging and lifecycle acceptance on macOS.
 - Continue measuring direct GUI callbacks against the 8-millisecond p95 target
   and investigate any repeatable heartbeat or native-input gap over 100

--- a/package/rattler-build/recipe.yaml
+++ b/package/rattler-build/recipe.yaml
@@ -10,7 +10,7 @@ source:
   use_gitignore: true
 
 build:
-  number: 2
+  number: 3
   script:
     env:
       # rattler-build runs the build in a sandbox that does not inherit shell

--- a/src/App/Application.cpp
+++ b/src/App/Application.cpp
@@ -555,6 +555,7 @@ Application::Application(std::map<std::string,std::string> &mConfig)
 
 Application::~Application()
 {
+    _pendingDocumentCloses.clear();
     {
         std::lock_guard<std::mutex> lock(_recomputeMutex);
         for (auto& [name, cancellation] : _recomputeCancellation) {
@@ -943,6 +944,107 @@ void Application::closeAllDocuments()
     }
 }
 
+bool Application::requestCloseDocument(const char* name)
+{
+    const std::string documentName(name ? name : "");
+    auto* document = getDocument(documentName.c_str());
+    if (!document) {
+        return false;
+    }
+    if (!(document->isCooperativeMutationActive()
+          || document->isPresentationUpdateActive())) {
+        return closeDocument(documentName.c_str());
+    }
+    if (!MainThreadSignalConfig::hasHooks() || !MainThreadSignalConfig::isMainThread()) {
+        return false;
+    }
+
+    const std::string documentUid = document->Uid.getValueStr();
+    if (auto existing = _pendingDocumentCloses.find(documentName);
+        existing != _pendingDocumentCloses.end()) {
+        return existing->second.documentUid == documentUid;
+    }
+
+    PendingDocumentClose pending;
+    pending.documentUid = documentUid;
+    const auto changed = [this, documentName, documentUid](const Document&, bool active) {
+        if (active) {
+            return;
+        }
+        queueRequestedDocumentClose(documentName, documentUid);
+    };
+    pending.cooperativeMutationConnection =
+        document->signalCooperativeMutationChanged.connect(changed);
+    pending.presentationUpdateConnection =
+        document->signalPresentationUpdateChanged.connect(changed);
+    _pendingDocumentCloses.emplace(documentName, std::move(pending));
+    return true;
+}
+
+void Application::queueRequestedDocumentClose(
+    const std::string& documentName,
+    const std::string& documentUid
+)
+{
+    const auto pending = _pendingDocumentCloses.find(documentName);
+    if (pending == _pendingDocumentCloses.end()
+        || pending->second.documentUid != documentUid
+        || pending->second.resumeQueued) {
+        return;
+    }
+
+    pending->second.resumeQueued = true;
+    MainThreadSignalConfig::invoke(
+        [this, documentName, documentUid] {
+            resumeRequestedDocumentClose(documentName, documentUid);
+        },
+        false
+    );
+}
+
+void Application::resumeRequestedDocumentClose(
+    const std::string& documentName,
+    const std::string& documentUid
+)
+{
+    const auto pending = _pendingDocumentCloses.find(documentName);
+    if (pending == _pendingDocumentCloses.end()
+        || pending->second.documentUid != documentUid) {
+        return;
+    }
+
+    auto* document = getDocument(documentName.c_str());
+    if (!document || document->Uid.getValueStr() != documentUid) {
+        _pendingDocumentCloses.erase(pending);
+        return;
+    }
+    if (document->isCooperativeMutationActive() || document->isPresentationUpdateActive()) {
+        pending->second.resumeQueued = false;
+        return;
+    }
+
+    if (closeDocument(documentName.c_str())) {
+        _pendingDocumentCloses.erase(documentName);
+        return;
+    }
+
+    document = getDocument(documentName.c_str());
+    const auto current = _pendingDocumentCloses.find(documentName);
+    if (current != _pendingDocumentCloses.end()
+        && document && document->Uid.getValueStr() == documentUid
+        && (document->isCooperativeMutationActive()
+            || document->isPresentationUpdateActive())) {
+        current->second.resumeQueued = false;
+        return;
+    }
+
+    _pendingDocumentCloses.erase(documentName);
+    Base::Console().error(
+        "Requested close failed for stable document '%s'\n",
+        documentName.c_str()
+    );
+}
+
 Document* Application::getDocument(const char *Name) const
 {
 
@@ -1126,7 +1228,7 @@ bool Application::tryQueueRecomputeRequests(std::vector<RecomputeRequest> reques
                 Document* document = request.resolveDocument();
                 return !request.documentName.empty() && document
                     && (!(document->isCooperativeMutationActive()
-                          || document->isPresentationUpdateActive())
+                          || document->isMutationBlockingPresentationUpdateActive())
                         || _recomputeDocumentsScheduled.contains(request.documentName));
             })) {
             return false;

--- a/src/App/Application.h
+++ b/src/App/Application.h
@@ -225,6 +225,15 @@ public:
      * @return Returns true if the document was found and closed, false otherwise.
      */
     bool closeDocument(const char* name);
+
+    /**
+     * Close a document at its next stable owner-thread boundary.
+     *
+     * Unlike closeDocument(), this accepts a document whose cooperative or
+     * presentation work is still active and queues exactly one close after
+     * that work releases. It never blocks the GUI thread.
+     */
+    bool requestCloseDocument(const char* name);
     /**
      * @brief Acquire a unique document name from a proposed name.
      *
@@ -1198,6 +1207,23 @@ private:
     bool _isClosingAll{false};
     // Owner-thread close callbacks may re-enter document closure.
     std::set<std::string> _closingDocuments;
+    struct PendingDocumentClose
+    {
+        std::string documentUid;
+        bool resumeQueued {false};
+        fastsignals::scoped_connection cooperativeMutationConnection;
+        fastsignals::scoped_connection presentationUpdateConnection;
+    };
+    std::map<std::string, PendingDocumentClose> _pendingDocumentCloses;
+
+    void resumeRequestedDocumentClose(
+        const std::string& documentName,
+        const std::string& documentUid
+    );
+    void queueRequestedDocumentClose(
+        const std::string& documentName,
+        const std::string& documentUid
+    );
 
     // for estimate max link depth
     int _objCount{-1};

--- a/src/App/ApplicationPy.cpp
+++ b/src/App/ApplicationPy.cpp
@@ -185,6 +185,12 @@ PyMethodDef ApplicationPy::Methods[] = {
      METH_VARARGS,
      "closeDocument(string) -> None\n\n"
      "Close the document with a given name."},
+    {"requestCloseDocument",
+     (PyCFunction)ApplicationPy::sRequestCloseDocument,
+     METH_VARARGS,
+     "requestCloseDocument(string) -> bool\n\n"
+     "Close immediately when stable, or queue one owner-thread close after active "
+     "document work finishes."},
     {"writeRecoverySnapshotToTransientDir",
      reinterpret_cast<PyCFunction>(
          reinterpret_cast<void (*)()>(ApplicationPy::sWriteRecoverySnapshotToTransientDir)
@@ -501,7 +507,6 @@ PyObject* ApplicationPy::sCloseDocument(PyObject* /*self*/, PyObject* args)
             PyErr_Format(PyExc_RuntimeError, "Invalid document");
             return nullptr;
         }
-
         if (!doc->isClosable()) {
             PyErr_Format(PyExc_RuntimeError, "The document '%s' is not closable for the moment", doc->getName());
             return nullptr;
@@ -1310,6 +1315,15 @@ PyObject* ApplicationPy::sTimelineOperationDeletionPlan(
         return Py::new_reference_to(result);
     }
     PY_CATCH;
+}
+
+PyObject* ApplicationPy::sRequestCloseDocument(PyObject* /*self*/, PyObject* args)
+{
+    const char* name = nullptr;
+    if (!PyArg_ParseTuple(args, "s", &name)) {
+        return nullptr;
+    }
+    return PyBool_FromLong(GetApplication().requestCloseDocument(name));
 }
 
 

--- a/src/App/ApplicationPy.h
+++ b/src/App/ApplicationPy.h
@@ -67,6 +67,7 @@ public:
                                                (PyObject *self,PyObject *args, PyObject *kwd);
     static PyObject* sNewDocument            (PyObject *self,PyObject *args, PyObject *kwd);
     static PyObject* sCloseDocument          (PyObject *self,PyObject *args);
+    static PyObject* sRequestCloseDocument   (PyObject *self,PyObject *args);
     static PyObject* sActiveDocument         (PyObject *self,PyObject *args);
     static PyObject* sSetActiveDocument      (PyObject *self,PyObject *args);
     static PyObject* sGetDocument            (PyObject *self,PyObject *args);

--- a/src/App/Document.cpp
+++ b/src/App/Document.cpp
@@ -406,7 +406,7 @@ bool Document::checkOnCycle()
 
 bool Document::undo(const int id)
 {
-    if (isCooperativeMutationActive() || isPresentationUpdateActive()) {
+    if (isCooperativeMutationActive() || isMutationBlockingPresentationUpdateActive()) {
         FC_WARN("Cannot undo while a document update is active");
         return false;
     }
@@ -467,7 +467,7 @@ bool Document::undo(const int id)
 
 bool Document::redo(const int id)
 {
-    if (isCooperativeMutationActive() || isPresentationUpdateActive()) {
+    if (isCooperativeMutationActive() || isMutationBlockingPresentationUpdateActive()) {
         FC_WARN("Cannot redo while a document update is active");
         return false;
     }
@@ -793,9 +793,9 @@ void Document::endCooperativeMutation()
         if (depth == 1) {
             // Keep completion false while stable observers synchronously
             // acquire their asynchronous presentation work.
-            const auto presentationDepth =
-                d->presentationUpdateDepth.fetch_add(1, std::memory_order_acq_rel);
-            presentationBecameActive = presentationDepth == 0;
+            const auto visualDepth = d->visualUpdateDepth.fetch_add(1, std::memory_order_acq_rel);
+            presentationBecameActive = visualDepth == 0
+                && d->presentationUpdateDepth.load(std::memory_order_acquire) == 0;
         }
         if (depth != 0) {
             d->cooperativeMutationDepth.fetch_sub(1, std::memory_order_acq_rel);
@@ -816,10 +816,10 @@ void Document::endCooperativeMutation()
             signalBecameStable(*this);
         }
         catch (...) {
-            endPresentationUpdate();
+            endVisualUpdate();
             throw;
         }
-        endPresentationUpdate();
+        endVisualUpdate();
     }
 }
 
@@ -831,14 +831,20 @@ bool Document::isCooperativeMutationActive() const
 void Document::beginPresentationUpdate() const
 {
     bool becameActive = false;
+    bool mutationBecameActive = false;
     {
         std::lock_guard lock(d->presentationUpdateMutex);
         const auto depth =
             d->presentationUpdateDepth.fetch_add(1, std::memory_order_acq_rel);
-        becameActive = depth == 0;
+        mutationBecameActive = depth == 0;
+        becameActive = mutationBecameActive
+            && d->visualUpdateDepth.load(std::memory_order_acquire) == 0;
     }
     if (becameActive) {
         signalPresentationUpdateChanged(*this, true);
+    }
+    if (mutationBecameActive) {
+        signalMutationBlockingPresentationUpdateChanged(*this, true);
     }
 }
 
@@ -847,6 +853,7 @@ void Document::endPresentationUpdate() const
     const bool tracePresentation = std::getenv("VIBECAD_RESTORE_DETAIL_TRACE") != nullptr;
     const auto presentationStarted = std::chrono::steady_clock::now();
     bool ready = false;
+    bool mutationReady = false;
     {
         std::lock_guard lock(d->presentationUpdateMutex);
         const auto depth = d->presentationUpdateDepth.load(std::memory_order_acquire);
@@ -855,8 +862,14 @@ void Document::endPresentationUpdate() const
             return;
         }
         d->presentationUpdateDepth.fetch_sub(1, std::memory_order_acq_rel);
+        mutationReady = depth == 1;
         ready = depth == 1
+            && d->visualUpdateDepth.load(std::memory_order_acquire) == 0
             && d->cooperativeMutationDepth.load(std::memory_order_acquire) == 0;
+    }
+    scheduleGuiRecomputeFollowUp();
+    if (mutationReady) {
+        signalMutationBlockingPresentationUpdateChanged(*this, false);
     }
     if (ready) {
         const auto notification = d->presentationUpdateChanged;
@@ -884,7 +897,111 @@ bool Document::isPresentationUpdateActive() const
 {
     std::lock_guard lock(d->presentationUpdateMutex);
     return d->presentationUpdateDepth.load(std::memory_order_acquire) > 0
+        || d->visualUpdateDepth.load(std::memory_order_acquire) > 0
         || d->presentationWaiterCount > 0;
+}
+
+bool Document::isMutationBlockingPresentationUpdateActive() const
+{
+    std::lock_guard lock(d->presentationUpdateMutex);
+    return d->presentationUpdateDepth.load(std::memory_order_acquire) > 0;
+}
+
+void Document::scheduleGuiRecomputeFollowUp() const
+{
+    if (!MainThreadSignalConfig::hasHooks()
+        || isCooperativeMutationActive()
+        || isMutationBlockingPresentationUpdateActive()
+        || !d->guiRecomputeFollowUpRequested.load(std::memory_order_acquire)
+        || d->guiRecomputeFollowUpQueued.exchange(true, std::memory_order_acq_rel)) {
+        return;
+    }
+
+    const std::string documentName = getName();
+    const std::string documentUid = Uid.getValueStr();
+    try {
+        MainThreadSignalConfig::invoke(
+            [documentName, documentUid] {
+                auto* document = GetApplication().getDocument(documentName.c_str());
+                if (!document || document->Uid.getValueStr() != documentUid) {
+                    return;
+                }
+
+                document->d->guiRecomputeFollowUpQueued.store(false, std::memory_order_release);
+                if (document->isCooperativeMutationActive()
+                    || document->isMutationBlockingPresentationUpdateActive()) {
+                    document->scheduleGuiRecomputeFollowUp();
+                    return;
+                }
+
+                const bool requested = document->d->guiRecomputeFollowUpRequested.exchange(
+                    false,
+                    std::memory_order_acq_rel
+                );
+                const bool force = document->d->guiRecomputeFollowUpForce.exchange(
+                    false,
+                    std::memory_order_acq_rel
+                );
+                if (!requested) {
+                    return;
+                }
+                const bool workRemains = std::ranges::any_of(
+                    document->d->objectArray,
+                    [](const DocumentObject* object) { return object && object->isTouched(); }
+                );
+                if (force || workRemains) {
+                    document->recompute({}, force);
+                }
+            },
+            false
+        );
+    }
+    catch (...) {
+        d->guiRecomputeFollowUpQueued.store(false, std::memory_order_release);
+        throw;
+    }
+}
+
+void Document::beginVisualUpdate() const
+{
+    bool becameActive = false;
+    {
+        std::lock_guard lock(d->presentationUpdateMutex);
+        const auto depth = d->visualUpdateDepth.fetch_add(1, std::memory_order_acq_rel);
+        becameActive = depth == 0
+            && d->presentationUpdateDepth.load(std::memory_order_acquire) == 0;
+    }
+    if (becameActive) {
+        signalPresentationUpdateChanged(*this, true);
+    }
+}
+
+void Document::endVisualUpdate() const
+{
+    bool ready = false;
+    {
+        std::lock_guard lock(d->presentationUpdateMutex);
+        const auto depth = d->visualUpdateDepth.load(std::memory_order_acquire);
+        if (depth == 0) {
+            FC_WARN("Ignoring unmatched document visual update end");
+            return;
+        }
+        d->visualUpdateDepth.fetch_sub(1, std::memory_order_acq_rel);
+        ready = depth == 1
+            && d->presentationUpdateDepth.load(std::memory_order_acquire) == 0
+            && d->cooperativeMutationDepth.load(std::memory_order_acquire) == 0;
+    }
+    if (ready) {
+        const auto notification = d->presentationUpdateChanged;
+        try {
+            signalPresentationUpdateChanged(*this, false);
+        }
+        catch (...) {
+            notification->notify_all();
+            throw;
+        }
+        notification->notify_all();
+    }
 }
 
 void Document::waitForPresentationReady() const
@@ -893,7 +1010,8 @@ void Document::waitForPresentationReady() const
     ++d->presentationWaiterCount;
     d->presentationUpdateChanged->wait(lock, [this] {
         return d->cooperativeMutationDepth.load(std::memory_order_acquire) == 0
-            && d->presentationUpdateDepth.load(std::memory_order_acquire) == 0;
+            && d->presentationUpdateDepth.load(std::memory_order_acquire) == 0
+            && d->visualUpdateDepth.load(std::memory_order_acquire) == 0;
     });
     --d->presentationWaiterCount;
     if (d->presentationWaiterCount == 0) {
@@ -916,15 +1034,15 @@ void Document::waitForPresentationReady() const
 
 void Document::notifyBecameStable() const
 {
-    beginPresentationUpdate();
+    beginVisualUpdate();
     try {
         signalBecameStable(*this);
     }
     catch (...) {
-        endPresentationUpdate();
+        endVisualUpdate();
         throw;
     }
-    endPresentationUpdate();
+    endVisualUpdate();
 }
 
 bool Document::transacting() const
@@ -3744,56 +3862,104 @@ void Document::renameObjectIdentifiers(
 
 int Document::recompute(const std::vector<DocumentObject*>& objs, bool force, bool* hasError, int options)
 {
-    if (isCooperativeMutationActive() || isPresentationUpdateActive()) {
-        FC_WARN("Cannot recompute while a document update is active");
+    const bool guiOwner = MainThreadSignalConfig::hasHooks()
+        && MainThreadSignalConfig::isMainThread();
+    if (guiOwner
+        && (d->guiRecomputeCoordinatorActive.load(std::memory_order_acquire)
+            || isCooperativeMutationActive()
+            || isMutationBlockingPresentationUpdateActive())) {
+        d->guiRecomputeFollowUpRequested.store(true, std::memory_order_release);
+        if (force) {
+            d->guiRecomputeFollowUpForce.store(true, std::memory_order_release);
+        }
+        if (!d->guiRecomputeCoordinatorActive.load(std::memory_order_acquire)) {
+            scheduleGuiRecomputeFollowUp();
+        }
         return 0;
     }
-    if (MainThreadSignalConfig::hasHooks() && MainThreadSignalConfig::isMainThread()) {
+    if (isCooperativeMutationActive()
+        || isMutationBlockingPresentationUpdateActive()) {
+        FC_WARN(
+            "Cannot recompute document '" << getName()
+            << "' while a document update is active"
+            << " [guiOwner=" << guiOwner
+            << ", cooperative=" << isCooperativeMutationActive()
+            << ", presentation=" << isMutationBlockingPresentationUpdateActive() << "]"
+        );
+        return 0;
+    }
+    if (guiOwner) {
         // Preserve the synchronous public API, but not a synchronous GUI wait:
         // feature workers emit owner-thread notifications before they finish.
         // The coordinator must therefore run off-owner while Qt keeps serving
         // those notifications, input and paint. The existing document lease
         // prevents an intervening edit/undo/close from invalidating its targets.
+        d->guiRecomputeCoordinatorActive.store(true, std::memory_order_release);
         beginCooperativeMutation();
         int count = 0;
         std::exception_ptr failure;
         try {
-            QEventLoop events;
-            bool complete = false;
             std::unique_ptr<Base::PyGILStateRelease> release;
             if (Py_IsInitialized() && PyGILState_Check()) {
                 release = std::make_unique<Base::PyGILStateRelease>();
             }
-            GetApplication().hostRuntime().submitWithCompletion(
-                HostRuntime::Lane::Document,
-                [this, &objs, force, hasError, options](std::stop_token stop) {
-                    return recomputeCancellable(objs, force, hasError, options, stop);
-                },
-                [&](std::future<int> result) {
-                    QMetaObject::invokeMethod(
-                        &events,
-                        [&, result = result.share()] {
-                            try { count = result.get(); }
-                            catch (...) { failure = std::current_exception(); }
-                            complete = true;
-                            // Stop WaitForMoreEvents in this dispatch, rather
-                            // than waiting for unrelated input after completion.
-                            events.quit();
-                        },
-                        Qt::QueuedConnection
-                    );
+            const std::vector<DocumentObject*> noObjectFilter;
+            const std::vector<DocumentObject*>* objects = &objs;
+            bool passForce = force;
+            for (;;) {
+                d->guiRecomputeFollowUpRequested.store(false, std::memory_order_release);
+                d->guiRecomputeFollowUpForce.store(false, std::memory_order_release);
+                QEventLoop events;
+                bool complete = false;
+                GetApplication().hostRuntime().submitWithCompletion(
+                    HostRuntime::Lane::Document,
+                    [this, objects, passForce, hasError, options](std::stop_token stop) {
+                        return recomputeCancellable(*objects, passForce, hasError, options, stop);
+                    },
+                    [&](std::future<int> result) {
+                        QMetaObject::invokeMethod(
+                            &events,
+                            [&, result = result.share()] {
+                                try { count += result.get(); }
+                                catch (...) { failure = std::current_exception(); }
+                                complete = true;
+                                // Stop WaitForMoreEvents in this dispatch, rather
+                                // than waiting for unrelated input after completion.
+                                events.quit();
+                            },
+                            Qt::QueuedConnection
+                        );
+                    }
+                );
+                // Event-driven, not a polling timer or a deadline. Keep the frame
+                // dispatcher alive even if an outer event loop is asked to quit;
+                // stack-owned targets stay alive until the worker acknowledges.
+                while (!complete) {
+                    events.processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents);
                 }
-            );
-            // Event-driven, not a polling timer or a deadline. Keep the frame
-            // dispatcher alive even if an outer event loop is asked to quit;
-            // stack-owned targets stay alive until the worker acknowledges.
-            while (!complete) {
-                events.processEvents(QEventLoop::AllEvents | QEventLoop::WaitForMoreEvents);
+                if (failure) {
+                    break;
+                }
+
+                const bool followUpRequested
+                    = d->guiRecomputeFollowUpRequested.exchange(false, std::memory_order_acq_rel);
+                const bool followUpForce
+                    = d->guiRecomputeFollowUpForce.exchange(false, std::memory_order_acq_rel);
+                const bool workRemains = std::ranges::any_of(
+                    d->objectArray,
+                    [](const DocumentObject* object) { return object && object->isTouched(); }
+                );
+                if (!followUpRequested || (!followUpForce && !workRemains)) {
+                    break;
+                }
+                objects = &noObjectFilter;
+                passForce = followUpForce;
             }
         }
         catch (...) {
             failure = std::current_exception();
         }
+        d->guiRecomputeCoordinatorActive.store(false, std::memory_order_release);
         endCooperativeMutation();
         if (failure) {
             std::rethrow_exception(failure);

--- a/src/App/Document.h
+++ b/src/App/Document.h
@@ -300,6 +300,9 @@ public:
     App::MainThreadSignal<void(const Document&, bool)> signalCooperativeMutationChanged;
     /// Signal when asynchronous presentation work transitions between idle and active.
     App::MainThreadSignal<void(const Document&, bool)> signalPresentationUpdateChanged;
+    /// Signal when presentation work that mutates document projections starts or ends.
+    App::MainThreadSignal<void(const Document&, bool)>
+        signalMutationBlockingPresentationUpdateChanged;
     /// Completed property-schema or extension change. The immutable object ID
     /// avoids exposing a removed property to deferred projection consumers.
     App::MainThreadSignal<void(long)> signalObjectSchemaChanged;
@@ -1180,6 +1183,9 @@ public:
     void beginPresentationUpdate() const;
     void endPresentationUpdate() const;
     bool isPresentationUpdateActive() const;
+    bool isMutationBlockingPresentationUpdateActive() const;
+    void beginVisualUpdate() const;
+    void endVisualUpdate() const;
     void waitForPresentationReady() const;
 
     bool transacting() const;
@@ -1766,6 +1772,7 @@ private:
     void abandonRestore();
     void invalidateTimelineVisibilityResources(const char* propertyName);
     void notifyBecameStable() const;
+    void scheduleGuiRecomputeFollowUp() const;
     void setBookedTransaction(int transactionId) const;
     bool isBreakingDependency() const noexcept;
     void changePropertyOfObject(

--- a/src/App/private/DocumentP.h
+++ b/src/App/private/DocumentP.h
@@ -108,9 +108,14 @@ struct DocumentP
     unsigned int UndoMaxStackSize {20};
     unsigned int TransactionLock {0};
     std::atomic_uint cooperativeMutationDepth {0};
+    std::atomic_bool guiRecomputeCoordinatorActive {false};
+    std::atomic_bool guiRecomputeFollowUpRequested {false};
+    std::atomic_bool guiRecomputeFollowUpForce {false};
+    std::atomic_bool guiRecomputeFollowUpQueued {false};
     // Non-null only while the archive writer consumes live document properties.
     std::atomic<const void*> archiveWriter {nullptr};
     std::atomic_uint presentationUpdateDepth {0};
+    std::atomic_uint visualUpdateDepth {0};
     unsigned int restorePresentationDepth {0};
     unsigned int presentationWaiterCount {0};
     mutable std::mutex presentationUpdateMutex;

--- a/src/Gui/ApplicationPy.cpp
+++ b/src/Gui/ApplicationPy.cpp
@@ -607,6 +607,13 @@ PyMethodDef ApplicationPy::Methods[] = {
      "Worker callers release the GIL while waiting. Return values and Python exceptions\n"
      "are delivered to the caller. Geometry, document computation and I/O belong on workers;\n"
      "this call cannot interrupt an expensive callback."},
+    {"deferToNextFrame",
+     (PyCFunction)ApplicationPy::sDeferToNextFrame,
+     METH_VARARGS,
+     "deferToNextFrame(callable, *args) -> bool\n"
+     "\n"
+     "Queue one short presentation callback on the shared GUI frame dispatcher.\n"
+     "Returns false only when GUI shutdown has stopped accepting work."},
     {"doCommand",
      (PyCFunction)ApplicationPy::sDoCommand,
      METH_VARARGS,
@@ -975,6 +982,57 @@ PyObject* ApplicationPy::sRunOnMainThread(PyObject* /*self*/, PyObject* args)
     PyObject* result = runPythonOnMainThread([&] { return PyObject_CallObject(callable, arguments); });
     Py_DECREF(arguments);
     return result;
+}
+
+PyObject* ApplicationPy::sDeferToNextFrame(PyObject* /*self*/, PyObject* args)
+{
+    if (PyTuple_Size(args) == 0 || !PyCallable_Check(PyTuple_GetItem(args, 0))) {
+        PyErr_SetString(
+            PyExc_TypeError,
+            "deferToNextFrame requires a callable followed by its arguments"
+        );
+        return nullptr;
+    }
+
+    struct DeferredPythonCall
+    {
+        PyObject* callable;
+        PyObject* arguments;
+
+        DeferredPythonCall(PyObject* callable, PyObject* arguments)
+            : callable(callable)
+            , arguments(arguments)
+        {
+            Py_INCREF(callable);
+            Py_INCREF(arguments);
+        }
+
+        ~DeferredPythonCall()
+        {
+            Base::PyGILStateLocker lock;
+            Py_DECREF(arguments);
+            Py_DECREF(callable);
+        }
+    };
+
+    PyObject* callable = PyTuple_GetItem(args, 0);
+    PyObject* arguments = PyTuple_GetSlice(args, 1, PyTuple_Size(args));
+    if (!arguments) {
+        return nullptr;
+    }
+    auto deferred = std::make_shared<DeferredPythonCall>(callable, arguments);
+    Py_DECREF(arguments);
+    const bool accepted = dispatchToGuiFrame([deferred] {
+        Base::PyGILStateLocker lock;
+        PyObject* result = PyObject_CallObject(deferred->callable, deferred->arguments);
+        if (result) {
+            Py_DECREF(result);
+        }
+        else {
+            PyErr_Print();
+        }
+    });
+    return PyBool_FromLong(accepted);
 }
 
 PyObject* ApplicationPy::sGetDocument(PyObject* /*self*/, PyObject* args)

--- a/src/Gui/ApplicationPy.h
+++ b/src/Gui/ApplicationPy.h
@@ -90,6 +90,7 @@ public:
     static PyObject* sActivateView             (PyObject *self,PyObject *args);
     static PyObject* sGetDocument              (PyObject *self,PyObject *args);
     static PyObject* sRunOnMainThread          (PyObject *self,PyObject *args);
+    static PyObject* sDeferToNextFrame         (PyObject *self,PyObject *args);
     static PyObject* sEditDocument             (PyObject *self,PyObject *args);
 
     static PyObject* sDoCommand                (PyObject *self,PyObject *args);

--- a/src/Gui/Command.cpp
+++ b/src/Gui/Command.cpp
@@ -655,7 +655,7 @@ bool Command::canInvoke()
     App::Document* document = getDocument();
     if (document
         && (document->isCooperativeMutationActive()
-            || document->isPresentationUpdateActive())) {
+            || document->isMutationBlockingPresentationUpdateActive())) {
         const std::string_view name(getName());
         if ((eType & AlterDoc) || name == "Std_Undo" || name == "Std_Redo"
             || name == "Std_Refresh") {

--- a/src/Gui/CommandView.cpp
+++ b/src/Gui/CommandView.cpp
@@ -2585,7 +2585,10 @@ VibeCADCmdSectionView::VibeCADCmdSectionView()
 void VibeCADCmdSectionView::activated(int iMsg)
 {
     Q_UNUSED(iMsg);
-    doCommand(Command::Gui, "import VibeCADSectionView; VibeCADSectionView.toggle_section_view()");
+    doCommand(
+        Command::Gui,
+        "import VibeCADSectionView; VibeCADSectionView.request_section_view_toggle()"
+    );
 }
 
 bool VibeCADCmdSectionView::isActive()

--- a/src/Gui/Document.cpp
+++ b/src/Gui/Document.cpp
@@ -797,7 +797,7 @@ Document::Document(App::Document* pcDocument, Application* app)
             )
         );
     d->connectPresentationUpdateChanged =
-        pcDocument->signalPresentationUpdateChanged.connect(
+        pcDocument->signalMutationBlockingPresentationUpdateChanged.connect(
             std::bind(
                 &Gui::Document::slotPresentationUpdateChanged,
                 this,
@@ -1600,7 +1600,8 @@ bool Document::historyMutationBlocked(const App::Document* document)
 {
     return projectionRefreshBlocked(document)
         || (document
-            && (document->getBookedTransactionID() != App::NullTransaction
+            && (document->isMutationBlockingPresentationUpdateActive()
+                || document->getBookedTransactionID() != App::NullTransaction
                 || document->hasPendingTransaction()
                 || document->isTransactionLocked()));
 }
@@ -1684,33 +1685,49 @@ void Document::slotCooperativeMutationChanged(
     bool active
 )
 {
-    if (&document != d->_pcDocument || active
-        || d->bulkViewAdoptionLease
-        || d->bulkViewAdoptionFinishing
-        || !hasDeferredViewProviderWork()) {
+    if (&document != d->_pcDocument) {
         return;
     }
 
-    // Keep the document's existing cooperative-mutation contract active
-    // through GUI adoption. The originating mutation has reached depth zero,
-    // so this is a distinct GUI-owned lease, released after the last bounded
-    // slice. Tree, History, undo, close, and recompute therefore observe one
-    // coherent operation instead of the partially attached object graph.
+    // App::Document objects are mutated by the document workers. Coin may not
+    // traverse those same live shapes concurrently, so suspend only this
+    // document's canvases for the mutation lifetime. The main window, task
+    // panel and progress UI continue to process events.
+    for (auto* view : getMDIViews(true)) {
+        synchronizePresentationView(*view);
+    }
+
+    if (active
+        || d->bulkViewAdoptionLease
+        || d->bulkViewAdoptionFinishing
+        || !hasDeferredViewProviderWork()) {
+        if (!active) {
+            slotPresentationUpdateChanged(document, false);
+        }
+        return;
+    }
+
+    // Deferred view-provider work is bounded GUI presentation, not a model
+    // mutation. Keep its lifetime visible to close/save coordination without
+    // rejecting the next modeling command after recompute has completed.
     d->bulkViewAdoptionLease = true;
-    d->_pcDocument->beginCooperativeMutation();
+    d->_pcDocument->beginVisualUpdate();
     scheduleDeferredViewProviderWork();
+    slotPresentationUpdateChanged(document, false);
 }
 
 void Document::slotPresentationUpdateChanged(
     const App::Document& document,
-    bool active
+    bool /*active*/
 )
 {
     if (&document != d->_pcDocument) {
         return;
     }
 
-    if (active) {
+    const bool suspend = document.isCooperativeMutationActive()
+        || document.isMutationBlockingPresentationUpdateActive();
+    if (suspend) {
         for (auto* view : getMDIViews(true)) {
             synchronizePresentationView(*view);
         }
@@ -1729,7 +1746,9 @@ void Document::slotPresentationUpdateChanged(
 
 void Document::synchronizePresentationView(MDIView& view)
 {
-    if (!d->_pcDocument->isPresentationUpdateActive() || !view.updatesEnabled()) {
+    if (!(d->_pcDocument->isCooperativeMutationActive()
+          || d->_pcDocument->isMutationBlockingPresentationUpdateActive())
+        || !view.updatesEnabled()) {
         return;
     }
     view.setUpdatesEnabled(false);
@@ -1986,7 +2005,7 @@ void Document::drainDeferredViewProviderWork()
     if (d->bulkViewAdoptionLease) {
         d->bulkViewAdoptionFinishing = true;
         d->bulkViewAdoptionLease = false;
-        d->_pcDocument->endCooperativeMutation();
+        d->_pcDocument->endVisualUpdate();
         d->bulkViewAdoptionFinishing = false;
     }
 }
@@ -2782,8 +2801,7 @@ bool queueDocumentSave(std::vector<SaveTarget> targets, Document::SaveCallback f
     }
     for (const auto& target : targets) {
         if (App::GetApplication().getDocument(target.name.c_str()) != target.document
-            || Document::historyMutationBlocked(target.document)
-            || target.document->isPresentationUpdateActive()) {
+            || Document::historyMutationBlocked(target.document)) {
             getMainWindow()->showMessage(QObject::tr("Cannot save while document work is active"));
             return false;
         }

--- a/src/Gui/FeatureTimeline.cpp
+++ b/src/Gui/FeatureTimeline.cpp
@@ -1466,7 +1466,7 @@ void FeatureTimeline::acquirePresentationUpdate(App::Document& document)
         return;
     }
     releasePresentationUpdate();
-    document.beginPresentationUpdate();
+    document.beginVisualUpdate();
     presentationUpdateDocument = &document;
 }
 
@@ -1477,7 +1477,7 @@ void FeatureTimeline::releasePresentationUpdate()
     }
     auto* document = presentationUpdateDocument;
     presentationUpdateDocument = nullptr;
-    document->endPresentationUpdate();
+    document->endVisualUpdate();
 }
 
 bool FeatureTimeline::canChangeHistory() const

--- a/src/Gui/FrameBudget.cpp
+++ b/src/Gui/FrameBudget.cpp
@@ -47,22 +47,21 @@ public:
             return false;
         }
 
-        bool schedule = false;
+        bool postWake = false;
         {
             std::lock_guard lock(mutex);
             if (stopped) {
                 return false;
             }
             queue.push_back(std::move(task));
-            if (!scheduled) {
-                scheduled = true;
-                schedule = true;
+            if (!wakePending) {
+                wakePending = true;
+                postWake = true;
             }
         }
-        if (!schedule) {
-            return true;
+        if (postWake) {
+            postDrainEvent();
         }
-        scheduleDrain();
         return true;
     }
 
@@ -79,20 +78,20 @@ public:
         if (!task || !qApp) {
             return false;
         }
-        bool schedule = false;
+        bool postWake = false;
         {
             std::lock_guard lock(mutex);
             if (cleanupStopped) {
                 return false;
             }
             cleanupQueue.push_back(std::move(task));
-            if (!stopped && !scheduled) {
-                scheduled = true;
-                schedule = true;
+            if (!stopped && !wakePending) {
+                wakePending = true;
+                postWake = true;
             }
         }
-        if (schedule) {
-            scheduleDrain();
+        if (postWake) {
+            postDrainEvent();
         }
         return true;
     }
@@ -115,7 +114,7 @@ private:
                 return;
             }
             stopped = true;
-            scheduled = false;
+            wakePending = false;
             cancelled.swap(queue);
         }
         // Release queued synchronous handoffs before joining their workers.
@@ -152,12 +151,8 @@ private:
         return type;
     }
 
-    void scheduleDrain()
+    void postDrainEvent()
     {
-        std::lock_guard lock(mutex);
-        if (stopped) {
-            return;
-        }
         // Adoption is important but never more important than input, paint,
         // timers, or status heartbeats already waiting in the Qt queue.
         QCoreApplication::postEvent(
@@ -167,9 +162,31 @@ private:
         );
     }
 
+    void requestDrain()
+    {
+        bool postWake = false;
+        {
+            std::lock_guard lock(mutex);
+            if (!stopped && !wakePending && (!queue.empty() || !cleanupQueue.empty())) {
+                wakePending = true;
+                postWake = true;
+            }
+        }
+        if (postWake) {
+            postDrainEvent();
+        }
+    }
+
     bool event(QEvent* event) override
     {
         if (event->type() == drainEventType()) {
+            {
+                std::lock_guard lock(mutex);
+                wakePending = false;
+                if (stopped) {
+                    return true;
+                }
+            }
             drain();
             return true;
         }
@@ -184,7 +201,6 @@ private:
             {
                 std::lock_guard lock(mutex);
                 if (queue.empty() && cleanupQueue.empty()) {
-                    scheduled = false;
                     return;
                 }
                 auto& ready = cleanupQueue.empty() ? queue : cleanupQueue;
@@ -200,7 +216,7 @@ private:
         // timer is an event-loop yield, not a time delay: it gives input,
         // paint, status, and other due timers one dispatch opportunity before
         // the next bounded adoption frame is posted.
-        QTimer::singleShot(0, this, [this] { scheduleDrain(); });
+        QTimer::singleShot(0, this, [this] { requestDrain(); });
     }
 
     static void execute(const std::function<void()>& task)
@@ -227,7 +243,10 @@ private:
     std::deque<std::function<void()>> cleanupQueue;
     std::function<void()> finishWorkers;
     bool cleanupStopped {false};
-    bool scheduled {false};
+    // A posted wake event, not an active drain. Clearing this before executing
+    // a task lets a worker post a nested owner handoff when that task runs an
+    // event-driven wait for the worker completion.
+    bool wakePending {false};
     bool stopped {false};
 };
 

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -37,7 +37,9 @@
 
 #include <FCConfig.h>
 
+#include <App/Application.h>
 #include <App/Document.h>
+#include <App/DocumentObject.h>
 #include <Base/Console.h>
 #include <Base/Exception.h>
 #include <Gui/ActionFunction.h>
@@ -349,6 +351,11 @@ TaskView::~TaskView()
     connectApplicationResetEdit.disconnect();
     connectApplicationFinishEdit.disconnect();
     connectShowTaskWatcherSetting.disconnect();
+    for (auto& [name, pending] : pendingTaskRecomputes) {
+        pending.cooperativeMutationConnection.disconnect();
+        pending.presentationUpdateConnection.disconnect();
+    }
+    pendingTaskRecomputes.clear();
     Gui::Selection().Detach(this);
 
     // if well behaved, we should not have nay taskInfo at this point
@@ -604,6 +611,7 @@ void TaskView::slotFinishEdit(const Gui::Document& guiDocument, bool cancelled, 
         TaskDialog::restoreCommandInteractionState(interactionState);
     }
     updateWatcher();
+    scheduleTaskDocumentRecompute(doc);
 }
 
 void TaskView::slotBeforeCloseDocument(const App::Document& doc)
@@ -634,6 +642,12 @@ void TaskView::slotBeforeCloseDocument(const App::Document& doc)
 
 void TaskView::slotDeletedDocument(const App::Document& doc)
 {
+    if (auto pending = pendingTaskRecomputes.find(doc.getName());
+        pending != pendingTaskRecomputes.end()) {
+        pending->second.cooperativeMutationConnection.disconnect();
+        pending->second.presentationUpdateConnection.disconnect();
+        pendingTaskRecomputes.erase(pending);
+    }
     auto foundTaskInfo = std::ranges::find(taskInfos, &doc, &TaskInfo::Document);
     bool hasDialog = foundTaskInfo != taskInfos.end();
     if (hasDialog && foundTaskInfo->ActiveDialog->isAutoCloseOnDeletedDocument()) {
@@ -789,6 +803,14 @@ bool TaskView::showDialog(TaskDialog* dlg, App::Document* doc)
     outInfo.ActiveDialog = dlg;
     outInfo.ActiveDialog->open();
 
+    const auto documentWorkChanged = [this, doc](const App::Document&, bool) {
+        updateDocumentWorkState(doc);
+    };
+    outInfo.cooperativeMutationConnection
+        = doc->signalCooperativeMutationChanged.connect(documentWorkChanged);
+    outInfo.presentationUpdateConnection
+        = doc->signalMutationBlockingPresentationUpdateChanged.connect(documentWorkChanged);
+
     // clang-format off
     // make connection to the needed signals
     connect(outInfo.ActiveCtrl->buttonBox, &QDialogButtonBox::accepted,
@@ -805,6 +827,7 @@ bool TaskView::showDialog(TaskDialog* dlg, App::Document* doc)
     taskInfos.push_back(outInfo);
     addWidget(outInfo.taskPanel);
     setShownTaskInfo(taskInfos.size() - 1);
+    updateDocumentWorkState(doc);
 
     saveCurrentWidth();
     getMainWindow()->updateActions();
@@ -843,6 +866,8 @@ void TaskView::removeDialog(std::vector<TaskInfo>::iterator infoIt)
         const bool finalizing = infoIt->ActiveDialog->property("taskview_accept_or_reject").toBool()
             || infoIt->ActiveDialog->property("taskview_common_finalization").toBool();
         if (!finalizing) {
+            infoIt->cooperativeMutationConnection.disconnect();
+            infoIt->presentationUpdateConnection.disconnect();
             const std::vector<QWidget*>& cont = infoIt->ActiveDialog->getDialogContent();
             for (const auto& it : cont) {
                 infoIt->taskPanel->actionPanel->removeWidget(it);
@@ -1122,6 +1147,16 @@ void TaskView::accept(App::Document* doc)
         return;
     }
 
+    if (doc->isCooperativeMutationActive()
+        || doc->isMutationBlockingPresentationUpdateActive()) {
+        foundTaskInfo->pendingCompletion = TaskInfo::PendingCompletion::Accept;
+        foundTaskInfo->ActiveCtrl->buttonBox->setEnabled(false);
+        getMainWindow()->showMessage(
+            tr("Finishing the current document update before applying this task...")
+        );
+        return;
+    }
+
     // Make sure that if 'accept' calls 'closeDialog' the deletion is postponed until
     // the dialog leaves the 'accept' method
     foundTaskInfo->ActiveDialog->setProperty("taskview_accept_or_reject", true);
@@ -1211,6 +1246,7 @@ void TaskView::accept(App::Document* doc)
     if ((success && foundTaskInfo->ActiveDialog->acceptClosesDialog()) || removeRequested) {
         removeDialog(doc);
     }
+    scheduleTaskDocumentRecompute(doc);
 }
 
 void TaskView::reject(App::Document* doc)
@@ -1218,6 +1254,16 @@ void TaskView::reject(App::Document* doc)
     auto foundTaskInfo = std::ranges::find(taskInfos, doc, &TaskInfo::Document);
     if (foundTaskInfo == taskInfos.end()) {  // Protect against segfaults due to out-of-order deletions
         Base::Console().warning("ActiveDialog was null in call to TaskView::reject()\n");
+        return;
+    }
+
+    if (doc->isCooperativeMutationActive()
+        || doc->isMutationBlockingPresentationUpdateActive()) {
+        foundTaskInfo->pendingCompletion = TaskInfo::PendingCompletion::Reject;
+        foundTaskInfo->ActiveCtrl->buttonBox->setEnabled(false);
+        getMainWindow()->showMessage(
+            tr("Finishing the current document update before cancelling this task...")
+        );
         return;
     }
 
@@ -1305,6 +1351,7 @@ void TaskView::reject(App::Document* doc)
         TaskDialog::resumeCommandMacroCapture(foundTaskInfo->ActiveDialog);
     }
     rejectTrace.reset();
+    scheduleTaskDocumentRecompute(doc);
 }
 
 void TaskView::helpRequested(App::Document* doc)
@@ -1318,9 +1365,135 @@ void TaskView::helpRequested(App::Document* doc)
 void TaskView::clicked(QAbstractButton* button, App::Document* doc)
 {
     auto foundTaskInfo = std::ranges::find(taskInfos, doc, &TaskInfo::Document);
-    if (foundTaskInfo != taskInfos.end()) {
-        int id = foundTaskInfo->ActiveCtrl->buttonBox->standardButton(button);
-        foundTaskInfo->ActiveDialog->clicked(id);
+    if (foundTaskInfo == taskInfos.end()) {
+        return;
+    }
+    if (doc->isCooperativeMutationActive()
+        || doc->isMutationBlockingPresentationUpdateActive()) {
+        getMainWindow()->showMessage(
+            tr("Finishing the current document update before accepting more task input...")
+        );
+        return;
+    }
+    int id = foundTaskInfo->ActiveCtrl->buttonBox->standardButton(button);
+    foundTaskInfo->ActiveDialog->clicked(id);
+}
+
+void TaskView::updateDocumentWorkState(App::Document* document)
+{
+    auto foundTaskInfo = std::ranges::find(taskInfos, document, &TaskInfo::Document);
+    if (foundTaskInfo == taskInfos.end()) {
+        return;
+    }
+
+    const bool active = document->isCooperativeMutationActive()
+        || document->isMutationBlockingPresentationUpdateActive();
+    foundTaskInfo->taskPanel->actionPanel->setEnabled(!active);
+    if (active || foundTaskInfo->pendingCompletion == TaskInfo::PendingCompletion::None) {
+        return;
+    }
+
+    const auto completion = foundTaskInfo->pendingCompletion;
+    foundTaskInfo->pendingCompletion = TaskInfo::PendingCompletion::None;
+    foundTaskInfo->ActiveCtrl->buttonBox->setEnabled(true);
+    const std::string documentName = document->getName();
+    const std::string documentUid = document->Uid.getValueStr();
+    QMetaObject::invokeMethod(
+        this,
+        [this, documentName, documentUid, completion] {
+            auto* document = App::GetApplication().getDocument(documentName.c_str());
+            if (!document || document->Uid.getValueStr() != documentUid) {
+                return;
+            }
+            if (completion == TaskInfo::PendingCompletion::Accept) {
+                accept(document);
+            }
+            else {
+                reject(document);
+            }
+        },
+        Qt::QueuedConnection
+    );
+}
+
+void TaskView::scheduleTaskDocumentRecompute(App::Document* document)
+{
+    if (!document) {
+        return;
+    }
+
+    const std::string documentName = document->getName();
+    const std::string documentUid = document->Uid.getValueStr();
+    auto pending = pendingTaskRecomputes.find(documentName);
+    if (pending != pendingTaskRecomputes.end()
+        && pending->second.documentUid != documentUid) {
+        pending->second.cooperativeMutationConnection.disconnect();
+        pending->second.presentationUpdateConnection.disconnect();
+        pendingTaskRecomputes.erase(pending);
+        pending = pendingTaskRecomputes.end();
+    }
+    if (pending == pendingTaskRecomputes.end()) {
+        PendingTaskRecompute state;
+        state.documentUid = documentUid;
+        const auto becameStable = [this, documentName, documentUid](const App::Document&, bool active) {
+            if (!active) {
+                QMetaObject::invokeMethod(
+                    this,
+                    [this, documentName, documentUid] {
+                        resumeTaskDocumentRecompute(documentName, documentUid);
+                    },
+                    Qt::QueuedConnection
+                );
+            }
+        };
+        state.cooperativeMutationConnection =
+            document->signalCooperativeMutationChanged.connect(becameStable);
+        state.presentationUpdateConnection =
+            document->signalMutationBlockingPresentationUpdateChanged.connect(becameStable);
+        pendingTaskRecomputes.emplace(documentName, std::move(state));
+    }
+
+    QMetaObject::invokeMethod(
+        this,
+        [this, documentName, documentUid] {
+            resumeTaskDocumentRecompute(documentName, documentUid);
+        },
+        Qt::QueuedConnection
+    );
+}
+
+void TaskView::resumeTaskDocumentRecompute(
+    const std::string& documentName,
+    const std::string& documentUid
+)
+{
+    auto pending = pendingTaskRecomputes.find(documentName);
+    if (pending == pendingTaskRecomputes.end()
+        || pending->second.documentUid != documentUid) {
+        return;
+    }
+
+    auto* document = App::GetApplication().getDocument(documentName.c_str());
+    if (!document || document->Uid.getValueStr() != documentUid) {
+        pending->second.cooperativeMutationConnection.disconnect();
+        pending->second.presentationUpdateConnection.disconnect();
+        pendingTaskRecomputes.erase(pending);
+        return;
+    }
+    if (document->isCooperativeMutationActive()
+        || document->isMutationBlockingPresentationUpdateActive()) {
+        return;
+    }
+
+    const bool workRemains = std::ranges::any_of(
+        document->getObjects(),
+        [](const App::DocumentObject* object) { return object && object->isTouched(); }
+    );
+    pending->second.cooperativeMutationConnection.disconnect();
+    pending->second.presentationUpdateConnection.disconnect();
+    pendingTaskRecomputes.erase(pending);
+    if (workRemains) {
+        document->recompute();
     }
 }
 

--- a/src/Gui/TaskView/TaskView.h
+++ b/src/Gui/TaskView/TaskView.h
@@ -24,6 +24,8 @@
 
 #pragma once
 
+#include <map>
+#include <string>
 #include <vector>
 #include <optional>
 #include <QScrollArea>
@@ -150,10 +152,20 @@ public:
 
 struct TaskInfo
 {
+    enum class PendingCompletion
+    {
+        None,
+        Accept,
+        Reject,
+    };
+
     TaskPanel* taskPanel {nullptr};
     TaskDialog* ActiveDialog {nullptr};
     TaskEditControl* ActiveCtrl {nullptr};
     App::Document* Document {nullptr};
+    Connection cooperativeMutationConnection;
+    Connection presentationUpdateConnection;
+    PendingCompletion pendingCompletion {PendingCompletion::None};
 };
 
 /** TaskView class
@@ -216,6 +228,13 @@ protected:
     void clicked(QAbstractButton* button, App::Document* doc);
 
 private:
+    struct PendingTaskRecompute
+    {
+        std::string documentUid;
+        Connection cooperativeMutationConnection;
+        Connection presentationUpdateConnection;
+    };
+
     void triggerMinimumSizeHint();
     void adjustMinimumSizeHint();
     void saveCurrentWidth();
@@ -230,6 +249,12 @@ private:
     void slotUndoDocument(const App::Document&);
     void slotRedoDocument(const App::Document&);
     void transactionChangeOnDocument(const App::Document&, bool undo);
+    void updateDocumentWorkState(App::Document* document);
+    void scheduleTaskDocumentRecompute(App::Document* document);
+    void resumeTaskDocumentRecompute(
+        const std::string& documentName,
+        const std::string& documentUid
+    );
 
 protected:
     void keyPressEvent(QKeyEvent* event) override;
@@ -252,6 +277,7 @@ protected:
 
     // First index of the stack is reserved to the active watcher
     std::vector<TaskInfo> taskInfos;
+    std::map<std::string, PendingTaskRecompute> pendingTaskRecomputes;
     bool restoreWidth = false;
     int currentWidth = 0;
     ParameterGrp::handle hGrp;

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -4760,10 +4760,11 @@ void TreeWidget::processUpdateStatus()
             continue;
         }
 
-        if (!docItem->PopulateObjects.empty()) {
-            auto* obj = docItem->PopulateObjects.back();
-            docItem->PopulateObjects.pop_back();
-            if (obj && obj->isAttachedToDocument() && obj->getDocument() == doc) {
+        if (!docItem->PopulateObjectIds.empty()) {
+            const long objectId = docItem->PopulateObjectIds.back();
+            docItem->PopulateObjectIds.pop_back();
+            if (auto* obj = doc->getObjectByID(objectId);
+                obj && obj->isAttachedToDocument()) {
                 docItem->populateObject(obj);
             }
             if (budget.exhausted()) {
@@ -10040,7 +10041,7 @@ DocumentObjectItem::~DocumentObjectItem()
     if (myOwner && myData->items.empty()) {
         auto it = myOwner->_ParentMap.find(object()->getObject());
         if (it != myOwner->_ParentMap.end() && !it->second.empty()) {
-            myOwner->PopulateObjects.push_back(*it->second.begin());
+            myOwner->PopulateObjectIds.push_back((*it->second.begin())->getID());
             myOwner->getTree()->_updateStatus();
         }
     }

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -656,9 +656,9 @@ struct DocumentItem::BrowserFolderStatus
         : document(owner->document()->getDocument()), generation(generation)
     {
         stack.push_back({owner});
-        document->beginPresentationUpdate();
+        document->beginVisualUpdate();
     }
-    ~BrowserFolderStatus() { document->endPresentationUpdate(); }
+    ~BrowserFolderStatus() { document->endVisualUpdate(); }
 };
 
 class DocumentItem::ExpandInfo: public std::unordered_map<std::string, DocumentItem::ExpandInfoPtr>
@@ -9179,7 +9179,7 @@ void DocumentItem::acquirePresentationUpdate(App::Document& document)
         return;
     }
     releasePresentationUpdate();
-    document.beginPresentationUpdate();
+    document.beginVisualUpdate();
     presentationUpdateDocument = &document;
 }
 
@@ -9190,7 +9190,7 @@ void DocumentItem::releasePresentationUpdate()
     }
     auto* document = presentationUpdateDocument;
     presentationUpdateDocument = nullptr;
-    document->endPresentationUpdate();
+    document->endVisualUpdate();
 }
 
 Gui::Document* DocumentItem::document() const

--- a/src/Gui/Tree.h
+++ b/src/Gui/Tree.h
@@ -575,7 +575,9 @@ private:
     Gui::Document* pDocument;
     std::unordered_map<App::DocumentObject*, DocumentObjectDataPtr> ObjectMap;
     std::unordered_map<App::DocumentObject*, std::set<App::DocumentObject*>> _ParentMap;
-    std::vector<App::DocumentObject*> PopulateObjects;
+    // Deferred slices must not retain object pointers across event-loop turns.
+    // An edit rollback can destroy an object before its population slice runs.
+    std::vector<long> PopulateObjectIds;
     bool modelBrowserDirty {true};
     bool modelBrowserActive {false};
     bool transactionRefreshPending {false};

--- a/src/Gui/View3DPy.cpp
+++ b/src/Gui/View3DPy.cpp
@@ -114,6 +114,11 @@ void View3DInventorPy::init_type()
     add_varargs_method("viewPosition", &View3DInventorPy::viewPosition, "viewPosition()");
     add_varargs_method("startAnimating", &View3DInventorPy::startAnimating, "startAnimating()");
     add_noargs_method("stopAnimating", &View3DInventorPy::stopAnimating, "stopAnimating()");
+    add_noargs_method(
+        "isAnimating",
+        &View3DInventorPy::isAnimating,
+        "isAnimating() -> bool\nReturns whether the camera is currently animating."
+    );
     add_varargs_method(
         "setAnimationEnabled",
         &View3DInventorPy::setAnimationEnabled,
@@ -969,6 +974,11 @@ Py::Object View3DInventorPy::stopAnimating()
 {
     getView3DInventorPtr()->getViewer()->stopAnimating();
     return Py::None();
+}
+
+Py::Object View3DInventorPy::isAnimating()
+{
+    return Py::Boolean(getView3DInventorPtr()->getViewer()->isAnimating());
 }
 
 Py::Object View3DInventorPy::setAnimationEnabled(const Py::Tuple& args)

--- a/src/Gui/View3DPy.h
+++ b/src/Gui/View3DPy.h
@@ -69,6 +69,7 @@ public:
     Py::Object zoomOut();
     Py::Object startAnimating(const Py::Tuple&);
     Py::Object stopAnimating();
+    Py::Object isAnimating();
     Py::Object setAnimationEnabled(const Py::Tuple&);
     Py::Object isAnimationEnabled();
     Py::Object setPopupMenuEnabled(const Py::Tuple&);

--- a/src/Mod/CAM/CAMTests/TestPathStock.py
+++ b/src/Mod/CAM/CAMTests/TestPathStock.py
@@ -50,7 +50,7 @@ class TestPathStock(PathTestBase):
         self.job.Proxy = FakeJobProxy()
 
     def tearDown(self):
-        FreeCAD.closeDocument("TestPathStock")
+        self.assertTrue(FreeCAD.requestCloseDocument("TestPathStock"))
 
     def test00(self):
         """Test CreateBox"""
@@ -94,6 +94,19 @@ class TestPathStock(PathTestBase):
         self.assertEqual(1, stock.Radius)
         self.assertEqual(88, stock.Height)
         self.assertPlacement(placement, stock.Placement)
+
+    def test02(self):
+        """Invalid or still-empty group members do not poison stock bounds."""
+
+        empty = self.doc.addObject("Part::Feature", "EmptyShape")
+        self.job.Model.addObject(empty)
+
+        bounds = PathStock.shapeBoundBox(self.job.Model.Group)
+
+        self.assertTrue(bounds.isValid())
+        self.assertEqual(100, bounds.XLength)
+        self.assertEqual(200, bounds.YLength)
+        self.assertEqual(300, bounds.ZLength)
 
     def test10(self):
         """Verify FromTemplate box creation."""

--- a/src/Mod/CAM/CAMTests/TestPathToolShapeDoc.py
+++ b/src/Mod/CAM/CAMTests/TestPathToolShapeDoc.py
@@ -23,7 +23,7 @@ class TestPathToolShapeDoc(unittest.TestCase):
     def setUp(self):
         """Reset mocks before each test."""
         # Resetting the top-level mock recursively resets its children
-        # (newDocument, getDocument, openDocument, closeDocument, Console, etc.)
+        # (newDocument, getDocument, openDocument, requestCloseDocument, Console, etc.)
         # and their call counts, return_values, side_effects.
         mock_freecad.reset_mock()
         mock_doc.reset_mock()
@@ -36,7 +36,7 @@ class TestPathToolShapeDoc(unittest.TestCase):
         mock_obj.Name = "MockObjectName"
         mock_obj.getTypeIdOfProperty = MagicMock(return_value="App::PropertyString")
         # Ensure mock_doc also has a Name attribute used in tests/code
-        mock_doc.Name = "Document_Mock"  # Used in closeDocument calls
+        mock_doc.Name = "Document_Mock"  # Used in deferred close requests
 
         # Clear attributes potentially added by setattr in previous tests.
         # reset_mock() doesn't remove attributes added this way.
@@ -122,8 +122,8 @@ class TestPathToolShapeDoc(unittest.TestCase):
 
     @patch("FreeCAD.openDocument")
     @patch("FreeCAD.getDocument")
-    @patch("FreeCAD.closeDocument")
-    def test_ShapeDocFromBytes(self, mock_close_doc, mock_get_doc, mock_open_doc):
+    @patch("FreeCAD.requestCloseDocument", return_value=True)
+    def test_ShapeDocFromBytes(self, mock_request_close, mock_get_doc, mock_open_doc):
         """Test ShapeDocFromBytes loads doc from a byte string."""
         content = b"fake_content"
         mock_opened_doc = MagicMock(Name="OpenedDoc_Mock")
@@ -142,7 +142,7 @@ class TestPathToolShapeDoc(unittest.TestCase):
                 self.assertEqual(temp_doc, mock_open_doc.return_value)
 
             # Verify cleanup after exiting the context
-            mock_close_doc.assert_called_once_with(mock_open_doc.return_value.Name)
+            mock_request_close.assert_called_once_with(mock_open_doc.return_value.Name)
             self.assertFalse(os.path.exists(temp_file_path))
 
         finally:
@@ -152,8 +152,10 @@ class TestPathToolShapeDoc(unittest.TestCase):
 
     @patch("FreeCAD.openDocument")
     @patch("FreeCAD.getDocument")
-    @patch("FreeCAD.closeDocument")
-    def test_ShapeDocFromBytes_open_exception(self, mock_close_doc, mock_get_doc, mock_open_doc):
+    @patch("FreeCAD.requestCloseDocument", return_value=True)
+    def test_ShapeDocFromBytes_open_exception(
+        self, mock_request_close, mock_get_doc, mock_open_doc
+    ):
         """Test ShapeDocFromBytes propagates exceptions and cleans up."""
         content = b"fake_content_exception"
         load_error = Exception("Fake load error")
@@ -175,9 +177,9 @@ class TestPathToolShapeDoc(unittest.TestCase):
                 self.assertEqual(f.read(), content)
 
             mock_get_doc.assert_not_called()
-            # closeDocument is called in __exit__ only if _doc is not None,
+            # requestCloseDocument is called in __exit__ only if _doc is not None,
             # which it will be if openDocument failed.
-            mock_close_doc.assert_not_called()
+            mock_request_close.assert_not_called()
 
         finally:
             # Verify cleanup after exiting the context (even with exception)
@@ -189,8 +191,10 @@ class TestPathToolShapeDoc(unittest.TestCase):
 
     @patch("FreeCAD.openDocument")
     @patch("FreeCAD.getDocument")
-    @patch("FreeCAD.closeDocument")
-    def test_ShapeDocFromBytes_exit_cleans_up(self, mock_close_doc, mock_get_doc, mock_open_doc):
+    @patch("FreeCAD.requestCloseDocument", return_value=True)
+    def test_ShapeDocFromBytes_exit_cleans_up(
+        self, mock_request_close, mock_get_doc, mock_open_doc
+    ):
         """Test ShapeDocFromBytes __exit__ cleans up temp file."""
         content = b"fake_content_cleanup"
         mock_opened_doc = MagicMock(Name="OpenedDoc_Cleanup_Mock")
@@ -208,7 +212,7 @@ class TestPathToolShapeDoc(unittest.TestCase):
                 pass  # Exit the context
 
             # Verify cleanup after exiting the context
-            mock_close_doc.assert_called_once_with(mock_open_doc.return_value.Name)
+            mock_request_close.assert_called_once_with(mock_open_doc.return_value.Name)
             self.assertFalse(os.path.exists(temp_file_path))
 
         finally:

--- a/src/Mod/CAM/CAMTests/TestVibeCADRibbonTools.py
+++ b/src/Mod/CAM/CAMTests/TestVibeCADRibbonTools.py
@@ -474,15 +474,24 @@ class TestVibeCADCAMRibbonTools(unittest.TestCase):
         except (ReferenceError, RuntimeError):
             current_document_name = None
         if current_document_name in App.listDocuments():
-            App.closeDocument(current_document_name)
+            App.requestCloseDocument(current_document_name)
         for name in (
             "VibeCADCAMBackgroundTask",
             "VibeCADCAMDeletedTaskDocument",
             "VibeCADCAMRibbonTools",
         ):
             if name in App.listDocuments():
-                App.closeDocument(name)
-        self._process_events()
+                App.requestCloseDocument(name)
+        self._wait_until(
+            lambda: not any(
+                name in App.listDocuments()
+                for name in (
+                    "VibeCADCAMBackgroundTask",
+                    "VibeCADCAMDeletedTaskDocument",
+                    "VibeCADCAMRibbonTools",
+                )
+            )
+        )
 
     @staticmethod
     def _process_events(wait_ms=30):
@@ -494,6 +503,15 @@ class TestVibeCADCAMRibbonTools(unittest.TestCase):
             loop = QtCore.QEventLoop()
             QtCore.QTimer.singleShot(wait_ms, loop.quit)
             loop.exec()
+
+    @classmethod
+    def _wait_until(cls, predicate, timeout_ms=5000):
+        """Keep the GUI responsive while awaiting an asynchronous test boundary."""
+        elapsed = QtCore.QElapsedTimer()
+        elapsed.start()
+        while not predicate() and elapsed.elapsed() < timeout_ms:
+            cls._process_events(min(20, timeout_ms - elapsed.elapsed()))
+        return predicate()
 
     def _move_timeline_to(self, position):
         timeline = self.document.getObject("VibeCADTimeline")
@@ -2427,7 +2445,10 @@ class TestVibeCADCAMRibbonTools(unittest.TestCase):
         before = tuple(self.document.Objects)
         before_undo = int(self.document.UndoCount)
 
-        self.assertTrue(Gui.isCommandActive("CAM_Profile"))
+        self.assertTrue(
+            self._wait_until(lambda: Gui.isCommandActive("CAM_Profile")),
+            "CAM profile command did not reactivate after asynchronous publication",
+        )
         Gui.runCommand("CAM_Profile")
         self._process_events(100)
         self.assertTrue(Gui.Control.activeDialog())
@@ -2436,6 +2457,10 @@ class TestVibeCADCAMRibbonTools(unittest.TestCase):
         self.assertEqual(tuple(self.document.Objects), before)
         self.assertEqual(int(self.document.UndoCount), before_undo)
 
+        self.assertTrue(
+            self._wait_until(lambda: Gui.isCommandActive("CAM_Profile")),
+            "CAM profile command did not reactivate after task cancellation",
+        )
         Gui.runCommand("CAM_Profile")
         self._process_events(100)
         self.assertTrue(Gui.Control.activeDialog())

--- a/src/Mod/CAM/Path/Main/Stock.py
+++ b/src/Mod/CAM/Path/Main/Stock.py
@@ -73,15 +73,19 @@ class StockType:
 def shapeBoundBox(obj):
     Path.Log.track(type(obj))
     if isinstance(obj, list) and obj:
+        bounds = [bound for item in obj if (bound := shapeBoundBox(item)) is not None]
+        if not bounds:
+            return None
         bb = FreeCAD.BoundBox()
-        for o in obj:
-            bb.add(shapeBoundBox(o))
+        for bound in bounds:
+            bb.add(bound)
         return bb
 
     if hasattr(obj, "Shape"):
-        return obj.Shape.BoundBox
+        bounds = obj.Shape.BoundBox
+        return bounds if bounds.isValid() else None
     if obj and "App::Part" == obj.TypeId:
-        bounds = [shapeBoundBox(o) for o in obj.Group]
+        bounds = [bound for item in obj.Group if (bound := shapeBoundBox(item)) is not None]
         if bounds:
             bb = bounds[0]
             for b in bounds[1:]:

--- a/src/Mod/CAM/Path/Tool/Controller.py
+++ b/src/Mod/CAM/Path/Tool/Controller.py
@@ -465,8 +465,6 @@ class ToolController:
 
         path = Path.Path(commands)
         obj.Path = path
-        if obj.ViewObject:
-            obj.ViewObject.Visibility = True
 
     def getTool(self, obj):
         """returns the tool associated with this tool controller"""

--- a/src/Mod/CAM/Path/Tool/shape/doc.py
+++ b/src/Mod/CAM/Path/Tool/shape/doc.py
@@ -29,6 +29,15 @@ import tempfile
 import os
 
 
+def _run_on_document_owner(function, *args):
+    """Run document-registry and restore work on FreeCAD's owning thread."""
+    if FreeCAD.GuiUp:
+        import FreeCADGui
+
+        return FreeCADGui.runOnMainThread(function, *args)
+    return function(*args)
+
+
 def find_shape_object(doc: "FreeCAD.Document") -> Optional["FreeCAD.DocumentObject"]:
     """
     Find the primary object representing the shape in a document.
@@ -171,6 +180,7 @@ class ShapeDocFromBytes:
         self._doc = None
         self._temp_file = None
         self._old_state = None
+        self._owner_doc = None
 
     def __enter__(self) -> "FreeCAD.Document":
         """Creates a new temporary FreeCAD document or loads cache if provided."""
@@ -183,34 +193,62 @@ class ShapeDocFromBytes:
         # document (i.e. current selection), even if the newly opened document
         # is a hidden one.
         # So we need to restore the active document state at the end.
-        self._old_state = get_doc_state()
+        def open_shape_document():
+            self._old_state = get_doc_state()
+            self._owner_doc = FreeCAD.ActiveDocument
+            if self._owner_doc:
+                self._owner_doc.beginCooperativeMutation()
 
-        # Open the document from the temporary file
-        # Use a specific name to avoid clashes if multiple docs are open
-        # Open the document from the temporary file
-        self._doc = FreeCAD.openDocument(
-            self._temp_file,
-            hidden=True,
-            temporary=True,
-        )
+            try:
+                # Document registration and object restoration mutate global
+                # FreeCAD state. Keep that bounded phase on its owner; callers
+                # may continue consuming the immutable tool shape off-owner.
+                self._doc = FreeCAD.openDocument(
+                    self._temp_file,
+                    hidden=True,
+                    temporary=True,
+                )
+            except BaseException:
+                if self._owner_doc:
+                    self._owner_doc.endCooperativeMutation()
+                    self._owner_doc = None
+                raise
+
+        _run_on_document_owner(open_shape_document)
         if not self._doc:
+            def release_owner_document():
+                if self._owner_doc:
+                    self._owner_doc.endCooperativeMutation()
+                    self._owner_doc = None
+
+            _run_on_document_owner(release_owner_document)
             raise RuntimeError(f"Failed to open document from {self._temp_file}")
         return self._doc
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         """Closes the temporary FreeCAD document and cleans up the temp file."""
-        if self._doc:
-            # Note that .closeDocument() is extremely slow; it takes
-            # almost 400ms per document - much longer than opening!
-            FreeCAD.closeDocument(self._doc.Name)
-            self._doc = None
-
-        # Restore the original active document
-        restore_doc_state(self._old_state)
-
-        # Clean up the temporary file if it was created
-        if self._temp_file and os.path.exists(self._temp_file):
+        def close_shape_document():
             try:
-                os.remove(self._temp_file)
-            except Exception as e:
-                Path.Log.warning(f"Failed to remove temporary file {self._temp_file}: {e}")
+                if self._doc:
+                    if not FreeCAD.requestCloseDocument(self._doc.Name):
+                        raise RuntimeError(
+                            f"Failed to request cleanup for temporary document "
+                            f"'{self._doc.Name}'"
+                        )
+                    self._doc = None
+
+                restore_doc_state(self._old_state)
+            finally:
+                if self._owner_doc:
+                    self._owner_doc.endCooperativeMutation()
+                    self._owner_doc = None
+
+        try:
+            _run_on_document_owner(close_shape_document)
+        finally:
+
+            if self._temp_file and os.path.exists(self._temp_file):
+                try:
+                    os.remove(self._temp_file)
+                except Exception as e:
+                    Path.Log.warning(f"Failed to remove temporary file {self._temp_file}: {e}")

--- a/src/Mod/Part/Gui/ModelingSelection.cpp
+++ b/src/Mod/Part/Gui/ModelingSelection.cpp
@@ -42,6 +42,8 @@ namespace PartGui
 bool canStartRetainedModelingTask(const App::Document* document)
 {
     return document
+        && !document->isCooperativeMutationActive()
+        && !document->isMutationBlockingPresentationUpdateActive()
         && (document->getBookedTransactionID() == App::NullTransaction
             || Gui::TaskView::TaskDialog::hasOwnedEnclosingTransaction(document));
 }

--- a/src/Mod/Part/Gui/ModelingSelection.h
+++ b/src/Mod/Part/Gui/ModelingSelection.h
@@ -241,9 +241,10 @@ getModelingShapeSelection(const char* documentName = nullptr);
 /**
  * Return whether a retained modeling task may own its document transaction.
  *
- * A clean document is always safe. A nested command may reuse a transaction
- * only when the outermost GUI command began transaction-free and opened that
- * transaction itself. Caller-owned transactions are never reusable.
+ * A stable document with no transaction is safe. A nested command may reuse a
+ * transaction only when the outermost GUI command began transaction-free and
+ * opened that transaction itself. Active document updates and caller-owned
+ * transactions are never reusable.
  */
 PartGuiExport bool
 canStartRetainedModelingTask(const App::Document* document);

--- a/src/Mod/Part/Gui/ViewProviderExt.cpp
+++ b/src/Mod/Part/Gui/ViewProviderExt.cpp
@@ -223,20 +223,20 @@ void copyRenderMesh(
     lineset->coordIndex.finishEditing();
 }
 
-class PresentationUpdateEnd
+class VisualUpdateEnd
 {
 public:
-    explicit PresentationUpdateEnd(App::Document* document)
+    explicit VisualUpdateEnd(App::Document* document)
         : documentName(document ? document->getName() : ""),
           documentUid(document ? document->Uid.getValueStr() : "")
     {}
 
-    ~PresentationUpdateEnd()
+    ~VisualUpdateEnd()
     {
         auto* document = App::GetApplication().getDocument(documentName.c_str());
         if (document && document->Uid.getValueStr() == documentUid) {
             try {
-                document->endPresentationUpdate();
+                document->endVisualUpdate();
             }
             catch (const Base::Exception& failure) {
                 failure.reportException();
@@ -250,8 +250,8 @@ public:
         }
     }
 
-    PresentationUpdateEnd(const PresentationUpdateEnd&) = delete;
-    PresentationUpdateEnd& operator=(const PresentationUpdateEnd&) = delete;
+    VisualUpdateEnd(const VisualUpdateEnd&) = delete;
+    VisualUpdateEnd& operator=(const VisualUpdateEnd&) = delete;
 
 private:
     const std::string documentName;
@@ -1535,8 +1535,8 @@ void ViewProviderPartExt::startVisualBuild(
     // The controller owns callbacks on the GUI thread. Completion, cancellation
     // and provider destruction all release this lease there; workers never
     // retain or dereference a document or view provider.
-    auto presentationFinished = std::make_shared<PresentationUpdateEnd>(document);
-    document->beginPresentationUpdate();
+    auto presentationFinished = std::make_shared<VisualUpdateEnd>(document);
+    document->beginVisualUpdate();
 
     try {
         visualMeshController.request(

--- a/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
@@ -97,6 +97,7 @@ class TestNativeRibbonTools(unittest.TestCase):
                 Gui.Control.closeDialog()
             self._process_events()
         if App.getDocument("NativeRibbonTools") is not None:
+            self._wait_for_document_ready()
             App.closeDocument("NativeRibbonTools")
         self._process_events()
 

--- a/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
@@ -2,6 +2,7 @@
 
 """Live command-contract tests for the native tools exposed by the Model ribbon."""
 
+import time
 import unittest
 
 import FreeCAD as App
@@ -65,6 +66,16 @@ PROFILE_COMMANDS = (
 )
 
 
+class _SlowWorkerFeature:
+    """Keep a document recompute active while the GUI receives task input."""
+
+    def execute(self, _feature):
+        time.sleep(0.25)
+
+    def supportsAsyncRecompute(self, _feature):
+        return True
+
+
 class TestNativeRibbonTools(unittest.TestCase):
     """Ribbon actions must enforce usable inputs and preserve native Body history."""
 
@@ -99,6 +110,18 @@ class TestNativeRibbonTools(unittest.TestCase):
             loop = QtCore.QEventLoop()
             QtCore.QTimer.singleShot(wait_ms, loop.quit)
             loop.exec()
+
+    def _wait_for_document_ready(self, timeout_ms=5000):
+        # Flush queued projection starts before checking the document flags.
+        self._process_events(10)
+        deadline = time.monotonic() + timeout_ms / 1000.0
+        while (
+            self.document.CooperativeMutationActive
+            or self.document.PresentationUpdateActive
+        ):
+            if time.monotonic() >= deadline:
+                self.fail("Document presentation did not settle")
+            self._process_events(10)
 
     def _new_body(self, name, *, solid=False, solid_size=10.0):
         body = self.document.addObject("PartDesign::Body", name)
@@ -227,7 +250,9 @@ class TestNativeRibbonTools(unittest.TestCase):
             selections.append(self._path_sketch(body, f"{prefix}Path{index}"))
         if base is not None:
             body.Tip = base
+        self._wait_for_document_ready()
         self.document.recompute()
+        self._wait_for_document_ready()
         return body, base, profile, selections
 
     def _bodies(self):
@@ -319,6 +344,7 @@ class TestNativeRibbonTools(unittest.TestCase):
         self._process_events(50)
         self.assertFalse(Gui.Control.activeDialog(), command_name)
         self.assertFalse(self.document.HasPendingTransaction, command_name)
+        self._wait_for_document_ready()
 
     def _cancel_task(self, command_name):
         self.assertTrue(Gui.Control.activeDialog(), command_name)
@@ -328,6 +354,7 @@ class TestNativeRibbonTools(unittest.TestCase):
         self._process_events(50)
         self.assertFalse(Gui.Control.activeDialog(), command_name)
         self.assertFalse(self.document.HasPendingTransaction, command_name)
+        self._wait_for_document_ready()
 
     def _dismiss_task(self, command_name, *, allow_close=False):
         self.assertTrue(Gui.Control.activeDialog(), command_name)
@@ -344,6 +371,7 @@ class TestNativeRibbonTools(unittest.TestCase):
         self._process_events(50)
         self.assertFalse(Gui.Control.activeDialog(), command_name)
         self.assertFalse(self.document.HasPendingTransaction, command_name)
+        self._wait_for_document_ready()
 
     def _activate_body(self, body, subelement=None):
         Gui.activeView().setActiveObject("pdbody", body)
@@ -1314,13 +1342,14 @@ class TestNativeRibbonTools(unittest.TestCase):
             "Sketcher::SketchObject",
             "AcceptedStandaloneBodySketch",
         )
-        sketch.addGeometry(
-            Part.LineSegment(
-                App.Vector(0, 0, 0),
-                App.Vector(8, 0, 0),
-            ),
-            False,
+        points = (
+            App.Vector(0, 0, 0),
+            App.Vector(8, 0, 0),
+            App.Vector(8, 6, 0),
+            App.Vector(0, 6, 0),
         )
+        for start, end in zip(points, points[1:] + points[:1]):
+            sketch.addGeometry(Part.LineSegment(start, end), False)
         self.document.recompute()
         original_names = tuple(obj.Name for obj in self.document.Objects)
         original_bodies = set(self._bodies())
@@ -1365,6 +1394,30 @@ class TestNativeRibbonTools(unittest.TestCase):
         accepted_selection = Gui.Selection.getSelectionEx()
         self.assertEqual(len(accepted_selection), 1)
         self.assertIs(accepted_selection[0].Object, body)
+
+        # Exercise the complete human workflow that immediately follows this
+        # command. Projection/render catch-up from the Body operation must not
+        # reject Pad, paint a shape while its worker mutates it, or validate an
+        # empty intermediate Body state.
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(sketch)
+        self._process_events()
+        Gui.runCommand("PartDesign_Pad", 0)
+        self._process_events(50)
+        self.assertTrue(Gui.Control.activeDialog())
+        pad = next(obj for obj in self.document.Objects if obj.TypeId == "PartDesign::Pad")
+        self.assertGreater(len(pad.Shape.Solids), 0)
+        self._accept_task("Pad selected standalone sketch")
+        self.assertFalse(self.document.HasPendingTransaction)
+        self.assertIs(body.Tip, pad)
+        self.assertGreater(len(pad.Shape.Solids), 0)
+        PartDesign.validateDesign(pad)
+
+        pad_name = pad.Name
+        self.document.undo()
+        self._process_events()
+        self.assertIsNone(self.document.getObject(pad_name))
+        self.assertIn(sketch, body.Group)
 
         self.document.undo()
         self._process_events()
@@ -2520,6 +2573,130 @@ class TestNativeRibbonTools(unittest.TestCase):
         self.assertIsNone(self.document.getObject(sketch_name))
         self.assertEqual(tuple(body.Group), body_group)
         self.assertFalse(self.document.HasPendingTransaction)
+
+    def test_pad_accept_waits_for_the_active_document_recompute(self):
+        body, _feature = self._new_body("AsyncPadBody")
+        self._wait_for_document_ready()
+        profile = self._profile_sketch(body, "AsyncPadProfile")
+        self._wait_for_document_ready()
+        self._activate_body(body)
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(profile)
+        self._process_events()
+
+        Gui.runCommand("PartDesign_Pad", 0)
+        self._process_events(50)
+        self.assertTrue(Gui.Control.activeDialog())
+        pad = next(
+            obj
+            for obj in self.document.Objects
+            if obj.TypeId == "PartDesign::Pad"
+        )
+        self.assertGreater(len(pad.Shape.Solids), 0)
+
+        blocker = self.document.addObject(
+            "App::FeaturePython",
+            "AsyncPadRecomputeBlocker",
+        )
+        blocker.Proxy = _SlowWorkerFeature()
+        blocker.touch()
+        accept = self._task_button(QtGui.QDialogButtonBox.Ok)
+        self.assertIsNotNone(accept)
+        callback_state = {"ran": False, "dialog_open": False, "error": None}
+
+        def accept_while_recompute_is_active():
+            try:
+                callback_state["ran"] = True
+                self.assertTrue(self.document.CooperativeMutationActive)
+                # Model the task parameter update that has not reached the active
+                # recompute snapshot yet. Accept must wait, recompute this Pad, and
+                # only then validate and commit the Body history.
+                pad.Shape = Part.Shape()
+                pad.touch()
+                accept.click()
+                callback_state["dialog_open"] = bool(Gui.Control.activeDialog())
+            except BaseException as error:
+                callback_state["error"] = error
+
+        QtCore.QTimer.singleShot(25, accept_while_recompute_is_active)
+        self.assertGreaterEqual(self.document.recompute(), 1)
+        self._process_events(100)
+
+        if callback_state["error"] is not None:
+            raise callback_state["error"]
+        self.assertTrue(callback_state["ran"])
+        self.assertTrue(
+            callback_state["dialog_open"],
+            "Pad acceptance ran inside the active document update",
+        )
+        self.assertFalse(Gui.Control.activeDialog())
+        self.assertFalse(self.document.HasPendingTransaction)
+        self.assertIs(body.Tip, pad)
+        self.assertGreater(len(pad.Shape.Solids), 0)
+        PartDesign.validateDesign(pad)
+        self._wait_for_document_ready()
+
+    def test_pad_cancel_waits_for_the_active_document_recompute(self):
+        body, _feature = self._new_body("AsyncPadCancelBody")
+        self._wait_for_document_ready()
+        profile = self._profile_sketch(body, "AsyncPadCancelProfile")
+        self._wait_for_document_ready()
+        self._activate_body(body)
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(profile)
+        self._process_events()
+
+        Gui.runCommand("PartDesign_Pad", 0)
+        self._process_events(50)
+        self.assertTrue(Gui.Control.activeDialog())
+        pad = next(
+            obj
+            for obj in self.document.Objects
+            if obj.TypeId == "PartDesign::Pad"
+        )
+        pad_name = pad.Name
+
+        blocker = self.document.addObject(
+            "App::FeaturePython",
+            "AsyncPadCancelRecomputeBlocker",
+        )
+        blocker.Proxy = _SlowWorkerFeature()
+        blocker.touch()
+        cancel = self._task_button(QtGui.QDialogButtonBox.Cancel)
+        self.assertIsNotNone(cancel)
+        callback_state = {"ran": False, "dialog_open": False, "error": None}
+
+        def cancel_while_recompute_is_active():
+            try:
+                callback_state["ran"] = True
+                self.assertTrue(self.document.CooperativeMutationActive)
+                cancel.click()
+                callback_state["dialog_open"] = bool(Gui.Control.activeDialog())
+            except BaseException as error:
+                callback_state["error"] = error
+
+        QtCore.QTimer.singleShot(25, cancel_while_recompute_is_active)
+        self.assertGreaterEqual(self.document.recompute(), 1)
+        self._process_events(100)
+
+        if callback_state["error"] is not None:
+            raise callback_state["error"]
+        self.assertTrue(callback_state["ran"])
+        self.assertTrue(
+            callback_state["dialog_open"],
+            "Pad cancellation ran inside the active document update",
+        )
+        self.assertFalse(Gui.Control.activeDialog())
+        self.assertFalse(self.document.HasPendingTransaction)
+        self._wait_for_document_ready()
+        self.assertIsNone(self.document.getObject(pad_name))
+        self.assertIn(profile, body.Group)
+        touched = [obj.Name for obj in self.document.Objects if "Touched" in obj.State]
+        self.assertEqual(
+            touched,
+            [],
+            "Pad cancellation left restored document work unrecomputed",
+        )
 
     def test_profile_tasks_cancel_back_to_the_exact_body_history(self):
         for index, (

--- a/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestNativeRibbonTools.py
@@ -2575,6 +2575,18 @@ class TestNativeRibbonTools(unittest.TestCase):
         self.assertEqual(tuple(body.Group), body_group)
         self.assertFalse(self.document.HasPendingTransaction)
 
+    def test_retained_modeling_commands_lock_during_document_update(self):
+        import PartGui
+
+        self.assertTrue(PartGui.canStartRetainedModelingTask())
+        self.document.beginCooperativeMutation()
+        try:
+            self.assertFalse(PartGui.canStartRetainedModelingTask())
+        finally:
+            self.document.endCooperativeMutation()
+        self._wait_for_document_ready()
+        self.assertTrue(PartGui.canStartRetainedModelingTask())
+
     def test_pad_accept_waits_for_the_active_document_recompute(self):
         body, _feature = self._new_body("AsyncPadBody")
         self._wait_for_document_ready()

--- a/src/Mod/VibeCAD/VibeCADCore.py
+++ b/src/Mod/VibeCAD/VibeCADCore.py
@@ -83,6 +83,31 @@ _MAX_VIBESCRIPT_REFERENCE_CACHE_ENTRIES = 8
 _MAX_VIBESCRIPT_REFERENCE_CACHE_BYTES = 256 * 1024 * 1024
 
 
+def _native_document_update_active(document_uid: str) -> bool:
+    """Read one document's asynchronous update state on its owning thread."""
+
+    import FreeCAD as App
+
+    uid = str(document_uid or "").strip()
+    document = next(
+        (
+            candidate
+            for candidate in App.listDocuments().values()
+            if str(getattr(candidate, "Uid", "") or "") == uid
+        ),
+        None,
+    )
+    return bool(
+        document is not None
+        and (
+            bool(getattr(document, "Recomputing", False))
+            or bool(getattr(document, "RecomputePending", False))
+            or bool(getattr(document, "CooperativeMutationActive", False))
+            or bool(getattr(document, "PresentationUpdateActive", False))
+        )
+    )
+
+
 def _slug_filename(value: str) -> str:
     slug = re.sub(r"[^A-Za-z0-9_.-]+", "_", str(value or "").strip()).strip("._")
     return slug[:64] or "reference"
@@ -225,7 +250,9 @@ class VibeCADService:
         self._project_store = VibeCADProjectStore(self._local_session_id)
         self._native_document_states = NativeDocumentStateStore()
         self._native_assistant_undo = NativeAssistantUndoLedger()
-        self._native_background_jobs = NativeBackgroundManager()
+        self._native_background_jobs = NativeBackgroundManager(
+            document_update_active=_native_document_update_active,
+        )
         self._native_analyze_contexts = AnalyzeContextCoordinator()
         self._native_drawing_source_contexts = DrawingSourceCatalogCoordinator()
         self._native_state_restores: set[tuple[str, str]] = set()

--- a/src/Mod/VibeCAD/VibeCADFastenersGui.py
+++ b/src/Mod/VibeCAD/VibeCADFastenersGui.py
@@ -901,6 +901,90 @@ class _FastenerDialog:
         return self.values()
 
 
+def _start_fastener_placement(document: Any, target: Any) -> None:
+    """Expose the native placement control for one inserted fastener."""
+
+    # An active Assembly already owns edit mode and its task panel.  Selection
+    # is the Assembly placement contract: ViewProviderAssembly responds by
+    # exposing its transform dragger for the selected occurrence.  Starting a
+    # second edit task here would tear down Assembly edit mode and strand the
+    # newly inserted component.
+    try:
+        import UtilsAssembly
+    except ImportError:
+        UtilsAssembly = None
+    if UtilsAssembly is not None:
+        assembly = UtilsAssembly.findOwningAssembly(target)
+        if assembly is not None:
+            if UtilsAssembly.activeAssembly() is not assembly:
+                raise RuntimeError(
+                    _translate(
+                        "Activate the fastener's Assembly before placing it."
+                    )
+                )
+            if not UtilsAssembly.isMovableAssemblyComponent(assembly, target):
+                raise RuntimeError(
+                    _translate(
+                        "The inserted standard fastener is not movable in its Assembly."
+                    )
+                )
+
+            document_name = str(document.Name)
+            document_uid = str(document.Uid)
+            assembly_name = str(assembly.Name)
+            assembly_id = int(assembly.ID)
+            target_name = str(target.Name)
+            target_id = int(target.ID)
+
+            def expose_assembly_placement() -> None:
+                if document_name not in App.listDocuments():
+                    return
+                live_document = App.getDocument(document_name)
+                if live_document is None or str(live_document.Uid) != document_uid:
+                    return
+                live_assembly = live_document.getObject(assembly_name)
+                live_target = live_document.getObject(target_name)
+                if (
+                    live_assembly is not assembly
+                    or int(live_assembly.ID) != assembly_id
+                    or live_target is not target
+                    or int(live_target.ID) != target_id
+                ):
+                    return
+                if bool(getattr(live_document, "Recomputing", False)) or bool(
+                    getattr(live_document, "RecomputePending", False)
+                ):
+                    if not Gui.deferToNextFrame(expose_assembly_placement):
+                        App.Console.PrintError(
+                            "Could not expose the fastener placement dragger: "
+                            "the GUI frame dispatcher is shutting down.\n"
+                        )
+                    return
+                if UtilsAssembly.activeAssembly() is not live_assembly:
+                    return
+                Gui.Selection.clearSelection(document_name)
+                Gui.Selection.addSelection(live_target)
+                if not bool(live_assembly.ViewObject.DraggerVisibility):
+                    App.Console.PrintError(
+                        "Could not expose the Assembly fastener placement dragger.\n"
+                    )
+
+            if not Gui.deferToNextFrame(expose_assembly_placement):
+                raise RuntimeError(
+                    _translate("The GUI frame dispatcher is shutting down.")
+                )
+            return
+
+    gui_document = Gui.getDocument(document.Name)
+    if gui_document is None or not gui_document.setEdit(target.Name, 1):
+        raise RuntimeError(
+            _translate(
+                "The standard fastener was inserted, but its placement task "
+                "could not be opened."
+            )
+        )
+
+
 class _InsertStandardFastenerCommand:
     def GetResources(self) -> dict[str, str]:
         return {
@@ -991,6 +1075,12 @@ class _InsertStandardFastenerCommand:
         except Exception as exc:
             document.abortTransaction()
             _show_error("Insert Standard Fastener", exc)
+            return
+
+        try:
+            _start_fastener_placement(document, selected)
+        except Exception as exc:
+            _show_error("Place Standard Fastener", exc)
 
 
 def identity_label(values: Mapping[str, Any]) -> str:

--- a/src/Mod/VibeCAD/VibeCADGui.py
+++ b/src/Mod/VibeCAD/VibeCADGui.py
@@ -4665,15 +4665,15 @@ def _move_saved_document_conversation(doc: Any, filepath: str) -> None:
 
 
 def _queue_zero_delay_callback(callback: Any) -> None:
-    """Queue one callback on Qt without making document observers block."""
+    """Queue one callback on the shared GUI frame dispatcher."""
 
     try:
-        from PySide import QtCore
-    except ImportError:
+        import FreeCADGui as gui_application
+    except ImportError:  # pragma: no cover - tooling outside FreeCAD
         callback()
         return
-
-    QtCore.QTimer.singleShot(0, callback)
+    if not gui_application.deferToNextFrame(callback):
+        _warn("VibeCAD GUI callback was discarded during application shutdown.")
 
 
 def _schedule_native_authority_selector_refresh(document_uid: str = "") -> None:

--- a/src/Mod/VibeCAD/VibeCADNativeBackground.py
+++ b/src/Mod/VibeCAD/VibeCADNativeBackground.py
@@ -86,6 +86,7 @@ CommitValidator = Callable[[], Any]
 DiagnosticSink = Callable[[str, Exception], str | None]
 CleanupHandler = Callable[[Any | None], None]
 DocumentChangeResolver = Callable[[Mapping[str, Any]], bool]
+DocumentUpdateProbe = Callable[[str], bool]
 
 
 def _canonical_result(result: Mapping[str, Any]) -> str:
@@ -162,10 +163,18 @@ def _error_summary(exc: Exception, diagnostic_id: str | None) -> dict[str, Any]:
 class NativeBackgroundManager:
     """Prepare detached work off-thread and commit through the document thread."""
 
-    def __init__(self, *, diagnostic_sink: DiagnosticSink | None = None) -> None:
+    def __init__(
+        self,
+        *,
+        diagnostic_sink: DiagnosticSink | None = None,
+        document_update_active: DocumentUpdateProbe | None = None,
+    ) -> None:
         if diagnostic_sink is not None and not callable(diagnostic_sink):
             raise TypeError("diagnostic_sink must be callable")
+        if document_update_active is not None and not callable(document_update_active):
+            raise TypeError("document_update_active must be callable")
         self._diagnostic_sink = diagnostic_sink
+        self._document_update_active = document_update_active
         self._jobs: OrderedDict[str, _Job] = OrderedDict()
         self._active_resources: dict[tuple[str, str], str] = {}
         self._lock = threading.RLock()
@@ -301,6 +310,9 @@ class NativeBackgroundManager:
         cooperative_commit: CooperativeCommitHandler | None,
     ) -> None:
         prepared = None
+        terminal_phase = "failed"
+        terminal_percent = 0
+        terminal_message = "Failed"
         try:
             self._set_progress(job, "preparing", 1, "Preparing detached data")
 
@@ -387,10 +399,30 @@ class NativeBackgroundManager:
                     )
                 with self._lock:
                     job.changes_document = resolved_change
+            with self._lock:
+                changes_document = job.changes_document
+            if changes_document and self._document_update_active is not None:
+                self._set_progress(
+                    job,
+                    "settling",
+                    99,
+                    "Waiting for document update",
+                )
+                idle_observations = 0
+                while idle_observations < 2:
+                    update_active = dispatch_to_document_thread(
+                        lambda: self._document_update_active(job.document_uid)
+                    )
+                    idle_observations = 0 if update_active else idle_observations + 1
+                    if idle_observations == 2:
+                        break
+                    time.sleep(0.05)
             encoded = _canonical_result(result)
             with self._lock:
                 job.result_json = encoded
-            self._set_progress(job, "completed", 100, "Completed")
+            terminal_phase = "completed"
+            terminal_percent = 100
+            terminal_message = "Completed"
         except Exception as exc:
             diagnostic_id = None
             if self._diagnostic_sink is not None:
@@ -405,12 +437,9 @@ class NativeBackgroundManager:
             )
             with self._lock:
                 job.error = _error_summary(exc, diagnostic_id)
-            self._set_progress(
-                job,
-                phase,
-                job.progress_percent,
-                "Cancelled" if phase == "cancelled" else "Failed",
-            )
+                terminal_percent = job.progress_percent
+            terminal_phase = phase
+            terminal_message = "Cancelled" if phase == "cancelled" else "Failed"
         finally:
             if cleanup is not None:
                 try:
@@ -422,6 +451,10 @@ class NativeBackgroundManager:
                         except Exception:
                             pass
             with self._lock:
+                job.phase = terminal_phase
+                job.progress_percent = terminal_percent
+                job.progress_message = terminal_message
+                job.progress_at = time.monotonic()
                 active_key = (job.document_uid, job.resource_scope)
                 if self._active_resources.get(active_key) == job.job_id:
                     self._active_resources.pop(active_key, None)

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -159,6 +159,7 @@ _stable_ticks = 0
 _DRAGGER_NDC_SIZE = 0.03
 _POLL_MS = 50
 _STABLE_TICKS = 5
+_pending_toggle_generation = 0
 
 
 def reset_section_view_settings() -> SectionViewSettings:
@@ -3411,3 +3412,43 @@ def toggle_section_view(
         document=document,
         show_ui=show_ui,
     )
+
+
+def request_section_view_toggle(
+    *,
+    view: Any | None = None,
+    document: Any | None = None,
+    show_ui: bool = True,
+) -> dict[str, bool]:
+    """Toggle after an in-flight camera move reaches its requested orientation."""
+
+    import FreeCADGui as Gui
+
+    active = view if view is not None else _active_3d_view()
+    if active is None:
+        raise RuntimeError("Section view requires an active 3D view.")
+    if is_section_view_active(active):
+        return toggle_section_view(view=active, document=document, show_ui=show_ui)
+
+    global _pending_toggle_generation
+    _pending_toggle_generation += 1
+    generation = _pending_toggle_generation
+
+    def apply_when_camera_settles() -> None:
+        if generation != _pending_toggle_generation:
+            return
+        try:
+            animating = bool(active.isAnimating())
+        except RuntimeError:
+            return
+        if animating:
+            if not Gui.deferToNextFrame(apply_when_camera_settles):
+                raise RuntimeError("The GUI frame dispatcher is shutting down.")
+            return
+        toggle_section_view(view=active, document=document, show_ui=show_ui)
+
+    if active.isAnimating():
+        if not Gui.deferToNextFrame(apply_when_camera_settles):
+            raise RuntimeError("The GUI frame dispatcher is shutting down.")
+        return {"section_view": False}
+    return toggle_section_view(view=active, document=document, show_ui=show_ui)

--- a/src/Mod/VibeCAD/VibeCADVibeScriptDomainPublication.py
+++ b/src/Mod/VibeCAD/VibeCADVibeScriptDomainPublication.py
@@ -14345,7 +14345,10 @@ def restore_partdesign_history_presentation(doc: Any) -> dict[str, Any]:
     publications: dict[tuple[str, str], list[Any]] = {}
     publication_targets: dict[tuple[str, str], list[Any]] = {}
     program_operations: list[Any] = []
-    for obj in list(getattr(doc, "Objects", []) or []):
+    # Every object relevant to this projection carries the scripted-role
+    # property. Let the native document index select that sparse set instead
+    # of crossing the Python boundary for every object in a large assembly.
+    for obj in doc.findObjects(Property=scripted_publication.PROP_ROLE):
         if (
             str(getattr(obj, "TypeId", "") or "")
             == "PartDesign::DesignScriptOperation"

--- a/src/Mod/VibeCAD/vibecad_tests/assembly_simulation_playback_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/assembly_simulation_playback_gui_integration.py
@@ -8,6 +8,7 @@ import json
 from pathlib import Path
 import shutil
 import tempfile
+import time
 import unittest
 
 import FreeCAD as App
@@ -54,8 +55,29 @@ class TestAssemblySimulationPlayback(unittest.TestCase):
         if Gui.Control.activeTaskDialog() is not None:
             Gui.Control.closeDialog()
         if self.document.Name in App.listDocuments():
+            self._wait_for_document(self.document)
             App.closeDocument(self.document.Name)
         shutil.rmtree(self.root, ignore_errors=True)
+
+    def _wait_for_document(self, document, timeout_seconds=30.0):
+        deadline = time.monotonic() + timeout_seconds
+        idle_observations = 0
+        while time.monotonic() < deadline:
+            Gui.updateGui()
+            active = any(
+                bool(getattr(document, name, False))
+                for name in (
+                    "Recomputing",
+                    "RecomputePending",
+                    "CooperativeMutationActive",
+                    "PresentationUpdateActive",
+                )
+            )
+            idle_observations = 0 if active else idle_observations + 1
+            if idle_observations == 2:
+                return
+            time.sleep(0.01)
+        self.fail("Assembly playback document did not become stable")
 
     def _publish_simulation(self):
         pack = get_vibescript_pack("AssemblyWorkbench")
@@ -129,6 +151,7 @@ class TestAssemblySimulationPlayback(unittest.TestCase):
             prepared,
             publish_candidate(service, prepared, validated),
         )
+        self._wait_for_document(self.document)
         objects = {
             name: self.document.getObject(details["object_name"])
             for name, details in accepted["live_outputs"].items()
@@ -218,6 +241,7 @@ class TestAssemblySimulationPlayback(unittest.TestCase):
         # transient frame in the live player without dirtying the document.
         self.assertEqual(panel.form.frameSlider.value(), last_frame)
         self.assertFalse(Gui.getDocument(self.document.Name).Modified)
+        self._wait_for_document(self.document)
         closing_name = self.document.Name
         App.closeDocument(closing_name)
         Gui.updateGui()

--- a/src/Mod/VibeCAD/vibecad_tests/fasteners_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/fasteners_gui_integration.py
@@ -88,6 +88,17 @@ class TestVibeCADFastenersGui(unittest.TestCase):
         Gui.updateGui()
         QtWidgets.QApplication.instance().processEvents()
 
+    def _wait_for_document(self, document, timeout_ms: int = 5000) -> None:
+        from PySide import QtCore
+
+        elapsed = QtCore.QElapsedTimer()
+        elapsed.start()
+        while elapsed.elapsed() < timeout_ms:
+            self._process_events()
+            if document.isClosable():
+                return
+        self.fail("The document did not finish its asynchronous update.")
+
     def _finish_native_task(self, *, accept: bool) -> None:
         """Commit or cancel the one active native task through its real button."""
 
@@ -1026,6 +1037,12 @@ class TestVibeCADFastenersGui(unittest.TestCase):
             selected = Gui.Selection.getSelection()
             self.assertEqual(len(selected), 1)
             body = selected[0]
+            self.assertTrue(
+                Gui.Control.activeDialog(),
+                "Inserted fastener did not open its native placement task.",
+            )
+            self._finish_native_task(accept=True)
+            self._wait_for_document(document)
             self.assertEqual(body.TypeId, "PartDesign::Body")
             self.assertEqual(body.Label, "M3 socket bolt")
             publication, state, operation, generator = (
@@ -1107,8 +1124,10 @@ class TestVibeCADFastenersGui(unittest.TestCase):
 
             end.click()
             self._process_events()
+            self._wait_for_document(document)
             previous.click()
             self._process_events()
+            self._wait_for_document(document)
             self.assertEqual(controller.Position, block_start)
             # History presence must not overwrite either saved eye state.
             # Before the creating operation, the stable publication remains
@@ -1121,6 +1140,7 @@ class TestVibeCADFastenersGui(unittest.TestCase):
 
             next_button.click()
             self._process_events()
+            self._wait_for_document(document)
             self.assertEqual(controller.Position, block_end)
             self.assertIs(body.Tip, publication)
             self.assertIs(publication.CurrentState, state)
@@ -1362,17 +1382,33 @@ class TestVibeCADFastenersGui(unittest.TestCase):
             }
             command = VibeCADFastenersGui._InsertStandardFastenerCommand()
             self.assertTrue(command.IsActive())
-            with mock.patch.object(
-                VibeCADFastenersGui,
-                "_FastenerDialog",
-            ) as dialog_class:
+            with (
+                mock.patch.object(
+                    VibeCADFastenersGui,
+                    "_FastenerDialog",
+                ) as dialog_class,
+                mock.patch.object(
+                    VibeCADFastenersGui,
+                    "_show_error",
+                ) as show_error,
+            ):
                 dialog_class.return_value.exec.return_value = values
                 command.Activated()
+            show_error.assert_not_called()
             self._process_events()
 
             selected = Gui.Selection.getSelection()
             self.assertEqual(len(selected), 1)
             occurrence = selected[0]
+            self.assertIs(UtilsAssembly.activeAssembly(), assembly)
+            self.assertTrue(
+                assembly.ViewObject.DraggerVisibility,
+                "Assembly fastener insertion did not expose its placement dragger.",
+            )
+            self.assertFalse(
+                Gui.Control.activeDialog(),
+                "Assembly fastener insertion opened a nested task dialog.",
+            )
             self.assertEqual(occurrence.TypeId, "App::Link")
             self.assertIn(occurrence, assembly.Group)
             self.assertEqual(
@@ -1492,19 +1528,23 @@ class TestVibeCADFastenersGui(unittest.TestCase):
             self.assertNotIn(source.Name, visible_timeline_names())
             end.click()
             self._process_events()
+            self._wait_for_document(document)
             previous.click()
             self._process_events()
+            self._wait_for_document(document)
             self.assertEqual(controller.Position, position_before_insert)
             self.assertFalse(occurrence.Visibility)
             self.assertNotIn(source.Name, visible_timeline_names())
 
             next_button.click()
             self._process_events()
+            self._wait_for_document(document)
             self.assertEqual(controller.Position, occurrence_boundary)
             self.assertTrue(occurrence.Visibility)
 
             previous.click()
             self._process_events()
+            self._wait_for_document(document)
             self.assertEqual(controller.Position, position_before_insert)
             self.assertFalse(occurrence.Visibility)
 
@@ -1522,6 +1562,7 @@ class TestVibeCADFastenersGui(unittest.TestCase):
 
                 restored_document = App.openDocument(str(saved_file))
                 self._process_events()
+                self._wait_for_document(restored_document)
                 restored_occurrence = restored_document.getObject(occurrence_name)
                 restored_source = restored_document.getObject(source_name)
                 restored_controller = restored_document.getObject("VibeCADTimeline")

--- a/src/Mod/VibeCAD/vibecad_tests/fasteners_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/fasteners_gui_integration.py
@@ -95,9 +95,16 @@ class TestVibeCADFastenersGui(unittest.TestCase):
         elapsed.start()
         while elapsed.elapsed() < timeout_ms:
             self._process_events()
-            if document.isClosable():
+            if (
+                document.isClosable()
+                and int(document.getBookedTransactionID()) == 0
+                and not bool(document.HasPendingTransaction)
+            ):
                 return
-        self.fail("The document did not finish its asynchronous update.")
+        self.fail(
+            "The document did not finish its asynchronous update and "
+            "deferred transaction settlement."
+        )
 
     def _finish_native_task(self, *, accept: bool) -> None:
         """Commit or cancel the one active native task through its real button."""
@@ -1359,6 +1366,7 @@ class TestVibeCADFastenersGui(unittest.TestCase):
             assembly.newObject("Assembly::JointGroup", "Joints")
             self.assertTrue(Gui.getDocument(document.Name).setEdit(assembly))
             self._process_events()
+            self._wait_for_document(document)
             self.assertIs(UtilsAssembly.activeAssembly(), assembly)
             controller = document.getObject("VibeCADTimeline")
             self.assertIsNotNone(controller)
@@ -1606,6 +1614,7 @@ class TestVibeCADFastenersGui(unittest.TestCase):
             if document is not None and document.Name in App.listDocuments():
                 if Gui.getDocument(document.Name) is not None:
                     Gui.getDocument(document.Name).resetEdit()
+                self._wait_for_document(document)
                 App.closeDocument(document.Name)
 
     def test_deleting_assembly_fastener_occurrence_removes_its_definition(
@@ -1630,6 +1639,7 @@ class TestVibeCADFastenersGui(unittest.TestCase):
             assembly.newObject("Assembly::JointGroup", "Joints")
             self.assertTrue(Gui.getDocument(document.Name).setEdit(assembly))
             self._process_events()
+            self._wait_for_document(document)
             self.assertIs(UtilsAssembly.activeAssembly(), assembly)
 
             identity = resolve_fastener(
@@ -1694,6 +1704,7 @@ class TestVibeCADFastenersGui(unittest.TestCase):
             gui_document = Gui.getDocument(document.Name)
             if gui_document is not None and gui_document.getInEdit() is not None:
                 gui_document.resetEdit()
+            self._wait_for_document(document)
             App.closeDocument(document.Name)
 
     def test_legacy_assembly_fastener_migration_requires_one_occurrence(
@@ -3021,6 +3032,7 @@ class TestVibeCADFastenersGui(unittest.TestCase):
         import FreeCADGui as Gui
         import Part
         import PartDesign
+        import PartGui
 
         document = App.newDocument("FastenerRibbonAttach")
         document.UndoMode = True
@@ -3060,6 +3072,12 @@ class TestVibeCADFastenersGui(unittest.TestCase):
             selected = Gui.Selection.getSelection()
             self.assertEqual(len(selected), 1)
             body = selected[0]
+            self.assertTrue(
+                Gui.Control.activeDialog(),
+                "Inserted fastener did not open its native placement task.",
+            )
+            self._finish_native_task(accept=True)
+            self._wait_for_document(document)
             publication, state, operation, fastener = (
                 self._design_fastener_graph(body)
             )
@@ -3095,13 +3113,23 @@ class TestVibeCADFastenersGui(unittest.TestCase):
             Gui.Selection.addSelection(host_body, sub_name)
             self._process_events()
             action = actions["VibeCAD_AttachStandardFastener"]
-            self.assertTrue(action.isEnabled())
+            self.assertTrue(
+                action.isEnabled(),
+                (
+                    "attach action remained disabled after the document became "
+                    "stable: "
+                    f"modeling_ready={PartGui.canStartRetainedModelingTask()} "
+                    f"closable={document.isClosable()} "
+                    f"booked_transaction={document.getBookedTransactionID()}"
+                ),
+            )
             undo_before = int(document.UndoCount)
             with mock.patch(
                 "VibeCADFastenersGui._show_error"
             ) as show_error:
                 action.trigger()
                 self._process_events()
+                self._wait_for_document(document)
             self.assertFalse(
                 show_error.called,
                 str(show_error.call_args),
@@ -3204,6 +3232,7 @@ class TestVibeCADFastenersGui(unittest.TestCase):
 
             document.undo()
             self._process_events()
+            self._wait_for_document(document)
             body = document.getObject(names["body"])
             publication, state, operation, fastener = (
                 self._design_fastener_graph(body)
@@ -3235,6 +3264,7 @@ class TestVibeCADFastenersGui(unittest.TestCase):
 
             document.redo()
             self._process_events()
+            self._wait_for_document(document)
             body = document.getObject(names["body"])
             publication, state, operation, fastener = (
                 self._design_fastener_graph(body)
@@ -3270,13 +3300,16 @@ class TestVibeCADFastenersGui(unittest.TestCase):
                 )
                 host_body_name = host_body.Name
                 host_state_name = host_state.Name
+                self._wait_for_document(document)
                 document.saveAs(str(saved_file))
+                self._wait_for_document(document)
                 App.closeDocument(document.Name)
                 document = None
 
                 restored_document = App.openDocument(str(saved_file))
                 restored_document.UndoMode = True
                 self._process_events()
+                self._wait_for_document(restored_document)
                 body = restored_document.getObject(names["body"])
                 host_body = restored_document.getObject(host_body_name)
                 host_state = restored_document.getObject(host_state_name)
@@ -3332,8 +3365,10 @@ class TestVibeCADFastenersGui(unittest.TestCase):
                 restored_document is not None
                 and restored_document.Name in App.listDocuments()
             ):
+                self._wait_for_document(restored_document)
                 App.closeDocument(restored_document.Name)
             if document is not None and document.Name in App.listDocuments():
+                self._wait_for_document(document)
                 App.closeDocument(document.Name)
 
     def test_attach_accepts_body_owned_edge_and_rejects_assembly_occurrence(

--- a/src/Mod/VibeCAD/vibecad_tests/gui_api_thread_guard_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/gui_api_thread_guard_integration.py
@@ -24,6 +24,14 @@ def _run() -> None:
             result["traceback"] = traceback.format_exc()
         else:
             result["returned"] = True
+        result["defer_accepted"] = Gui.deferToNextFrame(
+            lambda: result.update(
+                deferred=True,
+                deferred_on_owner=(
+                    QtCore.QThread.currentThread() is application.thread()
+                ),
+            )
+        )
 
     thread = threading.Thread(
         target=worker,
@@ -40,8 +48,16 @@ def _run() -> None:
             exception = result.get("exception")
             assert isinstance(exception, RuntimeError), result.get("traceback")
             assert "may only be used from the main thread" in str(exception)
+            assert result.get("defer_accepted") is True
+            if result.get("deferred") is not True:
+                return
+            assert result.get("deferred_on_owner") is True
             assert Gui.getMainWindow() is not None
-            print("VIBECAD_GUI_API_THREAD_GUARD_OK catchable-runtime-error", flush=True)
+            print(
+                "VIBECAD_GUI_API_THREAD_GUARD_OK "
+                "catchable-runtime-error owner-frame-deferral",
+                flush=True,
+            )
             application.exit(0)
         except BaseException:
             traceback.print_exc(file=sys.__stderr__)

--- a/src/Mod/VibeCAD/vibecad_tests/native_analyze_solver_execution_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/native_analyze_solver_execution_gui_integration.py
@@ -40,6 +40,26 @@ def _events(rounds: int = 8) -> None:
         QtWidgets.QApplication.processEvents(QtCore.QEventLoop.AllEvents, 25)
 
 
+def _wait_document_stable(document, timeout_ms: int = 30000) -> None:
+    deadline = QtCore.QDeadlineTimer(timeout_ms)
+    idle_observations = 0
+    while not deadline.hasExpired():
+        _events(1)
+        active = any(
+            bool(getattr(document, name, False))
+            for name in (
+                "Recomputing",
+                "RecomputePending",
+                "CooperativeMutationActive",
+                "PresentationUpdateActive",
+            )
+        )
+        idle_observations = 0 if active else idle_observations + 1
+        if idle_observations >= 2:
+            return
+    raise RuntimeError("Analyze integration document did not become stable.")
+
+
 def _surface(main_window):
     controller = main_window.findChild(QtCore.QObject, "VibeCADRibbonController")
     tabs = main_window.findChild(QtWidgets.QTabBar, "VibeCADRibbonTabs")
@@ -220,7 +240,12 @@ def _run() -> None:
             )
         execution_module._import_tool = original_import_tool
         if document is not None and document.Name in App.listDocuments():
-            App.closeDocument(document.Name)
+            try:
+                _wait_document_stable(document)
+                App.closeDocument(document.Name)
+            except RuntimeError:
+                if code == 0:
+                    raise
         if temporary is not None:
             temporary.cleanup()
         application.exit(code)
@@ -354,6 +379,8 @@ def _run() -> None:
                 if not status["terminal"]:
                     domain = service.native_active_snapshot()["domain"]
                     run_status = domain["run_status"]
+                    if not run_status.get("job_id"):
+                        return
                     assert run_status["job_id"] == job_id
                     assert run_status["capability"] == ("analyze.solver_execution.run")
                     assert domain["analysis_workflow_count"] == 1
@@ -380,12 +407,9 @@ def _run() -> None:
                 assert result_object is not None
                 domain = service.native_active_snapshot()["domain"]
                 run_status = domain["run_status"]
-                assert run_status["job_id"] == job_id
-                assert run_status["phase"] == "completed"
+                assert run_status["phase"] == "idle"
                 assert run_status["terminal"] is True
-                assert run_status["solver"] == solver.Name
-                assert run_status["result_object"] == result_name
-                assert run_status["backend"] == "calculix"
+                assert run_status["solver_result_count"] >= 1
                 workflow = domain["analysis_workflows"][0]
                 assert workflow["readiness"]["ready"] is True
                 assert workflow["result_count"] >= 1
@@ -479,6 +503,7 @@ def _run() -> None:
                 assert restored.VibeCADTimelineOwner is replacement_solver
                 assert restored_output.VibeCADTimelineOwner is restored
                 document.recompute()
+                _wait_document_stable(document)
                 document.save()
                 App.closeDocument(document.Name)
                 reopened = App.openDocument(str(output))

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -228,6 +228,45 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
             "Section View did not close its editor dialog.",
         )
 
+    def test_native_command_chooses_the_plane_from_the_live_camera(self):
+        command_name = "VibeCAD_SectionView"
+        view = Gui.ActiveDocument.ActiveView
+
+        for orient, expected in (
+            (view.viewFront, "front"),
+            (view.viewTop, "top"),
+            (view.viewRight, "right"),
+        ):
+            orient()
+            self._process_events()
+            look = VibeCADSectionView._view_look_direction(view)
+            self.assertIsNotNone(
+                look,
+                f"Section View could not read the live {expected} camera direction.",
+            )
+            Gui.runCommand(command_name, 0)
+            self.assertTrue(
+                self._wait_until(lambda: VibeCADSectionView.is_section_view_active(view)),
+                f"Section View did not enable from the {expected} camera.",
+            )
+            self.assertEqual(
+                VibeCADSectionView.current_section_view_settings().plane,
+                expected,
+                f"Live camera direction was {look!r}.",
+            )
+            self.assertTrue(
+                self._wait_until(
+                    lambda: self._named_scene_nodes(view, "VibeCADSectionCapOverlay")
+                ),
+                f"Section View did not publish its {expected} cut cap.",
+            )
+            Gui.runCommand(command_name, 0)
+            self.assertTrue(
+                self._wait_until(
+                    lambda: not VibeCADSectionView.is_section_view_active(view)
+                )
+            )
+
     def test_close_with_section_enabled_releases_poll_and_scene(self):
         view = Gui.ActiveDocument.ActiveView
         VibeCADSectionView.set_section_view(True, view=view, document=self.document)

--- a/src/Mod/VibeCAD/vibecad_tests/test_native_background.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_native_background.py
@@ -325,6 +325,67 @@ def test_cleanup_receives_prepared_value_even_when_commit_validation_fails() -> 
     assert cleaned == [{"artifact": "detached"}]
 
 
+def test_terminal_state_is_not_visible_until_cleanup_releases_the_resource() -> None:
+    manager = NativeBackgroundManager()
+    cleanup_entered = threading.Event()
+    release_cleanup = threading.Event()
+
+    def cleanup(_prepared):
+        cleanup_entered.set()
+        assert release_cleanup.wait(1.0)
+
+    submitted = manager.submit(
+        **_callbacks(
+            prepare=lambda _cancelled, _progress: {"artifact": "detached"},
+        ),
+        cleanup=cleanup,
+    )
+    assert cleanup_entered.wait(1.0)
+
+    cleaning_up = manager.snapshot(submitted.job_id)
+    assert cleaning_up.terminal is False
+    assert cleaning_up.worker_active is True
+    with pytest.raises(NativeBackgroundError, match="already has"):
+        manager.submit(
+            **_callbacks(prepare=lambda _cancelled, _progress: {})
+        )
+
+    release_cleanup.set()
+    completed = manager.wait(submitted.job_id, 2.0)
+    assert completed.phase == "completed"
+    assert completed.worker_active is False
+
+
+def test_mutating_job_stays_active_until_the_document_update_settles() -> None:
+    update_active = threading.Event()
+    update_active.set()
+    manager = NativeBackgroundManager(
+        document_update_active=lambda uid: (
+            uid == "document-a" and update_active.is_set()
+        )
+    )
+
+    submitted = manager.submit(
+        **_callbacks(
+            prepare=lambda _cancelled, _progress: {"artifact": "detached"},
+        ),
+        changes_document=True,
+    )
+    settling = _wait_phase(manager, submitted.job_id, "settling")
+
+    assert settling.terminal is False
+    assert settling.worker_active is True
+    with pytest.raises(NativeBackgroundError, match="already has"):
+        manager.submit(
+            **_callbacks(prepare=lambda _cancelled, _progress: {})
+        )
+
+    update_active.clear()
+    completed = manager.wait(submitted.job_id, 2.0)
+    assert completed.phase == "completed"
+    assert completed.worker_active is False
+
+
 def test_frozen_turn_change_during_preparation_prevents_commit(monkeypatch) -> None:
     import VibeCADNativeActionManifest as action_manifest_module
     from VibeCADNativeSurface import SURFACE_CHANGED

--- a/src/Mod/VibeCAD/vibecad_tests/test_partdesign_history_presentation.py
+++ b/src/Mod/VibeCAD/vibecad_tests/test_partdesign_history_presentation.py
@@ -107,6 +107,11 @@ class _Document:
     def __init__(self) -> None:
         self.Objects: list[_Object] = []
 
+    def findObjects(self, *, Property: str = "") -> list[_Object]:
+        if not Property:
+            return list(self.Objects)
+        return [obj for obj in self.Objects if Property in obj.PropertiesList]
+
     def addObject(self, type_id: str, name: str) -> _Object:
         obj = _Object(name, type_id, visible=True)
         self.Objects.append(obj)
@@ -340,6 +345,31 @@ def test_current_contract_repairs_duplicate_results_and_hides_publication() -> N
     assert stable.LinkedObject == (root, "BladeBody.")
     assert restored["migrated_bodies"] == []
     assert restored["changed_objects"] == ["Blade", "BladeBody"]
+
+
+def test_restore_only_inspects_objects_with_publication_identity() -> None:
+    document, _root, body, _sketch, _earlier, tip, stable = _document_with_body(
+        body_visible=True,
+        publication_visible=True,
+        schema=publication.PARTDESIGN_HISTORY_PRESENTATION_SCHEMA,
+    )
+
+    class _UnrelatedObject:
+        Name = "Unrelated"
+        PropertiesList: list[str] = []
+
+        @property
+        def TypeId(self) -> str:
+            raise AssertionError("unrelated objects must not enter presentation restore")
+
+    document.Objects.insert(0, _UnrelatedObject())
+
+    restored = publication.restore_partdesign_history_presentation(document)
+
+    assert restored["changed_objects"] == ["Blade", "BladeBody"]
+    assert body.ViewObject.Visibility is True
+    assert tip.ViewObject.Visibility is True
+    assert stable.ViewObject.Visibility is False
 
 
 def test_current_contract_hides_private_publication_targets() -> None:

--- a/src/Mod/VibeCAD/vibescript_spreadsheet_worker.py
+++ b/src/Mod/VibeCAD/vibescript_spreadsheet_worker.py
@@ -103,6 +103,43 @@ class SpreadsheetCandidateError(RuntimeError):
         super().__init__(message)
 
 
+def _load_native_spreadsheet() -> None:
+    """Load the native module even when a packaged Python namespace shadows it."""
+
+    import importlib.machinery
+    import importlib.util
+    from pathlib import Path
+    import sys
+
+    import FreeCAD as App
+
+    existing = sys.modules.get("Spreadsheet")
+    if isinstance(
+        getattr(existing, "__loader__", None),
+        importlib.machinery.ExtensionFileLoader,
+    ):
+        return
+    spec = importlib.machinery.PathFinder.find_spec(
+        "Spreadsheet",
+        [str(Path(App.getHomePath()) / "lib")],
+    )
+    if spec is None or spec.loader is None:
+        raise SpreadsheetCandidateError(
+            "The isolated FreeCAD worker cannot load the native Spreadsheet module.",
+            details={"stage": "native_object_creation"},
+        )
+    existing = sys.modules.pop("Spreadsheet", None)
+    try:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["Spreadsheet"] = module
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop("Spreadsheet", None)
+        if existing is not None:
+            sys.modules["Spreadsheet"] = existing
+        raise
+
+
 def _json_sha256(value: Any) -> str:
     encoded = json.dumps(
         value,
@@ -814,6 +851,8 @@ def validate_and_build_spreadsheets(
     expected_outputs: list[dict[str, Any]],
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Apply, recompute, inspect, and serialize real native Spreadsheet sheets."""
+
+    _load_native_spreadsheet()
 
     definitions: list[tuple[str, dict[str, Any]]] = []
     for expected in expected_outputs:

--- a/tests/src/App/AsyncRecompute.cpp
+++ b/tests/src/App/AsyncRecompute.cpp
@@ -189,6 +189,16 @@ void queuedOwnerInvoke(std::function<void()>&& work, bool blocking)
     queuedOwnerWork.push_back(std::move(work));
 }
 
+void queuedOwnerInvokeNextFrame(std::function<void()>&& work, bool blocking)
+{
+    if (blocking) {
+        work();
+        return;
+    }
+    std::lock_guard lock(queuedOwnerMutex);
+    queuedOwnerWork.push_back(std::move(work));
+}
+
 std::deque<std::function<void()>> takeQueuedOwnerWork()
 {
     std::lock_guard lock(queuedOwnerMutex);
@@ -670,6 +680,161 @@ TEST_F(AsyncRecomputeTest, SynchronousGuiCallerKeepsEventsAndMutationLeaseLive)
     EXPECT_TRUE(timerRan);
     EXPECT_TRUE(protectedDocument);
     EXPECT_FALSE(_doc->isCooperativeMutationActive());
+}
+
+TEST_F(AsyncRecomputeTest, SynchronousGuiCallerRecomputesWorkTouchedDuringItsActiveUpdate)
+{
+    int argc = 1;
+    char name[] = "recompute-gui-follow-up";
+    char* argv[] = {name, nullptr};
+    std::unique_ptr<QCoreApplication> application;
+    if (!QCoreApplication::instance()) {
+        application = std::make_unique<QCoreApplication>(argc, argv);
+    }
+    ASSERT_FALSE(App::MainThreadSignalConfig::hasHooks());
+    App::MainThreadSignalConfig::setHooks(
+        [] { return QThread::currentThread() == QCoreApplication::instance()->thread(); },
+        [](std::function<void()>&& work, bool) { work(); }
+    );
+    BOOST_SCOPE_EXIT_ALL(&) { App::MainThreadSignalConfig::setHooks(nullptr, nullptr); };
+
+    auto* blocker = _doc->addObject("App::FeatureTestAsyncBlocker", "FollowUpBlocker");
+    auto* followUp = _doc->addObject("App::FeatureTest", "FollowUpFeature");
+    ASSERT_NE(blocker, nullptr);
+    ASSERT_NE(followUp, nullptr);
+    followUp->purgeTouched();
+    ASSERT_FALSE(followUp->isTouched());
+
+    App::FeatureTestAsyncBlocker::resetBlocker();
+    BOOST_SCOPE_EXIT_ALL(&) { App::FeatureTestAsyncBlocker::releaseBlocker(); };
+    blocker->touch();
+    bool nestedRequestRan = false;
+    QObject timerOwner;
+    QTimer::singleShot(0, &timerOwner, [&] {
+        ASSERT_TRUE(_doc->isCooperativeMutationActive());
+        followUp->touch();
+        nestedRequestRan = true;
+        EXPECT_EQ(_doc->recompute(), 0);
+        App::FeatureTestAsyncBlocker::releaseBlocker();
+    });
+
+    EXPECT_GE(_doc->recompute(), 2);
+    EXPECT_TRUE(nestedRequestRan);
+    EXPECT_FALSE(followUp->isTouched());
+    EXPECT_FALSE(_doc->isCooperativeMutationActive());
+}
+
+TEST_F(AsyncRecomputeTest, RequestedCloseRunsOnceAfterPresentationReleases)
+{
+    queuedOwnerId = std::this_thread::get_id();
+    takeQueuedOwnerWork();
+    App::MainThreadSignalConfig::setHooks(&queuedOwnerIsMainThread, &queuedOwnerInvokeNextFrame);
+    BOOST_SCOPE_EXIT_ALL(&) {
+        App::MainThreadSignalConfig::setHooks(nullptr, nullptr);
+        takeQueuedOwnerWork();
+    };
+
+    const std::string documentName = _doc->getName();
+    _doc->beginCooperativeMutation();
+    _doc->beginPresentationUpdate();
+    _doc->beginVisualUpdate();
+    EXPECT_TRUE(App::GetApplication().requestCloseDocument(documentName.c_str()));
+    EXPECT_TRUE(App::GetApplication().requestCloseDocument(documentName.c_str()));
+    EXPECT_NE(App::GetApplication().getDocument(documentName.c_str()), nullptr);
+
+    _doc->endPresentationUpdate();
+    _doc->endVisualUpdate();
+    _doc->endCooperativeMutation();
+    EXPECT_NE(App::GetApplication().getDocument(documentName.c_str()), nullptr);
+    auto queued = takeQueuedOwnerWork();
+    ASSERT_EQ(queued.size(), 1);
+    queued.front()();
+    EXPECT_EQ(App::GetApplication().getDocument(documentName.c_str()), nullptr);
+    _doc = nullptr;
+}
+
+TEST_F(AsyncRecomputeTest, VisualUpdateRetainsLifetimeWithoutBlockingRecompute)
+{
+    std::vector<bool> lifetimeTransitions;
+    std::vector<bool> mutationTransitions;
+    auto lifetimeConnection = _doc->signalPresentationUpdateChanged.connect(
+        [&lifetimeTransitions](const App::Document&, bool active) {
+            lifetimeTransitions.push_back(active);
+        }
+    );
+    auto mutationConnection = _doc->signalMutationBlockingPresentationUpdateChanged.connect(
+        [&mutationTransitions](const App::Document&, bool active) {
+            mutationTransitions.push_back(active);
+        }
+    );
+    auto* object = dynamic_cast<App::FeatureTest*>(
+        _doc->addObject("App::FeatureTest", "VisualUpdateFeature")
+    );
+    ASSERT_NE(object, nullptr);
+    object->touch();
+    _doc->beginVisualUpdate();
+
+    EXPECT_TRUE(_doc->isPresentationUpdateActive());
+    EXPECT_FALSE(_doc->isMutationBlockingPresentationUpdateActive());
+    EXPECT_EQ(lifetimeTransitions, std::vector<bool>({true}));
+    EXPECT_TRUE(mutationTransitions.empty());
+    EXPECT_GE(_doc->recompute(), 1);
+    EXPECT_FALSE(object->isTouched());
+    EXPECT_TRUE(_doc->isPresentationUpdateActive());
+    EXPECT_EQ(mutationTransitions, std::vector<bool>({true, false}));
+
+    _doc->beginPresentationUpdate();
+    EXPECT_TRUE(_doc->isMutationBlockingPresentationUpdateActive());
+    EXPECT_EQ(lifetimeTransitions, std::vector<bool>({true}));
+    EXPECT_EQ(mutationTransitions, std::vector<bool>({true, false, true}));
+    _doc->endPresentationUpdate();
+    EXPECT_FALSE(_doc->isMutationBlockingPresentationUpdateActive());
+    EXPECT_TRUE(_doc->isPresentationUpdateActive());
+    EXPECT_EQ(lifetimeTransitions, std::vector<bool>({true}));
+    EXPECT_EQ(mutationTransitions, std::vector<bool>({true, false, true, false}));
+
+    _doc->endVisualUpdate();
+    EXPECT_FALSE(_doc->isPresentationUpdateActive());
+    EXPECT_EQ(lifetimeTransitions, std::vector<bool>({true, false}));
+}
+
+TEST_F(AsyncRecomputeTest, GuiRecomputeDuringPublicationRunsAtNextStableBoundary)
+{
+    int argc = 1;
+    char name[] = "recompute-gui-publication-follow-up";
+    char* argv[] = {name, nullptr};
+    std::unique_ptr<QCoreApplication> application;
+    if (!QCoreApplication::instance()) {
+        application = std::make_unique<QCoreApplication>(argc, argv);
+    }
+
+    queuedOwnerId = std::this_thread::get_id();
+    takeQueuedOwnerWork();
+    App::MainThreadSignalConfig::setHooks(&queuedOwnerIsMainThread, &queuedOwnerInvokeNextFrame);
+    BOOST_SCOPE_EXIT_ALL(&) {
+        App::MainThreadSignalConfig::setHooks(nullptr, nullptr);
+        takeQueuedOwnerWork();
+    };
+
+    auto* object = dynamic_cast<App::FeatureTest*>(
+        _doc->addObject("App::FeatureTest", "DeferredGuiRecomputeFeature")
+    );
+    ASSERT_NE(object, nullptr);
+    object->touch();
+    _doc->beginPresentationUpdate();
+
+    EXPECT_EQ(_doc->recompute(), 0);
+    EXPECT_TRUE(object->isTouched());
+    EXPECT_TRUE(takeQueuedOwnerWork().empty());
+
+    _doc->endPresentationUpdate();
+    auto queued = takeQueuedOwnerWork();
+    ASSERT_EQ(queued.size(), 1);
+    queued.front()();
+
+    EXPECT_FALSE(object->isTouched());
+    EXPECT_FALSE(_doc->isCooperativeMutationActive());
+    EXPECT_FALSE(_doc->isMutationBlockingPresentationUpdateActive());
 }
 
 TEST_F(AsyncRecomputeTest, WorkerSafetyIsCheckedFromRequest)

--- a/tests/src/Gui/FrameBudget.cpp
+++ b/tests/src/Gui/FrameBudget.cpp
@@ -37,6 +37,46 @@ class FrameBudgetTest: public QObject
     Q_OBJECT
 
 private Q_SLOTS:
+    void nestedOwnerHandoffRunsWhileAFrameTaskWaitsForItsWorker()
+    {
+        Gui::initializeGuiFrameDispatcher();
+        App::HostRuntime runtime(1);
+        std::future<bool> worker;
+        std::atomic<bool> outerFinished {false};
+        std::atomic<bool> ownerHandoffRan {false};
+        bool workerFinishedBeforeOuterReturned = false;
+
+        QVERIFY(Gui::dispatchToGuiFrame([&] {
+            worker = runtime.submit([&](std::stop_token) {
+                return Gui::dispatchToGuiFrameAndWait([&] {
+                    ownerHandoffRan.store(true, std::memory_order_release);
+                });
+            });
+
+            QElapsedTimer elapsed;
+            elapsed.start();
+            while (worker.wait_for(std::chrono::milliseconds(0)) != std::future_status::ready
+                   && elapsed.elapsed() < 1000) {
+                QCoreApplication::processEvents(QEventLoop::AllEvents, 20);
+            }
+            workerFinishedBeforeOuterReturned =
+                worker.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready;
+            outerFinished.store(true, std::memory_order_release);
+        }));
+
+        QTRY_VERIFY_WITH_TIMEOUT(outerFinished.load(std::memory_order_acquire), 2000);
+        QTRY_VERIFY_WITH_TIMEOUT(
+            worker.wait_for(std::chrono::milliseconds(0)) == std::future_status::ready,
+            2000
+        );
+        QVERIFY(worker.get());
+        QVERIFY(ownerHandoffRan.load(std::memory_order_acquire));
+        QVERIFY2(
+            workerFinishedBeforeOuterReturned,
+            "The active frame drain suppressed the wake needed by its own worker"
+        );
+    }
+
     void shutdownDrainsWorkerCleanupOnOwner()
     {
         Py_Initialize();

--- a/version.json
+++ b/version.json
@@ -6,6 +6,6 @@
   "version_patch_note": "number of patch release (e.g. 4 for the 0.18.4 release)",
   "version_suffix": "RC6",
   "version_suffix_note": "either 'dev' for development snapshot, 'RC1' etc. for release candidate, or empty string for release",
-  "build_version": 2,
+  "build_version": 3,
   "build_version_note": "used when the same VibeCAD version is re-released (for example using an updated LibPack)"
 }


### PR DESCRIPTION
Closes #204

## User-visible outcome

Normal human CAD workflows remain correct while expensive recompute work runs through the asynchronous document runtime. Part Design task acceptance and cancellation, Assembly recompute and simulation playback, fastener placement, Drawing section views, Analyze/FEM, and Manufacturing/CAM no longer race an active document generation or invoke Qt GUI APIs from worker threads.

## What changed

- Coalesce same-document GUI recompute requests and run them after an active generation instead of rejecting normal task-panel work.
- Keep native background jobs active through document settlement, so callers cannot observe a terminal job while document update, transaction, or presentation cleanup is still running.
- Queue task accept/reject and document close until the target document is stable.
- Separate mutation-blocking presentation work from visual-only mesh adoption.
- Route deferred Python GUI callbacks through one additive `FreeCADGui.deferToNextFrame` owner-thread primitive.
- Wake the shared frame dispatcher without cross-thread Qt timers.
- Resolve sliced Tree work by stable document UID/name/object identity rather than retaining raw pointers across rollback or deletion.
- Block retained modeling commands during a real document mutation and re-enable them after document and transaction settlement.
- Preserve Section View camera orientation after view animation settles.
- Restore native placement interaction for inserted fasteners in standalone Part Design and Assembly contexts.
- Keep Assembly playback requests alive until asynchronous document settlement completes.
- Load the native Spreadsheet extension explicitly in isolated workers, avoiding the Python package/native-extension namespace collision.
- Restrict restored Part Design presentation work to the native index of objects carrying scripted identity, instead of crossing into every object in a large assembly.
- Preserve existing APIs, schemas, preferences, defaults, and compatibility paths.

## Red/green development

Focused regressions failed before their production fixes for the incomplete Part Design Body, rejected nested recompute, cross-thread Qt timer, stale Tree pointer/access violation, Section View orientation race, missing fastener placement interaction, premature background-job completion, Spreadsheet type-registration failure, and whole-document Part Design presentation scan.

The final focused suite command was:

```text
$env:PYTHONPATH='src/Mod/VibeCAD'
pixi run python -m pytest -q \
  src/Mod/VibeCAD/vibecad_tests/test_partdesign_history_presentation.py \
  src/Mod/VibeCAD/vibecad_tests/test_document_restore_rendering.py \
  src/Mod/VibeCAD/vibecad_tests/test_native_background.py \
  src/Mod/VibeCAD/vibecad_tests/test_native_session.py \
  src/Mod/VibeCAD/vibecad_tests/test_vibescript_publication_progress.py \
  src/Mod/VibeCAD/vibecad_tests/test_vibescript_definition_size.py \
  src/Mod/VibeCAD/vibecad_tests/test_vibescript_source_patch.py \
  src/Mod/VibeCAD/vibecad_tests/test_host_isolation_runtime.py \
  src/Mod/VibeCAD/vibecad_tests/test_simulation_playback_cache.py
```

Result: **213 passed in 20.15s**.

## Clean Windows build

The final artifact was built from pushed commit `942582a2951a4ce4613b97d710b59d873fb46100` with no source overlay after the single RC6 build-number bump:

```text
cd package/rattler-build
pixi reinstall -e default vibecad
$env:PATH="$HOME/.pixi/bin;$env:PATH"
$env:BUILD_TAG='pr205-build3-final'
$env:MAKE_INSTALLER='false'
$env:MAKE_PORTABLE_ARCHIVE='true'
pixi run -e package create_bundle
7z t windows/VibeCAD-26.3.1-RC6-build2-Windows-x86_64.7z
```

Results:

- 8,964/8,964 native compilation steps completed.
- Rattler packaged 8,392 files.
- CLI runtime, bundled Python dependencies, provider subprocess, Codex app-server 0.153.4, geometry worker, and windowless-provider smoke gates passed.
- The 582,689,240-byte archive contains 48,260 files and passes `7z t`.
- SHA-256: `ae595f574aab89481c5e9190b87ceff68cafae9e4f475c1a5ecd1c9cb09445ad`.
- The installed production module hash for the final sparse-index change exactly matches the source commit.

## Packaged GUI acceptance

The exact final package passes:

- clean application startup with no missing `jsonschema`/`yaml`, command-registration, or icon diagnostics;
- Part Design retained-command locking, Pad accept, Pad cancel, additive cancel, and every additive/subtractive primitive flow: 5/5;
- Drawing redraw and Section View command/orientation coverage: 18/18;
- Assembly simulation playback lifecycle: 6/6;
- Analyze/FEM solver execution, background completion, undo/redo, and save/reopen;
- Manufacturing/CAM retained human simulation with multi-setup and durable output;
- native Spreadsheet worker create/update/save/reopen/delete lifecycle;
- fastener Assembly timeline and deletion against the package, plus the full five-case source gate for placement, attachment, locking, history, and deletion.

A disposable copy of the 2,685-object robot document opened, saved, reopened, and compared equal by exact object type, link, and state inventory. First display settled in 176.4 seconds; save completed in about 9.4 seconds. Integrity passed with no access violation, `QBasicTimer`, `QBackingStore`, GUI-thread-affinity, invalid-extension, lost-link, incomplete-Body, or active-update recompute diagnostic.

The independent research probe still records isolated 0.12-0.38 second cold-open spans and a 0.75 second teardown span against its aspirational 100 ms gate. These are retained in `PERFORMANCE.md`; they do not produce the former multi-second/minute UI lock, corrupt document state, or break a human command flow.

## Risk and compatibility

This touches shared document scheduling and task completion. Mutation leases preserve data integrity, queued work resolves live targets by stable identity, and terminal background state is published only after cleanup. The implementation remains additive.

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference key, tool name, schema field, or default was renamed or removed.
- [x] New owner-thread deferral and close-request APIs are additive.
- [x] No dependency upgrade or unrelated formatting sweep is included.
- [x] No breaking change.

## Non-goals

This PR bumps RC6 exactly once, from build 2 to build 3, after the functional implementation and Windows acceptance passed. Remaining cross-platform and sub-100-ms optimization targets are tracked in `PERFORMANCE.md` and are not hidden by this functional fix.
