### PR TITLE
macOS: fix the release/update contract suite on macOS and run it in CI

### DIFF
--- a/.github/workflows/vibecad-update-validate.yml
+++ b/.github/workflows/vibecad-update-validate.yml
@@ -94,3 +94,32 @@ jobs:
           src.Tools.tests.test_vibecad_update.UpdateServiceTests.test_windows_detached_helper_executes_powershell_after_parent_exits
           src.Tools.tests.test_vibecad_update.UpdateServiceTests.test_spawn_detached_helper_outlives_the_parent_process
           src.Tools.tests.test_windows_installer_version.TestWindowsInstallerVersion.test_in_app_updater_launches_normal_installer_without_flags
+
+  validate-macos-contracts:
+    name: Validate release and update contracts on macOS
+    runs-on: macos-15
+    timeout-minutes: 10
+    steps:
+      - name: Check out source
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        with:
+          python-version: "3.11"
+
+      # The macOS packaging and updater paths are only exercised here. Running
+      # the same contracts on Linux and Windows alone lets macOS-only path
+      # behaviour, such as the /var -> /private/var symlink, regress unseen.
+      - name: Run release and update contract tests
+        shell: bash
+        run: >-
+          python -m unittest
+          src.Tools.tests.test_sync_version
+          src.Tools.tests.test_release_artifact_name
+          src.Tools.tests.test_windows_installer_version
+          src.Tools.tests.test_generate_update_manifest
+          src.Tools.tests.test_release_workflow
+          src.Tools.tests.test_vibecad_update
+          src.Tools.tests.test_macos_bundle_audit
+          src.Tools.tests.test_macos_build_toolchain

--- a/src/Tools/tests/test_vibecad_update.py
+++ b/src/Tools/tests/test_vibecad_update.py
@@ -322,7 +322,11 @@ class UpdateServiceTests(unittest.TestCase):
         payload = b"unsigned installer fixture"
         asset = self._windows_asset(payload)
         with tempfile.TemporaryDirectory() as temp_dir:
-            update_dir = Path(temp_dir)
+            # UpdateService resolves the directories it is handed, so the
+            # expected path has to be resolved too. On macOS the per-user
+            # temporary directory sits under the /var -> /private/var
+            # symlink, where an unresolved path never compares equal.
+            update_dir = Path(temp_dir).resolve()
             downloads = update_dir / "downloads"
             downloads.mkdir()
             cached = downloads / asset.name


### PR DESCRIPTION
> **AI-authored contribution** (CONTRIBUTING.md §5.14, AGENTS.md §5). Written by Claude Opus 5, driven by a human contributor who reviewed and submitted it. The commit carries a `Co-Authored-By: Claude Opus 5` trailer. Per §5.14 this change is red/green: the updated assertion fails on macOS on a clean checkout of `main` and passes after the change, with the exact commands and their results in the Verification section below. No new files and no production code are added, so licensing is unchanged; all edits are original to this PR.

`src/Tools/tests` fails on macOS, and CI cannot see it because `vibecad-update-validate.yml` runs the release and update contracts on `ubuntu-24.04` and `windows-2022` only. One assertion had already regressed unnoticed.

`UpdateService` resolves the directories it is handed (`VibeCADUpdate.py`, `self.download_directory = download_directory.resolve()`). On macOS the per-user temporary directory lives under the `/var` → `/private/var` symlink, so `test_cached_windows_installer_uses_manifest_size_and_hash_without_authenticode` compared a resolved result against an unresolved expectation:

```
AssertionError: PosixPath('/private/var/folders/nz/…/…installer.exe')
            != PosixPath('/var/folders/nz/…/…installer.exe')
```

On Linux `/var` is a real directory, so the same assertion passes there. Any contributor on a Mac currently gets a red suite on a clean checkout of `main`.

## What changed

- Resolve the expected path in that test the same way `UpdateService` does. This fixes the test, not the product: resolving the download directory is deliberate — it backs the containment checks in `record_pending_install` and `remove_downloaded_package` — so the production behaviour is correct and unchanged.
- Add a `validate-macos-contracts` job on `macos-15` running the same contracts, so the next macOS-only difference fails in CI.

The new job mirrors the existing `validate-windows-launch` job: checkout, `setup-python`, `python -m unittest`. It needs no extra dependencies — the hash-locked TUF install stays exclusive to the Linux `validate` job.

## Deliberately unchanged

- `test_tampered_cached_windows_installer_is_not_reused` also builds an unresolved `Path(temp_dir)` but only asserts `cached.exists()`, which resolves through the symlink either way. I left it alone rather than widen the diff.
- No production code is touched.

## Risk

Adds one macOS CI job (~1 minute). If you would rather not spend macOS runner minutes on every PR, the second commit can be dropped on its own and the test fix still stands — but then this class of bug stays invisible until someone builds on a Mac.

## Verification

- [x] For code changes, a test failed before the implementation and passes afterward; for non-code changes, the PR explains why TDD does not apply.
- [x] The PR lists the exact build and test commands and their results.

Run on macOS 26.2 (arm64), Python 3.13.7, using exactly the command the new CI job runs.

**Red** — clean `main`, before the fix:

```
$ python -m unittest src.Tools.tests.test_sync_version \
    src.Tools.tests.test_release_artifact_name src.Tools.tests.test_windows_installer_version \
    src.Tools.tests.test_generate_update_manifest src.Tools.tests.test_release_workflow \
    src.Tools.tests.test_vibecad_update src.Tools.tests.test_macos_bundle_audit \
    src.Tools.tests.test_macos_build_toolchain
AssertionError: PosixPath('/private/var/folders/nz/…exe') != PosixPath('/var/folders/nz/…exe')
Ran 124 tests in 14.606s
FAILED (failures=1, skipped=2)
```

**Green** — same command, after the fix:

```
Ran 124 tests in 14.599s
OK (skipped=2)
```

Whole directory under pytest:

```
$ python -m pytest src/Tools/tests -q
125 passed, 2 skipped, 29 subtests passed in 15.32s
```

Workflow parses and the job is wired up:

```
$ python -c "import yaml; d=yaml.safe_load(open('.github/workflows/vibecad-update-validate.yml')); print(list(d['jobs']))"
['validate', 'validate-windows-launch', 'validate-macos-contracts']
```

## Compatibility checklist

- [x] Existing public functions/APIs still present and behaviorally compatible — no production code changed.
- [x] No preference keys, tool names, or schema fields renamed/removed.
- [x] Defaults preserve previous behavior.
- [ ] Deprecations — none.
- [ ] Breaking changes — none.

## Issues

No existing issue; found while reproducing #212 on a Mac. Independent of #213 — the two do not touch the same files and can merge in either order. If #213 lands, `src.Tools.tests.test_macos_bundle_identity` is worth adding to this job's list.

## Before and After Images

No GUI change — test and CI only.


## Maintainer integration validation — 2026-09-12

Codex merged current main `f69e96eb` normally; current PR head is `1b60fa4f`. No additional implementation or workflow changes were needed. A Linux temporary-directory symlink reproduced the same resolved-versus-unresolved assertion: main failed and this PR passed.

Current full test command from the PR checkout:

```sh
/tmp/vibecad-merge-plan-review/py311/bin/python -m pytest -q src/Tools/tests
```

**132 passed, 5 skipped, 29 subtests passed** on Linux/Python 3.11.

[Current-head CI passed](https://github.com/10-X-eng/vibecad/actions/runs/34724077819): Linux release/update contracts, Windows updater launch, and the new **macOS release/update contract job**. No C++ or CMake changes require a separate full build for this PR. The CI jobs run contract tests, not a macOS application build. Merge before #213 so its identity regression can be added to the macOS job.
