### PR TITLE
Fix async human CAD interaction regressions

### DIFF
--- a/docs/developer-launch-windows.md
+++ b/docs/developer-launch-windows.md
@@ -382,6 +382,13 @@ $RepoRoot = (Get-Location).Path
 $NativeRoot = (Resolve-Path 'build/authoritative-runtime-native').Path
 $PortableRoot = (Resolve-Path 'package/rattler-build/windows/<portable-folder>').Path
 $DependencyRoot = (Resolve-Path 'package/rattler-build/.pixi/bld/vibecad/<build-id>/host').Path
+# The native CMake tree does not bundle the packaged Codex executables.
+# Stage the complete runtime from the matching portable build, including its
+# manifest, code-mode companion, and resources (not just app-server.exe).
+if (!(Test-Path "$NativeRoot/Mod/VibeCAD/codex_runtime")) {
+    Copy-Item -LiteralPath "$PortableRoot/Mod/VibeCAD/codex_runtime" `
+        -Destination "$NativeRoot/Mod/VibeCAD/codex_runtime" -Recurse
+}
 $ModuleDirectories = Get-ChildItem "$NativeRoot/Mod" -Directory | ForEach-Object FullName
 $env:PATH = (@("$NativeRoot/bin") + $ModuleDirectories + @(
     "$DependencyRoot/Library/bin", "$DependencyRoot/DLLs", $DependencyRoot,
@@ -410,6 +417,11 @@ executable selects its matching Python runtime. Verify the launch logs and the
 process-specific agent endpoint before handing over the window. Rebuild the
 changed native targets and update their installed Python modules first; a
 source revision marker alone does not verify the loaded binaries.
+Check provider readiness too: `assistant_available` only confirms command
+registration, not that the bundled provider runtime exists. A pre-existing
+`codex_runtime` must match the checkout's pinned version. Use
+`-DisableKeepAlive` with PowerShell readiness requests so an exiting shell
+does not reset an idle HTTP connection and print a server traceback.
 
 ## Requirements
 

--- a/docs/developer-launch-windows.md
+++ b/docs/developer-launch-windows.md
@@ -369,6 +369,48 @@ the launcher, but a skipped rebuild is not evidence that the existing binary or
 installed modules were produced from that commit. Do not use it for release
 acceptance. `-SkipRebuild -ReleaseAttestation` is refused.
 
+## Incremental native build for a local spot check
+
+For an already configured native tree, use its matching dependency environment
+and the Python packages from a complete portable build. Set the three paths
+below relative to the repository root; the dependency environment must be the
+one recorded in that native tree's `CMakeCache.txt`, not another installed Python.
+This is an incremental test launch, not a release package verification.
+
+```powershell
+$RepoRoot = (Get-Location).Path
+$NativeRoot = (Resolve-Path 'build/authoritative-runtime-native').Path
+$PortableRoot = (Resolve-Path 'package/rattler-build/windows/<portable-folder>').Path
+$DependencyRoot = (Resolve-Path 'package/rattler-build/.pixi/bld/vibecad/<build-id>/host').Path
+$ModuleDirectories = Get-ChildItem "$NativeRoot/Mod" -Directory | ForEach-Object FullName
+$env:PATH = (@("$NativeRoot/bin") + $ModuleDirectories + @(
+    "$DependencyRoot/Library/bin", "$DependencyRoot/DLLs", $DependencyRoot,
+    "$PortableRoot/bin", $env:PATH
+)) -join ';'
+$env:QT_PLUGIN_PATH = "$DependencyRoot/Library/lib/qt6/plugins"
+$env:QT_QPA_PLATFORM_PLUGIN_PATH = "$env:QT_PLUGIN_PATH/platforms"
+$env:QT_QPA_PLATFORM = 'windows'
+Remove-Item Env:PYTHONHOME -ErrorAction SilentlyContinue
+Remove-Item Env:FC_PYTHONHOME -ErrorAction SilentlyContinue
+$env:VIBECAD_DEV_MODE = '1'
+$env:VIBECAD_DEV_SOURCE_ROOT = $RepoRoot
+$env:VIBECAD_DEV_SOURCE_SHA = git rev-parse HEAD
+$env:VIBECAD_DEV_SOURCE_TREE = git write-tree
+$env:VIBECAD_AGENT_HOME = "$RepoRoot/.vibecad-dev/agent"
+Start-Process -FilePath "$NativeRoot/bin/FreeCAD.exe" `
+    -ArgumentList @('-P', ('"{0}/bin/Lib/site-packages"' -f $PortableRoot)) `
+    -WorkingDirectory $NativeRoot `
+    -RedirectStandardOutput "$RepoRoot/build/incremental-launch.out.log" `
+    -RedirectStandardError "$RepoRoot/build/incremental-launch.err.log"
+```
+
+`-P` is required: ambient `PYTHONPATH` does not add these packages to the
+embedded interpreter. Leave `PYTHONHOME` and `FC_PYTHONHOME` unset so the native
+executable selects its matching Python runtime. Verify the launch logs and the
+process-specific agent endpoint before handing over the window. Rebuild the
+changed native targets and update their installed Python modules first; a
+source revision marker alone does not verify the loaded binaries.
+
 ## Requirements
 
 - Windows

--- a/src/Gui/Inventor/Draggers/SoLinearDragger.cpp
+++ b/src/Gui/Inventor/Draggers/SoLinearDragger.cpp
@@ -74,6 +74,9 @@ SoLinearDragger::SoLinearDragger()
     FC_ADD_CATALOG_ENTRY(secondaryColor, SoBaseColor, activeSwitch);
     FC_ADD_CATALOG_ENTRY(labelSwitch, SoToggleSwitch, geomSeparator);
     FC_ADD_CATALOG_ENTRY(labelSeparator, SoSeparator, labelSwitch);
+    // Optional world-sized pick surface, translated by the same motion matrix
+    // as the arrow. Keep it before the arrow's screen-size scaling.
+    FC_ADD_CATALOG_ENTRY(dragSurface, SoSeparator, geomSeparator);
     FC_ADD_CATALOG_ENTRY(scale, SoScale, geomSeparator);
     SO_KIT_ADD_CATALOG_ABSTRACT_ENTRY(
         arrow,

--- a/src/Gui/Inventor/Draggers/SoLinearDragger.h
+++ b/src/Gui/Inventor/Draggers/SoLinearDragger.h
@@ -60,6 +60,7 @@ class GuiExport SoLinearDragger: public SoDragger
     SO_KIT_CATALOG_ENTRY_HEADER(labelSwitch);
     SO_KIT_CATALOG_ENTRY_HEADER(labelSeparator);
     SO_KIT_CATALOG_ENTRY_HEADER(scale);
+    SO_KIT_CATALOG_ENTRY_HEADER(dragSurface);
     SO_KIT_CATALOG_ENTRY_HEADER(arrow);
 
 public:

--- a/src/Gui/MDIView.cpp
+++ b/src/Gui/MDIView.cpp
@@ -248,7 +248,15 @@ void MDIView::closeEvent(QCloseEvent* e)
                 guard->closePreparationPending = false;
                 if (!ready) { return; }
                 guard->closePrepared = true;
-                guard->close();
+                // Re-enter through the owning MDI window. Closing only the
+                // child view removes the document while leaving QMdiArea's
+                // tab container behind until a second close request.
+                if (auto* subWindow = qobject_cast<QMdiSubWindow*>(guard->parentWidget())) {
+                    subWindow->close();
+                }
+                else {
+                    guard->close();
+                }
                 if (guard) { guard->closePrepared = false; }
             }, true);
         }

--- a/src/Gui/TaskView/TaskView.cpp
+++ b/src/Gui/TaskView/TaskView.cpp
@@ -766,7 +766,8 @@ bool TaskView::showDialog(TaskDialog* dlg, App::Document* doc)
 
     dlg->adoptCommandInteractionState(doc);
 
-    TaskInfo outInfo {.Document = doc};
+    TaskInfo outInfo {};
+    outInfo.Document = doc;
     // first create the control element, set it up and wire it:
     outInfo.ActiveCtrl = new TaskEditControl(this);
     outInfo.ActiveCtrl->buttonBox->setStandardButtons(dlg->getStandardButtons());

--- a/src/Gui/Tree.cpp
+++ b/src/Gui/Tree.cpp
@@ -4592,15 +4592,23 @@ void TreeWidget::processUpdateStatus()
         const auto changedStatus = changedEntry->second;
         ChangedObjects.erase(changedEntry);
 
+        // Touch notifications also include internal objects without a view
+        // provider. Their deletion emits no GUI provider-removal signal, so a
+        // pending address can already be dead. Check the tree's live provider
+        // registry before calling anything on it, including isAttachedToDocument.
+        auto iter = ObjectTable.find(obj);
+        if (iter == ObjectTable.end()) {
+            if (budget.exhausted()) {
+                scheduleNextSlice();
+                return;
+            }
+            continue;
+        }
+
         if (obj && obj->isAttachedToDocument() && obj->getDocument()) {
             statusUpdateObjects.push_back(
                 {obj->getDocument()->getName(), obj->getID()}
             );
-        }
-
-        auto iter = ObjectTable.find(obj);
-        if (iter == ObjectTable.end()) {
-            continue;
         }
 
         if (changedStatus.test(CS_Error) && obj->isError()) {

--- a/src/Gui/ViewProviderDragger.cpp
+++ b/src/Gui/ViewProviderDragger.cpp
@@ -104,6 +104,16 @@ void ViewProviderDragger::resetTransformOrigin()
 }
 
 
+bool ViewProviderDragger::setGizmosVisible(bool visible)
+{
+    if (!gizmoContainer) {
+        return false;
+    }
+    const bool previous = gizmoContainer->visible.getValue();
+    gizmoContainer->visible = visible;
+    return previous;
+}
+
 void ViewProviderDragger::setGizmoContainer(Gui::GizmoContainer* gizmoContainer)
 {
     this->gizmoContainer = gizmoContainer;
@@ -252,14 +262,27 @@ void ViewProviderDragger::setEditViewer(Gui::View3DInventorViewer* viewer, int M
     }
 
     if (gizmoContainer) {
+        if (!gizmoEventRedirectionActive) {
+            previousGizmoEventRedirection = viewer->isRedirectedToSceneGraph();
+            gizmoEventRedirectionActive = true;
+        }
+        // Let the editing controls consume their gestures before navigation
+        // modes such as Inventor interpret a left drag as camera rotation.
+        // Unhandled events still reach the selected navigation style.
+        viewer->setRedirectToSceneGraph(true);
         auto originPlacement = App::GeoFeature::getGlobalPlacement(getObject())
             * getObjectPlacement().inverse();
         gizmoContainer->attachViewer(viewer, originPlacement);
     }
 }
 
-void ViewProviderDragger::unsetEditViewer([[maybe_unused]] Gui::View3DInventorViewer* viewer)
-{}
+void ViewProviderDragger::unsetEditViewer(Gui::View3DInventorViewer* viewer)
+{
+    if (viewer && gizmoEventRedirectionActive) {
+        viewer->setRedirectToSceneGraph(previousGizmoEventRedirection);
+        gizmoEventRedirectionActive = false;
+    }
+}
 
 void ViewProviderDragger::dragStartCallback(void* data, [[maybe_unused]] SoDragger* d)
 {

--- a/src/Gui/ViewProviderDragger.h
+++ b/src/Gui/ViewProviderDragger.h
@@ -78,6 +78,8 @@ public:
     void resetTransformOrigin();
 
     void setGizmoContainer(Gui::GizmoContainer* gizmoContainer);
+    /// Temporarily show/hide task gizmos; returns their previous visibility.
+    bool setGizmosVisible(bool visible);
 
 public:
     /** @name Edit methods */
@@ -156,6 +158,8 @@ private:
     );
 
     GizmoContainer* gizmoContainer = nullptr;
+    bool previousGizmoEventRedirection {false};
+    bool gizmoEventRedirectionActive {false};
 };
 
 }  // namespace Gui

--- a/src/Mod/PartDesign/App/DesignFeature.cpp
+++ b/src/Mod/PartDesign/App/DesignFeature.cpp
@@ -785,6 +785,24 @@ App::DocumentObjectExecReturn* computeOutputShapes(
                     intersects = true;
                     break;
                 }
+                if (resultOperation == "Join") {
+                    // Solid/solid Common discards lower-dimensional contact.
+                    // An outward pad shares a face with its support, so test
+                    // the tool boundary as faces. Edge/point contact remains
+                    // invalid; compound Body policy is validated below.
+                    Part::TopoShape boundary;
+                    boundary.makeElementCompound(toolSolid.getSubTopoShapes(TopAbs_FACE));
+                    overlap.makeElementBoolean(
+                        Part::OpCodes::Common,
+                        {base, boundary},
+                        nullptr,
+                        fuzzyTolerance
+                    );
+                    if (!overlap.isNull() && overlap.hasSubShape(TopAbs_FACE)) {
+                        intersects = true;
+                        break;
+                    }
+                }
             }
             if (!intersects) {
                 return outputError(

--- a/src/Mod/PartDesign/App/DesignFeature.cpp
+++ b/src/Mod/PartDesign/App/DesignFeature.cpp
@@ -65,6 +65,35 @@
 
 using namespace PartDesign;
 
+bool PartDesign::designToolContactsBody(
+    const Part::TopoShape& body,
+    const Part::TopoShape& tool,
+    bool allowFaceContact,
+    double fuzzyTolerance
+)
+{
+    for (const auto& solid : tool.getSubTopoShapes(TopAbs_SOLID)) {
+        Part::TopoShape overlap;
+        overlap.makeElementBoolean(Part::OpCodes::Common, {body, solid}, nullptr, fuzzyTolerance);
+        if (!overlap.isNull() && overlap.hasSubShape(TopAbs_SOLID)) {
+            return true;
+        }
+        if (allowFaceContact) {
+            // Solid Common discards shared faces. Join permits face contact,
+            // but Cut/Intersect require volume; edge/point contact is not enough.
+            Part::TopoShape boundary;
+            boundary.makeElementCompound(solid.getSubTopoShapes(TopAbs_FACE));
+            overlap.makeElementBoolean(
+                Part::OpCodes::Common, {body, boundary}, nullptr, fuzzyTolerance
+            );
+            if (!overlap.isNull() && overlap.hasSubShape(TopAbs_FACE)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
 namespace
 {
 
@@ -687,6 +716,12 @@ App::DocumentObjectExecReturn* computeOutputShapes(
         return outputError("The operation did not generate a valid tool solid");
     }
 
+    if (inputs.empty() && inputBodyIds.empty() && inputFrames.empty()
+        && outputBodyIds.empty() && outputFrames.empty() && previousInputIndices.empty()
+        && outputComponentIds.empty()
+        && (resultOperation == "Join" || resultOperation == "Cut" || resultOperation == "Intersect")) {
+        return outputError("Select at least one target Body for " + std::string(resultOperation));
+    }
     if (inputs.size() != inputBodyIds.size() || inputs.size() != inputFrames.size()
         || outputBodyIds.empty() || outputFrames.size() != outputBodyIds.size()
         || previousInputIndices.size() != outputBodyIds.size()
@@ -772,38 +807,9 @@ App::DocumentObjectExecReturn* computeOutputShapes(
             }
             const Part::TopoShape localTool = transformedShape(tool, outputFrames[index].inverse());
 
-            bool intersects = false;
-            for (const auto& toolSolid : localTool.getSubTopoShapes(TopAbs_SOLID)) {
-                Part::TopoShape overlap;
-                overlap.makeElementBoolean(
-                    Part::OpCodes::Common,
-                    {base, toolSolid},
-                    nullptr,
-                    fuzzyTolerance
-                );
-                if (!overlap.isNull() && overlap.hasSubShape(TopAbs_SOLID)) {
-                    intersects = true;
-                    break;
-                }
-                if (resultOperation == "Join") {
-                    // Solid/solid Common discards lower-dimensional contact.
-                    // An outward pad shares a face with its support, so test
-                    // the tool boundary as faces. Edge/point contact remains
-                    // invalid; compound Body policy is validated below.
-                    Part::TopoShape boundary;
-                    boundary.makeElementCompound(toolSolid.getSubTopoShapes(TopAbs_FACE));
-                    overlap.makeElementBoolean(
-                        Part::OpCodes::Common,
-                        {base, boundary},
-                        nullptr,
-                        fuzzyTolerance
-                    );
-                    if (!overlap.isNull() && overlap.hasSubShape(TopAbs_FACE)) {
-                        intersects = true;
-                        break;
-                    }
-                }
-            }
+            const bool intersects = designToolContactsBody(
+                base, localTool, resultOperation == "Join", fuzzyTolerance
+            );
             if (!intersects) {
                 return outputError(
                     std::string("The operation does not intersect selected Body '")

--- a/src/Mod/PartDesign/App/DesignFeature.h
+++ b/src/Mod/PartDesign/App/DesignFeature.h
@@ -31,6 +31,17 @@ namespace PartDesign
 
 class Body;
 
+/** Exact contact rule shared by Design Boolean execution and target suggestions.
+ * Shapes must use the same coordinate frame. Callers doing concurrent work
+ * must supply private geometry copies, not mutable document-owned shapes.
+ */
+PartDesignExport bool designToolContactsBody(
+    const Part::TopoShape& body,
+    const Part::TopoShape& tool,
+    bool allowFaceContact,
+    double fuzzyTolerance = 0.0
+);
+
 /** UUID sentinel used when a publication points to a legacy non-state tip. */
 inline constexpr const char* NoDesignBodyStateId = "00000000-0000-4000-8000-000000000000";
 

--- a/src/Mod/PartDesign/Gui/TaskDesignOperation.cpp
+++ b/src/Mod/PartDesign/Gui/TaskDesignOperation.cpp
@@ -12,6 +12,8 @@
 #include <QListWidget>
 #include <QMessageBox>
 #include <QPushButton>
+#include <QPointer>
+#include <QTimer>
 #include <QSignalBlocker>
 #include <QSpinBox>
 #include <QVBoxLayout>
@@ -26,6 +28,8 @@
 #include <unordered_set>
 
 #include <App/Document.h>
+#include <App/Application.h>
+#include <App/HostRuntime.h>
 #include <App/DocumentTimeline.h>
 #include <App/GeoFeature.h>
 #include <App/Part.h>
@@ -36,6 +40,7 @@
 #include <Gui/BitmapFactory.h>
 #include <Gui/Command.h>
 #include <Gui/MainWindow.h>
+#include <Gui/FrameBudget.h>
 #include <Gui/Selection/Selection.h>
 #include <Gui/ViewProvider.h>
 #include <Mod/Part/App/Part2DObject.h>
@@ -49,6 +54,8 @@
 
 #include "ReferenceSelection.h"
 #include "Utils.h"
+#include "TaskDialogState.h"
+#include "ViewProvider.h"
 
 using namespace PartDesignGui;
 
@@ -69,6 +76,7 @@ QString bodyDisplayName(const PartDesign::Body& body)
 
 TaskDesignProfileRegions::TaskDesignProfileRegions(App::DocumentObject* operation, QWidget* parent)
     : TaskBox(Gui::BitmapFactory().pixmap("Sketcher_Sketch"), tr("Profiles"), true, parent)
+    , Gui::SelectionObserver(false)
     , operation(operation)
     , sketchName(new QLabel(this))
     , regionSummary(new QLabel(this))
@@ -151,19 +159,23 @@ void TaskDesignProfileRegions::setError(const QString& message)
 
 void TaskDesignProfileRegions::restoreSelectionSketchVisibility()
 {
-    if (selectionSketchName.empty() || !operation || !operation->getDocument()
-        || selectionSketchWasVisible || !Gui::Application::Instance) {
-        selectionSketchName.clear();
-        selectionSketchWasVisible = false;
+    detachSelection();
+    if (!pickingVisibility) {
         return;
     }
-    if (auto* sketch = operation->getDocument()->getObject(selectionSketchName.c_str())) {
-        if (auto* viewProvider = Gui::Application::Instance->getViewProvider(sketch)) {
-            viewProvider->hide();
+    auto* document = App::GetApplication().getDocument(selectionDocumentName.c_str());
+    if (document) {
+        pickingVisibility->restore(document);
+        auto* object = document->getObjectByID(selectionOperationId);
+        if (auto* view = object
+                ? Gui::Application::Instance->getViewProvider<PartDesignGui::ViewProvider>(object)
+                : nullptr) {
+            view->setProfilePicking(false);
+            view->showPreview(pickingPreviewWasEnabled);
         }
     }
-    selectionSketchName.clear();
-    selectionSketchWasVisible = false;
+    pickingVisibility.reset();
+    selectionDocumentName.clear();
 }
 
 void TaskDesignProfileRegions::toggleRegionSelection(bool selecting)
@@ -179,7 +191,23 @@ void TaskDesignProfileRegions::toggleRegionSelection(bool selecting)
 
     if (selecting) {
         restoreSelectionSketchVisibility();
-        selectionSketchName = sketch->getNameInDocument();
+        pickingVisibility = std::make_unique<TaskInternal::VisibilitySnapshot>();
+        selectionDocumentName = operation->getDocument()->getName();
+        selectionOperationId = operation->getID();
+        pickingVisibility->captureObject(sketch);
+        for (auto* body : operation->getDocument()->getObjectsOfType<PartDesign::Body>()) {
+            pickingVisibility->captureObject(body);
+            if (auto* view = Gui::Application::Instance->getViewProvider(body)) {
+                view->hide();
+            }
+        }
+        pickingVisibility->captureObject(operation);
+        if (auto* view = Gui::Application::Instance->getViewProvider<PartDesignGui::ViewProvider>(operation)) {
+            view->setProfilePicking(true);
+            pickingPreviewWasEnabled = view->isPreviewEnabled();
+            view->showPreview(false);
+            view->hide();
+        }
         if (auto* sketchObject = freecad_cast<Sketcher::SketchObject*>(sketch);
             sketchObject && !sketchObject->MakeInternals.getValue()) {
             sketchObject->MakeInternals.setValue(true);
@@ -187,14 +215,15 @@ void TaskDesignProfileRegions::toggleRegionSelection(bool selecting)
         }
         if (Gui::Application::Instance) {
             if (auto* viewProvider = Gui::Application::Instance->getViewProvider(sketch)) {
-                selectionSketchWasVisible = viewProvider->isVisible();
                 viewProvider->show();
             }
         }
         Gui::Selection().clearSelection(sketch->getDocument()->getName());
+        attachSelection();
+        regionSummary->setText(tr("No areas selected"));
         selectRegions->setText(tr("Done"));
         entireSketch->setEnabled(false);
-        setError(tr("Select one or more filled sketch areas in the 3D view, then click Done."));
+        setError(tr("Bodies are temporarily hidden. Click inside a filled sketch area; use Ctrl-click for more areas, then click Done. Edges are not areas."));
         return;
     }
 
@@ -231,6 +260,29 @@ bool TaskDesignProfileRegions::applyViewportSelection()
         return false;
     }
     return setProfile(*selection.sketch, selection.regions);
+}
+
+void TaskDesignProfileRegions::onSelectionChanged(const Gui::SelectionChanges&)
+{
+    if (!selectRegions->isChecked() || !operation || !operation->getDocument()) {
+        return;
+    }
+    SketchProfileSelection selection;
+    for (auto& selected : Gui::Selection().getSelectionEx(operation->getDocument()->getName())) {
+        auto* sketch = freecad_cast<Part::Part2DObject*>(selected.getObject());
+        if (!sketch) {
+            selection.valid = false;
+            continue;
+        }
+        mergeSketchProfileSelection(selection, *sketch, selected.getSubNames());
+    }
+    regionSummary->setText(tr("%n selected area(s)", nullptr, static_cast<int>(selection.regions.size())));
+    if (!selection.valid || selection.wholeSketch) {
+        setError(tr("Click inside a filled sketch area, not an edge or a tree item."));
+    }
+    else if (!selection.regions.empty()) {
+        setError(tr("Selected areas are highlighted in the view. Ctrl-click to add/remove areas; click Done to use them."));
+    }
 }
 
 bool TaskDesignProfileRegions::setProfile(
@@ -496,6 +548,10 @@ TaskDesignOperationTargets::TaskDesignOperationTargets(App::DocumentObject* oper
         proxy
     ));
     layout->addWidget(targetBodies);
+    targetHint = new QLabel(proxy);
+    targetHint->setObjectName(QStringLiteral("DesignTargetHint"));
+    targetHint->setWordWrap(true);
+    layout->addWidget(targetHint);
     if (splitMode) {
         auto* buttons = new QHBoxLayout();
         buttons->addWidget(addSplitDefinitions);
@@ -523,7 +579,35 @@ TaskDesignOperationTargets::TaskDesignOperationTargets(App::DocumentObject* oper
         this,
         &TaskDesignOperationTargets::applySelection
     );
-    connect(targetBodies, &QListWidget::itemChanged, this, &TaskDesignOperationTargets::applySelection);
+    connect(targetBodies, &QListWidget::itemChanged, this, [this]() {
+        targetSelectionExplicit = true;
+        if (targetSearch) {
+            targetSearch->request_stop();
+        }
+        applySelection();
+    });
+    targetGeometryConnection = operation->getDocument()->signalChangedObject.connect(
+        [this](const App::DocumentObject& object, const App::Property& property) {
+            const std::string_view name = property.getName();
+            if ((&object == this->operation && name == "AddSubShape")
+                || name == "Shape" || name == "Placement") {
+                queueTargetSuggestion();
+            }
+        }
+    );
+    targetDeletionConnection = operation->getDocument()->signalDeletedObject.connect(
+        [this](const App::DocumentObject& object) {
+            if (&object == this->operation) {
+                // Cancel rolls the provisional operation back before Qt deletes
+                // its task widgets. Invalidate queued work at that boundary.
+                targetGeometryConnection.disconnect();
+                if (targetSearch) {
+                    targetSearch->request_stop();
+                }
+                this->operation = nullptr;
+            }
+        }
+    );
     if (scaleMode) {
         connect(scaleUniform, &QCheckBox::toggled, this, [this](bool uniform) {
             scaleUniformFactor->setEnabled(uniform);
@@ -619,7 +703,156 @@ TaskDesignOperationTargets::TaskDesignOperationTargets(App::DocumentObject* oper
     }
 }
 
-TaskDesignOperationTargets::~TaskDesignOperationTargets() = default;
+TaskDesignOperationTargets::~TaskDesignOperationTargets()
+{
+    if (targetSearch) {
+        targetSearch->request_stop();
+    }
+}
+
+void TaskDesignOperationTargets::queueTargetSuggestion()
+{
+    if (targetSearch) {
+        targetSearch->request_stop();
+    }
+    if (suggestionQueued) {
+        return;
+    }
+    suggestionQueued = true;
+    QTimer::singleShot(0, this, [this]() {
+        suggestionQueued = false;
+        suggestTargets();
+    });
+}
+
+void TaskDesignOperationTargets::suggestTargets()
+{
+    auto* feature = freecad_cast<PartDesign::ProfileBased*>(operation);
+    const auto mode = resultMode->currentData().toString();
+    if (!feature || fixedResultMode || fixedModifyMode
+        || (mode != QStringLiteral("Join") && mode != QStringLiteral("Cut")
+            && mode != QStringLiteral("Intersect"))) {
+        targetHint->clear();
+        return;
+    }
+    if (!selectedBodies().empty()) {
+        targetHint->setText(tr("Checked Bodies will be modified. Uncheck a Body to exclude it."));
+        return;
+    }
+    if (targetSelectionExplicit) {
+        targetHint->setText(tr("Check at least one target Body to continue."));
+        return;
+    }
+    auto* additive = freecad_cast<PartDesign::FeatureAddSub*>(feature);
+    if (!additive || additive->AddSubShape.getShape().isNull()) {
+        targetHint->setText(tr("Set a valid profile and length before choosing target Bodies."));
+        return;
+    }
+
+    struct Candidate {
+        int row;
+        TopoDS_Shape shape;
+        Base::Placement frame;
+    };
+    std::vector<Candidate> candidates;
+    for (int row = 0; row < targetBodies->count(); ++row) {
+        auto* body = bodies.at(static_cast<std::size_t>(row));
+        auto* state = freecad_cast<Part::Feature*>(PartDesign::designBodyStateBefore(
+            body, edit.provisionalOperation ? nullptr : operation
+        ));
+        if (state && !state->Shape.getShape().isNull()
+            && targetBodies->item(row)->flags().testFlag(Qt::ItemIsEnabled)) {
+            candidates.push_back({row, state->Shape.getShape().getShape(),
+                                  App::GeoFeature::getGlobalPlacement(body)});
+        }
+    }
+    targetHint->setText(tr("Finding intersecting Bodies…"));
+    auto cancellation = std::make_shared<std::stop_source>();
+    targetSearch = cancellation;
+    QPointer<TaskDesignOperationTargets> task(this);
+    const auto frame = App::GeoFeature::getGlobalPlacement(feature);
+    const auto tool = additive->AddSubShape.getShape().getShape();
+    const auto* toleranceProperty = dynamic_cast<const App::PropertyFloat*>(feature->getPropertyByName("FuzzyTolerance"));
+    const double tolerance = toleranceProperty ? toleranceProperty->getValue() : 0.0;
+    auto* runtime = &App::GetApplication().hostRuntime();
+    runtime->submitWithCompletion(
+        App::HostRuntime::Lane::Compute,
+        [candidates = std::move(candidates), tool, frame, mode, tolerance, cancellation, runtime]
+        (std::stop_token stop) {
+            std::vector<int> matches;
+            std::vector<unsigned char> contact(candidates.size(), 0);
+            runtime->parallelFor(candidates.size(), [&](std::size_t index) {
+                if (stop.stop_requested() || cancellation->stop_requested()) {
+                    cancellation->request_stop();
+                    return;
+                }
+                const auto& candidate = candidates[index];
+                auto privateTool = Part::TopoShape(tool).makeElementCopy();
+                privateTool.transformShape(frame.toMatrix(), true, true);
+                auto privateBody = Part::TopoShape(candidate.shape).makeElementCopy();
+                privateBody.transformShape(candidate.frame.toMatrix(), true, true);
+                auto bounds = privateTool.getBoundBox();
+                bounds.Enlarge(tolerance);
+                if (bounds.Intersect(privateBody.getBoundBox()) && PartDesign::designToolContactsBody(
+                        privateBody, privateTool, mode == QStringLiteral("Join"), tolerance)) {
+                    contact[index] = 1;
+                }
+            });
+            for (std::size_t index = 0; index < candidates.size(); ++index) {
+                if (contact[index]) {
+                    matches.push_back(candidates[index].row);
+                }
+            }
+            return matches;
+        },
+        [task, cancellation](std::future<std::vector<int>> future) {
+            std::vector<int> matches;
+            QString error;
+            try {
+                matches = future.get();
+            }
+            catch (const Standard_Failure& failure) {
+                error = QString::fromUtf8(failure.GetMessageString());
+            }
+            catch (const std::exception& failure) {
+                error = QString::fromUtf8(failure.what());
+            }
+            Gui::dispatchToGuiFrame([task, cancellation, matches = std::move(matches), error]() {
+                if (!task || cancellation->stop_requested()
+                    || task->targetSearch != cancellation || task->targetSelectionExplicit) {
+                    return;
+                }
+                if (!error.isEmpty()) {
+                    task->targetHint->setText(tr("Target detection failed: %1. Select Bodies manually.").arg(error));
+                    return;
+                }
+                if (matches.size() == 1) {
+                    {
+                        const QSignalBlocker blocker(task->targetBodies);
+                        task->targetBodies->item(matches.front())->setCheckState(Qt::Checked);
+                    }
+                    task->configureOperation();
+                    task->targetHint->setText(tr("Selected the only intersecting Body. Review the checked target before accepting."));
+                }
+                else {
+                    const QSignalBlocker blocker(task->targetBodies);
+                    for (int row = 0; row < task->targetBodies->count(); ++row) {
+                        auto* item = task->targetBodies->item(row);
+                        auto font = item->font();
+                        font.setBold(std::ranges::find(matches, row) != matches.end());
+                        item->setFont(font);
+                    }
+                    for (int row : matches) {
+                        task->targetBodies->item(row)->setToolTip(tr("Intersects this operation; check to include."));
+                    }
+                    task->targetHint->setText(matches.empty()
+                        ? tr("No Body intersects this operation. Adjust its length or direction, or choose New Body.")
+                        : tr("%n Bodies intersect. Check the Bodies you want to modify.", nullptr, static_cast<int>(matches.size())));
+                }
+            });
+        }
+    );
+}
 
 PartDesign::DesignOperationProperties* TaskDesignOperationTargets::operationProperties() const
 {
@@ -1312,6 +1545,7 @@ void TaskDesignOperationTargets::configureOperation()
         feature->recomputeFeature();
         feature->recomputePreview();
     }
+    queueTargetSuggestion();
 }
 
 void TaskDesignOperationTargets::configureScale()

--- a/src/Mod/PartDesign/Gui/TaskDesignOperation.h
+++ b/src/Mod/PartDesign/Gui/TaskDesignOperation.h
@@ -4,6 +4,10 @@
 
 #include <string>
 #include <vector>
+#include <memory>
+#include <stop_token>
+#include <App/MainThreadSignal.h>
+#include <Gui/Selection/Selection.h>
 
 #include <App/PropertyLinks.h>
 #include <Base/Vector3D.h>
@@ -39,9 +43,10 @@ class ProfileBased;
 
 namespace PartDesignGui
 {
+namespace TaskInternal { class VisibilitySnapshot; }
 
 /** Select exact closed areas from one reusable sketch. */
-class TaskDesignProfileRegions: public Gui::TaskView::TaskBox
+class TaskDesignProfileRegions: public Gui::TaskView::TaskBox, public Gui::SelectionObserver
 {
     Q_OBJECT
 
@@ -63,6 +68,7 @@ private:
     void populate();
     void restoreSelectionSketchVisibility();
     void setError(const QString& message);
+    void onSelectionChanged(const Gui::SelectionChanges&) override;
 
     App::DocumentObject* operation {};
     QLabel* sketchName {};
@@ -70,8 +76,10 @@ private:
     QLabel* instruction {};
     QPushButton* selectRegions {};
     QPushButton* entireSketch {};
-    std::string selectionSketchName;
-    bool selectionSketchWasVisible {false};
+    std::string selectionDocumentName;
+    long selectionOperationId {0};
+    std::unique_ptr<TaskInternal::VisibilitySnapshot> pickingVisibility;
+    bool pickingPreviewWasEnabled {false};
 };
 
 /**
@@ -106,6 +114,8 @@ private:
     void populatePatternParameters();
     void populateScaleParameters();
     void configureOperation();
+    void queueTargetSuggestion();
+    void suggestTargets();
     void configurePattern();
     void configureScale();
     void updatePatternReferenceLabel();
@@ -149,6 +159,12 @@ private:
     QDoubleSpinBox* scaleYFactor {};
     QDoubleSpinBox* scaleZFactor {};
     QLabel* separateSummary {};
+    QLabel* targetHint {};
+    fastsignals::scoped_connection targetGeometryConnection;
+    fastsignals::scoped_connection targetDeletionConnection;
+    std::shared_ptr<std::stop_source> targetSearch;
+    bool suggestionQueued {false};
+    bool targetSelectionExplicit {false};
     QWidget* patternOriginEditor {};
     QWidget* patternDirectionEditor {};
     QWidget* scaleCenterEditor {};

--- a/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
+++ b/src/Mod/PartDesign/Gui/TaskExtrudeParameters.cpp
@@ -24,6 +24,9 @@
 
 #include <QSignalBlocker>
 #include <QAction>
+#include <Inventor/nodes/SoCoordinate3.h>
+#include <Inventor/nodes/SoFaceSet.h>
+#include <Inventor/nodes/SoMaterial.h>
 
 
 #include <App/Document.h>
@@ -1423,13 +1426,17 @@ void TaskExtrudeParameters::setGizmoPositions()
     }
 
     auto extrude = getObject<PartDesign::FeatureExtrude>();
-    if (!extrude || extrude->isError()) {
+    if (!extrude || !extrude->Profile.getValue()) {
         gizmoContainer->visible = false;
         return;
     }
     gizmoContainer->visible = true;
 
     PartDesign::TopoShape shape = extrude->getProfileShape();
+    if (shape.isNull()) {
+        gizmoContainer->visible = false;
+        return;
+    }
     Base::Vector3d center = getMidPointFromProfile(shape);
     std::string sideType = std::string(extrude->SideType.getValueAsString());
     std::string extrudeType = std::string(extrude->Type.getValueAsString());
@@ -1444,6 +1451,31 @@ void TaskExtrudeParameters::setGizmoPositions()
     lengthGizmo2->setVisibility(sideType == "Two sides" && extrudeType2 == "Length");
     taperAngleGizmo2->placeOverLinearGizmo(lengthGizmo2);
     taperAngleGizmo2->setVisibility(sideType == "Two sides" && extrudeType2 == "Length");
+
+    // The end plane uses the existing length dragger and spinbox binding:
+    // reverse, symmetric/two-sided lengths, expressions, snapping and undo
+    // therefore follow exactly the same path as the arrow.
+    const auto box = shape.getBoundBox();
+    const float halfSize = static_cast<float>(box.CalcDiagonalLength() * 0.5);
+    if (halfSize > 0) {
+        for (auto* gizmo : {lengthGizmo1, lengthGizmo2}) {
+            auto* dragger = gizmo->getDraggerContainer()->getDragger();
+            auto* surface = static_cast<SoSeparator*>(dragger->getPart("dragSurface", true));
+            surface->removeAllChildren();
+            auto* material = new SoMaterial;
+            material->diffuseColor.setValue(0.25F, 0.65F, 1.0F);
+            material->transparency = 0.8F;
+            auto* coordinates = new SoCoordinate3;
+            const SbVec3f points[] = {{-halfSize, 0, -halfSize}, {halfSize, 0, -halfSize},
+                                     {halfSize, 0, halfSize}, {-halfSize, 0, halfSize}};
+            coordinates->point.setValues(0, 4, points);
+            auto* face = new SoFaceSet;
+            face->numVertices = 4;
+            surface->addChild(material);
+            surface->addChild(coordinates);
+            surface->addChild(face);
+        }
+    }
 
     Base::Vector3d padDir = extrude->Direction.getValue().Normalized();
     Base::Vector3d sketchDir = extrude->getProfileNormal().Normalized();

--- a/src/Mod/PartDesign/Gui/ViewProvider.cpp
+++ b/src/Mod/PartDesign/Gui/ViewProvider.cpp
@@ -52,6 +52,7 @@
 #include <Mod/Part/Gui/SoBrepEdgeSet.h>
 
 #include "TaskFeatureParameters.h"
+#include "TaskDialogState.h"
 #include "StyleParameters.h"
 
 #include "ViewProvider.h"
@@ -118,6 +119,7 @@ ViewProvider::~ViewProvider() = default;
 
 void ViewProvider::beforeDelete()
 {
+    finalResultRecomputeConnection.disconnect();
     ViewProviderPart::beforeDelete();
 }
 
@@ -251,6 +253,9 @@ TaskDlgFeatureParameters* ViewProvider::getEditDialog()
 
 void ViewProvider::unsetEdit(int ModNum)
 {
+    if (finalResultVisibility) {
+        showPreviousFeature(true);
+    }
     showPreview(false);
 
     // return to the WB we were in before editing the PartDesign feature
@@ -274,6 +279,12 @@ void ViewProvider::unsetEdit(int ModNum)
 
 void ViewProvider::updateData(const App::Property* prop)
 {
+    if (auto* operation = dynamic_cast<PartDesign::DesignOperationProperties*>(getObject());
+        finalResultVisibility && operation
+        && (prop == &operation->OutputShapes || prop == &operation->OutputFrames
+            || prop == &operation->OutputPresence)) {
+        updateVisual();
+    }
     if (auto* operation = dynamic_cast<PartDesign::DesignOperationProperties*>(getObject());
         operation && prop == &operation->ResultOperation) {
         updateOperationPreviewColor(*this);
@@ -454,6 +465,51 @@ Part::TopoShape ViewProvider::getPreviewShape() const
     return {};
 }
 
+Part::TopoShape ViewProvider::getRenderedShape() const
+{
+    auto* operation = dynamic_cast<const PartDesign::DesignOperationProperties*>(getObject());
+    if (!finalResultVisibility || !operation) {
+        return inherited::getRenderedShape();
+    }
+    if (getObject()->isError() || profilePicking) {
+        return {};
+    }
+    const auto& outputs = operation->OutputShapes.getValues();
+    const auto& frames = operation->OutputFrames.getValues();
+    const auto& present = operation->OutputPresence.getValues();
+    if (outputs.size() != frames.size() || outputs.size() != present.size()) {
+        return {};
+    }
+    std::vector<Part::TopoShape> shapes;
+    const auto local = App::GeoFeature::getGlobalPlacement(getObject()).inverse();
+    for (std::size_t index = 0; index < outputs.size(); ++index) {
+        if (present[index] && !outputs[index].isNull()) {
+            auto shape = outputs[index];
+            shape.transformShape((local * frames[index]).toMatrix(), true, true);
+            shapes.push_back(std::move(shape));
+        }
+    }
+    Part::TopoShape result;
+    if (!shapes.empty()) {
+        result.makeElementCompound(shapes);
+    }
+    return result;
+}
+
+void ViewProvider::setProfilePicking(bool enabled)
+{
+    if (enabled == profilePicking) {
+        return;
+    }
+    profilePicking = enabled;
+    if (enabled) {
+        gizmosBeforePicking = setGizmosVisible(false);
+    }
+    else {
+        setGizmosVisible(gizmosBeforePicking);
+    }
+}
+
 void ViewProvider::showPreviousFeature(bool enable)
 {
     PartDesign::Feature* feature {getObject<PartDesign::Feature>()};
@@ -462,6 +518,44 @@ void ViewProvider::showPreviousFeature(bool enable)
     ViewProvider* baseFeatureViewProvider {nullptr};
 
     if (!feature) {
+        return;
+    }
+
+    if (auto* operation = dynamic_cast<PartDesign::DesignOperationProperties*>(feature)) {
+        if (enable) {
+            finalResultRecomputeConnection.disconnect();
+            if (finalResultVisibility) {
+                finalResultVisibility->restore(feature->getDocument());
+                finalResultVisibility.reset();
+            }
+            hide();
+        }
+        else {
+            if (!finalResultRecomputeConnection.connected()) {
+                finalResultRecomputeConnection = feature->getDocument()->signalRecomputedObject.connect(
+                    [this](const App::DocumentObject& object) {
+                        if (&object == getObject() && finalResultVisibility) {
+                            showPreviousFeature(false);
+                        }
+                    }
+                );
+            }
+            if (finalResultVisibility) {
+                finalResultVisibility->restore(feature->getDocument());
+            }
+            finalResultVisibility = std::make_unique<TaskInternal::VisibilitySnapshot>();
+            const auto& ids = operation->OutputBodyIds.getValues();
+            for (auto* body : feature->getDocument()->getObjectsOfType<PartDesign::Body>()) {
+                if (std::ranges::find(ids, body->VibeCADBodyId.getValueStr()) != ids.end()) {
+                    finalResultVisibility->captureObject(body);
+                    if (auto* view = Gui::Application::Instance->getViewProvider(body)) {
+                        view->hide();
+                    }
+                }
+            }
+            show();
+        }
+        updateVisual();
         return;
     }
 

--- a/src/Mod/PartDesign/Gui/ViewProvider.h
+++ b/src/Mod/PartDesign/Gui/ViewProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <App/DocumentObject.h>
+#include <App/MainThreadSignal.h>
 #include <Gui/ViewProviderFeaturePython.h>
 #include <Gui/ViewProviderSuppressibleExtension.h>
 #include <Mod/Part/Gui/ViewProvider.h>
@@ -38,6 +39,10 @@
 
 namespace PartDesignGui
 {
+namespace TaskInternal
+{
+class VisibilitySnapshot;
+}
 
 class TaskDlgFeatureParameters;
 
@@ -92,8 +97,10 @@ public:
 
     /// Provides preview shape
     Part::TopoShape getPreviewShape() const override;
+    Part::TopoShape getRenderedShape() const override;
     /// Toggles visibility of the preview
     void showPreviousFeature(bool);
+    void setProfilePicking(bool enabled);
 
     PyObject* getPyObject() override;
 
@@ -129,6 +136,10 @@ protected:
     bool isSetTipIcon {false};
 
 private:
+    std::unique_ptr<TaskInternal::VisibilitySnapshot> finalResultVisibility;
+    fastsignals::scoped_connection finalResultRecomputeConnection;
+    bool profilePicking {false};
+    bool gizmosBeforePicking {false};
     Gui::CoinPtr<PartGui::SoPreviewShape> pcToolPreview;
 };
 

--- a/src/Mod/PartDesign/PartDesignTests/TestDesignModeling.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestDesignModeling.py
@@ -623,6 +623,77 @@ class TestDesignModeling(unittest.TestCase):
         self.assertEqual(len(reopened_body.Shape.Solids), 18)
         PartDesign.validateDesign(reopened_operation)
 
+    def test_extrude_join_accepts_face_contact_with_target_body(self):
+        _, body, initial = self._component_body("FaceContactJoin", 0)
+        sketch = self._rectangle_sketch("FaceContactJoinProfile", 2, 6, 2, 6)
+        sketch.Placement.Base.z = 10
+
+        self.document.openTransaction("Join outward extrusion to target face")
+        operation = self.document.addObject(
+            "PartDesign::DesignExtrude",
+            "FaceContactJoinOperation",
+        )
+        edit = PartDesign.beginDesignOperationEdit(operation)
+        operation.Profile = sketch
+        operation.Length = 5
+        PartDesign.setDesignOperationTargets(edit, "Join", [body])
+        self.document.recompute()
+
+        self.assertTrue(operation.isValid(), operation.getStatusString())
+        self.assertEqual(len(operation.OutputShapes), 1)
+        self.assertEqual(len(operation.OutputShapes[0].Solids), 1)
+        self.assertAlmostEqual(
+            operation.OutputShapes[0].Volume,
+            initial.Shape.Volume + 80.0,
+            places=6,
+        )
+
+        outputs = PartDesign.finalizeDesignOperationEdit(edit)
+        self.document.commitTransaction()
+        self.assertEqual(outputs, [body])
+        self.assertAlmostEqual(body.Shape.Volume, 1080.0, places=6)
+        PartDesign.validateDesign(operation)
+
+    def test_extrude_contact_modes_preserve_boolean_and_compound_contracts(self):
+        for mode, x, y, z, accepted, expected_volume in (
+            ("Join", 2, 2, 10, True, 1080),  # shared face
+            ("Join", 2, 2, 9, True, 1064),  # volume overlap
+            ("Join", 2, 2, 10.01, False, None),  # gap
+            ("Join", 10, 2, 10, False, None),  # shared edge
+            ("Join", 10, 10, 10, False, None),  # shared vertex
+            ("Cut", 2, 2, 10, False, None),
+            ("Intersect", 2, 2, 10, False, None),
+            ("Cut", 2, 2, 9, True, 984),
+            ("Intersect", 2, 2, 9, True, 16),
+        ):
+            for compound in (False, True):
+                with self.subTest(mode=mode, x=x, y=y, z=z, compound=compound):
+                    self.document.openTransaction("Check extrusion contact")
+                    body, initial = self._compound_body(
+                        "ContactTarget", [(0, 0, 0), (30, 0, 0)] if compound else [(0, 0, 0)]
+                    )
+                    body.AllowCompound = compound
+                    sketch = self.document.addObject("Sketcher::SketchObject", "ContactProfile")
+                    for a, b in (((x, y), (x + 4, y)), ((x + 4, y), (x + 4, y + 4)),
+                                 ((x + 4, y + 4), (x, y + 4)), ((x, y + 4), (x, y))):
+                        sketch.addGeometry(Part.LineSegment(App.Vector(*a, 0), App.Vector(*b, 0)), False)
+                    sketch.Placement.Base.z = z
+                    operation = self.document.addObject("PartDesign::DesignExtrude", "ContactExtrude")
+                    edit = PartDesign.beginDesignOperationEdit(operation)
+                    operation.Profile = sketch
+                    operation.Length = 5
+                    PartDesign.setDesignOperationTargets(edit, mode, [body])
+                    self.document.recompute()
+                    self.assertEqual(operation.isValid(), accepted, operation.getStatusString())
+                    if accepted:
+                        output = operation.OutputShapes[0]
+                        self.assertTrue(output.isValid())
+                        extra_volume = 1000 if compound and mode != "Intersect" else 0
+                        self.assertAlmostEqual(output.Volume, expected_volume + extra_volume, places=6)
+                        self.assertEqual(len(output.Solids), 2 if extra_volume else 1)
+                    self.assertAlmostEqual(initial.Shape.Volume, 2000 if compound else 1000)
+                    self.document.abortTransaction()
+
     def test_new_body_accepts_disconnected_profile_regions_when_compounds_are_allowed(self):
         sketch, _ = self._master_circle_sketch("CompoundNewBodyProfile")
         operation, body = self._new_body_operation(

--- a/src/Mod/PartDesign/PartDesignTests/TestDesignProfileRegionsGui.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestDesignProfileRegionsGui.py
@@ -315,6 +315,41 @@ class TestDesignProfileRegionsGui(unittest.TestCase):
         self._process_events()
         assert_preview_rgb((0.0, 1.0, 0.6))
 
+    def test_face_attached_extrude_join_accepts_through_task_panel(self):
+        self.document.openTransaction("Create supported extrusion profile")
+        body = self.document.addObject("PartDesign::Body", "JoinTarget")
+        initial = body.newObject("PartDesign::Feature", "JoinInitial")
+        initial.Shape = Part.makeBox(10, 10, 10)
+        body.Tip = initial
+        sketch = self.document.addObject("Sketcher::SketchObject", "SupportedProfile")
+        sketch.AttachmentSupport = [(initial, ["Face6"])]
+        sketch.MapMode = "FlatFace"
+        for a, b in (((2, 2), (6, 2)), ((6, 2), (6, 6)),
+                     ((6, 6), (2, 6)), ((2, 6), (2, 2))):
+            sketch.addGeometry(Part.LineSegment(App.Vector(*a, 0), App.Vector(*b, 0)), False)
+        self.document.recompute()
+        PartDesign.finalizeDesignDefinition(sketch)
+        self.document.commitTransaction()
+        self.document.recompute()
+        self._process_events(50)
+        Gui.Selection.clearSelection()
+        Gui.Selection.addSelection(sketch)
+        Gui.Selection.addSelection(body)
+        Gui.runCommand("PartDesign_DesignExtrude", 0)
+        self._process_events(50)
+        self.assertTrue(Gui.Control.activeDialog())
+        operation = next(obj for obj in self.document.Objects
+                         if obj.TypeId == "PartDesign::DesignExtrude")
+        self.assertEqual(operation.TypeId, "PartDesign::DesignExtrude")
+        self.assertEqual(operation.ResultOperation, "Join")
+        self.assertTrue(operation.isValid(), operation.getStatusString())
+        expected_volume = 1000 + 16 * operation.Length.Value
+        self.assertAlmostEqual(operation.OutputShapes[0].Volume, expected_volume, places=6)
+        self._close_task(QtGui.QDialogButtonBox.Ok)
+        self.assertTrue(body.Shape.isValid())
+        self.assertEqual(len(body.Shape.Solids), 1)
+        self.assertAlmostEqual(body.Shape.Volume, expected_volume, places=6)
+        PartDesign.validateDesign(operation)
 
 if __name__ == "__main__":
     unittest.main()

--- a/src/Mod/PartDesign/PartDesignTests/TestDesignProfileRegionsGui.py
+++ b/src/Mod/PartDesign/PartDesignTests/TestDesignProfileRegionsGui.py
@@ -103,8 +103,8 @@ class TestDesignProfileRegionsGui(unittest.TestCase):
         button = self._task_button(standard_button)
         self.assertIsNotNone(button)
         button.click()
-        self._process_events(50)
-        self.assertFalse(Gui.Control.activeDialog())
+        self.assertTrue(self._wait_until(lambda: not Gui.Control.activeDialog()),
+                        "The task did not finish accepting or cancelling")
 
     def _profile_button(self):
         button = Gui.getMainWindow().findChild(
@@ -237,6 +237,197 @@ class TestDesignProfileRegionsGui(unittest.TestCase):
             1,
         )
         PartDesign.validateDesign(operation)
+
+    def test_final_result_checkbox_renders_unpublished_design_output(self):
+        from pivy import coin
+
+        sketch = self._master_sketch()
+        Gui.Selection.addSelection(sketch, "InternalFace1")
+        Gui.runCommand("PartDesign_DesignExtrude", 0)
+        self.assertTrue(self._wait_until(lambda: Gui.Control.activeDialog()))
+        operation = next(
+            obj for obj in self.document.Objects
+            if obj.TypeId == "PartDesign::DesignExtrude"
+        )
+        final = Gui.getMainWindow().findChild(QtGui.QCheckBox, "showFinalCheckBox")
+        overlay = Gui.getMainWindow().findChild(
+            QtGui.QCheckBox, "showTransparentPreviewCheckBox"
+        )
+        self.assertIsNotNone(final)
+        self.assertIsNotNone(overlay)
+        overlay.setChecked(False)
+        final.setChecked(True)
+
+        def displayed_bounds():
+            action = coin.SoGetBoundingBoxAction(coin.SbViewportRegion(640, 480))
+            action.apply(operation.ViewObject.RootNode)
+            bounds = action.getBoundingBox()
+            return None if bounds.isEmpty() else bounds.getSize().getValue()
+
+        bounds = self._wait_until(displayed_bounds)
+        self.assertIsNotNone(bounds, "Final result has no visible scene geometry")
+        self.assertAlmostEqual(bounds[0], 4, places=2)
+        self.assertAlmostEqual(bounds[1], 4, places=2)
+        self.assertAlmostEqual(bounds[2], operation.Length.Value, places=2)
+        self.assertTrue(operation.Shape.isNull(), "Preview must not publish the controller Shape")
+        final.setChecked(False)
+        self._process_events()
+        self.assertIsNone(displayed_bounds())
+        self._close_task(QtGui.QDialogButtonBox.Cancel)
+
+    def test_cut_suggests_unique_intersecting_body_without_viewport_selection(self):
+        body = self.document.addObject("PartDesign::Body", "Target")
+        base = body.newObject("PartDesign::Feature", "Base")
+        base.Shape = Part.makeBox(10, 10, 10, App.Vector(-5, -5, 0))
+        body.Tip = base
+        sketch = self._master_sketch()
+        Gui.Selection.addSelection(sketch, "InternalFace1")
+        Gui.runCommand("PartDesign_DesignExtrude", 0)
+        self.assertTrue(self._wait_until(lambda: Gui.Control.activeDialog()))
+        operation = next(
+            obj for obj in self.document.Objects
+            if obj.TypeId == "PartDesign::DesignExtrude"
+        )
+        mode = Gui.getMainWindow().findChild(QtGui.QComboBox, "DesignResultOperation")
+        length = Gui.getMainWindow().findChild(QtGui.QWidget, "lengthEdit")
+        self.assertIsNotNone(length)
+        self.assertTrue(length.setProperty("rawValue", 5.0))
+        self.assertEqual(operation.Length.Value, 5.0)
+        mode.setCurrentIndex(mode.findData("Cut"))
+        self.assertTrue(
+            self._wait_until(lambda: operation.TargetBodyIds == [body.VibeCADBodyId]),
+            "The single intersecting Body was not suggested for Cut",
+        )
+        self.assertTrue(operation.isValid(), operation.getStatusString())
+        self._close_task(QtGui.QDialogButtonBox.Ok)
+        self.assertAlmostEqual(body.Shape.Volume, 1000 - 20 * 3.14159265, places=4)
+
+    def test_extrude_provides_pickable_end_plane_for_length_dragging(self):
+        from pivy import coin
+
+        view = Gui.activeDocument().activeView()
+        view.setNavigationType("Gui::InventorNavigationStyle")
+        view.setAnimationEnabled(False)
+        previous_redirection = view.getViewer().isRedirectedToSceneGraph()
+        sketch = self._master_sketch()
+        Gui.Selection.addSelection(sketch, "InternalFace1")
+        Gui.runCommand("PartDesign_DesignExtrude", 0)
+        self.assertTrue(self._wait_until(lambda: Gui.Control.activeDialog()))
+        searching = coin.SoBaseKit.isSearchingChildren()
+        try:
+            coin.SoBaseKit.setSearchingChildren(True)
+            search = coin.SoSearchAction()
+            search.setType(coin.SoType.fromName("SoLinearDragger"))
+            search.setInterest(coin.SoSearchAction.ALL)
+            search.apply(Gui.activeDocument().activeView().getSceneGraph())
+            draggers = [path.getTail() for path in search.getPaths()]
+            self.assertTrue(draggers, "Extrude length dragger is not visible")
+            surfaces = [d.getPart("dragSurface", False) for d in draggers]
+            self.assertTrue(
+                any(s is not None and s.getNumChildren() > 0 for s in surfaces),
+                "No pickable end plane is attached to the length dragger",
+            )
+        finally:
+            coin.SoBaseKit.setSearchingChildren(searching)
+
+        operation = next(o for o in self.document.Objects if o.TypeId == "PartDesign::DesignExtrude")
+        Gui.getMainWindow().findChild(QtGui.QCheckBox, "showFinalCheckBox").setChecked(True)
+        self._process_events(100)
+        view = Gui.activeDocument().activeView()
+        view.viewAxonometric()
+        view.fitAll()
+        self._process_events(100)
+        viewport = view.graphicsView().viewport()
+        initial = operation.Length.Value
+
+        def screen_point(point):
+            x, y = view.getPointOnScreen(point)
+            _, height = view.getSize()
+            ratio = viewport.devicePixelRatioF()
+            return QtCore.QPoint(round(x / ratio), round((height - y - 1) / ratio))
+
+        start = screen_point(App.Vector(1.2, 1.2, initial))
+        end = screen_point(App.Vector(1.2, 1.2, initial + 3))
+        self.assertTrue(viewport.rect().contains(start))
+
+        def mouse(kind, point, button, buttons):
+            receiver = view.graphicsView()
+            local = viewport.mapTo(receiver, point)
+            event = QtGui.QMouseEvent(
+                kind, local, viewport.mapToGlobal(point), button, buttons, QtCore.Qt.NoModifier
+            )
+            QtGui.QApplication.sendEvent(receiver, event)
+            self._process_events()
+
+        mouse(QtCore.QEvent.MouseMove, start, QtCore.Qt.NoButton, QtCore.Qt.NoButton)
+        mouse(QtCore.QEvent.MouseButtonPress, start, QtCore.Qt.LeftButton, QtCore.Qt.LeftButton)
+        self.assertTrue(
+            any(d.getPart("dragger", False).getField("active").getValue() for d in draggers),
+            "Pressing the end plane did not activate its length dragger",
+        )
+        for step in range(1, 6):
+            point = start + (end - start) * (step / 5)
+            mouse(QtCore.QEvent.MouseMove, point, QtCore.Qt.NoButton, QtCore.Qt.LeftButton)
+        mouse(QtCore.QEvent.MouseButtonRelease, end, QtCore.Qt.LeftButton, QtCore.Qt.NoButton)
+        self.assertGreater(operation.Length.Value, initial, "Dragging the end plane did not extend the feature")
+        self._close_task(QtGui.QDialogButtonBox.Cancel)
+        self.assertEqual(view.getViewer().isRedirectedToSceneGraph(), previous_redirection)
+
+    def test_area_picker_shows_live_count_and_restores_body_visibility(self):
+        body = self.document.addObject("PartDesign::Body", "Target")
+        base = body.newObject("PartDesign::Feature", "Base")
+        base.Shape = Part.makeBox(10, 10, 10)
+        body.Tip = base
+        sketch = self._master_sketch()
+        body.ViewObject.show()
+        Gui.Selection.addSelection(sketch)
+        Gui.runCommand("PartDesign_DesignExtrude", 0)
+        self.assertTrue(self._wait_until(lambda: Gui.Control.activeDialog()))
+        self._profile_button().click()
+        self.assertFalse(body.ViewObject.Visibility, "A Body can obscure the selectable sketch areas")
+        Gui.Selection.addSelection(sketch, "InternalFace1")
+        self._process_events()
+        summary = Gui.getMainWindow().findChild(QtGui.QLabel, "DesignProfileRegions")
+        self.assertEqual(summary.text(), "1 selected area(s)")
+        Gui.Selection.addSelection(sketch, "InternalFace2")
+        self._process_events()
+        self.assertEqual(summary.text(), "2 selected area(s)")
+        self._profile_button().click()
+        self._process_events()
+        self.assertTrue(body.ViewObject.Visibility)
+        self._close_task(QtGui.QDialogButtonBox.Cancel)
+
+    def test_cut_target_suggestions_leave_ambiguous_and_explicit_choices_to_user(self):
+        report = next(widget for widget in Gui.getMainWindow().findChildren(QtGui.QTextEdit)
+                      if widget.metaObject().className().endswith("ReportOutput"))
+        report_start = len(report.toPlainText())
+        for name in ("First", "Second"):
+            body = self.document.addObject("PartDesign::Body", name)
+            base = body.newObject("PartDesign::Feature", name + "Base")
+            base.Shape = Part.makeBox(10, 10, 10, App.Vector(-5, -5, 0))
+            body.Tip = base
+        sketch = self._master_sketch()
+        Gui.Selection.addSelection(sketch, "InternalFace1")
+        Gui.runCommand("PartDesign_DesignExtrude", 0)
+        self.assertTrue(self._wait_until(lambda: Gui.Control.activeDialog()))
+        mode = Gui.getMainWindow().findChild(QtGui.QComboBox, "DesignResultOperation")
+        mode.setCurrentIndex(mode.findData("Cut"))
+        hint = Gui.getMainWindow().findChild(QtGui.QLabel, "DesignTargetHint")
+        self.assertTrue(self._wait_until(lambda: "2 Bodies intersect" in hint.text()))
+        choices = Gui.getMainWindow().findChild(QtGui.QListWidget, "DesignBodyList")
+        self.assertEqual(choices.item(0).checkState(), QtCore.Qt.Unchecked)
+        self.assertEqual(choices.item(1).checkState(), QtCore.Qt.Unchecked)
+        choices.item(0).setCheckState(QtCore.Qt.Checked)
+        self._process_events()
+        choices.item(0).setCheckState(QtCore.Qt.Unchecked)
+        self._process_events(200)
+        self.assertEqual(choices.item(0).checkState(), QtCore.Qt.Unchecked)
+        self.assertIn("Check at least one", hint.text())
+        operation = next(o for o in self.document.Objects if o.TypeId == "PartDesign::DesignExtrude")
+        self.assertIn("Select at least one target Body", operation.getStatusString())
+        self._close_task(QtGui.QDialogButtonBox.Cancel)
+        self._process_events(100)
+        self.assertNotIn("Unhandled Base::Exception", report.toPlainText()[report_start:])
 
     def test_command_accepts_multiple_areas_but_not_ambiguous_edges(self):
         sketch = self._master_sketch()

--- a/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
+++ b/src/Mod/Sketcher/Gui/ViewProviderSketch.cpp
@@ -46,6 +46,7 @@
 #include <QMessageBox>
 #include <QScreen>
 #include <QTextStream>
+#include <QThread>
 #include <QToolTip>
 #include <QWindow>
 
@@ -66,6 +67,7 @@
 #include <Gui/CommandT.h>
 #include <Gui/Control.h>
 #include <Gui/Document.h>
+#include <Gui/FrameBudget.h>
 #include <Gui/MainWindow.h>
 #include <Gui/MenuManager.h>
 #include <Gui/Selection/Selection.h>
@@ -3709,6 +3711,15 @@ void ViewProviderSketch::updateData(const App::Property* prop) {
 
 void ViewProviderSketch::slotSolverUpdate()
 {
+    // Document recomputes run on a document worker. The solver signal is
+    // synchronous, but everything below belongs to Qt/Coin (task widgets,
+    // the edit view provider, and the scene graph). Keep the solve on its
+    // worker and adopt only its presentation update on Qt's owner thread.
+    if (qApp && QThread::currentThread() != qApp->thread()) {
+        Gui::dispatchToGuiFrameAndWait([this] { slotSolverUpdate(); });
+        return;
+    }
+
     if (!isInEditMode()) {
         return;
     }

--- a/src/Mod/Sketcher/SketcherTests/TestVibeCADRibbonTools.py
+++ b/src/Mod/Sketcher/SketcherTests/TestVibeCADRibbonTools.py
@@ -1253,13 +1253,28 @@ class TestVibeCADSketchRibbonTools(SketcherGuiTestCase):
         self.flush_gui()
         before = self.sketch.ConstraintCount
 
-        self._respond_to_modal(True)
-        Gui.runCommand("Sketcher_ConstrainRadius", 0)
-        self.flush_gui(80)
+        messages = []
+        previous_handler = QtCore.qInstallMessageHandler(
+            lambda _kind, _context, message: messages.append(str(message))
+        )
+        preferences = App.ParamGet("User parameter:BaseApp/Preferences/Mod/Sketcher")
+        original_auto_recompute = preferences.GetBool("AutoRecompute", False)
+        try:
+            preferences.SetBool("AutoRecompute", True)
+            self._respond_to_modal(True)
+            Gui.runCommand("Sketcher_ConstrainRadius", 0)
+            self.flush_gui(80)
+        finally:
+            preferences.SetBool("AutoRecompute", original_auto_recompute)
+            QtCore.qInstallMessageHandler(previous_handler)
 
         self.assertEqual(before + 1, self.sketch.ConstraintCount)
         self.assertEqual("Radius", self.sketch.Constraints[-1].Type)
         self.assertFalse(self.doc.HasPendingTransaction)
+        self.assertFalse(
+            [message for message in messages if "Timer" in message and "thread" in message],
+            messages,
+        )
 
     def test_group_constraint_accepts_two_distinct_native_geometries(self):
         self._enter_edit()

--- a/src/Mod/VibeCAD/VibeCADSectionView.py
+++ b/src/Mod/VibeCAD/VibeCADSectionView.py
@@ -2958,11 +2958,10 @@ def _start_plane_drag(view):
                 # vertical dragging then uses the view's world-units-per-pixel.
                 a = view.getPoint(pixel_x, pixel_y)
                 b = view.getPoint(pixel_x, pixel_y + 1)
-                # A face-on pull has no projected normal. Keep its world
-                # direction tied to the camera when Flip reverses the normal.
-                look = _view_look_direction(view)
-                toward_camera = tuple(-value for value in look)
-                self.pixel_scale = (b - a).Length * (1 if _dot(normal, toward_camera) >= 0 else -1)
+                # A face-on plane has no projected normal. Map an upward pull
+                # to the positive direction of the active section normal, so
+                # Flip reverses both the handle and its interaction together.
+                self.pixel_scale = (b - a).Length
                 self.dragging = True
                 return True
             if not self.dragging:

--- a/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
+++ b/src/Mod/VibeCAD/vibecad_tests/section_view_gui_integration.py
@@ -520,6 +520,10 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
         point = view.getPointOnScreen(App.Vector(-0.8, -0.4, 5))
         start = QtCore.QPoint(int(point[0]), widget.height() - 1 - int(point[1]))
         finish = start + QtCore.QPoint(0, -40)
+        bounds = VibeCADSectionView._bounds_for_view(view, self.document)
+        before_origin, _ = VibeCADSectionView.clip_plane_from_settings(
+            VibeCADSectionView.current_section_view_settings(), bounds.center)
+        before_screen = view.getPointOnScreen(App.Vector(*before_origin))
         box = self.document.getObject("SectionBox")
         placement = box.Placement
         undo = self.document.UndoCount
@@ -534,10 +538,23 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
             QtCore.QCoreApplication.sendEvent(widget, event)
         self._process_events()
         self.assertNotAlmostEqual(VibeCADSectionView.current_section_view_settings().offset, 0)
+        after_origin, _ = VibeCADSectionView.clip_plane_from_settings(
+            VibeCADSectionView.current_section_view_settings(), bounds.center)
+        after_screen = view.getPointOnScreen(App.Vector(*after_origin))
+        plane_motion = QtCore.QPointF(
+            after_screen[0] - before_screen[0],
+            before_screen[1] - after_screen[1],
+        )
+        mouse_motion = QtCore.QPointF(finish - start)
+        self.assertGreater(
+            plane_motion.x() * mouse_motion.x() + plane_motion.y() * mouse_motion.y(),
+            0.0,
+            "Section plane moved away from the pointer during its drag",
+        )
         self.assertEqual(box.Placement, placement)
         self.assertEqual(self.document.UndoCount, undo)
 
-    def test_face_on_plane_pull_keeps_world_direction_when_flipped(self):
+    def test_face_on_plane_pull_follows_active_normal_when_flipped(self):
         view = Gui.ActiveDocument.ActiveView
         view.viewTop()
         view.fitAll()
@@ -547,9 +564,7 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
             VibeCADSectionView.configure_section_view(plane="top", flipped=flipped)
             VibeCADSectionView.set_section_view(True, view=view, document=self.document)
             self._process_events()
-            bounds = VibeCADSectionView._bounds_for_view(view, self.document)
-            before, _ = VibeCADSectionView.clip_plane_from_settings(
-                VibeCADSectionView.current_section_view_settings(), bounds.center)
+            before = VibeCADSectionView.current_section_view_settings()
             point = view.getPointOnScreen(App.Vector(-0.8, -0.4, 5))
             start = QtCore.QPoint(int(point[0]), widget.height() - 1 - int(point[1]))
             finish = start + QtCore.QPoint(0, -10)
@@ -562,10 +577,14 @@ class TestVibeCADSectionViewCommand(unittest.TestCase):
                                          QtCore.QPointF(widget.mapToGlobal(position)),
                                          button, buttons, QtCore.Qt.NoModifier)
                 QtCore.QCoreApplication.sendEvent(widget, event)
-            after, _ = VibeCADSectionView.clip_plane_from_settings(
-                VibeCADSectionView.current_section_view_settings(), bounds.center)
-            self.assertGreater(after[2], before[2], f"Pull reversed with flipped={flipped}")
+            after = VibeCADSectionView.current_section_view_settings()
+            self.assertGreater(
+                after.offset,
+                before.offset,
+                f"Pull opposed the active section normal with flipped={flipped}",
+            )
             VibeCADSectionView.set_section_view(False, view=view, document=self.document)
+            self._process_events()
 
     def test_scene_helpers_do_not_expand_section_bounds(self):
         from pivy import coin

--- a/src/Tools/tests/check_section_compilation.py
+++ b/src/Tools/tests/check_section_compilation.py
@@ -32,6 +32,7 @@ def main():
             ("src/Mod/Part/App", "Part", "SectionGeometry.cpp"),
             ("src/Mod/Part/App", "Part", "GizmoHelper.cpp"),
             ("src/Gui", "FreeCADGui", "NaviCube.cpp"),
+            ("src/Gui", "FreeCADGui", "TaskView/TaskView.cpp"),
         ):
             obj = f"{directory}/CMakeFiles/{target}.dir/{filename}.o"
             commands = subprocess.check_output(
@@ -54,6 +55,7 @@ def main():
                     cleaned.append(flag)
             production = source / directory / filename
             probe = Path(temporary) / filename
+            probe.parent.mkdir(parents=True, exist_ok=True)
             probe.write_text(f'#include "{production.as_posix()}"\n' + (
                 "// MSVC eagerly instantiates this exported nested destructor.\n"
                 "// Force the same completeness requirement on other compilers.\n"

--- a/tests/src/Gui/DocumentBulkMutation.cpp
+++ b/tests/src/Gui/DocumentBulkMutation.cpp
@@ -65,6 +65,20 @@
 namespace
 {
 
+// Undo keeps the removed object alive, allowing the test to detect stale tree
+// dereferences deterministically instead of relying on freed-memory contents.
+class RemovedObjectProbe final: public App::DocumentObject
+{
+public:
+    mutable int attachmentQueries {0};
+
+    bool isAttachedToDocument() const override
+    {
+        ++attachmentQueries;
+        return App::DocumentObject::isAttachedToDocument();
+    }
+};
+
 #ifdef _MSC_VER
 LONG CALLBACK captureAccessViolation(EXCEPTION_POINTERS* exception)
 {
@@ -209,6 +223,41 @@ class DocumentBulkMutationTest: public QObject
 #endif
 
 private Q_SLOTS:
+    void treeDoesNotDereferenceRemovedObjectWithoutViewProvider()
+    {
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("RemovedUnpresentedObject");
+        auto* object = new RemovedObjectProbe;
+        document->addObject(object, "InternalObject");
+        QVERIFY(!application->getDocument(document)->getViewProvider(object));
+        QTRY_VERIFY(document->isClosable());
+
+        QTreeWidget* tree = nullptr;
+        for (auto* candidate : window->findChildren<QTreeWidget*>()) {
+            if (candidate->inherits("Gui::TreeWidget")) {
+                tree = candidate;
+                break;
+            }
+        }
+        QVERIFY(tree);
+        document->setUndoMode(1);
+        document->openTransaction("Remove internal object");
+        object->touch();
+        document->removeObject("InternalObject");
+        document->commitTransaction();
+        QVERIFY(!document->containsObject(object));
+        object->attachmentQueries = 0;
+
+        QVERIFY(QMetaObject::invokeMethod(tree, "onUpdateStatus", Qt::DirectConnection));
+        bool dispatched = false;
+        QVERIFY(Gui::dispatchToGuiFrame([&] { dispatched = true; }));
+        QTRY_VERIFY(dispatched);
+        QTRY_VERIFY(document->isClosable());
+        const int queries = object->attachmentQueries;
+        QVERIFY(app.closeDocument("RemovedUnpresentedObject"));
+        QCOMPARE(queries, 0);
+    }
+
     void closeRemainsRejectedWhenAnObserverStartsFinalization()
     {
         auto& guiApplication = *application;

--- a/tests/src/Gui/DocumentBulkMutation.cpp
+++ b/tests/src/Gui/DocumentBulkMutation.cpp
@@ -12,6 +12,7 @@
 #include <QElapsedTimer>
 #include <QMouseEvent>
 #include <QMessageBox>
+#include <QMdiSubWindow>
 #include <QAbstractButton>
 #include <QListWidget>
 #include <QTest>
@@ -1168,6 +1169,26 @@ private Q_SLOTS:
         QVERIFY(!app.getDocument(name.c_str()));
         QTRY_VERIFY_WITH_TIMEOUT(view.isNull(), 5000);
         QVERIFY(!window->findChild<QMessageBox*>("confirmSave"));
+    }
+
+    void approvedLastViewCloseRemovesItsMdiSubWindow()
+    {
+        auto& app = App::GetApplication();
+        auto* document = app.newDocument("single_click_view_close");
+        auto* guiDocument = application->getDocument(document);
+        guiDocument->setModified(false);
+
+        const auto views = guiDocument->getMDIViews();
+        QCOMPARE(views.size(), std::size_t(1));
+        QPointer<Gui::MDIView> view = views.front();
+        QPointer<QMdiSubWindow> subWindow = qobject_cast<QMdiSubWindow*>(view->parentWidget());
+        QVERIFY(subWindow);
+
+        subWindow->close();
+
+        QTRY_VERIFY_WITH_TIMEOUT(!app.getDocument("single_click_view_close"), 5000);
+        QTRY_VERIFY_WITH_TIMEOUT(view.isNull(), 5000);
+        QTRY_VERIFY_WITH_TIMEOUT(subWindow.isNull(), 5000);
     }
 
     void queuedCloseAllPreservesDocumentsCreatedWhilePrompting()


### PR DESCRIPTION
## Outcome

Fixes async human-CAD interaction regressions and face-supported extrusion Join without moving document recompute back to the GUI thread:

- Sketcher solver notifications now marshal only Qt/Coin presentation work to Qt's owner thread. The native document solve remains on its worker.
- An approved document close now closes the owning MDI subwindow, so one click removes both the document and its tab.
- Face-on Section View dragging follows the active section normal in both flip states and follows pointer motion in perspective views.

Closes #206.
Closes #207.
Closes #208.

## Root cause

`SketchObject::signalSolverUpdate` is synchronous. Async recompute therefore invoked `ViewProviderSketch::slotSolverUpdate` on the document worker, where it touched task widgets and the Coin scene graph. The close callback re-entered through the child view instead of its MDI owner. The face-on section fallback added a camera-dependent sign that inverted interaction after Flip.

## Red/green development

Red before implementation:

- radius-dimension acceptance with `AutoRecompute=true` captured a Qt timer/thread warning;
- closing the last view left its `QMdiSubWindow` alive;
- face-on drag after Flip produced a negative active-normal offset (`-0.70177`).

Green after implementation:

```text
cmake --build build/authoritative-runtime-native --config Release --target FreeCADApp SketcherGui DocumentBulkMutation_Tests_run
# success

build/authoritative-runtime-native/bin/FreeCAD.exe --run-test SketcherTests.TestVibeCADRibbonTools.TestVibeCADSketchRibbonTools.test_dimension_composite_child_creates_a_native_radius_constraint
# 1 test, OK; no Qt timer/thread warning

build/authoritative-runtime-native/bin/DocumentBulkMutation_Tests_run.exe approvedLastViewCloseRemovesItsMdiSubWindow -silent
# 3 passed, 0 failed

build/authoritative-runtime-native/bin/FreeCAD.exe --run-test VibeCAD.vibecad_tests.section_view_gui_integration
# 18 tests, OK
```

The Sketcher test was rerun after removing an experimental `QThread` worker conversion. This confirms the fix comes from the actual GUI boundary, not from suppressing Qt's diagnostic.

## Risk

The original fixes are localized; the later Extrude additions also touch shared edit-gizmo routing and asynchronous target-detection lifetime. The full Windows native build succeeded, and focused GUI/geometry tests cover the changed behavior. The Sketcher change affects only the presentation callback when it arrives off the Qt owner thread. Existing APIs and document-worker execution remain unchanged. Close behavior still uses the existing preparation/approval contract. Section changes affect only the degenerate face-on drag mapping.

## Compatibility checklist

- [x] Existing public functions/APIs remain present and behaviorally compatible.
- [x] No preference keys, tool names, or schema fields were renamed or removed.
- [x] Defaults preserve previous behavior outside the corrected regressions.
- [x] No deprecations.
- [x] No breaking changes.

## Platform validation

The implementation uses shared Qt APIs and contains no platform-specific branch. Windows native build and GUI execution are verified above. Linux full strict Release compilation and the targeted runtime checks below are now verified. macOS compilation/execution of this PR remains unverified.

## Face-supported extrusion Join

Creating a sketch on an existing Body face and extruding outward previously failed with `The operation does not intersect selected Body`. The shared Design Boolean path required solid-volume overlap even for Join. It now also accepts shared face area for Join, using a Common operation against the tool boundary. Cut and Intersect retain their volume-overlap requirement. Existing compound-Body policy, coordinate frames, tolerance, public APIs, and publication validation remain in place. The fix applies to callers of the shared native path, including AI-driven operations.

Red: `test_extrude_join_accepts_face_contact_with_target_body` failed on the previous native binary with the reported intersection error.

Green on the rebuilt Windows native runtime:

```text
cmake --build build/authoritative-runtime-native --config Release --target PartDesign --parallel 6
# success

FreeCADCmd.exe -P "$PortableRoot/bin/Lib/site-packages" --run-test PartDesignTests.TestDesignModeling.TestDesignModeling.test_extrude_join_accepts_face_contact_with_target_body
# 1 test passed
FreeCADCmd.exe -P "$PortableRoot/bin/Lib/site-packages" --run-test PartDesignTests.TestDesignModeling.TestDesignModeling.test_extrude_contact_modes_preserve_boolean_and_compound_contracts
# 1 test passed: 18 cases covering face/edge/vertex contact, gaps, overlap,
# Join/Cut/Intersect, and both single-solid and compound Bodies
FreeCADCmd.exe -P "$PortableRoot/bin/Lib/site-packages" --run-test PartDesignTests.TestDesignModeling.TestDesignModeling.test_compound_body_join_preserves_one_body_identity
# 1 test passed, including save/reopen of an 18-solid Body
FreeCAD.exe -P "$PortableRoot/bin/Lib/site-packages" --run-test PartDesignTests.TestDesignProfileRegionsGui.TestDesignProfileRegionsGui.test_face_attached_extrude_join_accepts_through_task_panel
# 1 GUI test passed (2.814 seconds): mapped sketch on Face6, Extrude,
# Join, task-panel OK, one valid published solid and expected volume
```

`docs/developer-launch-windows.md` records the incremental native launch environment using repository-relative variables. Its documentation-only addition does not require TDD.

## Extrude/Cut task-panel improvements

Included in commit `406b3966`:

- Pickable end-plane length dragging using the existing length controls; editing gestures reach the gizmo before Inventor camera navigation, with prior routing restored on exit.
- **Show final result** renders unpublished output geometry and restores target visibility afterward.
- **Select areas** isolates the sketch, provides instructions and a live selection count, then restores the previous view.
- Missing targets produce an actionable message instead of an inconsistent-port error.
- Background intersection-based target suggestions use the shared Boolean contact rules, preserve explicit user choices, and cancel queued work when rollback deletes the provisional operation.

### Final Windows build and validation

```powershell
cmake --build build/authoritative-runtime-native --config Release --parallel 6
# PASS: exit code 0, complete configured native build

FreeCAD.exe -P "$PortableRoot/bin/Lib/site-packages" --run-test PartDesignTests.TestDesignProfileRegionsGui.TestDesignProfileRegionsGui
# PASS: 10 GUI tests, 18.543 seconds
FreeCAD.exe -P "$PortableRoot/bin/Lib/site-packages" --run-test PartDesignTests.TestNativeRibbonTools.TestNativeRibbonTools.test_pad_accept_waits_for_the_active_document_recompute
# PASS: 1 test
FreeCAD.exe -P "$PortableRoot/bin/Lib/site-packages" --run-test PartDesignTests.TestNativeRibbonTools.TestNativeRibbonTools.test_pad_cancel_waits_for_the_active_document_recompute
# PASS: 1 test
```

The three geometry/compound tests listed above were rerun successfully. A local GUI fixture using a copy of the owner's saved Cut reproduction also passed: automatic target selection, reversed Cut acceptance, asynchronous publication, reduced Body volume and design validity. No customer documents are included.

[Detailed red/green evidence and commands](https://github.com/10-X-eng/vibecad/pull/209#issuecomment-5637111908).

The full-build instance launched with the documented runtime environment; its startup error log was empty, the GUI was responsive, and the assistant was available. The owner subsequently reported that it works with no errors to report.

### Remaining limitations / scope

- The owner reports that detection of the intended operation does **not** work as expected, but explicitly accepts deferring it. Do not describe intent detection or automatic mode/direction/parameter inference as completed. Intersection-based target suggestions are narrower than engineering-intent inference.
- `TestNativeRibbonTools.test_profile_tasks_cancel_back_to_the_exact_body_history` stopped at a modal `A reusable Design Sketch must remain at document scope` error and was terminated. This broader regression run is not passing evidence; its cause remains unverified. The subsequent aggregate cancellation test was not run.
- macOS execution remains unverified. Linux validation and its remaining failures are recorded below; neither owner spot-testing nor the targeted checks constitute complete suite coverage.
- This update does not merge the PR or cut a release.



## Linux crash fix and strict-build follow-up

The queued model-tree refresh could dereference a deleted internal document object. Touch notifications include objects without view providers; those objects do not emit the GUI provider-deletion notification used to remove pending entries. The refresh called `isAttachedToDocument()` before checking the live tree registry. A captured Linux Release SIGSEGV stopped at that exact call, and inspection of all 39 registry entries confirmed the crashing address was absent.

Commit `182e2afb` moves the existing registry lookup ahead of all object dereferences. Discarded entries still respect the frame budget. This preserves cooperative tree updates, transient simulation-placement suppression, public APIs, and defaults. It does not establish that the earlier `malloc(): unaligned tcache chunk detected` abort or the untriaged Mac crash has the same cause.

Commit `2b31eeb2` also fixes Clang's missing aggregate-field initializer error in TaskView by value-initializing every member before assigning the document. The compiler regression probe now includes TaskView.

### Red/green and build

Using the packaged Linux dependency environment (Clang 21, Qt 6.8.3, OCCT 7.8.1), Release, warnings as errors, sanitizers disabled, and 12 build jobs:

```sh
python src/Tools/tests/check_section_compilation.py build/strict-package-release --compiler clang++
# RED before TaskView fix: missing cooperativeMutationConnection initializer.
# GREEN afterward: all five compile probes passed.

cmake --build build/strict-package-release --target DocumentBulkMutation_Tests_run --parallel 12
xvfb-run -a build/strict-package-release/tests/DocumentBulkMutation_Tests_run treeDoesNotDereferenceRemovedObjectWithoutViewProvider
# RED before tree fix: removed-object attachment queries = 1, expected 0.
# GREEN after tree fix: passed, with setup and cleanup also passing.

cmake --build build/strict-package-release --parallel 12
# PASS: complete configured Release build, exit 0.
```

Runtime commands used private profiles, data/temp/socket directories, Xvfb, and the just-built shared libraries through `LD_LIBRARY_PATH`. The new test keeps the removed object alive in undo history and counts virtual attachment queries, detecting the lifetime violation deterministically without relying on freed-memory contents.

Additional native command:

```sh
xvfb-run -a build/strict-package-release/tests/DocumentBulkMutation_Tests_run \
  treeDoesNotDereferenceRemovedObjectWithoutViewProvider \
  visibilityBurstUpdatesFolderWithoutReplacingHierarchy \
  transientLinkPlacementsDoNotScheduleTreeRefresh \
  restoresGuiArchivePropertiesFromDocumentWorker \
  queuesNativeDocumentOpenWithoutBlockingInput \
  queuesInteractiveSaveAndKeepsDocumentLeasedUntilCompletion \
  defersViewProviderAttachmentUntilDocumentIsStable \
  blockingWorkerNotificationsShareTheGuiFrameBudget \
  destroysTreeWhileItsDocumentRemainsOpen
```

Eight targeted cases passed. `defersViewProviderAttachmentUntilDocumentIsStable` failed before reaching its later checks: notification count 2 versus expected 3. Running that same test against the preserved **pre-fix** libraries reproduced the identical failure; this is not passing evidence and was not relaxed or hidden.

The isolated GUI harness also passed these three unittest cases:

- `SketcherTests.TestVibeCADRibbonTools.TestVibeCADSketchRibbonTools.test_dimension_composite_child_creates_a_native_radius_constraint` (explicitly rejects timer/thread Qt warnings during automatic recompute).
- `PartDesignTests.TestNativeRibbonTools.TestNativeRibbonTools.test_pad_accept_waits_for_the_active_document_recompute`.
- `PartDesignTests.TestNativeRibbonTools.TestNativeRibbonTools.test_pad_cancel_waits_for_the_active_document_recompute`.

Five GDB-supervised repetitions of the original combined extrusion-GUI/geometry stress sequence exited normally after the fix, with no fatal signals. These are **crash-stress results, not five clean test-suite passes**: running headless geometry tests in that GUI harness produces four document-close errors, and the preview-bounds assertion also fails. Cleanup waits for document work to finish before closing the synthetic documents; there is no process timeout. The three geometry tests pass in their intended FreeCADCmd environment.

Other Linux findings retained for review: the preview-bounds test reports 3.994131565 versus 4 at its two-decimal tolerance, and the broader profile-cancellation test reproduces the already documented reusable-Design-Sketch modal error. Neither assertion was weakened. No user document, core dump, or machine-specific diagnostic file is committed.
